### PR TITLE
fix(auth): swap argument order in buildFileTokenRepository call

### DIFF
--- a/pkg/aruba/builder.go
+++ b/pkg/aruba/builder.go
@@ -321,7 +321,7 @@ func buildRedisTokenRepository(clientID string, options *redisTokenRepositoryOpt
 }
 
 func buildFileTokenRepository(clientID string, options *fileTokenRepositoryOptions) (*file_token_repo.TokenRepository, error) {
-	return file_token_repo.NewFileTokenRepository(options.baseDir, clientID), nil
+	return file_token_repo.NewFileTokenRepository(clientID, options.baseDir), nil
 }
 
 //


### PR DESCRIPTION
## Summary

- `buildFileTokenRepository` passed `(options.baseDir, clientID)` to `NewFileTokenRepository` which expects `(clientID, baseDir)` — the arguments were swapped
- This caused the base directory to be used as the client ID (and vice versa), producing wrong token file paths and breaking file-based token persistence entirely

Closes #111

## Test plan
- [x] `go build ./...` succeeds
- [x] File token repository tests pass (`go test ./internal/impl/auth/tokenrepository/file/`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)