### PR TITLE
fix(auth): store preloaded access token in NewTokenRepositoryWithAccessToken

### DIFF
--- a/internal/impl/auth/tokenrepository/memory/memory.go
+++ b/internal/impl/auth/tokenrepository/memory/memory.go
@@ -54,7 +54,9 @@ func NewTokenRepository() *TokenRepository {
 // never consider the token as expired.
 // Tokens stored here are lost when the application restarts.
 func NewTokenRepositoryWithAccessToken(accessToken string) *TokenRepository {
-	return &TokenRepository{}
+	return &TokenRepository{
+		token: &auth.Token{AccessToken: accessToken},
+	}
 }
 
 // NewTokenProxy creates a repository that caches tokens in memory but

--- a/internal/impl/auth/tokenrepository/memory/memory_test.go
+++ b/internal/impl/auth/tokenrepository/memory/memory_test.go
@@ -37,6 +37,30 @@ func TestTokenRepository_FetchToken(t *testing.T) {
 		require.Nil(t, token)
 	})
 
+	t.Run("should return a preloaded access token with no expiry", func(t *testing.T) {
+		// Given a TokenRepository created with a preloaded access token
+		tokenRepository := NewTokenRepositoryWithAccessToken(accessToken)
+
+		// When we try to fetch the token
+		token, err := tokenRepository.FetchToken(t.Context())
+
+		// Then no error should be reported
+		require.NoError(t, err)
+
+		// And a token containing the preloaded access token should be returned
+		require.NotNil(t, token)
+		require.Equal(t, accessToken, token.AccessToken)
+
+		// And the token should have zero expiry (never expires)
+		require.True(t, token.Expiry.IsZero())
+
+		// And the token should be valid (zero expiry means never expires)
+		require.True(t, token.IsValid())
+
+		// And the returned token should be a copy, not the same pointer
+		require.NotSame(t, tokenRepository.token, token)
+	})
+
 	t.Run("should return an expired token with no error", func(t *testing.T) {
 		// Given a fresh new TokenRepository which contains an expired token
 		tokenRepository := NewTokenRepository()


### PR DESCRIPTION
## Summary

- `NewTokenRepositoryWithAccessToken(accessToken)` ignored its parameter and returned an empty `TokenRepository{}`, causing `WithToken()` static auth to silently fail (all requests got 401)
- Initialize the `token` field with `&auth.Token{AccessToken: accessToken}` (zero `Expiry` = never expires), matching the doc comment
- Add a test verifying the preloaded token is returned correctly

Closes #112

## Test plan
- [x] New test `should return a preloaded access token with no expiry` passes
- [x] All existing tests in `internal/impl/auth/tokenrepository/memory/` pass
- [x] Race detector clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)