### PR TITLE
fix(restclient): apply caller headers before SDK-controlled Content-Type

### DIFF
--- a/internal/restclient/client.go
+++ b/internal/restclient/client.go
@@ -72,14 +72,14 @@ func (c *Client) DoRequest(ctx context.Context, method, path string, body io.Rea
 		c.logger.Debugf("Added query parameters: %v", queryParams)
 	}
 
-	// Set content type for requests with body
-	if body != nil {
-		req.Header.Set("Content-Type", "application/json")
-	}
-
-	// Add additional headers before authentication headers
+	// Add caller-supplied headers first so SDK-controlled headers applied below cannot be overridden
 	for k, v := range headers {
 		req.Header.Set(k, v)
+	}
+
+	// Set content type for requests with body; applied after caller headers to prevent override
+	if body != nil {
+		req.Header.Set("Content-Type", "application/json")
 	}
 
 	// Log request headers (before auth)


### PR DESCRIPTION
## Summary

- `DoRequest` was setting `Content-Type: application/json` first, then applying caller-supplied headers with `Header.Set` — which silently overwrote the SDK's value
- Fixed by reversing the order: caller headers are applied first, then SDK-controlled headers are set unconditionally afterward
- `Authorization` was already safe (injected by the interceptor after this block); this change covers `Content-Type`

Closes #119

## Test plan
- [x] `go build ./...` succeeds
- [x] Full test suite passes with race detector (`go test -race ./...`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)