### PR TITLE
docs: add Claude Code guidance files and tech debt backlog

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,6 +31,9 @@ go.work.sum
 # .idea/
 # .vscode/
 
+# Claude Code local session data (memory, plans, logs)
+.claude/
+
 # Documentation (docs/website/)
 docs/website/node_modules/
 docs/website/build/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,13 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+Detailed guidance is split across files in the `ai/` folder. Read only what is relevant to the current task:
+
+| Task type | File to read |
+|---|---|
+| Building, running tests, linting, CI, reference docs | [`ai/DEVEX.md`](ai/DEVEX.md) |
+| Finding files, understanding package structure, service groups | [`ai/REPO.md`](ai/REPO.md) |
+| Implementing features, understanding design patterns, adding resources | [`ai/ARCHITECTURE.md`](ai/ARCHITECTURE.md) |
+| Naming, code style, type conventions, error handling rules | [`ai/CONVENTIONS.md`](ai/CONVENTIONS.md) |
+| Known bugs, risks, and refactoring backlog | [`ai/TECH_DEBT.md`](ai/TECH_DEBT.md) |

--- a/ai/ARCHITECTURE.md
+++ b/ai/ARCHITECTURE.md
@@ -6,10 +6,11 @@ The public entry point is `NewClient(options *Options) (Client, error)` in `pkg/
 
 `buildClient()` performs cascading construction in this order:
 1. Validate options via `options.validate()`
-2. Build logger (`buildLogger()`)
-3. Build REST client (`buildRESTClient()`) — injects logger and HTTP client
-4. Build token manager (`buildTokenManager()`) — binds itself as the last interceptor
-5. Build each of the 10 service group clients sequentially
+2. Build REST client via `buildRESTClient()` — internally constructs:
+   - HTTP client (`buildHTTPClient()`) — defaults to `http.DefaultClient`
+   - Logger (`buildLogger()`)
+   - Middleware (`buildMiddleware()`) — builds the token manager and binds it as the last interceptor
+3. Build each of the 10 service group clients sequentially
 
 `pkg/aruba.Options` is a fluent builder (~40 methods). Key injection points:
 - `WithCustomHTTPClient(*http.Client)` — defaults to `http.DefaultClient`

--- a/ai/ARCHITECTURE.md
+++ b/ai/ARCHITECTURE.md
@@ -1,0 +1,169 @@
+# Architecture
+
+## Client construction (`pkg/aruba/`)
+
+The public entry point is `NewClient(options *Options) (Client, error)` in `pkg/aruba/aruba.go`, which delegates to `buildClient()` in `builder.go`.
+
+`buildClient()` performs cascading construction in this order:
+1. Validate options via `options.validate()`
+2. Build logger (`buildLogger()`)
+3. Build REST client (`buildRESTClient()`) — injects logger and HTTP client
+4. Build token manager (`buildTokenManager()`) — binds itself as the last interceptor
+5. Build each of the 10 service group clients sequentially
+
+`pkg/aruba.Options` is a fluent builder (~40 methods). Key injection points:
+- `WithCustomHTTPClient(*http.Client)` — defaults to `http.DefaultClient`
+- `WithCustomLogger(logger.Logger)` / `WithNativeLogger()` / `WithNoLogs()`
+- `WithCustomMiddleware(interceptor.Interceptor)` — defaults to `standard.NewInterceptor()`
+- `WithToken(token)` or `WithClientCredentials(clientID, secret)` — selects auth strategy
+
+`pkg/aruba.Client` exposes 10 service group accessors (`FromCompute()`, `FromNetwork()`, etc.). Each returns an interface backed by an unexported impl in `internal/clients/<service>/`.
+
+**Cross-client injection:** Some service clients receive other concrete impl clients at build time to enforce resource pre-conditions. For example, `SecurityGroupRulesClientImpl` holds a `*securityGroupsClientImpl` and calls `waitForSecurityGroupActive()` before creating a rule. These dependencies are always concrete types, not interfaces, because they call internal methods not on any interface.
+
+## HTTP request lifecycle (`internal/restclient/`)
+
+`restclient.Client.DoRequest(ctx, method, path, body, queryParams, headers)` follows these steps:
+
+1. Construct full URL from `baseURL + path`
+2. Log request details (auth header is redacted as `Bearer [REDACTED]`)
+3. Create `*http.Request` with context
+4. Attach query parameters to URL
+5. Set `Content-Type: application/json` if body is present
+6. Merge caller-supplied headers
+7. **Run middleware chain** via `middleware.Intercept(ctx, req)` — this is where the auth token is injected
+8. Execute via `httpClient.Do(req)`
+9. Log response status and headers; re-wrap body for caller (logging consumed the stream)
+10. Return `*http.Response`
+
+## Interceptor/middleware chain (`internal/impl/interceptor/`)
+
+The `Interceptor` interface has two methods: `Bind(...InterceptFunc)` and `Intercept(ctx, req)`. `InterceptFunc` is `func(ctx context.Context, r *http.Request) error`.
+
+The standard implementation collects a slice of `InterceptFunc` values and executes them in order on each request. Execution stops on the first error.
+
+The token manager always binds itself **last** via `BindTo(interceptable)`, so auth injection is always the final middleware step. Custom middleware added by the caller via `WithCustomMiddleware` runs before the token manager.
+
+## Auth subsystem (`internal/impl/auth/`)
+
+Core interfaces (defined in `internal/ports/auth/auth.go`):
+
+```
+TokenManager       — binds as interceptor, injects Bearer token on each request
+TokenRepository    — FetchToken / SaveToken (multiple backends)
+ProviderConnector  — RequestToken (OAuth2 client credentials flow)
+CredentialsRepository — FetchCredentials (static memory or Vault)
+```
+
+**Token injection with double-checked locking:**
+1. Read lock: fetch token from repository; capture ticket counter
+2. If missing or expired and a connector is configured:
+   - Acquire write lock
+   - If ticket changed (another goroutine refreshed), reuse the new token
+   - Otherwise: call `connector.RequestToken()`, `repository.SaveToken()`, increment ticket
+3. Inject `Authorization: Bearer <token>` header
+
+**Token repository implementations:**
+- **Memory** — standalone in-memory store; supports configurable `expirationDriftSeconds` safety buffer
+- **Memory proxy** — wraps a persistent store (write-through on save, read-through on miss)
+- **File** — persists tokens to `<baseDir>/<clientID>.token.json` with `0o600` permissions
+- **Redis** — stores tokens by a key derived from `clientID`
+
+`NewTokenProxyWithRandomExpirationDriftSeconds(persistent, maxDrift)` randomizes the expiry drift to avoid synchronized refresh storms across a fleet.
+
+**Credentials repository implementations:**
+- **Memory** — holds static `ClientID` + `ClientSecret`
+- **Vault** — fetches credentials from HashiCorp Vault using AppRole authentication (KV v2)
+
+The OAuth2 connector (`internal/impl/auth/providerconnector/oauth2/`) uses `golang.org/x/oauth2/clientcredentials` (Client Credentials flow, RFC 6749). HTTP 401 maps to `auth.ErrAuthenticationFailed`, HTTP 403 to `auth.ErrInsufficientPrivileges`.
+
+## Types package (`pkg/types/`)
+
+**`Response[T any]`** — generic wrapper returned by every API call:
+
+```go
+type Response[T any] struct {
+    Data         *T
+    Error        *ErrorResponse
+    HTTPResponse *http.Response
+    StatusCode   int
+    Headers      http.Header
+    RawBody      []byte
+}
+func (r *Response[T]) IsSuccess() bool  // StatusCode 2xx
+func (r *Response[T]) IsError() bool    // StatusCode 4xx/5xx
+```
+
+**`RequestParameters`** — all optional pointer fields:
+
+```go
+type RequestParameters struct {
+    Filter     *string
+    Sort       *string
+    Projection *string
+    Accept     *AcceptHeader
+    Offset     *int32
+    Limit      *int32
+    APIVersion *string
+}
+func (r *RequestParameters) ToQueryParams() map[string]string
+func (r *RequestParameters) ToHeaders() map[string]string
+```
+
+**`ErrorResponse`** (RFC 7807-based): `Type`, `Title`, `Status`, `Detail`, `Instance`, `TraceID`, `Errors []ValidationError`, `Extensions map[string]interface{}`. Custom `UnmarshalJSON` captures unknown keys into `Extensions` for forward compatibility.
+
+**Validation helpers** in `pkg/types/utils.go`:
+`ValidateProject`, `ValidateProjectAndResource`, `ValidateDBaaSResource`, `ValidateDatabaseGrant`, `ValidateVPCResource`, `ValidateSecurityGroupRule`, and more.
+
+**`ParseResponseBody[T any](httpResp)`** — utility function that reads the body, unmarshals into `Data` (2xx) or `Error` (4xx/5xx), and stores raw bytes.
+
+## Async polling (`pkg/async/`)
+
+**`AsyncClient[T]`** — holds a channel and a cached `Result[T]` (protected by `sync.Mutex`). `Await(ctx)` blocks until the result arrives and caches it on first call.
+
+**`WaitFor[T](ctx, retries, baseDelay, timeout, callFunc, checkFunc)`** — core polling loop:
+- Launches a goroutine retrying `callFunc()` up to `retries` times
+- Fixed `baseDelay` between attempts (no exponential backoff — intentional for predictability)
+- Enforces `timeout` as a context deadline
+- `checkFunc` receives the full `*Response[T]` to decide success
+
+**Defaults** (`DefaultWaitFor`): `retries=10`, `baseDelay=10s`, `timeout=60s`.
+
+## Multitenant client management (`pkg/multitenant/`)
+
+`Multitenant` manages a `map[string]*entry` (tenant ID → client + `lastUsage` timestamp) behind a `sync.RWMutex`.
+
+```go
+New(tenant)                              // create from template Options (deep-copied)
+NewFromOptions(tenant, *aruba.Options)   // create from custom options
+Add(tenant, aruba.Client)                // register a pre-built client
+Get / MustGet / GetOrNil                 // all update lastUsage on access
+CleanUp(from time.Duration)              // remove entries idle longer than `from`
+```
+
+`StartCleanupRoutine(ctx, tickInterval, fromDuration)` runs a background goroutine that calls `CleanUp` on the given interval (default tick: 1 hour, default idle threshold: 24 hours).
+
+`NewWithTemplate(template *aruba.Options)` deep-copies the template for each `New()` call (slices are deep-copied; `*http.Client`, logger, and middleware are shallow-copied as shared singletons).
+
+## Service client standard method flow
+
+Every resource method in `internal/clients/<service>/` follows this sequence:
+
+1. `c.client.Logger().Debugf("...")` — log the operation and key IDs
+2. Call `types.Validate*(...)` — fail fast on nil/empty IDs
+3. Inject default `APIVersion` if `params.APIVersion == nil`
+4. `params.ToQueryParams()` / `params.ToHeaders()`
+5. Marshal body with `json.Marshal(body)` (if applicable)
+6. `c.client.DoRequest(ctx, method, path, body, queryParams, headers)`
+7. `defer httpResp.Body.Close()`
+8. `types.ParseResponseBody[T](httpResp)` or manual unmarshal for complex responses
+
+## Adding a new resource
+
+1. Define request/response types in `pkg/types/<domain>.<resource>.go`.
+2. Add API path constants to `internal/clients/<service>/path.go`.
+3. Add per-operation API version constants to `internal/clients/<service>/version.go`.
+4. Create the resource file `internal/clients/<service>/<resource>.go` — define the interface and `*Impl` struct, implement all methods following the standard flow above.
+5. Expose the resource from the service group file `internal/clients/<service>/<group>.go`.
+6. If the resource depends on another resource's state, accept the dependency as a constructor parameter (concrete impl type).
+7. Wire to `pkg/aruba/Client` if this is a new service group.

--- a/ai/CONVENTIONS.md
+++ b/ai/CONVENTIONS.md
@@ -1,0 +1,88 @@
+# Conventions
+
+## Package boundary
+
+- Public API surface lives in `pkg/` — types, interfaces, and the `NewClient` entry point
+- Concrete implementations live in `internal/` — not importable by external modules
+- Only interfaces and data types are exported; concrete impl structs are always unexported
+
+## Naming
+
+### Types
+
+| Kind | Suffix | Example |
+|---|---|---|
+| Input/request struct | `Request` | `CloudServerRequest` |
+| Single output struct | `Response` | `CloudServerResponse` |
+| Collection output struct | `List` (embeds `ListResponse`) | `CloudServerList` |
+| Service client interface | none (domain name) | `CloudServersClient` |
+| Service client implementation | `Impl` (unexported) | `cloudServersClientImpl` |
+| Constructor | `New<TypeName>` | `NewCloudServersClientImpl` |
+
+### Files
+
+- Types in `pkg/types/`: `<domain>.<resource>.go` — e.g., `compute.cloudserver.go`, `network.vpc.go`
+- Client files in `internal/clients/<domain>/`: one file per resource — e.g., `cloudserver.go`
+- Each client file has a paired test file: `cloudserver_test.go`
+- Shared per-domain constants split into two files:
+  - `path.go` — API path constants (e.g., `CloudServersPath`)
+  - `version.go` — per-operation API version constants (e.g., `ComputeCloudServerList`)
+- Optional `common.go` for helpers shared across resources in the same domain
+
+### Constants
+
+- Path constants: `PascalCase` (e.g., `CloudServersPath`, `CloudServerPath`)
+- API version constants: `<Domain><Resource><Action>` (e.g., `ComputeCloudServerList`, `NetworkVPCCreate`)
+
+## Method receivers
+
+All methods on impl types use **pointer receivers**: `func (c *cloudServersClientImpl) List(...)`. No value receivers.
+
+## Service method structure
+
+Every resource method must follow this sequence exactly:
+
+1. `c.client.Logger().Debugf("...")` — log operation and key IDs at the start
+2. `types.Validate*(...)` — fail fast before any HTTP call
+3. If `params == nil`, initialize `params = &types.RequestParameters{}`
+4. If `params.APIVersion == nil`, set the domain-specific version constant
+5. `params.ToQueryParams()` / `params.ToHeaders()` — convert parameters
+6. Marshal body with `json.Marshal` if the method takes a body
+7. `c.client.DoRequest(ctx, method, path, body, queryParams, headers)`
+8. `defer httpResp.Body.Close()`
+9. `types.ParseResponseBody[T](httpResp)` for standard responses; manual unmarshal only for complex cases
+
+## Error handling
+
+- Check `resp.IsSuccess()` / `resp.IsError()` before accessing `resp.Data`; never inspect raw HTTP status codes in business logic
+- Validation errors (pre-request) return as the `error` return value using `fmt.Errorf("project cannot be empty")`
+- API errors (HTTP 4xx/5xx) are unmarshaled into `resp.Error` (`*types.ErrorResponse`); field-level details are in `resp.Error.Errors []ValidationError`
+- Use `fmt.Errorf("context: %w", err)` for error wrapping (Go 1.13+ idiom)
+
+## RequestParameters nil-safety
+
+`RequestParameters` is always a pointer parameter. Service methods must handle a `nil` input — create a new struct rather than panicking. Never assume the caller provided an API version.
+
+## Logging
+
+Logger interface (`internal/ports/logger/logger.go`) has four methods: `Debugf`, `Infof`, `Warnf`, `Errorf`. Access it via `c.client.Logger()`.
+
+- Use `Debugf` at the start of every service method
+- Never log a raw `Authorization` header; the restclient already redacts it as `Bearer [REDACTED]`
+- Use `noop.NoOpLogger{}` in all tests
+
+## Testing
+
+- Each resource file has a paired `_test.go` in the same package
+- Tests use `httptest.NewServer` to mock both the `/token` endpoint and the resource API endpoint
+- Test setup: `restclient.NewClient(baseURL, httpClient, interceptor, logger)` with `noop.NoOpLogger{}`
+- Use subtests: `t.Run("scenario", func(t *testing.T) { ... })`
+- Mocks generated with MockGen (`go.uber.org/mock/gomock`); generated files are named `zz_mock_<type>_test.go`
+
+## Documentation
+
+- Package comments: `// Package <name> provides ...`
+- Type comments: start with the type name — `// CloudServersClient is the interface for ...`
+- Method comments: start with the method name — `// List retrieves all cloud servers ...`
+- Document all exported interfaces and their methods individually
+- Path and version constants are self-documenting by name; minimal comments needed

--- a/ai/DEVEX.md
+++ b/ai/DEVEX.md
@@ -1,0 +1,30 @@
+# Development Experience
+
+## Build & test commands
+
+```bash
+make build        # go build ./...
+make test         # run all tests with race detection and coverage
+make test-short   # quick tests without coverage
+make lint         # go fmt + go vet
+make verify       # lint + test (recommended before committing)
+make all          # tidy + lint + build + test
+```
+
+Run a single test:
+```bash
+go test -v -run TestName ./pkg/...
+go test -v -run TestName ./internal/...
+```
+
+## Linting
+
+The CI pipeline uses golangci-lint v2.11.4 (timeout 5 min). Active linters: `errcheck`, `govet`, `staticcheck`, `unused`, `misspell`, `unparam`, `unconvert`, `goconst`, `gocyclo`. Generated code in `pkg/generated` and examples in `cmd/example` are excluded.
+
+## Reference documentation
+
+- `doc/OPTIONS.md` — Client configuration reference
+- `doc/FILTERS.md` — Filter syntax and examples
+- `doc/RESPONSE_HANDLING.md` — Error handling patterns
+- `doc/RESOURCES.md` — Full API groups and resource listing
+- `doc/TYPES.md` — Data model guide

--- a/ai/DEVEX.md
+++ b/ai/DEVEX.md
@@ -19,12 +19,12 @@ go test -v -run TestName ./internal/...
 
 ## Linting
 
-The CI pipeline uses golangci-lint v2.11.4 (timeout 5 min). Active linters: `errcheck`, `govet`, `staticcheck`, `unused`, `misspell`, `unparam`, `unconvert`, `goconst`, `gocyclo`. Generated code in `pkg/generated` and examples in `cmd/example` are excluded.
+The CI pipeline uses golangci-lint v2.11.4 (timeout 5 min). Active linters: `errcheck`, `govet`, `ineffassign`, `staticcheck`, `unused`, `misspell`, `unparam`, `unconvert`, `goconst`, `gocyclo`. Generated code in `pkg/generated` and examples in `cmd/example` are excluded.
 
 ## Reference documentation
 
-- `doc/OPTIONS.md` — Client configuration reference
-- `doc/FILTERS.md` — Filter syntax and examples
-- `doc/RESPONSE_HANDLING.md` — Error handling patterns
-- `doc/RESOURCES.md` — Full API groups and resource listing
-- `doc/TYPES.md` — Data model guide
+- `docs/website/docs/options.md` — Client configuration reference
+- `docs/website/docs/filters.md` — Filter syntax and examples
+- `docs/website/docs/response-handling.md` — Error handling patterns
+- `docs/website/docs/resources.md` — Full API groups and resource listing
+- `docs/website/docs/types.md` — Data model guide

--- a/ai/REPO.md
+++ b/ai/REPO.md
@@ -15,7 +15,7 @@ internal/clients/    — Service-specific HTTP client implementations (one dir p
 internal/impl/       — Pluggable subsystems: auth, interceptor, logger
 internal/restclient/ — Low-level HTTP execution layer
 cmd/example/         — Usage examples (excluded from linting)
-doc/                 — Markdown reference guides
+docs/                — Testing docs, versioning scripts, and Docusaurus site
 docs/website/        — Docusaurus documentation site (multi-locale, includes Italian)
 ```
 

--- a/ai/REPO.md
+++ b/ai/REPO.md
@@ -1,0 +1,39 @@
+# Repository Organization
+
+## Module
+
+`github.com/Arubacloud/sdk-go` — Official Go SDK for the Aruba Cloud API (Go 1.24+, currently Alpha / unstable API).
+
+## Package layout
+
+```
+pkg/aruba/           — Public client entry point and Options builder
+pkg/types/           — All request/response data models
+pkg/async/           — Polling utilities for long-running operations
+pkg/multitenant/     — Multi-tenant client management
+internal/clients/    — Service-specific HTTP client implementations (one dir per service)
+internal/impl/       — Pluggable subsystems: auth, interceptor, logger
+internal/restclient/ — Low-level HTTP execution layer
+cmd/example/         — Usage examples (excluded from linting)
+doc/                 — Markdown reference guides
+docs/website/        — Docusaurus documentation site (multi-locale, includes Italian)
+```
+
+## Service groups
+
+The top-level `Client` interface exposes ten service groups:
+
+| Accessor | Service |
+|---|---|
+| `FromCompute()` | Cloud servers, key pairs |
+| `FromNetwork()` | Networking resources |
+| `FromStorage()` | Storage resources |
+| `FromProject()` | Project management |
+| `FromDatabase()` | Managed databases |
+| `FromContainer()` | Container services |
+| `FromAudit()` | Audit logs |
+| `FromMetric()` | Metrics |
+| `FromSchedule()` | Scheduled jobs |
+| `FromSecurity()` | Security resources |
+
+Each group is backed by an implementation under `internal/clients/<service>/`.

--- a/ai/TECH_DEBT.md
+++ b/ai/TECH_DEBT.md
@@ -1,0 +1,162 @@
+# TECH_DEBT.md — Technical Debt & Refactoring Backlog
+
+Issues are grouped by severity. Address Critical items before new features ship; High items before any public release.
+
+## Resolved
+
+None yet.
+
+---
+
+## Critical
+
+### TD-001 · Parameter order swap in file token repository constructor — [#111](https://github.com/Arubacloud/sdk-go/issues/111)
+`pkg/aruba/builder.go` calls `NewFileTokenRepository(options.baseDir, clientID)` but the function signature is `NewFileTokenRepository(clientID, baseDir string)`. The arguments are swapped: the base directory is used as the client ID and vice versa, producing a wrong token file path and breaking file-based token persistence entirely.
+
+**Fix:** Change the call to `NewFileTokenRepository(clientID, options.baseDir)`.
+
+---
+
+### TD-002 · Static token is never stored — access token parameter silently ignored — [#112](https://github.com/Arubacloud/sdk-go/issues/112)
+`internal/impl/auth/tokenrepository/memory/memory.go` — `NewTokenRepositoryWithAccessToken(accessToken string)` ignores its parameter and returns `&TokenRepository{}`. Any client created with `WithToken()` will always get an empty token, causing all requests to fail authentication silently.
+
+**Fix:** Initialize the struct with `token: &auth.Token{AccessToken: accessToken}`.
+
+---
+
+### TD-003 · Race condition: `lastUsage` written under read lock in Multitenant — [#113](https://github.com/Arubacloud/sdk-go/issues/113)
+`pkg/multitenant/multitenant.go` — `Get()`, `MustGet()`, and `GetOrNil()` all hold `RLock` while writing `e.lastUsage = time.Now()`. Mutating a struct field through a map value under a read lock is a data race detected by the Go race detector.
+
+**Fix:** Upgrade to `Lock()` for the update, or store `lastUsage` as an `atomic.Int64` (Unix nanoseconds) so it can be updated without a write lock.
+
+---
+
+### TD-004 · Interceptor `Bind()` and `Intercept()` are not thread-safe — [#114](https://github.com/Arubacloud/sdk-go/issues/114)
+`internal/impl/interceptor/standard/standard.go` — `Bind()` appends to `interceptFuncs` without any synchronization. Concurrent calls to `Bind()` and `Intercept()` produce an unsynchronized read/write on a slice — a data race. While `Bind` is today called only at construction time, the interface contract does not prevent concurrent use.
+
+**Fix:** Add a `sync.RWMutex` to the struct. `Bind()` takes a write lock; `Intercept()` copies the slice under a read lock then iterates the copy.
+
+---
+
+## High
+
+### TD-005 · Typo in builder function name: `buildDetebaseClient` — [#115](https://github.com/Arubacloud/sdk-go/issues/115)
+`pkg/aruba/builder.go` — the function is named `buildDetebaseClient` instead of `buildDatabaseClient`. Harmless at runtime but breaks searchability and violates naming consistency.
+
+**Fix:** Rename to `buildDatabaseClient`.
+
+---
+
+### TD-006 · Goroutine leak in `WaitFor` on context cancellation — [#116](https://github.com/Arubacloud/sdk-go/issues/116)
+`pkg/async/async_client.go` — the goroutine launched by `WaitFor()` writes to `resultCh` unconditionally. If the caller's context is cancelled and `Await()` is never called (or returns early), the goroutine blocks forever on the channel send. The channel buffer is 1, so if the slot is already filled, the goroutine leaks.
+
+**Fix:** Wrap the channel send in a `select` with `ctx.Done()`.
+
+---
+
+### TD-007 · Variable shadowing creates unreachable `AsyncClient` in `WaitFor` nil-call path — [#117](https://github.com/Arubacloud/sdk-go/issues/117)
+`pkg/async/async_client.go` — when `callFunc == nil`, a new inner `asyncClient` variable (`:=`) shadows the outer one. The outer variable is discarded; the inner one is returned. The code works by accident but is fragile and confusing.
+
+**Fix:** Remove the inner `:=` and reuse the outer `asyncClient`.
+
+---
+
+### TD-008 · Polling loop always sleeps before the first attempt — [#118](https://github.com/Arubacloud/sdk-go/issues/118)
+`internal/restclient/polling.go` — `time.Sleep(config.Interval)` is called at the top of each iteration, including the very first one. This adds an unnecessary 5-second delay before the initial state check. Additionally, the last iteration checks `attempt == config.MaxAttempts` and returns a timeout error after having just called `getter`, discarding the final state.
+
+**Fix:** Move the sleep to the bottom of the loop (or skip when `attempt == 1`) and always check the state before emitting a timeout error.
+
+---
+
+### TD-009 · Caller headers can override SDK-controlled `Content-Type` — [#119](https://github.com/Arubacloud/sdk-go/issues/119)
+`internal/restclient/client.go` — the code sets `Content-Type: application/json` then overwrites headers with caller-supplied values using `req.Header.Set(k, v)`. A caller can silently override `Content-Type` (and in principle `Authorization`), breaking server-side request parsing.
+
+**Fix:** Apply caller headers before SDK-controlled headers, or explicitly protect `Content-Type` and `Authorization` from being overridden.
+
+---
+
+### TD-010 · Create/Update methods duplicate `ParseResponseBody` logic across ~15 client files — [#120](https://github.com/Arubacloud/sdk-go/issues/120)
+`internal/clients/compute/cloudserver.go`, `internal/clients/compute/keypair.go`, `internal/clients/network/vpc.go`, `internal/clients/network/security-group.go`, and ~11 more — List/Get/Delete methods call `types.ParseResponseBody[T]()`. Create/Update methods in the same files manually re-implement the same logic: marshal body → `DoRequest` → `io.ReadAll` → construct `Response[T]` wrapper → unmarshal success/error branches. This is ~40 lines duplicated per mutating method, totalling 2 000+ lines across the codebase. Any bug fix to the parsing logic must be applied in all locations.
+
+**Fix:** Add a generic helper to `restclient.Client`:
+```go
+func DoAndParse[T any](c *Client, ctx context.Context, method, path string,
+    body io.Reader, queryParams, headers map[string]string) (*types.Response[T], error)
+```
+Replace all manual implementations with calls to this helper.
+
+---
+
+## Medium
+
+### TD-011 · Silent failure when parsing error response body — [#121](https://github.com/Arubacloud/sdk-go/issues/121)
+`pkg/types/utils.go` — in `ParseResponseBody`, when a 4xx/5xx response body cannot be unmarshalled as JSON, the error is swallowed silently (`if err == nil { ... }`). `response.Error` remains `nil`, making it impossible for the caller to understand what the server returned.
+
+**Fix:** Log the unmarshal error at WARN level, or document that `RawBody` should be used as the fallback for non-JSON error bodies.
+
+---
+
+### TD-012 · Token manager injects expired/nil token after failed refresh — [#122](https://github.com/Arubacloud/sdk-go/issues/122)
+`internal/impl/auth/tokenmanager/standard/standard.go` — in the write-lock branch, if the ticket has already changed (another goroutine refreshed), the code re-fetches from the repository. If that second fetch fails, execution falls through and injects an empty or expired token into the `Authorization` header with no error returned to the caller.
+
+**Fix:** Check the error from the second `FetchToken()` and return it before reaching the header-injection step.
+
+---
+
+### TD-013 · Memory proxy `SaveToken` increments ticket before confirming persistent write — [#123](https://github.com/Arubacloud/sdk-go/issues/123)
+`internal/impl/auth/tokenrepository/memory/memory.go` — `saveTicket++` runs before `r.persistentRepository.SaveToken(...)`. If the persistent write fails, the ticket has already been incremented, invalidating the in-memory cache. Subsequent reads see a miss and re-read from persistent storage, which still has the old token.
+
+**Fix:** Increment the ticket only after a successful persistent write.
+
+---
+
+### TD-014 · `ParseResponseBody` panics on nil `httpResp` — [#124](https://github.com/Arubacloud/sdk-go/issues/124)
+`pkg/types/utils.go` — the function calls `io.ReadAll(httpResp.Body)` without a nil guard. If `DoRequest` returns a nil response alongside a non-nil error and the caller forgets to check the error, the function panics.
+
+**Fix:** Add `if httpResp == nil { return nil, fmt.Errorf("http response is nil") }` at the top of the function.
+
+---
+
+### TD-015 · `DefaultWaitFor` timeout of 60 s is too short for cloud operations — [#125](https://github.com/Arubacloud/sdk-go/issues/125)
+`pkg/async/async_client.go` — cloud resource provisioning (VMs, databases, VPCs) routinely takes several minutes. The defaults (`retries=10`, `baseDelay=10s`, `timeout=60s`) mean callers must always pass custom values or operations will time out spuriously.
+
+**Fix:** Raise defaults to at least `retries=36`, `baseDelay=10s`, `timeout=600s`, or expose a named constant set (e.g., `LongOperationDefaults`) for callers to use.
+
+---
+
+### TD-016 · Logger interface supports only printf-style formatting — no structured logging — [#126](https://github.com/Arubacloud/sdk-go/issues/126)
+`internal/ports/logger/logger.go` — all log calls use `%s`/`%v` format strings. In production environments using log aggregators (ELK, Loki, Cloud Logging), querying by structured fields (project ID, resource ID, trace ID) requires string parsing. The SDK's `ErrorResponse` already carries a `TraceID` field that is never emitted as a structured log field.
+
+**Fix:** Add optional structured variants to the logger interface, or adopt `slog` (stdlib since Go 1.21) as the native logger implementation.
+
+---
+
+### TD-017 · `WARN` log level writes to `os.Stdout` instead of `os.Stderr` — [#127](https://github.com/Arubacloud/sdk-go/issues/127)
+`internal/impl/logger/native/logger.go` — `DEBUG` and `INFO` correctly go to `os.Stdout`; `ERROR` correctly goes to `os.Stderr`. `WARN` also goes to `os.Stdout`, which breaks shell pipelines and container log routers that separate informational output from diagnostic output.
+
+**Fix:** Change `WARN` to write to `os.Stderr`.
+
+---
+
+### TD-018 · Injected concrete dependencies not nil-checked in constructors — [#128](https://github.com/Arubacloud/sdk-go/issues/128)
+`internal/clients/network/security-group.go`, `internal/clients/network/security-group-rule.go` — `SecurityGroupsClientImpl` receives a `*vpcsClientImpl` dependency and `SecurityGroupRulesClientImpl` receives a `*securityGroupsClientImpl`. Neither constructor validates that the injected pointer is non-nil. A nil pointer passed at build time causes a panic deep inside a `Create` call, far from the construction site.
+
+**Fix:** Add explicit nil checks in all constructors that accept dependency pointers.
+
+---
+
+## Low
+
+### TD-019 · Missing compile-time interface satisfaction checks — [#129](https://github.com/Arubacloud/sdk-go/issues/129)
+Logger implementations (`internal/impl/logger/native/`, `internal/impl/logger/noop/`) and most client `*Impl` types lack `var _ Interface = (*Impl)(nil)` guards. Only the interceptor has this check. A missed method or signature change will only surface at runtime rather than at compile time.
+
+**Fix:** Add `var _ logger.Logger = (*DefaultLogger)(nil)` (and equivalent for each impl type) at package scope in every implementation file.
+
+---
+
+### TD-020 · Test coverage limited to happy path and empty-ID validation — [#130](https://github.com/Arubacloud/sdk-go/issues/130)
+All `internal/clients/*/_test.go` files — existing tests cover successful responses and empty project/resource IDs. Missing: HTTP 4xx/5xx error responses, malformed JSON bodies, network-level errors, `nil` params handling, and request body marshaling failures.
+
+**Fix:** Add table-driven subtests for each error scenario in every client test file using `httptest.NewServer` to return controlled error responses.
+
+---

--- a/ai/TECH_DEBT.md
+++ b/ai/TECH_DEBT.md
@@ -15,7 +15,6 @@ Issues are grouped by severity. Address Critical items before new features ship;
 | [TD-003](#td-003) | `lastUsage` race under RLock | Critical | S | High |
 | [TD-004](#td-004) | Interceptor not thread-safe | Critical | S | Medium |
 | [TD-005](#td-005) | Typo `buildDetebaseClient` | High | XS | Low |
-| [TD-006](#td-006) | Goroutine leak in `WaitFor` | High | S | High |
 | [TD-007](#td-007) | Variable shadowing in `WaitFor` | High | XS | Low |
 | [TD-008](#td-008) | Polling sleeps before first attempt | High | S | Medium |
 | [TD-009](#td-009) | Caller headers override `Content-Type` | High | XS | Medium |
@@ -35,7 +34,7 @@ Issues are grouped by severity. Address Critical items before new features ship;
 
 **Wave 1 — Quick Wins** (XS effort, ship same PR): TD-001, TD-002, TD-005, TD-007, TD-009, TD-013, TD-014, TD-015, TD-017
 
-**Wave 2 — High-value focused fixes** (S effort, High+ impact): TD-003, TD-006, TD-012
+**Wave 2 — High-value focused fixes** (S effort, High+ impact): TD-003, TD-012
 
 **Wave 3 — Medium fixes** (S effort, Medium/Low impact): TD-004, TD-008, TD-011, TD-018, TD-019
 
@@ -45,7 +44,12 @@ Issues are grouped by severity. Address Critical items before new features ship;
 
 ## Resolved
 
-None yet.
+### TD-006 · Goroutine leak in `WaitFor` on context cancellation — [#116](https://github.com/Arubacloud/sdk-go/issues/116) · **Closed as invalid**
+The original claim was that the goroutine writes to `resultCh` unconditionally without guarding on `ctx.Done()`. Investigation of `pkg/async/async_client.go` shows:
+1. The goroutine checks `ctxTimeout.Done()` via `select` before each retry attempt (lines 115-120) and after each failed attempt before sleeping (lines 146-152).
+2. The result channel is buffered (`make(chan Result[T], 1)`), so the single channel send the goroutine performs can never block.
+
+No goroutine leak exists. Issue #116 closed as invalid.
 
 ---
 
@@ -108,17 +112,6 @@ None yet.
 
 ---
 
-### TD-006 · Goroutine leak in `WaitFor` on context cancellation — [#116](https://github.com/Arubacloud/sdk-go/issues/116)
-`pkg/async/async_client.go` — the goroutine launched by `WaitFor()` writes to `resultCh` unconditionally. If the caller's context is cancelled and `Await()` is never called (or returns early), the goroutine blocks forever on the channel send. The channel buffer is 1, so if the slot is already filled, the goroutine leaks.
-
-**Fix:** Wrap the channel send in a `select` with `ctx.Done()`.
-
-**Effort:** S — add a `select` block in 1 goroutine closure.
-
-**Impact:** High — goroutine leak under cancellation in production; accumulated leaks cause memory exhaustion in long-lived services.
-
----
-
 ### TD-007 · Variable shadowing creates unreachable `AsyncClient` in `WaitFor` nil-call path — [#117](https://github.com/Arubacloud/sdk-go/issues/117)
 `pkg/async/async_client.go` — when `callFunc == nil`, a new inner `asyncClient` variable (`:=`) shadows the outer one. The outer variable is discarded; the inner one is returned. The code works by accident but is fragile and confusing.
 
@@ -131,13 +124,13 @@ None yet.
 ---
 
 ### TD-008 · Polling loop always sleeps before the first attempt — [#118](https://github.com/Arubacloud/sdk-go/issues/118)
-`internal/restclient/polling.go` — `time.Sleep(config.Interval)` is called at the top of each iteration, including the very first one. This adds an unnecessary 5-second delay before the initial state check. Additionally, the last iteration checks `attempt == config.MaxAttempts` and returns a timeout error after having just called `getter`, discarding the final state.
+`internal/restclient/polling.go` — `time.Sleep(config.Interval)` is called at the top of each iteration, including the very first one. This adds an unnecessary 5-second delay before the initial state check.
 
-**Fix:** Move the sleep to the bottom of the loop (or skip when `attempt == 1`) and always check the state before emitting a timeout error.
+**Fix:** Move the sleep to the bottom of the loop (or skip when `attempt == 1`) so the first check is immediate.
 
 **Effort:** S — restructure the loop in 1 function.
 
-**Impact:** Medium — 5 s wasted per poll operation; final state is discarded causing potentially misleading timeout errors.
+**Impact:** Medium — 5 s wasted per poll operation before any work is done.
 
 ---
 
@@ -181,14 +174,17 @@ Replace all manual implementations with calls to this helper.
 
 ---
 
-### TD-012 · Token manager injects expired/nil token after failed refresh — [#122](https://github.com/Arubacloud/sdk-go/issues/122)
-`internal/impl/auth/tokenmanager/standard/standard.go` — in the write-lock branch, if the ticket has already changed (another goroutine refreshed), the code re-fetches from the repository. If that second fetch fails, execution falls through and injects an empty or expired token into the `Authorization` header with no error returned to the caller.
+### TD-012 · Token manager mishandles post-refresh token fetch in the else-branch — [#122](https://github.com/Arubacloud/sdk-go/issues/122)
+`internal/impl/auth/tokenmanager/standard/standard.go` — in the write-lock branch, when the ticket has already changed (another goroutine refreshed), the code re-fetches from the repository. Two failure modes exist:
 
-**Fix:** Check the error from the second `FetchToken()` and return it before reaching the header-injection step.
+1. **Nil pointer panic:** If the second `FetchToken()` returns `auth.ErrTokenNotFound`, the error is filtered out by `!errors.Is(err, auth.ErrTokenNotFound)` and not returned. Execution falls through to `token.AccessToken` at the header-injection step with `token == nil`, causing a panic.
+2. **Silent expired token injection:** If `FetchToken()` returns a token without error but the token is expired, it is injected into the `Authorization` header without expiration validation.
 
-**Effort:** S — add 1 error check and early return in 1 function.
+**Fix:** (1) Return an error (or retry) when `ErrTokenNotFound` is received in the else-branch rather than falling through. (2) Add an expiration check before injecting the token.
 
-**Impact:** High — prevents silent auth failure after a transient token storage error; without the fix, the caller receives a 401 with no indication of the root cause.
+**Effort:** S — add nil/expiry checks in 1 function.
+
+**Impact:** High — the nil pointer panic causes an unrecoverable crash under concurrent token refresh with a temporarily unavailable token store; the expired-token path produces silent 401s.
 
 ---
 
@@ -261,11 +257,16 @@ Replace all manual implementations with calls to this helper.
 ## Low
 
 ### TD-019 · Missing compile-time interface satisfaction checks — [#129](https://github.com/Arubacloud/sdk-go/issues/129)
-Logger implementations (`internal/impl/logger/native/`, `internal/impl/logger/noop/`) and most client `*Impl` types lack `var _ Interface = (*Impl)(nil)` guards. Only the interceptor has this check. A missed method or signature change will only surface at runtime rather than at compile time.
+21 `var _ Interface = (*Impl)(nil)` guards already exist across `pkg/aruba/` (10 service group clients + main `Client`), `pkg/multitenant/`, and `internal/impl/` (auth repositories, connectors, token manager, interceptor). The gap is in two areas:
 
-**Fix:** Add `var _ logger.Logger = (*DefaultLogger)(nil)` (and equivalent for each impl type) at package scope in every implementation file.
+1. **Logger implementations:** `internal/impl/logger/native/` and `internal/impl/logger/noop/` have no `var _ logger.Logger` guard.
+2. **Resource-level client implementations:** All `*Impl` types under `internal/clients/` (e.g., `cloudServersClientImpl`, `vpcsClientImpl`, ~30 types) lack guards.
 
-**Effort:** S — mechanical addition of `var _` lines in ~20 files.
+A missed method or signature change in these types will only surface at runtime rather than at compile time.
+
+**Fix:** Add `var _ logger.Logger = (*DefaultLogger)(nil)` (and equivalent for each resource-level impl) at package scope in the affected files.
+
+**Effort:** S — mechanical addition of `var _` lines in ~32 files.
 
 **Impact:** Low — compile-time safety net; no runtime effect until a signature diverges.
 

--- a/ai/TECH_DEBT.md
+++ b/ai/TECH_DEBT.md
@@ -2,6 +2,47 @@
 
 Issues are grouped by severity. Address Critical items before new features ship; High items before any public release.
 
+**Effort scale:** XS < 30 min · S < 2 h · M half-day · L 1–2 days · XL 3+ days
+
+**Impact scale:** Critical — broken in production · High — leak/race/major debt · Medium — edge-case failures or observability · Low — cosmetic or defensive
+
+## Prioritization matrix
+
+| ID | Summary | Severity | Effort | Impact |
+|---|---|---|---|---|
+| [TD-001](#td-001) | File token repo param order swap | Critical | XS | Critical |
+| [TD-002](#td-002) | Static token silently ignored | Critical | XS | Critical |
+| [TD-003](#td-003) | `lastUsage` race under RLock | Critical | S | High |
+| [TD-004](#td-004) | Interceptor not thread-safe | Critical | S | Medium |
+| [TD-005](#td-005) | Typo `buildDetebaseClient` | High | XS | Low |
+| [TD-006](#td-006) | Goroutine leak in `WaitFor` | High | S | High |
+| [TD-007](#td-007) | Variable shadowing in `WaitFor` | High | XS | Low |
+| [TD-008](#td-008) | Polling sleeps before first attempt | High | S | Medium |
+| [TD-009](#td-009) | Caller headers override `Content-Type` | High | XS | Medium |
+| [TD-010](#td-010) | 2 000+ lines duplicated response parsing | High | L | High |
+| [TD-011](#td-011) | Silent error body parse failure | Medium | S | Medium |
+| [TD-012](#td-012) | Expired token injected after failed refresh | Medium | S | High |
+| [TD-013](#td-013) | Memory proxy ticket incremented before write | Medium | XS | Medium |
+| [TD-014](#td-014) | `ParseResponseBody` panics on nil response | Medium | XS | Medium |
+| [TD-015](#td-015) | `DefaultWaitFor` timeout too short | Medium | XS | Medium |
+| [TD-016](#td-016) | No structured logging | Medium | L | Medium |
+| [TD-017](#td-017) | `WARN` writes to stdout | Medium | XS | Low |
+| [TD-018](#td-018) | Nil deps not checked in constructors | Medium | S | Low |
+| [TD-019](#td-019) | Missing interface satisfaction checks | Low | S | Low |
+| [TD-020](#td-020) | Test coverage gaps | Low | XL | High |
+
+### Recommended execution order
+
+**Wave 1 — Quick Wins** (XS effort, ship same PR): TD-001, TD-002, TD-005, TD-007, TD-009, TD-013, TD-014, TD-015, TD-017
+
+**Wave 2 — High-value focused fixes** (S effort, High+ impact): TD-003, TD-006, TD-012
+
+**Wave 3 — Medium fixes** (S effort, Medium/Low impact): TD-004, TD-008, TD-011, TD-018, TD-019
+
+**Wave 4 — Large refactors** (L/XL, plan separately): TD-010, TD-016, TD-020
+
+---
+
 ## Resolved
 
 None yet.
@@ -15,12 +56,20 @@ None yet.
 
 **Fix:** Change the call to `NewFileTokenRepository(clientID, options.baseDir)`.
 
+**Effort:** XS — swap 2 arguments at 1 call site.
+
+**Impact:** Critical — file-based token persistence is completely broken.
+
 ---
 
 ### TD-002 · Static token is never stored — access token parameter silently ignored — [#112](https://github.com/Arubacloud/sdk-go/issues/112)
 `internal/impl/auth/tokenrepository/memory/memory.go` — `NewTokenRepositoryWithAccessToken(accessToken string)` ignores its parameter and returns `&TokenRepository{}`. Any client created with `WithToken()` will always get an empty token, causing all requests to fail authentication silently.
 
 **Fix:** Initialize the struct with `token: &auth.Token{AccessToken: accessToken}`.
+
+**Effort:** XS — add 1 struct field initialization.
+
+**Impact:** Critical — `WithToken()` static auth is completely broken; every API call returns 401.
 
 ---
 
@@ -29,12 +78,20 @@ None yet.
 
 **Fix:** Upgrade to `Lock()` for the update, or store `lastUsage` as an `atomic.Int64` (Unix nanoseconds) so it can be updated without a write lock.
 
+**Effort:** S — change 3 methods in 1 file; atomic variant needs a small struct change.
+
+**Impact:** High — data race under concurrent multitenant use; triggers the race detector and can cause unpredictable behaviour in production.
+
 ---
 
 ### TD-004 · Interceptor `Bind()` and `Intercept()` are not thread-safe — [#114](https://github.com/Arubacloud/sdk-go/issues/114)
 `internal/impl/interceptor/standard/standard.go` — `Bind()` appends to `interceptFuncs` without any synchronization. Concurrent calls to `Bind()` and `Intercept()` produce an unsynchronized read/write on a slice — a data race. While `Bind` is today called only at construction time, the interface contract does not prevent concurrent use.
 
 **Fix:** Add a `sync.RWMutex` to the struct. `Bind()` takes a write lock; `Intercept()` copies the slice under a read lock then iterates the copy.
+
+**Effort:** S — add a mutex field and guards in 1 file.
+
+**Impact:** Medium — latent race that does not trigger today (Bind is only called at construction), but the public interface offers no guarantee.
 
 ---
 
@@ -45,12 +102,20 @@ None yet.
 
 **Fix:** Rename to `buildDatabaseClient`.
 
+**Effort:** XS — rename 1 unexported function.
+
+**Impact:** Low — cosmetic only; no runtime effect.
+
 ---
 
 ### TD-006 · Goroutine leak in `WaitFor` on context cancellation — [#116](https://github.com/Arubacloud/sdk-go/issues/116)
 `pkg/async/async_client.go` — the goroutine launched by `WaitFor()` writes to `resultCh` unconditionally. If the caller's context is cancelled and `Await()` is never called (or returns early), the goroutine blocks forever on the channel send. The channel buffer is 1, so if the slot is already filled, the goroutine leaks.
 
 **Fix:** Wrap the channel send in a `select` with `ctx.Done()`.
+
+**Effort:** S — add a `select` block in 1 goroutine closure.
+
+**Impact:** High — goroutine leak under cancellation in production; accumulated leaks cause memory exhaustion in long-lived services.
 
 ---
 
@@ -59,6 +124,10 @@ None yet.
 
 **Fix:** Remove the inner `:=` and reuse the outer `asyncClient`.
 
+**Effort:** XS — delete 1 `:=` keyword.
+
+**Impact:** Low — works today by accident; purely a correctness and readability cleanup.
+
 ---
 
 ### TD-008 · Polling loop always sleeps before the first attempt — [#118](https://github.com/Arubacloud/sdk-go/issues/118)
@@ -66,12 +135,20 @@ None yet.
 
 **Fix:** Move the sleep to the bottom of the loop (or skip when `attempt == 1`) and always check the state before emitting a timeout error.
 
+**Effort:** S — restructure the loop in 1 function.
+
+**Impact:** Medium — 5 s wasted per poll operation; final state is discarded causing potentially misleading timeout errors.
+
 ---
 
 ### TD-009 · Caller headers can override SDK-controlled `Content-Type` — [#119](https://github.com/Arubacloud/sdk-go/issues/119)
 `internal/restclient/client.go` — the code sets `Content-Type: application/json` then overwrites headers with caller-supplied values using `req.Header.Set(k, v)`. A caller can silently override `Content-Type` (and in principle `Authorization`), breaking server-side request parsing.
 
 **Fix:** Apply caller headers before SDK-controlled headers, or explicitly protect `Content-Type` and `Authorization` from being overridden.
+
+**Effort:** XS — reorder 3 lines in 1 function.
+
+**Impact:** Medium — silent request corruption if caller passes a `Content-Type` header; unlikely but a correctness guarantee violation.
 
 ---
 
@@ -85,6 +162,10 @@ func DoAndParse[T any](c *Client, ctx context.Context, method, path string,
 ```
 Replace all manual implementations with calls to this helper.
 
+**Effort:** L — design the helper, then update ~30 methods across ~15 files mechanically.
+
+**Impact:** High — eliminates 2 000+ lines of duplication; any bug fix to parsing logic will only need to be applied once.
+
 ---
 
 ## Medium
@@ -94,12 +175,20 @@ Replace all manual implementations with calls to this helper.
 
 **Fix:** Log the unmarshal error at WARN level, or document that `RawBody` should be used as the fallback for non-JSON error bodies.
 
+**Effort:** S — add a logger call or code comment in 1 function.
+
+**Impact:** Medium — improves debuggability of non-JSON error responses (e.g., plain-text 502 from a proxy); no production failure risk.
+
 ---
 
 ### TD-012 · Token manager injects expired/nil token after failed refresh — [#122](https://github.com/Arubacloud/sdk-go/issues/122)
 `internal/impl/auth/tokenmanager/standard/standard.go` — in the write-lock branch, if the ticket has already changed (another goroutine refreshed), the code re-fetches from the repository. If that second fetch fails, execution falls through and injects an empty or expired token into the `Authorization` header with no error returned to the caller.
 
 **Fix:** Check the error from the second `FetchToken()` and return it before reaching the header-injection step.
+
+**Effort:** S — add 1 error check and early return in 1 function.
+
+**Impact:** High — prevents silent auth failure after a transient token storage error; without the fix, the caller receives a 401 with no indication of the root cause.
 
 ---
 
@@ -108,12 +197,20 @@ Replace all manual implementations with calls to this helper.
 
 **Fix:** Increment the ticket only after a successful persistent write.
 
+**Effort:** XS — move 1 line after the error-check block.
+
+**Impact:** Medium — prevents transient cache corruption when the persistent store is briefly unavailable.
+
 ---
 
 ### TD-014 · `ParseResponseBody` panics on nil `httpResp` — [#124](https://github.com/Arubacloud/sdk-go/issues/124)
 `pkg/types/utils.go` — the function calls `io.ReadAll(httpResp.Body)` without a nil guard. If `DoRequest` returns a nil response alongside a non-nil error and the caller forgets to check the error, the function panics.
 
 **Fix:** Add `if httpResp == nil { return nil, fmt.Errorf("http response is nil") }` at the top of the function.
+
+**Effort:** XS — add 1 nil guard (3 lines).
+
+**Impact:** Medium — defensive fix; prevents a panic from a defensive coding mistake by a future caller.
 
 ---
 
@@ -122,12 +219,20 @@ Replace all manual implementations with calls to this helper.
 
 **Fix:** Raise defaults to at least `retries=36`, `baseDelay=10s`, `timeout=600s`, or expose a named constant set (e.g., `LongOperationDefaults`) for callers to use.
 
+**Effort:** XS — change 3 constants; add a release note as defaults are a breaking change for callers relying on them.
+
+**Impact:** Medium — prevents spurious timeouts for any caller using `DefaultWaitFor` on real cloud resources.
+
 ---
 
 ### TD-016 · Logger interface supports only printf-style formatting — no structured logging — [#126](https://github.com/Arubacloud/sdk-go/issues/126)
 `internal/ports/logger/logger.go` — all log calls use `%s`/`%v` format strings. In production environments using log aggregators (ELK, Loki, Cloud Logging), querying by structured fields (project ID, resource ID, trace ID) requires string parsing. The SDK's `ErrorResponse` already carries a `TraceID` field that is never emitted as a structured log field.
 
 **Fix:** Add optional structured variants to the logger interface, or adopt `slog` (stdlib since Go 1.21) as the native logger implementation.
+
+**Effort:** L — redesign the logger interface, update the native implementation, and update all ~50 call sites.
+
+**Impact:** Medium — major observability improvement for production use; no functional bug risk.
 
 ---
 
@@ -136,12 +241,20 @@ Replace all manual implementations with calls to this helper.
 
 **Fix:** Change `WARN` to write to `os.Stderr`.
 
+**Effort:** XS — change 1 line.
+
+**Impact:** Low — minor log routing correction; no functional impact.
+
 ---
 
 ### TD-018 · Injected concrete dependencies not nil-checked in constructors — [#128](https://github.com/Arubacloud/sdk-go/issues/128)
 `internal/clients/network/security-group.go`, `internal/clients/network/security-group-rule.go` — `SecurityGroupsClientImpl` receives a `*vpcsClientImpl` dependency and `SecurityGroupRulesClientImpl` receives a `*securityGroupsClientImpl`. Neither constructor validates that the injected pointer is non-nil. A nil pointer passed at build time causes a panic deep inside a `Create` call, far from the construction site.
 
 **Fix:** Add explicit nil checks in all constructors that accept dependency pointers.
+
+**Effort:** S — add nil checks to ~4 constructors.
+
+**Impact:** Low — defensive; prevents future wiring bugs from panicking far from their source.
 
 ---
 
@@ -152,11 +265,19 @@ Logger implementations (`internal/impl/logger/native/`, `internal/impl/logger/no
 
 **Fix:** Add `var _ logger.Logger = (*DefaultLogger)(nil)` (and equivalent for each impl type) at package scope in every implementation file.
 
+**Effort:** S — mechanical addition of `var _` lines in ~20 files.
+
+**Impact:** Low — compile-time safety net; no runtime effect until a signature diverges.
+
 ---
 
 ### TD-020 · Test coverage limited to happy path and empty-ID validation — [#130](https://github.com/Arubacloud/sdk-go/issues/130)
 All `internal/clients/*/_test.go` files — existing tests cover successful responses and empty project/resource IDs. Missing: HTTP 4xx/5xx error responses, malformed JSON bodies, network-level errors, `nil` params handling, and request body marshaling failures.
 
 **Fix:** Add table-driven subtests for each error scenario in every client test file using `httptest.NewServer` to return controlled error responses.
+
+**Effort:** XL — ~15 client files × ~5 error scenarios each; requires design of shared test helpers.
+
+**Impact:** High — major regression safety net; issues like TD-011 and TD-014 would have been caught by these tests.
 
 ---


### PR DESCRIPTION
## Summary

- Adds `CLAUDE.md` as a dispatcher that routes future Claude Code sessions to the right `ai/` file based on task type
- Introduces `ai/` folder with five focused guidance files built from deep codebase analysis
- Tracks 20 tech debt items (TD-001..TD-020), each linked to a dedicated GitHub issue (#111–#130)
- Excludes `.claude/` local Claude Code session data from version control

## Files

| File | Purpose |
|---|---|
| `CLAUDE.md` | Routing table → reads the right `ai/` file per task type |
| `ai/DEVEX.md` | Build, test, lint commands; reference doc pointers |
| `ai/REPO.md` | Module identity, package layout, service group table |
| `ai/ARCHITECTURE.md` | Client wiring, request lifecycle, auth subsystem, async/multitenant patterns |
| `ai/CONVENTIONS.md` | Naming, method structure, error handling, testing, documentation standards |
| `ai/TECH_DEBT.md` | 20 tracked issues covering critical bugs, race conditions, duplication, observability gaps |

## Tech debt issues opened
#111 #112 #113 #114 #115 #116 #117 #118 #119 #120 #121 #122 #123 #124 #125 #126 #127 #128 #129 #130

## Test plan
- [ ] Verify all five `ai/` files render correctly on GitHub
- [ ] Confirm `.claude/` is not tracked (`git status` shows no `.claude/` entries)
- [ ] Review each linked GitHub issue for completeness

🤖 Generated with [Claude Code](https://claude.com/claude-code)