### PR TITLE
fix(restclient): remove initial poll sleep and preserve final state in timeout

### DIFF
--- a/ai/TECH_DEBT.md
+++ b/ai/TECH_DEBT.md
@@ -15,7 +15,6 @@ Issues are grouped by severity. Address Critical items before new features ship;
 | [TD-003](#td-003) | `lastUsage` race under RLock | Critical | S | High |
 | [TD-005](#td-005) | Typo `buildDetebaseClient` | High | XS | Low |
 | [TD-007](#td-007) | Variable shadowing in `WaitFor` | High | XS | Low |
-| [TD-008](#td-008) | Polling sleeps before first attempt | High | S | Medium |
 | [TD-009](#td-009) | Caller headers override `Content-Type` | High | XS | Medium |
 | [TD-010](#td-010) | 2 000+ lines duplicated response parsing | High | L | High |
 | [TD-011](#td-011) | Silent error body parse failure | Medium | S | Medium |
@@ -35,7 +34,7 @@ Issues are grouped by severity. Address Critical items before new features ship;
 
 **Wave 2 — High-value focused fixes** (S effort, High+ impact): TD-003, TD-012
 
-**Wave 3 — Medium fixes** (S effort, Medium/Low impact): TD-008, TD-011, TD-018, TD-019
+**Wave 3 — Medium fixes** (S effort, Medium/Low impact): TD-011, TD-018, TD-019
 
 **Wave 4 — Large refactors** (L/XL, plan separately): TD-010, TD-016, TD-020
 
@@ -58,6 +57,13 @@ The original claim was that concurrent calls to `Bind()` and `Intercept()` produ
 Investigation shows that `Bind` is a construction/setup method — it is only ever called from `tokenmanager.NewStandard` (`internal/impl/auth/tokenmanager/standard/standard.go:54`) during client bootstrap, before the interceptor enters the hot request path. A sibling constructor `NewInterceptorWithFuncs` exists for fully-initialized construction. The race only materialises if a caller mutates the interceptor after bootstrap, which is not the intended usage.
 
 The root cause was the absence of a documented contract. Resolved by adding godoc to `Interceptable.Bind` (`internal/ports/interceptor/interceptor.go`) and the standard impl (`internal/impl/interceptor/standard/standard.go`) stating that `Bind` is construction-only and not safe for concurrent use with `Intercept`. Adding a mutex to the hot path to defend against an unsupported usage pattern was rejected as an unnecessary tradeoff. Issue #114 closed as working as intended.
+
+---
+
+### TD-008 · Polling loop always sleeps before the first attempt, discards final state — [#118](https://github.com/Arubacloud/sdk-go/issues/118) · **Resolved**
+`internal/restclient/polling.go` — two bugs in `WaitForResourceState`: (1) `time.Sleep(config.Interval)` was called at the top of the loop, wasting a full interval before the first status check; (2) when the last attempt's getter returned an error, the `continue` skipped the timeout-with-state branch, causing the final timeout error to be generic rather than including the last known state.
+
+Resolved by restructuring the loop: the sleep moved to the bottom, guarded by `if attempt < config.MaxAttempts`; a `lastState` / `lastErr` pair is tracked across iterations so the post-loop timeout error always carries the last observed state (or wraps the last getter error when no state was ever retrieved). `slices.Contains` replaces the manual success/failure loops. First polling tests added in `internal/restclient/polling_test.go`. Issue #118 closed.
 
 ---
 
@@ -117,17 +123,6 @@ The root cause was the absence of a documented contract. Resolved by adding godo
 **Effort:** XS — delete 1 `:=` keyword.
 
 **Impact:** Low — works today by accident; purely a correctness and readability cleanup.
-
----
-
-### TD-008 · Polling loop always sleeps before the first attempt — [#118](https://github.com/Arubacloud/sdk-go/issues/118)
-`internal/restclient/polling.go` — `time.Sleep(config.Interval)` is called at the top of each iteration, including the very first one. This adds an unnecessary 5-second delay before the initial state check.
-
-**Fix:** Move the sleep to the bottom of the loop (or skip when `attempt == 1`) so the first check is immediate.
-
-**Effort:** S — restructure the loop in 1 function.
-
-**Impact:** Medium — 5 s wasted per poll operation before any work is done.
 
 ---
 

--- a/internal/restclient/polling.go
+++ b/internal/restclient/polling.go
@@ -3,6 +3,7 @@ package restclient
 import (
 	"context"
 	"fmt"
+	"slices"
 	"time"
 )
 
@@ -48,43 +49,45 @@ func (c *Client) WaitForResourceState(ctx context.Context, resourceType, resourc
 
 	c.logger.Debugf("Waiting for %s '%s' to become active...", resourceType, resourceID)
 
+	var lastState string
+	var lastErr error
+
 	for attempt := 1; attempt <= config.MaxAttempts; attempt++ {
-		// Check context cancellation
 		select {
 		case <-ctx.Done():
 			return fmt.Errorf("context cancelled while waiting for %s '%s'", resourceType, resourceID)
 		default:
 		}
 
-		time.Sleep(config.Interval)
-
 		state, err := getter(ctx)
 		if err != nil {
+			lastErr = err
 			c.logger.Debugf("Error checking %s '%s' status (attempt %d/%d): %v", resourceType, resourceID, attempt, config.MaxAttempts, err)
-			continue
-		}
+		} else {
+			lastState = state
+			lastErr = nil
+			c.logger.Debugf("%s '%s' state: %s (attempt %d/%d)", resourceType, resourceID, state, attempt, config.MaxAttempts)
 
-		c.logger.Debugf("%s '%s' state: %s (attempt %d/%d)", resourceType, resourceID, state, attempt, config.MaxAttempts)
-
-		// Check for success states
-		for _, successState := range config.SuccessStates {
-			if state == successState {
+			if slices.Contains(config.SuccessStates, state) {
 				c.logger.Debugf("%s '%s' is now %s", resourceType, resourceID, state)
 				return nil
 			}
-		}
 
-		// Check for failure states
-		for _, failureState := range config.FailureStates {
-			if state == failureState {
+			if slices.Contains(config.FailureStates, state) {
 				return fmt.Errorf("%s '%s' reached failure state: %s", resourceType, resourceID, state)
 			}
 		}
 
-		if attempt == config.MaxAttempts {
-			return fmt.Errorf("timeout waiting for %s '%s' to become active (last state: %s)", resourceType, resourceID, state)
+		if attempt < config.MaxAttempts {
+			time.Sleep(config.Interval)
 		}
 	}
 
+	if lastState != "" {
+		return fmt.Errorf("timeout waiting for %s '%s' to become active (last state: %s)", resourceType, resourceID, lastState)
+	}
+	if lastErr != nil {
+		return fmt.Errorf("timeout waiting for %s '%s' to become active: %w", resourceType, resourceID, lastErr)
+	}
 	return fmt.Errorf("timeout waiting for %s '%s' to become active", resourceType, resourceID)
 }

--- a/internal/restclient/polling_test.go
+++ b/internal/restclient/polling_test.go
@@ -1,0 +1,125 @@
+package restclient
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/Arubacloud/sdk-go/internal/impl/logger/noop"
+)
+
+func newTestClient() *Client {
+	return &Client{logger: &noop.NoOpLogger{}}
+}
+
+func TestWaitForResourceState(t *testing.T) {
+	const fast = 1 * time.Millisecond
+
+	t.Run("success on first attempt without initial sleep", func(t *testing.T) {
+		calls := 0
+		getter := func(_ context.Context) (string, error) {
+			calls++
+			return "Active", nil
+		}
+		cfg := PollingConfig{MaxAttempts: 5, Interval: 100 * time.Millisecond, SuccessStates: []string{"Active"}}
+
+		start := time.Now()
+		err := newTestClient().WaitForResourceState(context.Background(), "R", "id", getter, cfg)
+		elapsed := time.Since(start)
+
+		if err != nil {
+			t.Fatalf("expected nil error, got %v", err)
+		}
+		if calls != 1 {
+			t.Fatalf("expected 1 getter call, got %d", calls)
+		}
+		// Should return well before one Interval (100ms). 50ms is a comfortable ceiling on any CI machine.
+		if elapsed >= 50*time.Millisecond {
+			t.Fatalf("first attempt took %v; initial sleep not removed", elapsed)
+		}
+	})
+
+	t.Run("success after multiple attempts", func(t *testing.T) {
+		calls := 0
+		getter := func(_ context.Context) (string, error) {
+			calls++
+			if calls < 3 {
+				return "Pending", nil
+			}
+			return "Active", nil
+		}
+		cfg := PollingConfig{MaxAttempts: 5, Interval: fast, SuccessStates: []string{"Active"}}
+
+		if err := newTestClient().WaitForResourceState(context.Background(), "R", "id", getter, cfg); err != nil {
+			t.Fatalf("expected nil error, got %v", err)
+		}
+		if calls != 3 {
+			t.Fatalf("expected 3 getter calls, got %d", calls)
+		}
+	})
+
+	t.Run("failure state returns error immediately", func(t *testing.T) {
+		getter := func(_ context.Context) (string, error) { return "Failed", nil }
+		cfg := PollingConfig{MaxAttempts: 5, Interval: fast, SuccessStates: []string{"Active"}, FailureStates: []string{"Failed"}}
+
+		err := newTestClient().WaitForResourceState(context.Background(), "R", "id", getter, cfg)
+		if err == nil {
+			t.Fatal("expected error for failure state")
+		}
+		if !strings.Contains(err.Error(), "reached failure state") {
+			t.Fatalf("unexpected error message: %v", err)
+		}
+	})
+
+	t.Run("timeout preserves last known state", func(t *testing.T) {
+		getter := func(_ context.Context) (string, error) { return "Pending", nil }
+		cfg := PollingConfig{MaxAttempts: 3, Interval: fast, SuccessStates: []string{"Active"}}
+
+		err := newTestClient().WaitForResourceState(context.Background(), "R", "id", getter, cfg)
+		if err == nil {
+			t.Fatal("expected timeout error")
+		}
+		if !strings.Contains(err.Error(), "last state: Pending") {
+			t.Fatalf("expected last state in error, got: %v", err)
+		}
+	})
+
+	t.Run("timeout wraps getter error when no state was ever observed", func(t *testing.T) {
+		sentinel := errors.New("api unreachable")
+		getter := func(_ context.Context) (string, error) { return "", sentinel }
+		cfg := PollingConfig{MaxAttempts: 3, Interval: fast, SuccessStates: []string{"Active"}}
+
+		err := newTestClient().WaitForResourceState(context.Background(), "R", "id", getter, cfg)
+		if err == nil {
+			t.Fatal("expected timeout error")
+		}
+		if !errors.Is(err, sentinel) {
+			t.Fatalf("expected sentinel in error chain, got: %v", err)
+		}
+	})
+
+	t.Run("context cancellation is respected before first attempt", func(t *testing.T) {
+		calls := 0
+		getter := func(_ context.Context) (string, error) {
+			calls++
+			return "Pending", nil
+		}
+		cfg := PollingConfig{MaxAttempts: 5, Interval: fast, SuccessStates: []string{"Active"}}
+
+		ctx, cancel := context.WithCancel(context.Background())
+		cancel()
+
+		err := newTestClient().WaitForResourceState(ctx, "R", "id", getter, cfg)
+		if err == nil {
+			t.Fatal("expected error on cancelled context")
+		}
+		if !strings.Contains(err.Error(), "context cancelled") {
+			t.Fatalf("unexpected error message: %v", err)
+		}
+		if calls != 0 {
+			t.Fatalf("getter should not have been called; called %d times", calls)
+		}
+	})
+}


### PR DESCRIPTION
## Summary

Fixes two bugs in `WaitForResourceState` (`internal/restclient/polling.go`):

- **Initial sleep wasted.** `time.Sleep(config.Interval)` was called at the top of each loop iteration, including the very first. Every polling operation burned a full interval (default 5 s) before the first status check — even when the resource was already in a terminal state.
- **Final state discarded.** When the last attempt's getter returned an error, the `continue` skipped the `if attempt == config.MaxAttempts` branch that included the last state in the error message. The timeout fell through to a generic message, dropping both the last known state and the getter's error from the diagnostic.

## Changes

- Sleep moved to the bottom of the loop, guarded by `if attempt < config.MaxAttempts` — no sleep on the last attempt, and no sleep before the first check.
- `lastState` / `lastErr` tracked across iterations so the post-loop timeout error always carries the last observed state (preferred) or wraps the last getter error when no state was ever retrieved.
- Manual success/failure loops replaced with `slices.Contains`.
- First test file added: `internal/restclient/polling_test.go` with 6 subtests covering all fixed paths, including a regression guard for the final-state-discard bug.

## Test plan

- [x] `make verify` — all tests pass with race detection enabled
- [x] `go test -race -run TestWaitForResourceState ./internal/restclient/...` — all 6 subtests green
- [x] `go build ./...` — clean

Closes #118

🤖 Generated with [Claude Code](https://claude.com/claude-code)