### PR TITLE
docs(interceptor): tighten Bind construction-only contract, close TD-004

### DIFF
--- a/ai/TECH_DEBT.md
+++ b/ai/TECH_DEBT.md
@@ -13,7 +13,6 @@ Issues are grouped by severity. Address Critical items before new features ship;
 | [TD-001](#td-001) | File token repo param order swap | Critical | XS | Critical |
 | [TD-002](#td-002) | Static token silently ignored | Critical | XS | Critical |
 | [TD-003](#td-003) | `lastUsage` race under RLock | Critical | S | High |
-| [TD-004](#td-004) | Interceptor not thread-safe | Critical | S | Medium |
 | [TD-005](#td-005) | Typo `buildDetebaseClient` | High | XS | Low |
 | [TD-007](#td-007) | Variable shadowing in `WaitFor` | High | XS | Low |
 | [TD-008](#td-008) | Polling sleeps before first attempt | High | S | Medium |
@@ -36,7 +35,7 @@ Issues are grouped by severity. Address Critical items before new features ship;
 
 **Wave 2 — High-value focused fixes** (S effort, High+ impact): TD-003, TD-012
 
-**Wave 3 — Medium fixes** (S effort, Medium/Low impact): TD-004, TD-008, TD-011, TD-018, TD-019
+**Wave 3 — Medium fixes** (S effort, Medium/Low impact): TD-008, TD-011, TD-018, TD-019
 
 **Wave 4 — Large refactors** (L/XL, plan separately): TD-010, TD-016, TD-020
 
@@ -50,6 +49,15 @@ The original claim was that the goroutine writes to `resultCh` unconditionally w
 2. The result channel is buffered (`make(chan Result[T], 1)`), so the single channel send the goroutine performs can never block.
 
 No goroutine leak exists. Issue #116 closed as invalid.
+
+---
+
+### TD-004 · Interceptor `Bind()` and `Intercept()` are not thread-safe — [#114](https://github.com/Arubacloud/sdk-go/issues/114) · **Closed as working as intended**
+The original claim was that concurrent calls to `Bind()` and `Intercept()` produce an unsynchronized read/write on the `interceptFuncs` slice. The proposed fix was a `sync.RWMutex` guarding both methods.
+
+Investigation shows that `Bind` is a construction/setup method — it is only ever called from `tokenmanager.NewStandard` (`internal/impl/auth/tokenmanager/standard/standard.go:54`) during client bootstrap, before the interceptor enters the hot request path. A sibling constructor `NewInterceptorWithFuncs` exists for fully-initialized construction. The race only materialises if a caller mutates the interceptor after bootstrap, which is not the intended usage.
+
+The root cause was the absence of a documented contract. Resolved by adding godoc to `Interceptable.Bind` (`internal/ports/interceptor/interceptor.go`) and the standard impl (`internal/impl/interceptor/standard/standard.go`) stating that `Bind` is construction-only and not safe for concurrent use with `Intercept`. Adding a mutex to the hot path to defend against an unsupported usage pattern was rejected as an unnecessary tradeoff. Issue #114 closed as working as intended.
 
 ---
 
@@ -85,17 +93,6 @@ No goroutine leak exists. Issue #116 closed as invalid.
 **Effort:** S — change 3 methods in 1 file; atomic variant needs a small struct change.
 
 **Impact:** High — data race under concurrent multitenant use; triggers the race detector and can cause unpredictable behaviour in production.
-
----
-
-### TD-004 · Interceptor `Bind()` and `Intercept()` are not thread-safe — [#114](https://github.com/Arubacloud/sdk-go/issues/114)
-`internal/impl/interceptor/standard/standard.go` — `Bind()` appends to `interceptFuncs` without any synchronization. Concurrent calls to `Bind()` and `Intercept()` produce an unsynchronized read/write on a slice — a data race. While `Bind` is today called only at construction time, the interface contract does not prevent concurrent use.
-
-**Fix:** Add a `sync.RWMutex` to the struct. `Bind()` takes a write lock; `Intercept()` copies the slice under a read lock then iterates the copy.
-
-**Effort:** S — add a mutex field and guards in 1 file.
-
-**Impact:** Medium — latent race that does not trigger today (Bind is only called at construction), but the public interface offers no guarantee.
 
 ---
 

--- a/internal/impl/interceptor/standard/standard.go
+++ b/internal/impl/interceptor/standard/standard.go
@@ -13,7 +13,8 @@ import (
 // Interceptor is the concrete type that holds and executes a chain of
 // interceptor.InterceptFunc functions.
 //
-// It embeds the slice of functions to be executed.
+// interceptFuncs is expected to be frozen after construction. See Bind for the
+// concurrency contract.
 type Interceptor struct {
 	interceptFuncs []interceptor.InterceptFunc
 }
@@ -41,6 +42,8 @@ func NewInterceptorWithFuncs(interceptFuncs ...interceptor.InterceptFunc) (*Inte
 	return &Interceptor{interceptFuncs: interceptFuncs}, nil
 }
 
+// Bind implements interceptor.Interceptable. It is intended for
+// construction/setup only and must not be called concurrently with Intercept.
 func (i *Interceptor) Bind(interceptFuncs ...interceptor.InterceptFunc) error {
 	if err := validateInterceptFuncs(interceptFuncs...); err != nil {
 		return err
@@ -51,6 +54,8 @@ func (i *Interceptor) Bind(interceptFuncs ...interceptor.InterceptFunc) error {
 	return nil
 }
 
+// Intercept implements interceptor.Interceptor. Concurrent calls to Intercept
+// are safe as long as Bind is not called concurrently.
 func (i *Interceptor) Intercept(ctx context.Context, r *http.Request) error {
 	if r == nil {
 		return fmt.Errorf("%w: nil http requests are not allowed to be intercepted", interceptor.ErrInvalidHTTPRequest)

--- a/internal/ports/interceptor/interceptor.go
+++ b/internal/ports/interceptor/interceptor.go
@@ -30,6 +30,14 @@ type InterceptFunc func(ctx context.Context, r *http.Request) error
 type Interceptable interface {
 	// Bind adds the provided InterceptFuncs to the interceptable component's
 	// execution chain.
+	//
+	// Bind is intended for construction/setup only. It must be called before
+	// any concurrent use of Intercept begins. It is not safe to call Bind
+	// concurrently with Intercept. Callers that require runtime mutation after
+	// the interceptor is in use must provide their own external synchronization.
+	//
+	// When all functions are known at construction time, prefer
+	// NewInterceptorWithFuncs over a separate Bind call.
 	Bind(interceptFuncs ...InterceptFunc) error
 }
 
@@ -37,7 +45,8 @@ type Interceptable interface {
 // logic.
 //
 // Components that implement this interface are responsible for running the
-// bound InterceptFuncs.
+// bound InterceptFuncs. Concurrent calls to Intercept are safe as long as
+// Bind is not called concurrently (see Interceptable.Bind).
 type Interceptor interface {
 	// Intercept executes all bound InterceptFuncs in order.
 	//


### PR DESCRIPTION
## Summary

- Documents that `Interceptable.Bind` is a construction/setup-only method and must not be called concurrently with `Intercept`
- Adds matching godoc to the standard `Interceptor` impl (`Bind`, `Intercept`, and the struct)
- Moves TD-004 from the active backlog to the Resolved section in `ai/TECH_DEBT.md`

## Why no mutex

The proposed fix in #114 was a `sync.RWMutex` on every `Intercept` call. `Bind` is only ever called from `tokenmanager.NewStandard` during client bootstrap — the race only materialises under a usage pattern we do not support. Paying a lock on the hot request path to defend against that is an unnecessary tradeoff. The real gap was the missing contract documentation.

## Test plan

- [x] `go build ./...` — clean
- [x] `go vet ./...` — clean
- [x] `go test ./internal/impl/interceptor/...` — pass
- [x] Godoc verified with `go doc`
- [x] Issue #114 commented and closed as working as intended

Closes #114

🤖 Generated with [Claude Code](https://claude.com/claude-code)