### PR TITLE
chore(logger): add compile-time interface assertions

### DIFF
--- a/internal/impl/logger/native/logger.go
+++ b/internal/impl/logger/native/logger.go
@@ -3,7 +3,12 @@ package native
 import (
 	"log"
 	"os"
+
+	"github.com/Arubacloud/sdk-go/internal/ports/logger"
 )
+
+// Compile-time assertion that *DefaultLogger satisfies logger.Logger.
+var _ logger.Logger = (*DefaultLogger)(nil)
 
 // DefaultLogger is a simple logger implementation using standard log package
 type DefaultLogger struct {

--- a/internal/impl/logger/noop/logger.go
+++ b/internal/impl/logger/noop/logger.go
@@ -1,5 +1,10 @@
 package noop
 
+import "github.com/Arubacloud/sdk-go/internal/ports/logger"
+
+// Compile-time assertion that *NoOpLogger satisfies logger.Logger.
+var _ logger.Logger = (*NoOpLogger)(nil)
+
 // NoOpLogger is a logger that does nothing
 type NoOpLogger struct{}
 


### PR DESCRIPTION
## Summary

Add `var _ logger.Logger = (*DefaultLogger)(nil)` to `internal/impl/logger/native/logger.go` and `var _ logger.Logger = (*NoOpLogger)(nil)` to `internal/impl/logger/noop/logger.go`, so a missed method signature on the logger interface surfaces at compile time instead of runtime.

## Partial fix note

The issue body also asks for the same treatment on `*Impl` types under `internal/clients/` (e.g. `cloudServersClientImpl`). That sweep is deferred because of a package-boundary constraint:

- The interfaces live under `pkg/aruba/` (e.g. `CloudServersClient` in `pkg/aruba/compute.go`).
- The impl types live under `internal/clients/.../` and are unexported.
- `pkg/aruba/builder.go` already imports `internal/clients/compute`, so asserting from `internal/clients/compute/cloudserver.go` back against `pkg/aruba.CloudServersClient` would introduce an import cycle.
- Asserting from `pkg/aruba/compute.go` would require the impl type to be exported (or a public constructor signature that returns the interface, which is a wider API choice).

This looked like a design decision the maintainers should make (move interfaces into `internal/ports/` next to the loggers, or switch the impl types to exported). Happy to follow up with whichever direction you pick. Closing this PR as "partial" so the logger wins land independently.

## Test plan

- [x] `go build ./...` (passes)
- [x] `go vet ./internal/impl/logger/...` (passes)
- [x] `go test ./internal/impl/logger/...` (passes)

Partial fix for #129
[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
