### PR TITLE
fix(logger): write WARN log level to os.Stderr instead of os.Stdout

### DIFF
--- a/internal/impl/logger/native/logger.go
+++ b/internal/impl/logger/native/logger.go
@@ -23,7 +23,7 @@ func NewDefaultLogger() *DefaultLogger {
 	return &DefaultLogger{
 		debug: log.New(os.Stdout, "[DEBUG] ", log.LstdFlags),
 		info:  log.New(os.Stdout, "[INFO] ", log.LstdFlags),
-		warn:  log.New(os.Stdout, "[WARN] ", log.LstdFlags),
+		warn:  log.New(os.Stderr, "[WARN] ", log.LstdFlags),
 		err:   log.New(os.Stderr, "[ERROR] ", log.LstdFlags),
 	}
 }


### PR DESCRIPTION
## Summary

- WARN was writing to `os.Stdout` alongside DEBUG and INFO, but it is diagnostic output and belongs on `os.Stderr` with ERROR
- Changed `os.Stdout` → `os.Stderr` for the WARN logger in `NewDefaultLogger()`

Closes #127

## Test plan
- [x] `go build ./...` succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)