### PR TITLE
chore: add compile-time interface guards for all resource-level client impls (TD-019)

### DIFF
--- a/ai/TECH_DEBT.md
+++ b/ai/TECH_DEBT.md
@@ -24,7 +24,6 @@ Issues are grouped by severity. Address Critical items before new features ship;
 | [TD-016](#td-016) | No structured logging | Medium | L | Medium |
 | [TD-017](#td-017) | `WARN` writes to stdout | Medium | XS | Low |
 | [TD-018](#td-018) | Nil deps not checked in constructors | Medium | S | Low |
-| [TD-019](#td-019) | Missing interface satisfaction checks | Low | S | Low |
 | [TD-020](#td-020) | Test coverage gaps | Low | XL | High |
 
 ### Recommended execution order
@@ -33,7 +32,7 @@ Issues are grouped by severity. Address Critical items before new features ship;
 
 **Wave 2 — High-value focused fixes** (S effort, High+ impact): TD-003, TD-012
 
-**Wave 3 — Medium fixes** (S effort, Medium/Low impact): TD-011, TD-018, TD-019
+**Wave 3 — Medium fixes** (S effort, Medium/Low impact): TD-011, TD-018
 
 **Wave 4 — Large refactors** (L/XL, plan separately): TD-010, TD-016, TD-020
 
@@ -70,6 +69,15 @@ Resolved by restructuring the loop: the sleep moved to the bottom, guarded by `i
 `internal/impl/auth/tokenrepository/memory/memory.go` — `saveTicket++` ran before `r.persistentRepository.SaveToken(...)`, violating the double-checked-locking invariant that "a changed ticket means the cache was successfully refreshed". On a failed persistent write the ticket was already bumped, causing concurrent `FetchToken` calls to skip the persistent re-fetch and serve a stale (or nil) in-memory token.
 
 Resolved by reordering: persistent write first; on success, increment ticket and update cache; on error, return immediately leaving both unchanged. Two regression tests added to `memory_test.go`: a unit assertion on the `saveTicket` counter after a failed save, and a behavioural subtest that verifies a subsequent `FetchToken` still reaches the persistent store. Issue #123 closed.
+
+---
+
+### TD-019 · Missing compile-time interface satisfaction checks — [#129](https://github.com/Arubacloud/sdk-go/issues/129) · **Resolved**
+Guards were missing for all ~24 resource-level client impls under `internal/clients/`. Adding them directly inside those packages would create an import cycle (`pkg/aruba/builder.go` already imports every internal client package). The guards are consolidated in a new file `pkg/aruba/assertions.go`, using each impl's exported constructor with `nil` args to obtain a typed value of the unexported impl type — the exact same assignment the existing `buildXxxClient` return types already checked implicitly.
+
+The security domain is intentionally excluded: `KMSClient`, `KeyClient`, and `KmipClient` in `pkg/aruba/security.go` are type aliases to concrete pointer types, not interfaces, so satisfaction guards would be degenerate.
+
+The issue description incorrectly identified both logger implementations as missing guards; both already had them (`internal/impl/logger/native/logger.go:11`, `internal/impl/logger/noop/logger.go:6`). Three `for i := 0; i < N; i++` loops in test files were also modernized to `for range N` while in the area. Issue #129 closed.
 
 ---
 
@@ -242,22 +250,6 @@ Replace all manual implementations with calls to this helper.
 ---
 
 ## Low
-
-### TD-019 · Missing compile-time interface satisfaction checks — [#129](https://github.com/Arubacloud/sdk-go/issues/129)
-21 `var _ Interface = (*Impl)(nil)` guards already exist across `pkg/aruba/` (10 service group clients + main `Client`), `pkg/multitenant/`, and `internal/impl/` (auth repositories, connectors, token manager, interceptor). The gap is in two areas:
-
-1. **Logger implementations:** `internal/impl/logger/native/` and `internal/impl/logger/noop/` have no `var _ logger.Logger` guard.
-2. **Resource-level client implementations:** All `*Impl` types under `internal/clients/` (e.g., `cloudServersClientImpl`, `vpcsClientImpl`, ~30 types) lack guards.
-
-A missed method or signature change in these types will only surface at runtime rather than at compile time.
-
-**Fix:** Add `var _ logger.Logger = (*DefaultLogger)(nil)` (and equivalent for each resource-level impl) at package scope in the affected files.
-
-**Effort:** S — mechanical addition of `var _` lines in ~32 files.
-
-**Impact:** Low — compile-time safety net; no runtime effect until a signature diverges.
-
----
 
 ### TD-020 · Test coverage limited to happy path and empty-ID validation — [#130](https://github.com/Arubacloud/sdk-go/issues/130)
 All `internal/clients/*/_test.go` files — existing tests cover successful responses and empty project/resource IDs. Missing: HTTP 4xx/5xx error responses, malformed JSON bodies, network-level errors, `nil` params handling, and request body marshaling failures.

--- a/internal/impl/auth/tokenmanager/standard/standard_test.go
+++ b/internal/impl/auth/tokenmanager/standard/standard_test.go
@@ -297,7 +297,7 @@ func TestTokenManager_InjectToken(t *testing.T) {
 
 		bell.Lock() // make sure to block all calls
 
-		for i := 0; i < 100; i++ { // launch the simultaneous go routines
+		for range 100 { // launch the simultaneous go routines
 			wg.Add(1)
 			go func() {
 				defer wg.Done()

--- a/internal/impl/auth/tokenrepository/memory/memory_test.go
+++ b/internal/impl/auth/tokenrepository/memory/memory_test.go
@@ -346,7 +346,7 @@ func TestTokenProxy_FetchToken(t *testing.T) {
 
 		bell.Lock() // make sure to block all calls
 
-		for i := 0; i < 100; i++ { // launch the simultaneous go routines
+		for range 100 { // launch the simultaneous go routines
 			wg.Add(1)
 			go func() {
 				defer wg.Done()
@@ -587,7 +587,7 @@ func TestTokenProxy_SaveToken(t *testing.T) {
 			errChan <- err
 		}()
 
-		for i := 0; i < 999; i++ { // launch the simultaneous go routines
+		for range 999 { // launch the simultaneous go routines
 			wg.Add(1)
 
 			go func() {

--- a/pkg/aruba/assertions.go
+++ b/pkg/aruba/assertions.go
@@ -1,0 +1,73 @@
+package aruba
+
+// Compile-time assertions that internal client implementations satisfy their
+// public interfaces. A build failure here means an impl no longer implements
+// its declared interface — surfaced at compile time rather than at runtime.
+//
+// Guards are placed here (pkg/aruba) rather than in the internal packages
+// because pkg/aruba/builder.go already imports every internal client package;
+// the reverse import would create a cycle.
+//
+// The security domain is intentionally omitted: KMSClient, KeyClient, and
+// KmipClient are declared as type aliases to concrete pointer types, not
+// interfaces, so satisfaction guards are degenerate.
+
+import (
+	"github.com/Arubacloud/sdk-go/internal/clients/audit"
+	"github.com/Arubacloud/sdk-go/internal/clients/compute"
+	"github.com/Arubacloud/sdk-go/internal/clients/container"
+	"github.com/Arubacloud/sdk-go/internal/clients/database"
+	"github.com/Arubacloud/sdk-go/internal/clients/metric"
+	"github.com/Arubacloud/sdk-go/internal/clients/network"
+	"github.com/Arubacloud/sdk-go/internal/clients/project"
+	"github.com/Arubacloud/sdk-go/internal/clients/schedule"
+	"github.com/Arubacloud/sdk-go/internal/clients/storage"
+)
+
+var (
+	// Audit
+	_ EventsClient = audit.NewEventsClientImpl(nil)
+
+	// Compute
+	_ CloudServersClient = compute.NewCloudServersClientImpl(nil)
+	_ KeyPairsClient     = compute.NewKeyPairsClientImpl(nil)
+
+	// Container
+	_ KaaSClient              = container.NewKaaSClientImpl(nil)
+	_ ContainerRegistryClient = container.NewContainerRegistryClientImpl(nil)
+
+	// Database
+	_ DBaaSClient     = database.NewDBaaSClientImpl(nil)
+	_ DatabasesClient = database.NewDatabasesClientImpl(nil)
+	_ BackupsClient   = database.NewBackupsClientImpl(nil)
+	_ UsersClient     = database.NewUsersClientImpl(nil)
+	_ GrantsClient    = database.NewGrantsClientImpl(nil)
+
+	// Metric
+	_ AlertsClient  = metric.NewAlertsClientImpl(nil)
+	_ MetricsClient = metric.NewMetricsClientImpl(nil)
+
+	// Network
+	_ ElasticIPsClient         = network.NewElasticIPsClientImpl(nil)
+	_ LoadBalancersClient      = network.NewLoadBalancersClientImpl(nil)
+	_ VPCsClient               = network.NewVPCsClientImpl(nil)
+	_ SecurityGroupsClient     = network.NewSecurityGroupsClientImpl(nil, nil)
+	_ SecurityGroupRulesClient = network.NewSecurityGroupRulesClientImpl(nil, nil)
+	_ SubnetsClient            = network.NewSubnetsClientImpl(nil, nil)
+	_ VPCPeeringsClient        = network.NewVPCPeeringsClientImpl(nil)
+	_ VPCPeeringRoutesClient   = network.NewVPCPeeringRoutesClientImpl(nil)
+	_ VPNRoutesClient          = network.NewVPNRoutesClientImpl(nil)
+	_ VPNTunnelsClient         = network.NewVPNTunnelsClientImpl(nil)
+
+	// Project
+	_ ProjectClient = project.NewProjectsClientImpl(nil)
+
+	// Schedule
+	_ JobsClient = schedule.NewJobsClientImpl(nil)
+
+	// Storage
+	_ VolumesClient        = storage.NewVolumesClientImpl(nil)
+	_ SnapshotsClient      = storage.NewSnapshotsClientImpl(nil, nil)
+	_ StorageBackupsClient = storage.NewBackupClientImpl(nil)
+	_ StorageRestoreClient = storage.NewRestoreClientImpl(nil, nil)
+)


### PR DESCRIPTION
## Summary

Closes #129 (TD-019).

Adds `var _ Interface = constructor(nil)` compile-time assertions for all 24 resource-level client implementations across every domain (audit, compute, container, database, metric, network, project, schedule, storage).

## Why `pkg/aruba/assertions.go` and not `internal/clients/<domain>/<file>.go`

`pkg/aruba/builder.go` already imports every `internal/clients/<domain>` package. Adding an import of `pkg/aruba` back into those packages would create a cycle. The cycle-safe approach is to consolidate all guards in a single new file inside `pkg/aruba`, which already has access to every internal package.

Each guard uses the impl's exported constructor with `nil` args: e.g. `_ CloudServersClient = compute.NewCloudServersClientImpl(nil)`. All constructors audited are field-assignment only — passing `nil` is safe at init time. The check is semantically equivalent to the implicit check that already existed via each `buildXxxClient` return-type annotation in `builder.go`, but now it is explicit, standardised, and locatable at a glance.

## Intentional exclusions

- **Security domain:** `KMSClient`, `KeyClient`, `KmipClient` in `pkg/aruba/security.go` are *type aliases* to concrete pointer types, not interfaces. A satisfaction guard would be degenerate. This is a separate architectural question.
- **Logger implementations:** Both already had guards — `internal/impl/logger/native/logger.go:11` and `internal/impl/logger/noop/logger.go:6`. The issue description was stale on this point.

## Opportunistic cleanup

Three `for i := 0; i < N; i++` loops in concurrency test files modernized to `for range N` (Go 1.22+ range-over-int). Flagged by the IDE modernize analyzer but not by CI linters. No semantic change.

## Test plan

- [x] `go build ./pkg/aruba/...` — guards compile clean
- [x] `make verify` — full lint + race-enabled test suite passes
- [x] `golangci-lint run ./...` — zero findings (unchanged from baseline)

🤖 Generated with [Claude Code](https://claude.com/claude-code)