### PR TITLE
fix(async): raise DefaultWaitFor timeout from 60s to 600s

### DIFF
--- a/pkg/async/async_client.go
+++ b/pkg/async/async_client.go
@@ -11,7 +11,7 @@ import (
 
 // Default parameters for WaitFor
 const (
-	DefaultRetries   = 36
+	DefaultRetries   = 60
 	DefaultBaseDelay = 10 * time.Second
 	DefaultTimeout   = 600 * time.Second
 )
@@ -53,7 +53,7 @@ func (f *AsyncClient[T]) Await(ctx context.Context) (*types.Response[T], error) 
 }
 
 // DefaultWaitFor is a helper for WaitFor using default parameters:
-// 36 retries, 10 seconds delay between attempts, 600 seconds (10 min) total timeout.
+// 60 retries, 10 seconds delay between attempts, 600 seconds (10 min) total timeout.
 // Simplifies usage when you want standard retry behavior.
 func DefaultWaitFor[T any](
 	ctx context.Context,

--- a/pkg/async/async_client.go
+++ b/pkg/async/async_client.go
@@ -11,9 +11,9 @@ import (
 
 // Default parameters for WaitFor
 const (
-	DefaultRetries   = 10
+	DefaultRetries   = 36
 	DefaultBaseDelay = 10 * time.Second
-	DefaultTimeout   = 60 * time.Second
+	DefaultTimeout   = 600 * time.Second
 )
 
 // Result wraps the response from a WaitFor/Async operation and an error, if any.
@@ -53,7 +53,7 @@ func (f *AsyncClient[T]) Await(ctx context.Context) (*types.Response[T], error) 
 }
 
 // DefaultWaitFor is a helper for WaitFor using default parameters:
-// 10 retries, 10 seconds delay between attempts, 60 seconds total timeout.
+// 36 retries, 10 seconds delay between attempts, 600 seconds (10 min) total timeout.
 // Simplifies usage when you want standard retry behavior.
 func DefaultWaitFor[T any](
 	ctx context.Context,


### PR DESCRIPTION
## Summary

- Cloud resource provisioning (VMs, databases, VPCs) routinely takes several minutes
- Previous defaults (`retries=10`, `baseDelay=10s`, `timeout=60s`) caused spurious timeouts for any caller using `DefaultWaitFor`
- New defaults: `retries=60`, `baseDelay=10s`, `timeout=600s` (10 minutes)
- Updated the `DefaultWaitFor` doc comment to match

**Note:** This is a breaking change for callers relying on the old 60s timeout as a safety bound. The constants are exported, so dependents may reference them directly.

Closes #125

## Test plan
- [x] `go build ./...` succeeds
- [x] `go test -race ./pkg/async/` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)