### PR TITLE
fix(docs): sort versions in descending order for Docusaurus

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -66,7 +66,8 @@ jobs:
         if [ -d "versioned_docs" ]; then
           echo "Checking for version directories..."
           # Use find to reliably get all version directories (handles empty case)
-          VERSIONS=$(find versioned_docs -maxdepth 1 -type d -name "version-*" 2>/dev/null | sed 's|.*/version-||' | sort -V)
+          # Sort in reverse to get newest version first (required by Docusaurus)
+          VERSIONS=$(find versioned_docs -maxdepth 1 -type d -name "version-*" 2>/dev/null | sed 's|.*/version-||' | sort -Vr)
           
           if [ -n "$VERSIONS" ]; then
             # Build JSON array from existing directories


### PR DESCRIPTION
The sync step was using 'sort -V' which sorts in ascending order, but Docusaurus requires the latest version to be first in versions.json. Changed to 'sort -Vr' to sort in reverse (descending) order.