### PR TITLE
fix(auth): move saveTicket increment after successful persistent write

### DIFF
--- a/ai/TECH_DEBT.md
+++ b/ai/TECH_DEBT.md
@@ -19,7 +19,6 @@ Issues are grouped by severity. Address Critical items before new features ship;
 | [TD-010](#td-010) | 2 000+ lines duplicated response parsing | High | L | High |
 | [TD-011](#td-011) | Silent error body parse failure | Medium | S | Medium |
 | [TD-012](#td-012) | Expired token injected after failed refresh | Medium | S | High |
-| [TD-013](#td-013) | Memory proxy ticket incremented before write | Medium | XS | Medium |
 | [TD-014](#td-014) | `ParseResponseBody` panics on nil response | Medium | XS | Medium |
 | [TD-015](#td-015) | `DefaultWaitFor` timeout too short | Medium | XS | Medium |
 | [TD-016](#td-016) | No structured logging | Medium | L | Medium |
@@ -30,7 +29,7 @@ Issues are grouped by severity. Address Critical items before new features ship;
 
 ### Recommended execution order
 
-**Wave 1 — Quick Wins** (XS effort, ship same PR): TD-001, TD-002, TD-005, TD-007, TD-009, TD-013, TD-014, TD-015, TD-017
+**Wave 1 — Quick Wins** (XS effort, ship same PR): TD-001, TD-002, TD-005, TD-007, TD-009, TD-014, TD-015, TD-017
 
 **Wave 2 — High-value focused fixes** (S effort, High+ impact): TD-003, TD-012
 
@@ -64,6 +63,13 @@ The root cause was the absence of a documented contract. Resolved by adding godo
 `internal/restclient/polling.go` — two bugs in `WaitForResourceState`: (1) `time.Sleep(config.Interval)` was called at the top of the loop, wasting a full interval before the first status check; (2) when the last attempt's getter returned an error, the `continue` skipped the timeout-with-state branch, causing the final timeout error to be generic rather than including the last known state.
 
 Resolved by restructuring the loop: the sleep moved to the bottom, guarded by `if attempt < config.MaxAttempts`; a `lastState` / `lastErr` pair is tracked across iterations so the post-loop timeout error always carries the last observed state (or wraps the last getter error when no state was ever retrieved). `slices.Contains` replaces the manual success/failure loops. First polling tests added in `internal/restclient/polling_test.go`. Issue #118 closed.
+
+---
+
+### TD-013 · Memory proxy `SaveToken` increments ticket before confirming persistent write — [#123](https://github.com/Arubacloud/sdk-go/issues/123) · **Resolved**
+`internal/impl/auth/tokenrepository/memory/memory.go` — `saveTicket++` ran before `r.persistentRepository.SaveToken(...)`, violating the double-checked-locking invariant that "a changed ticket means the cache was successfully refreshed". On a failed persistent write the ticket was already bumped, causing concurrent `FetchToken` calls to skip the persistent re-fetch and serve a stale (or nil) in-memory token.
+
+Resolved by reordering: persistent write first; on success, increment ticket and update cache; on error, return immediately leaving both unchanged. Two regression tests added to `memory_test.go`: a unit assertion on the `saveTicket` counter after a failed save, and a behavioural subtest that verifies a subsequent `FetchToken` still reaches the persistent store. Issue #123 closed.
 
 ---
 
@@ -177,17 +183,6 @@ Replace all manual implementations with calls to this helper.
 **Effort:** S — add nil/expiry checks in 1 function.
 
 **Impact:** High — the nil pointer panic causes an unrecoverable crash under concurrent token refresh with a temporarily unavailable token store; the expired-token path produces silent 401s.
-
----
-
-### TD-013 · Memory proxy `SaveToken` increments ticket before confirming persistent write — [#123](https://github.com/Arubacloud/sdk-go/issues/123)
-`internal/impl/auth/tokenrepository/memory/memory.go` — `saveTicket++` runs before `r.persistentRepository.SaveToken(...)`. If the persistent write fails, the ticket has already been incremented, invalidating the in-memory cache. Subsequent reads see a miss and re-read from persistent storage, which still has the old token.
-
-**Fix:** Increment the ticket only after a successful persistent write.
-
-**Effort:** XS — move 1 line after the error-check block.
-
-**Impact:** Medium — prevents transient cache corruption when the persistent store is briefly unavailable.
 
 ---
 

--- a/internal/impl/auth/tokenrepository/memory/memory.go
+++ b/internal/impl/auth/tokenrepository/memory/memory.go
@@ -151,17 +151,20 @@ func (r *TokenRepository) SaveToken(ctx context.Context, token *auth.Token) erro
 	r.locker.Lock()
 	defer r.locker.Unlock()
 
-	// Increment saveTicket to invalidate any pending fetches in other goroutines.
-	r.saveTicket++
-
-	// Write-Through: Save to persistent storage first.
+	// Write-Through: Save to persistent storage first. If it fails, the
+	// in-memory cache and saveTicket must remain unchanged so that concurrent
+	// FetchToken calls continue to observe the prior-consistent state and do
+	// not skip the persistent re-fetch due to a spurious ticket change.
 	if r.persistentRepository != nil {
 		if err := r.persistentRepository.SaveToken(ctx, token.Copy()); err != nil {
 			return err
 		}
 	}
 
-	// Update in-memory cache.
+	// Persistent write succeeded (or there is no persistent layer).
+	// Bump saveTicket to invalidate any in-flight FetchToken double-checks
+	// and update the in-memory cache.
+	r.saveTicket++
 	r.token = token.Copy()
 
 	return nil

--- a/internal/impl/auth/tokenrepository/memory/memory_test.go
+++ b/internal/impl/auth/tokenrepository/memory/memory_test.go
@@ -479,6 +479,57 @@ func TestTokenProxy_SaveToken(t *testing.T) {
 
 		// And the token on the proxy should not be set
 		require.Nil(t, proxy.token)
+
+		// And the saveTicket must not have been incremented — a failed persistent
+		// write must leave the double-checked-locking sentinel unchanged so that
+		// concurrent FetchToken calls are not misled into skipping a re-fetch.
+		require.Equal(t, uint64(0), proxy.saveTicket)
+	})
+
+	t.Run("should not mark the cache as refreshed when the persistent save fails", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+
+		// Given a persistent repository that fails on save but succeeds on fetch
+		persistentRepository := NewMockTokenRepository(ctrl)
+
+		errConnection := errors.New("connection error")
+
+		persistentRepository.EXPECT().SaveToken(
+			gomock.AssignableToTypeOf(t.Context()),
+			gomock.AssignableToTypeOf(&auth.Token{}),
+		).Return(errConnection).Times(1)
+
+		persistentRepository.EXPECT().FetchToken(
+			gomock.AssignableToTypeOf(t.Context()),
+		).Return(&auth.Token{AccessToken: accessToken, Expiry: expiry}, nil).Times(1)
+
+		//
+		// And a proxy with an expired in-memory token
+		proxy := NewTokenProxy(persistentRepository)
+
+		proxy.token = &auth.Token{
+			AccessToken: "expired token",
+			Expiry:      time.Now().Add(-1 * time.Hour),
+		}
+
+		// When the save fails
+		err := proxy.SaveToken(t.Context(), &auth.Token{AccessToken: "new token", Expiry: expiry})
+
+		// Then the connection error should be reported
+		require.ErrorIs(t, err, errConnection)
+
+		// When a subsequent FetchToken is called
+		token, err := proxy.FetchToken(t.Context())
+
+		// Then no error should be reported — the fetch must have gone to the
+		// persistent store, not served the stale in-memory token, because the
+		// failed save must not have bumped saveTicket.
+		require.NoError(t, err)
+
+		// And the returned token should match the one from the persistent repository
+		require.Equal(t, accessToken, token.AccessToken)
+		require.Equal(t, expiry, token.Expiry)
 	})
 
 	t.Run("should not be overwriten by fetch calls", func(t *testing.T) {


### PR DESCRIPTION
## Summary

Fixes a double-checked-locking invariant violation in `(*TokenRepository).SaveToken` (`internal/impl/auth/tokenrepository/memory/memory.go`).

`saveTicket` is the sentinel `FetchToken` uses to decide whether another goroutine has already refreshed the in-memory cache (and therefore the expensive persistent re-fetch can be skipped). The invariant is: **a changed ticket means the cache was successfully refreshed**.

Before this fix, `saveTicket++` ran before the persistent write. When the write failed the ticket was already bumped, but `r.token` was not updated. Any `FetchToken` that had captured the old ticket value would see a mismatch, believe the cache was fresh, skip the persistent re-fetch, and serve the **stale** (or nil) in-memory token — until a subsequent successful save repopulated it.

## Changes

- Reorder `SaveToken`: persistent write runs first. Ticket and in-memory cache are only mutated after a successful write; a failed write returns immediately leaving both unchanged.
- Extend the existing `"should not update its token when the persistent repository reports some error"` subtest with a `saveTicket == 0` assertion — the direct regression guard.
- Add `"should not mark the cache as refreshed when the persistent save fails"` — a behavioural subtest that verifies a subsequent `FetchToken` still reaches the persistent store after a failed save.

## Test plan

- [x] `go test -race -run TestTokenProxy_SaveToken ./internal/impl/auth/tokenrepository/memory/...` — all 4 subtests pass
- [x] `make verify` — full lint + race-enabled test suite clean

Closes #123

🤖 Generated with [Claude Code](https://claude.com/claude-code)