### PR TITLE
fix(async): remove variable shadowing in WaitFor nil-call path

### DIFF
--- a/pkg/async/async_client.go
+++ b/pkg/async/async_client.go
@@ -87,7 +87,6 @@ func WaitFor[T any](
 
 	// Validate that call and check are not nil
 	if call == nil {
-		asyncClient := &AsyncClient[T]{resultCh: make(chan Result[T], 1)}
 		asyncClient.resultCh <- Result[T]{Response: nil, Error: fmt.Errorf("call function cannot be nil")}
 		return asyncClient
 	}


### PR DESCRIPTION
## Summary

- In `WaitFor`, when `call == nil`, a second `asyncClient` was allocated via `:=` (line 90) shadowing the outer one (line 86), wasting the first allocation
- Removed the inner declaration so the existing `asyncClient` is reused

Closes #117

## Test plan
- [x] `go build ./...` succeeds
- [x] `go test -race ./pkg/async/` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)