### PR TITLE
fix: add missing Zone field to DBaaSPropertiesRequest

### DIFF
--- a/cmd/example/main.go
+++ b/cmd/example/main.go
@@ -680,6 +680,7 @@ func createDBaaS(ctx context.Context, arubaClient aruba.Client, projectID string
 			},
 		},
 		Properties: types.DBaaSPropertiesRequest{
+			Zone: stringPtr("ITBG-1"),
 			Engine: &types.DBaaSEngine{
 				ID:         stringPtr("mysql-8.0"),
 				DataCenter: stringPtr("ITBG-1"),

--- a/cmd/example/update.go
+++ b/cmd/example/update.go
@@ -142,6 +142,7 @@ func updateDBaaS(ctx context.Context, arubaClient aruba.Client, projectID string
 			},
 		},
 		Properties: types.DBaaSPropertiesRequest{
+			Zone: stringPtr("ITBG-1"),
 			Engine: &types.DBaaSEngine{
 				ID:         stringPtr("mysql-8.0"),
 				DataCenter: stringPtr("ITBG-1"),

--- a/pkg/types/database.dbaas.go
+++ b/pkg/types/database.dbaas.go
@@ -143,6 +143,10 @@ type DBaaSAutoscalingResponse struct {
 
 // DBaaSPropertiesRequest contains properties required to create a DBaaS instance
 type DBaaSPropertiesRequest struct {
+	// Zone where DBaaS will be created (optional).
+	// If specified, the resource is zonal; otherwise, it is regional.
+	Zone *string `json:"dataCenter,omitempty"`
+
 	// Engine Database engine configuration
 	Engine *DBaaSEngine `json:"engine,omitempty"`
 


### PR DESCRIPTION
- Add Zone field to DBaaSPropertiesRequest matching CloudServerPropertiesRequest pattern
- Update examples in main.go and update.go to include Zone field
- Fixes issue where DBaaSPropertiesRequest was missing zone properties