### PR TITLE
fix: rename buildDetebaseClient to buildDatabaseClient

### DIFF
--- a/pkg/aruba/builder.go
+++ b/pkg/aruba/builder.go
@@ -63,7 +63,7 @@ func buildClient(options *Options) (Client, error) {
 		return nil, err // TODO: better error handling
 	}
 
-	databaseClient, err := buildDetebaseClient(restClient)
+	databaseClient, err := buildDatabaseClient(restClient)
 	if err != nil {
 		return nil, err // TODO: better error handling
 	}
@@ -399,7 +399,7 @@ func buildContainerRegistryClient(restClient *restclient.Client) (ContainerRegis
 //
 // Database domain clients
 
-func buildDetebaseClient(restClient *restclient.Client) (DatabaseClient, error) {
+func buildDatabaseClient(restClient *restclient.Client) (DatabaseClient, error) {
 	dbaasClient, err := buildDBaaSClient(restClient)
 	if err != nil {
 		return nil, err // TODO: better error handling


### PR DESCRIPTION
## Summary

- Renames `buildDetebaseClient` → `buildDatabaseClient` (typo: "Detebase" → "Database")
- Both the call site (line 66) and function definition (line 402) are updated
- No runtime impact — unexported function, cosmetic fix only

Closes #115

## Test plan
- [x] `go build ./...` succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)