### PR TITLE
fix(types): add nil guard to ParseResponseBody

### DIFF
--- a/pkg/types/utils.go
+++ b/pkg/types/utils.go
@@ -12,6 +12,10 @@ import (
 // For 4xx/5xx responses, it unmarshals into Error field.
 // Always stores the raw body in RawBody field.
 func ParseResponseBody[T any](httpResp *http.Response) (*Response[T], error) {
+	if httpResp == nil {
+		return nil, fmt.Errorf("http response is nil")
+	}
+
 	// Read the response body
 	bodyBytes, err := io.ReadAll(httpResp.Body)
 	if err != nil {


### PR DESCRIPTION
## Summary

- `ParseResponseBody` called `io.ReadAll(httpResp.Body)` without checking whether `httpResp` was nil, causing a panic if `DoRequest` returned a nil response alongside an error and the caller forgot to check
- Added a nil guard at the top of the function that returns a descriptive error instead of panicking

Closes #124

## Test plan
- [x] `go build ./...` succeeds
- [x] Full test suite passes with race detector (`go test -race ./...`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)