### PR TITLE
fix(types): log non-JSON error body parse failure at DEBUG level (TD-011)

### DIFF
--- a/ai/TECH_DEBT.md
+++ b/ai/TECH_DEBT.md
@@ -17,7 +17,6 @@ Issues are grouped by severity. Address Critical items before new features ship;
 | [TD-007](#td-007) | Variable shadowing in `WaitFor` | High | XS | Low |
 | [TD-009](#td-009) | Caller headers override `Content-Type` | High | XS | Medium |
 | [TD-010](#td-010) | 2 000+ lines duplicated response parsing | High | L | High |
-| [TD-011](#td-011) | Silent error body parse failure | Medium | S | Medium |
 | [TD-012](#td-012) | Expired token injected after failed refresh | Medium | S | High |
 | [TD-014](#td-014) | `ParseResponseBody` panics on nil response | Medium | XS | Medium |
 | [TD-015](#td-015) | `DefaultWaitFor` timeout too short | Medium | XS | Medium |
@@ -31,7 +30,7 @@ Issues are grouped by severity. Address Critical items before new features ship;
 
 **Wave 2 — High-value focused fixes** (S effort, High+ impact): TD-003, TD-012
 
-**Wave 3 — Medium fixes** (S effort, Medium/Low impact): TD-011
+**Wave 3 — Medium fixes** (S effort, Medium/Low impact): *(all resolved)*
 
 **Wave 4 — Large refactors** (L/XL, plan separately): TD-010, TD-016, TD-020
 
@@ -85,7 +84,14 @@ When TD-018 was subsequently resolved (#146), the multi-arg constructor calls in
 ### TD-018 · Injected concrete dependencies not nil-checked in constructors — [#128](https://github.com/Arubacloud/sdk-go/issues/128) · **Resolved**
 The issue named two constructors (`NewSecurityGroupsClientImpl`, `NewSecurityGroupRulesClientImpl`). A repo-wide grep (`^func New\w+ClientImpl\(.*,.*\)` against `internal/clients/`) found five constructors in total that accept injected `*xxxClientImpl` dependencies beyond the standard `*restclient.Client`: the two network ones named in the issue, `NewSubnetsClientImpl` (also network), `NewSnapshotsClientImpl`, and `NewRestoreClientImpl` (storage).
 
-All five now `panic("... is required and cannot be nil")` when the injected dep is nil. Corresponding panic-on-nil tests added to the paired test files. `pkg/aruba/assertions.go` updated to wire real sentinel instances for the affected constructors (avoiding init-time panics). Issue #128 closed.
+All five now `panic("... is required and cannot be nil")` when the injected dep is nil. Corresponding panic-on-nil tests added to the paired test files. `pkg/aruba/assertions_test.go` updated to wire real sentinel instances for the affected constructors (avoiding init-time panics). Issue #128 closed.
+
+---
+
+### TD-011 · Silent failure when parsing error response body — [#121](https://github.com/Arubacloud/sdk-go/issues/121) · **Resolved**
+`pkg/types/utils.go` — when a 4xx/5xx response body could not be unmarshalled as JSON, the error was silently discarded and `response.Error` remained `nil`.
+
+Resolved by adding a `DebugLogger` interface to `pkg/types` (one method: `Debugf`) and making `ParseResponseBody` accept it as a required parameter. On JSON-unmarshal failure the function now calls `logger.Debugf(...)` naming the HTTP status code, rather than WARN as the issue proposed — non-JSON error bodies are expected behaviour from this API (proxy HTML pages, plain-text 502s). Using a local interface keeps `pkg/types` independent of `internal/ports/logger`. All 31 call-site files across `internal/clients/` were updated to pass `c.client.Logger()`. Four unit tests added in `pkg/types/utils_test.go`. Issue #121 closed.
 
 ---
 
@@ -176,17 +182,6 @@ Replace all manual implementations with calls to this helper.
 ---
 
 ## Medium
-
-### TD-011 · Silent failure when parsing error response body — [#121](https://github.com/Arubacloud/sdk-go/issues/121)
-`pkg/types/utils.go` — in `ParseResponseBody`, when a 4xx/5xx response body cannot be unmarshalled as JSON, the error is swallowed silently (`if err == nil { ... }`). `response.Error` remains `nil`, making it impossible for the caller to understand what the server returned.
-
-**Fix:** Log the unmarshal error at WARN level, or document that `RawBody` should be used as the fallback for non-JSON error bodies.
-
-**Effort:** S — add a logger call or code comment in 1 function.
-
-**Impact:** Medium — improves debuggability of non-JSON error responses (e.g., plain-text 502 from a proxy); no production failure risk.
-
----
 
 ### TD-012 · Token manager mishandles post-refresh token fetch in the else-branch — [#122](https://github.com/Arubacloud/sdk-go/issues/122)
 `internal/impl/auth/tokenmanager/standard/standard.go` — in the write-lock branch, when the ticket has already changed (another goroutine refreshed), the code re-fetches from the repository. Two failure modes exist:

--- a/internal/clients/audit/event.go
+++ b/internal/clients/audit/event.go
@@ -48,5 +48,5 @@ func (s *eventsClientImpl) List(ctx context.Context, projectID string, params *t
 	}
 	defer httpResp.Body.Close()
 
-	return types.ParseResponseBody[types.AuditEventListResponse](httpResp)
+	return types.ParseResponseBody[types.AuditEventListResponse](httpResp, s.client.Logger())
 }

--- a/internal/clients/compute/cloudserver.go
+++ b/internal/clients/compute/cloudserver.go
@@ -49,7 +49,7 @@ func (c *cloudServersClientImpl) List(ctx context.Context, projectID string, par
 	}
 	defer httpResp.Body.Close()
 
-	return types.ParseResponseBody[types.CloudServerList](httpResp)
+	return types.ParseResponseBody[types.CloudServerList](httpResp, c.client.Logger())
 }
 
 // Get retrieves a specific cloud server by ID
@@ -79,7 +79,7 @@ func (c *cloudServersClientImpl) Get(ctx context.Context, projectID string, clou
 	}
 	defer httpResp.Body.Close()
 
-	return types.ParseResponseBody[types.CloudServerResponse](httpResp)
+	return types.ParseResponseBody[types.CloudServerResponse](httpResp, c.client.Logger())
 }
 
 // Create creates a new cloud server
@@ -237,7 +237,7 @@ func (c *cloudServersClientImpl) Delete(ctx context.Context, projectID string, c
 	}
 	defer httpResp.Body.Close()
 
-	return types.ParseResponseBody[any](httpResp)
+	return types.ParseResponseBody[any](httpResp, c.client.Logger())
 }
 
 // PowerOn powers on a cloud server
@@ -267,7 +267,7 @@ func (c *cloudServersClientImpl) PowerOn(ctx context.Context, projectID string, 
 	}
 	defer httpResp.Body.Close()
 
-	return types.ParseResponseBody[types.CloudServerResponse](httpResp)
+	return types.ParseResponseBody[types.CloudServerResponse](httpResp, c.client.Logger())
 }
 
 // PowerOff powers off a cloud server
@@ -297,7 +297,7 @@ func (c *cloudServersClientImpl) PowerOff(ctx context.Context, projectID string,
 	}
 	defer httpResp.Body.Close()
 
-	return types.ParseResponseBody[types.CloudServerResponse](httpResp)
+	return types.ParseResponseBody[types.CloudServerResponse](httpResp, c.client.Logger())
 }
 
 // SetPassword sets or changes the password for a cloud server
@@ -333,5 +333,5 @@ func (c *cloudServersClientImpl) SetPassword(ctx context.Context, projectID stri
 	}
 	defer httpResp.Body.Close()
 
-	return types.ParseResponseBody[any](httpResp)
+	return types.ParseResponseBody[any](httpResp, c.client.Logger())
 }

--- a/internal/clients/compute/keypair.go
+++ b/internal/clients/compute/keypair.go
@@ -49,7 +49,7 @@ func (c *keyPairsClientImpl) List(ctx context.Context, projectID string, params 
 	}
 	defer httpResp.Body.Close()
 
-	return types.ParseResponseBody[types.KeyPairListResponse](httpResp)
+	return types.ParseResponseBody[types.KeyPairListResponse](httpResp, c.client.Logger())
 }
 
 // Get retrieves a specific key pair by ID
@@ -79,7 +79,7 @@ func (c *keyPairsClientImpl) Get(ctx context.Context, projectID string, keyPairI
 	}
 	defer httpResp.Body.Close()
 
-	return types.ParseResponseBody[types.KeyPairResponse](httpResp)
+	return types.ParseResponseBody[types.KeyPairResponse](httpResp, c.client.Logger())
 }
 
 // Create creates a new key pair
@@ -173,5 +173,5 @@ func (c *keyPairsClientImpl) Delete(ctx context.Context, projectID string, keyPa
 	}
 	defer httpResp.Body.Close()
 
-	return types.ParseResponseBody[any](httpResp)
+	return types.ParseResponseBody[any](httpResp, c.client.Logger())
 }

--- a/internal/clients/container/containerregistry.go
+++ b/internal/clients/container/containerregistry.go
@@ -51,7 +51,7 @@ func (c *containerRegistryClientImpl) List(ctx context.Context, projectID string
 	}
 	defer httpResp.Body.Close()
 
-	return types.ParseResponseBody[types.ContainerRegistryList](httpResp)
+	return types.ParseResponseBody[types.ContainerRegistryList](httpResp, c.client.Logger())
 }
 
 // Get retrieves a specific Container Registry by ID
@@ -81,7 +81,7 @@ func (c *containerRegistryClientImpl) Get(ctx context.Context, projectID string,
 	}
 	defer httpResp.Body.Close()
 
-	return types.ParseResponseBody[types.ContainerRegistryResponse](httpResp)
+	return types.ParseResponseBody[types.ContainerRegistryResponse](httpResp, c.client.Logger())
 }
 
 // Create creates a new Container Registry
@@ -231,5 +231,5 @@ func (c *containerRegistryClientImpl) Delete(ctx context.Context, projectID stri
 	}
 	defer httpResp.Body.Close()
 
-	return types.ParseResponseBody[any](httpResp)
+	return types.ParseResponseBody[any](httpResp, c.client.Logger())
 }

--- a/internal/clients/container/kaas.go
+++ b/internal/clients/container/kaas.go
@@ -51,7 +51,7 @@ func (c *kaasClientImpl) List(ctx context.Context, projectID string, params *typ
 	}
 	defer httpResp.Body.Close()
 
-	return types.ParseResponseBody[types.KaaSList](httpResp)
+	return types.ParseResponseBody[types.KaaSList](httpResp, c.client.Logger())
 }
 
 // Get retrieves a specific KaaS cluster by ID
@@ -81,7 +81,7 @@ func (c *kaasClientImpl) Get(ctx context.Context, projectID string, kaasID strin
 	}
 	defer httpResp.Body.Close()
 
-	return types.ParseResponseBody[types.KaaSResponse](httpResp)
+	return types.ParseResponseBody[types.KaaSResponse](httpResp, c.client.Logger())
 }
 
 // Create creates a new KaaS cluster
@@ -239,7 +239,7 @@ func (c *kaasClientImpl) Delete(ctx context.Context, projectID string, kaasID st
 	}
 	defer httpResp.Body.Close()
 
-	return types.ParseResponseBody[any](httpResp)
+	return types.ParseResponseBody[any](httpResp, c.client.Logger())
 }
 
 // DownloadKubeconfig downloads the kubeconfig file for a KaaS cluster
@@ -269,5 +269,5 @@ func (c *kaasClientImpl) DownloadKubeconfig(ctx context.Context, projectID strin
 	}
 	defer httpResp.Body.Close()
 
-	return types.ParseResponseBody[types.KaaSKubeconfigResponse](httpResp)
+	return types.ParseResponseBody[types.KaaSKubeconfigResponse](httpResp, c.client.Logger())
 }

--- a/internal/clients/database/backup.go
+++ b/internal/clients/database/backup.go
@@ -49,7 +49,7 @@ func (c *backupsClientImpl) List(ctx context.Context, projectID string, params *
 	}
 	defer httpResp.Body.Close()
 
-	return types.ParseResponseBody[types.BackupList](httpResp)
+	return types.ParseResponseBody[types.BackupList](httpResp, c.client.Logger())
 }
 
 // Get retrieves a specific backup by ID
@@ -79,7 +79,7 @@ func (c *backupsClientImpl) Get(ctx context.Context, projectID string, backupID 
 	}
 	defer httpResp.Body.Close()
 
-	return types.ParseResponseBody[types.BackupResponse](httpResp)
+	return types.ParseResponseBody[types.BackupResponse](httpResp, c.client.Logger())
 }
 
 // Create creates a new backup
@@ -115,7 +115,7 @@ func (c *backupsClientImpl) Create(ctx context.Context, projectID string, body t
 	}
 	defer httpResp.Body.Close()
 
-	return types.ParseResponseBody[types.BackupResponse](httpResp)
+	return types.ParseResponseBody[types.BackupResponse](httpResp, c.client.Logger())
 }
 
 // Delete deletes a backup by ID
@@ -145,5 +145,5 @@ func (c *backupsClientImpl) Delete(ctx context.Context, projectID string, backup
 	}
 	defer httpResp.Body.Close()
 
-	return types.ParseResponseBody[any](httpResp)
+	return types.ParseResponseBody[any](httpResp, c.client.Logger())
 }

--- a/internal/clients/database/database.go
+++ b/internal/clients/database/database.go
@@ -50,7 +50,7 @@ func (c *databasesClientImpl) List(ctx context.Context, projectID string, dbaasI
 	}
 	defer httpResp.Body.Close()
 
-	return types.ParseResponseBody[types.DatabaseList](httpResp)
+	return types.ParseResponseBody[types.DatabaseList](httpResp, c.client.Logger())
 }
 
 // Get retrieves a specific database by ID
@@ -80,7 +80,7 @@ func (c *databasesClientImpl) Get(ctx context.Context, projectID string, dbaasID
 	}
 	defer httpResp.Body.Close()
 
-	return types.ParseResponseBody[types.DatabaseResponse](httpResp)
+	return types.ParseResponseBody[types.DatabaseResponse](httpResp, c.client.Logger())
 }
 
 // Create creates a new database
@@ -238,5 +238,5 @@ func (c *databasesClientImpl) Delete(ctx context.Context, projectID string, dbaa
 	}
 	defer httpResp.Body.Close()
 
-	return types.ParseResponseBody[any](httpResp)
+	return types.ParseResponseBody[any](httpResp, c.client.Logger())
 }

--- a/internal/clients/database/dbaas.go
+++ b/internal/clients/database/dbaas.go
@@ -49,7 +49,7 @@ func (c *dbaasClientImpl) List(ctx context.Context, projectID string, params *ty
 	}
 	defer httpResp.Body.Close()
 
-	return types.ParseResponseBody[types.DBaaSList](httpResp)
+	return types.ParseResponseBody[types.DBaaSList](httpResp, c.client.Logger())
 }
 
 // Get retrieves a specific DBaaS instance by ID
@@ -79,7 +79,7 @@ func (c *dbaasClientImpl) Get(ctx context.Context, projectID string, dbaasID str
 	}
 	defer httpResp.Body.Close()
 
-	return types.ParseResponseBody[types.DBaaSResponse](httpResp)
+	return types.ParseResponseBody[types.DBaaSResponse](httpResp, c.client.Logger())
 }
 
 // Create creates a new DBaaS instance
@@ -237,5 +237,5 @@ func (c *dbaasClientImpl) Delete(ctx context.Context, projectID string, dbaasID 
 	}
 	defer httpResp.Body.Close()
 
-	return types.ParseResponseBody[any](httpResp)
+	return types.ParseResponseBody[any](httpResp, c.client.Logger())
 }

--- a/internal/clients/database/grant.go
+++ b/internal/clients/database/grant.go
@@ -50,7 +50,7 @@ func (c *grantsClientImpl) List(ctx context.Context, projectID string, dbaasID s
 	}
 	defer httpResp.Body.Close()
 
-	return types.ParseResponseBody[types.GrantList](httpResp)
+	return types.ParseResponseBody[types.GrantList](httpResp, c.client.Logger())
 }
 
 // Get retrieves a specific grant by ID
@@ -80,7 +80,7 @@ func (c *grantsClientImpl) Get(ctx context.Context, projectID string, dbaasID st
 	}
 	defer httpResp.Body.Close()
 
-	return types.ParseResponseBody[types.GrantResponse](httpResp)
+	return types.ParseResponseBody[types.GrantResponse](httpResp, c.client.Logger())
 }
 
 // Create creates a new grant for a database
@@ -238,5 +238,5 @@ func (c *grantsClientImpl) Delete(ctx context.Context, projectID string, dbaasID
 	}
 	defer httpResp.Body.Close()
 
-	return types.ParseResponseBody[any](httpResp)
+	return types.ParseResponseBody[any](httpResp, c.client.Logger())
 }

--- a/internal/clients/database/user.go
+++ b/internal/clients/database/user.go
@@ -50,7 +50,7 @@ func (c *usersClientImpl) List(ctx context.Context, projectID string, dbaasID st
 	}
 	defer httpResp.Body.Close()
 
-	return types.ParseResponseBody[types.UserList](httpResp)
+	return types.ParseResponseBody[types.UserList](httpResp, c.client.Logger())
 }
 
 // Get retrieves a specific user by ID
@@ -80,7 +80,7 @@ func (c *usersClientImpl) Get(ctx context.Context, projectID string, dbaasID str
 	}
 	defer httpResp.Body.Close()
 
-	return types.ParseResponseBody[types.UserResponse](httpResp)
+	return types.ParseResponseBody[types.UserResponse](httpResp, c.client.Logger())
 }
 
 // Create creates a new user in a DBaaS instance
@@ -238,5 +238,5 @@ func (c *usersClientImpl) Delete(ctx context.Context, projectID string, dbaasID 
 	}
 	defer httpResp.Body.Close()
 
-	return types.ParseResponseBody[any](httpResp)
+	return types.ParseResponseBody[any](httpResp, c.client.Logger())
 }

--- a/internal/clients/metric/alert.go
+++ b/internal/clients/metric/alert.go
@@ -47,5 +47,5 @@ func (c *alertsClientImpl) List(ctx context.Context, projectID string, params *t
 	}
 	defer httpResp.Body.Close()
 
-	return types.ParseResponseBody[types.AlertsListResponse](httpResp)
+	return types.ParseResponseBody[types.AlertsListResponse](httpResp, c.client.Logger())
 }

--- a/internal/clients/metric/metric.go
+++ b/internal/clients/metric/metric.go
@@ -47,5 +47,5 @@ func (c *metricssClientImpl) List(ctx context.Context, projectID string, params 
 	}
 	defer httpResp.Body.Close()
 
-	return types.ParseResponseBody[types.MetricListResponse](httpResp)
+	return types.ParseResponseBody[types.MetricListResponse](httpResp, c.client.Logger())
 }

--- a/internal/clients/network/elastic-ip.go
+++ b/internal/clients/network/elastic-ip.go
@@ -49,7 +49,7 @@ func (c *elasticIPsClientImpl) List(ctx context.Context, projectID string, param
 	}
 	defer httpResp.Body.Close()
 
-	return types.ParseResponseBody[types.ElasticList](httpResp)
+	return types.ParseResponseBody[types.ElasticList](httpResp, c.client.Logger())
 }
 
 // Get retrieves a specific elastic IP by ID
@@ -79,7 +79,7 @@ func (c *elasticIPsClientImpl) Get(ctx context.Context, projectID string, elasti
 	}
 	defer httpResp.Body.Close()
 
-	return types.ParseResponseBody[types.ElasticIPResponse](httpResp)
+	return types.ParseResponseBody[types.ElasticIPResponse](httpResp, c.client.Logger())
 }
 
 // Create creates a new elastic IP
@@ -115,7 +115,7 @@ func (c *elasticIPsClientImpl) Create(ctx context.Context, projectID string, bod
 	}
 	defer httpResp.Body.Close()
 
-	return types.ParseResponseBody[types.ElasticIPResponse](httpResp)
+	return types.ParseResponseBody[types.ElasticIPResponse](httpResp, c.client.Logger())
 }
 
 // Update updates an existing elastic IP
@@ -151,7 +151,7 @@ func (c *elasticIPsClientImpl) Update(ctx context.Context, projectID string, ela
 	}
 	defer httpResp.Body.Close()
 
-	return types.ParseResponseBody[types.ElasticIPResponse](httpResp)
+	return types.ParseResponseBody[types.ElasticIPResponse](httpResp, c.client.Logger())
 }
 
 // Delete deletes an elastic IP by ID
@@ -181,5 +181,5 @@ func (c *elasticIPsClientImpl) Delete(ctx context.Context, projectID string, ela
 	}
 	defer httpResp.Body.Close()
 
-	return types.ParseResponseBody[any](httpResp)
+	return types.ParseResponseBody[any](httpResp, c.client.Logger())
 }

--- a/internal/clients/network/load-balancer.go
+++ b/internal/clients/network/load-balancer.go
@@ -45,7 +45,7 @@ func (c *loadBalancersClientImpl) List(ctx context.Context, projectID string, pa
 	}
 	defer httpResp.Body.Close()
 
-	return types.ParseResponseBody[types.LoadBalancerList](httpResp)
+	return types.ParseResponseBody[types.LoadBalancerList](httpResp, c.client.Logger())
 }
 
 // Get retrieves a specific load balancer by ID
@@ -73,5 +73,5 @@ func (c *loadBalancersClientImpl) Get(ctx context.Context, projectID string, loa
 	}
 	defer httpResp.Body.Close()
 
-	return types.ParseResponseBody[types.LoadBalancerResponse](httpResp)
+	return types.ParseResponseBody[types.LoadBalancerResponse](httpResp, c.client.Logger())
 }

--- a/internal/clients/network/security-group-rule.go
+++ b/internal/clients/network/security-group-rule.go
@@ -55,7 +55,7 @@ func (c *securityGroupRulesClientImpl) List(ctx context.Context, projectID strin
 	}
 	defer httpResp.Body.Close()
 
-	return types.ParseResponseBody[types.SecurityRuleList](httpResp)
+	return types.ParseResponseBody[types.SecurityRuleList](httpResp, c.client.Logger())
 }
 
 // Get retrieves a specific security group rule by ID
@@ -85,7 +85,7 @@ func (c *securityGroupRulesClientImpl) Get(ctx context.Context, projectID string
 	}
 	defer httpResp.Body.Close()
 
-	return types.ParseResponseBody[types.SecurityRuleResponse](httpResp)
+	return types.ParseResponseBody[types.SecurityRuleResponse](httpResp, c.client.Logger())
 }
 
 // Create creates a new security group rule
@@ -242,5 +242,5 @@ func (c *securityGroupRulesClientImpl) Delete(ctx context.Context, projectID str
 	}
 	defer httpResp.Body.Close()
 
-	return types.ParseResponseBody[any](httpResp)
+	return types.ParseResponseBody[any](httpResp, c.client.Logger())
 }

--- a/internal/clients/network/security-group.go
+++ b/internal/clients/network/security-group.go
@@ -55,7 +55,7 @@ func (c *securityGroupsClientImpl) List(ctx context.Context, projectID string, v
 	}
 	defer httpResp.Body.Close()
 
-	return types.ParseResponseBody[types.SecurityGroupList](httpResp)
+	return types.ParseResponseBody[types.SecurityGroupList](httpResp, c.client.Logger())
 }
 
 // Get retrieves a specific security group by ID
@@ -85,7 +85,7 @@ func (c *securityGroupsClientImpl) Get(ctx context.Context, projectID string, vp
 	}
 	defer httpResp.Body.Close()
 
-	return types.ParseResponseBody[types.SecurityGroupResponse](httpResp)
+	return types.ParseResponseBody[types.SecurityGroupResponse](httpResp, c.client.Logger())
 }
 
 // Create creates a new security group in a VPC
@@ -242,5 +242,5 @@ func (c *securityGroupsClientImpl) Delete(ctx context.Context, projectID string,
 	}
 	defer httpResp.Body.Close()
 
-	return types.ParseResponseBody[any](httpResp)
+	return types.ParseResponseBody[any](httpResp, c.client.Logger())
 }

--- a/internal/clients/network/subnet.go
+++ b/internal/clients/network/subnet.go
@@ -55,7 +55,7 @@ func (c *subnetsClientImpl) List(ctx context.Context, projectID string, vpcID st
 	}
 	defer httpResp.Body.Close()
 
-	return types.ParseResponseBody[types.SubnetList](httpResp)
+	return types.ParseResponseBody[types.SubnetList](httpResp, c.client.Logger())
 }
 
 // Get retrieves a specific subnet by ID
@@ -85,7 +85,7 @@ func (c *subnetsClientImpl) Get(ctx context.Context, projectID string, vpcID str
 	}
 	defer httpResp.Body.Close()
 
-	return types.ParseResponseBody[types.SubnetResponse](httpResp)
+	return types.ParseResponseBody[types.SubnetResponse](httpResp, c.client.Logger())
 }
 
 // Create creates a new subnet in a VPC
@@ -241,5 +241,5 @@ func (c *subnetsClientImpl) Delete(ctx context.Context, projectID string, vpcID 
 	}
 	defer httpResp.Body.Close()
 
-	return types.ParseResponseBody[any](httpResp)
+	return types.ParseResponseBody[any](httpResp, c.client.Logger())
 }

--- a/internal/clients/network/vpc-peering-route.go
+++ b/internal/clients/network/vpc-peering-route.go
@@ -50,7 +50,7 @@ func (c *vpcPeeringRoutesClientImpl) List(ctx context.Context, projectID string,
 	}
 	defer httpResp.Body.Close()
 
-	return types.ParseResponseBody[types.VPCPeeringRouteList](httpResp)
+	return types.ParseResponseBody[types.VPCPeeringRouteList](httpResp, c.client.Logger())
 }
 
 // Get retrieves a specific VPC peering route by ID
@@ -80,7 +80,7 @@ func (c *vpcPeeringRoutesClientImpl) Get(ctx context.Context, projectID string, 
 	}
 	defer httpResp.Body.Close()
 
-	return types.ParseResponseBody[types.VPCPeeringRouteResponse](httpResp)
+	return types.ParseResponseBody[types.VPCPeeringRouteResponse](httpResp, c.client.Logger())
 }
 
 // Create creates a new VPC peering route
@@ -230,5 +230,5 @@ func (c *vpcPeeringRoutesClientImpl) Delete(ctx context.Context, projectID strin
 	}
 	defer httpResp.Body.Close()
 
-	return types.ParseResponseBody[any](httpResp)
+	return types.ParseResponseBody[any](httpResp, c.client.Logger())
 }

--- a/internal/clients/network/vpc-peering.go
+++ b/internal/clients/network/vpc-peering.go
@@ -50,7 +50,7 @@ func (c *vpcPeeringsClientImpl) List(ctx context.Context, projectID string, vpcI
 	}
 	defer httpResp.Body.Close()
 
-	return types.ParseResponseBody[types.VPCPeeringList](httpResp)
+	return types.ParseResponseBody[types.VPCPeeringList](httpResp, c.client.Logger())
 }
 
 // Get retrieves a specific VPC peering by ID
@@ -80,7 +80,7 @@ func (c *vpcPeeringsClientImpl) Get(ctx context.Context, projectID string, vpcID
 	}
 	defer httpResp.Body.Close()
 
-	return types.ParseResponseBody[types.VPCPeeringResponse](httpResp)
+	return types.ParseResponseBody[types.VPCPeeringResponse](httpResp, c.client.Logger())
 }
 
 // Create creates a new VPC peering
@@ -230,5 +230,5 @@ func (c *vpcPeeringsClientImpl) Delete(ctx context.Context, projectID string, vp
 	}
 	defer httpResp.Body.Close()
 
-	return types.ParseResponseBody[any](httpResp)
+	return types.ParseResponseBody[any](httpResp, c.client.Logger())
 }

--- a/internal/clients/network/vpc.go
+++ b/internal/clients/network/vpc.go
@@ -50,7 +50,7 @@ func (c *vpcsClientImpl) List(ctx context.Context, projectID string, params *typ
 	}
 	defer httpResp.Body.Close()
 
-	return types.ParseResponseBody[types.VPCList](httpResp)
+	return types.ParseResponseBody[types.VPCList](httpResp, c.client.Logger())
 }
 
 // Get retrieves a specific VPC by ID
@@ -80,7 +80,7 @@ func (c *vpcsClientImpl) Get(ctx context.Context, projectID string, vpcID string
 	}
 	defer httpResp.Body.Close()
 
-	return types.ParseResponseBody[types.VPCResponse](httpResp)
+	return types.ParseResponseBody[types.VPCResponse](httpResp, c.client.Logger())
 }
 
 // Create creates a new VPC
@@ -230,5 +230,5 @@ func (c *vpcsClientImpl) Delete(ctx context.Context, projectID string, vpcID str
 	}
 	defer httpResp.Body.Close()
 
-	return types.ParseResponseBody[any](httpResp)
+	return types.ParseResponseBody[any](httpResp, c.client.Logger())
 }

--- a/internal/clients/network/vpn-route.go
+++ b/internal/clients/network/vpn-route.go
@@ -50,7 +50,7 @@ func (c *vpnRoutesClientImpl) List(ctx context.Context, projectID string, vpnTun
 	}
 	defer httpResp.Body.Close()
 
-	return types.ParseResponseBody[types.VPNRouteList](httpResp)
+	return types.ParseResponseBody[types.VPNRouteList](httpResp, c.client.Logger())
 }
 
 // Get retrieves a specific VPN route by ID
@@ -80,7 +80,7 @@ func (c *vpnRoutesClientImpl) Get(ctx context.Context, projectID string, vpnTunn
 	}
 	defer httpResp.Body.Close()
 
-	return types.ParseResponseBody[types.VPNRouteResponse](httpResp)
+	return types.ParseResponseBody[types.VPNRouteResponse](httpResp, c.client.Logger())
 }
 
 // Create creates a new VPN route in a VPN tunnel
@@ -230,5 +230,5 @@ func (c *vpnRoutesClientImpl) Delete(ctx context.Context, projectID string, vpnT
 	}
 	defer httpResp.Body.Close()
 
-	return types.ParseResponseBody[any](httpResp)
+	return types.ParseResponseBody[any](httpResp, c.client.Logger())
 }

--- a/internal/clients/network/vpn-tunnel.go
+++ b/internal/clients/network/vpn-tunnel.go
@@ -50,7 +50,7 @@ func (c *vpnTunnelsClientImpl) List(ctx context.Context, projectID string, param
 	}
 	defer httpResp.Body.Close()
 
-	return types.ParseResponseBody[types.VPNTunnelList](httpResp)
+	return types.ParseResponseBody[types.VPNTunnelList](httpResp, c.client.Logger())
 }
 
 // Get retrieves a specific VPN tunnel by ID
@@ -80,7 +80,7 @@ func (c *vpnTunnelsClientImpl) Get(ctx context.Context, projectID string, vpnTun
 	}
 	defer httpResp.Body.Close()
 
-	return types.ParseResponseBody[types.VPNTunnelResponse](httpResp)
+	return types.ParseResponseBody[types.VPNTunnelResponse](httpResp, c.client.Logger())
 }
 
 // Create creates a new VPN tunnel
@@ -230,5 +230,5 @@ func (c *vpnTunnelsClientImpl) Delete(ctx context.Context, projectID string, vpn
 	}
 	defer httpResp.Body.Close()
 
-	return types.ParseResponseBody[any](httpResp)
+	return types.ParseResponseBody[any](httpResp, c.client.Logger())
 }

--- a/internal/clients/project/project.go
+++ b/internal/clients/project/project.go
@@ -47,7 +47,7 @@ func (c *projectsClientImpl) List(ctx context.Context, params *types.RequestPara
 	}
 	defer httpResp.Body.Close()
 
-	return types.ParseResponseBody[types.ProjectList](httpResp)
+	return types.ParseResponseBody[types.ProjectList](httpResp, c.client.Logger())
 }
 
 // Get retrieves a specific project by ID
@@ -77,7 +77,7 @@ func (c *projectsClientImpl) Get(ctx context.Context, projectID string, params *
 	}
 	defer httpResp.Body.Close()
 
-	return types.ParseResponseBody[types.ProjectResponse](httpResp)
+	return types.ParseResponseBody[types.ProjectResponse](httpResp, c.client.Logger())
 }
 
 // Create creates a new project

--- a/internal/clients/schedule/job.go
+++ b/internal/clients/schedule/job.go
@@ -50,7 +50,7 @@ func (c *jobsClientImpl) List(ctx context.Context, projectID string, params *typ
 	}
 	defer httpResp.Body.Close()
 
-	return types.ParseResponseBody[types.JobList](httpResp)
+	return types.ParseResponseBody[types.JobList](httpResp, c.client.Logger())
 }
 
 // Get retrieves a specific schedule job by ID
@@ -80,7 +80,7 @@ func (c *jobsClientImpl) Get(ctx context.Context, projectID string, scheduleJobI
 	}
 	defer httpResp.Body.Close()
 
-	return types.ParseResponseBody[types.JobResponse](httpResp)
+	return types.ParseResponseBody[types.JobResponse](httpResp, c.client.Logger())
 }
 
 // Create creates a new schedule job
@@ -230,5 +230,5 @@ func (c *jobsClientImpl) Delete(ctx context.Context, projectID string, scheduleJ
 	}
 	defer httpResp.Body.Close()
 
-	return types.ParseResponseBody[any](httpResp)
+	return types.ParseResponseBody[any](httpResp, c.client.Logger())
 }

--- a/internal/clients/security/key.go
+++ b/internal/clients/security/key.go
@@ -51,7 +51,7 @@ func (c *KeyClientImpl) List(ctx context.Context, projectID string, kmsID string
 	}
 	defer httpResp.Body.Close()
 
-	return types.ParseResponseBody[types.KeyList](httpResp)
+	return types.ParseResponseBody[types.KeyList](httpResp, c.client.Logger())
 }
 
 // Get retrieves a specific Key by ID
@@ -85,7 +85,7 @@ func (c *KeyClientImpl) Get(ctx context.Context, projectID string, kmsID string,
 	}
 	defer httpResp.Body.Close()
 
-	return types.ParseResponseBody[types.KeyResponse](httpResp)
+	return types.ParseResponseBody[types.KeyResponse](httpResp, c.client.Logger())
 }
 
 // Create creates a new Key for a KMS instance
@@ -179,5 +179,5 @@ func (c *KeyClientImpl) Delete(ctx context.Context, projectID string, kmsID stri
 	}
 	defer httpResp.Body.Close()
 
-	return types.ParseResponseBody[any](httpResp)
+	return types.ParseResponseBody[any](httpResp, c.client.Logger())
 }

--- a/internal/clients/security/kmip.go
+++ b/internal/clients/security/kmip.go
@@ -51,7 +51,7 @@ func (c *KmipClientImpl) List(ctx context.Context, projectID string, kmsID strin
 	}
 	defer httpResp.Body.Close()
 
-	return types.ParseResponseBody[types.KmipList](httpResp)
+	return types.ParseResponseBody[types.KmipList](httpResp, c.client.Logger())
 }
 
 // Get retrieves a specific KMIP service by ID
@@ -85,7 +85,7 @@ func (c *KmipClientImpl) Get(ctx context.Context, projectID string, kmsID string
 	}
 	defer httpResp.Body.Close()
 
-	return types.ParseResponseBody[types.KmipResponse](httpResp)
+	return types.ParseResponseBody[types.KmipResponse](httpResp, c.client.Logger())
 }
 
 // Create creates a new KMIP service for a KMS instance
@@ -179,7 +179,7 @@ func (c *KmipClientImpl) Delete(ctx context.Context, projectID string, kmsID str
 	}
 	defer httpResp.Body.Close()
 
-	return types.ParseResponseBody[any](httpResp)
+	return types.ParseResponseBody[any](httpResp, c.client.Logger())
 }
 
 // Download downloads the KMIP certificate (key and cert) for a specific KMIP service
@@ -213,5 +213,5 @@ func (c *KmipClientImpl) Download(ctx context.Context, projectID string, kmsID s
 	}
 	defer httpResp.Body.Close()
 
-	return types.ParseResponseBody[types.KmipCertificateResponse](httpResp)
+	return types.ParseResponseBody[types.KmipCertificateResponse](httpResp, c.client.Logger())
 }

--- a/internal/clients/security/kms.go
+++ b/internal/clients/security/kms.go
@@ -51,7 +51,7 @@ func (c *kmsClientImpl) List(ctx context.Context, projectID string, params *type
 	}
 	defer httpResp.Body.Close()
 
-	return types.ParseResponseBody[types.KmsList](httpResp)
+	return types.ParseResponseBody[types.KmsList](httpResp, c.client.Logger())
 }
 
 // Get retrieves a specific KMS instance by ID
@@ -81,7 +81,7 @@ func (c *kmsClientImpl) Get(ctx context.Context, projectID string, kmsID string,
 	}
 	defer httpResp.Body.Close()
 
-	return types.ParseResponseBody[types.KmsResponse](httpResp)
+	return types.ParseResponseBody[types.KmsResponse](httpResp, c.client.Logger())
 }
 
 // Create creates a new KMS instance
@@ -231,5 +231,5 @@ func (c *kmsClientImpl) Delete(ctx context.Context, projectID string, kmsID stri
 	}
 	defer httpResp.Body.Close()
 
-	return types.ParseResponseBody[any](httpResp)
+	return types.ParseResponseBody[any](httpResp, c.client.Logger())
 }

--- a/internal/clients/storage/backup.go
+++ b/internal/clients/storage/backup.go
@@ -51,7 +51,7 @@ func (c *backupClientImpl) List(ctx context.Context, projectID string, params *t
 	}
 	defer httpResp.Body.Close()
 
-	return types.ParseResponseBody[types.StorageBackupList](httpResp)
+	return types.ParseResponseBody[types.StorageBackupList](httpResp, c.client.Logger())
 }
 
 // Get retrieves a specific Storage Backup by ID
@@ -81,7 +81,7 @@ func (c *backupClientImpl) Get(ctx context.Context, projectID string, backupID s
 	}
 	defer httpResp.Body.Close()
 
-	return types.ParseResponseBody[types.StorageBackupResponse](httpResp)
+	return types.ParseResponseBody[types.StorageBackupResponse](httpResp, c.client.Logger())
 }
 
 // Create creates a new Storage Backup
@@ -231,5 +231,5 @@ func (c *backupClientImpl) Delete(ctx context.Context, projectID string, backupI
 	}
 	defer httpResp.Body.Close()
 
-	return types.ParseResponseBody[any](httpResp)
+	return types.ParseResponseBody[any](httpResp, c.client.Logger())
 }

--- a/internal/clients/storage/block-storage.go
+++ b/internal/clients/storage/block-storage.go
@@ -48,7 +48,7 @@ func (c *volumesClientImpl) Update(ctx context.Context, projectID string, volume
 	}
 	defer httpResp.Body.Close()
 
-	return types.ParseResponseBody[types.BlockStorageResponse](httpResp)
+	return types.ParseResponseBody[types.BlockStorageResponse](httpResp, c.client.Logger())
 }
 
 // NewVolumesClientImpl creates a new unified Storage service
@@ -85,7 +85,7 @@ func (c *volumesClientImpl) List(ctx context.Context, projectID string, params *
 	}
 	defer httpResp.Body.Close()
 
-	return types.ParseResponseBody[types.BlockStorageList](httpResp)
+	return types.ParseResponseBody[types.BlockStorageList](httpResp, c.client.Logger())
 }
 
 // Get retrieves a specific block storage volume by ID
@@ -115,7 +115,7 @@ func (c *volumesClientImpl) Get(ctx context.Context, projectID string, volumeID 
 	}
 	defer httpResp.Body.Close()
 
-	return types.ParseResponseBody[types.BlockStorageResponse](httpResp)
+	return types.ParseResponseBody[types.BlockStorageResponse](httpResp, c.client.Logger())
 }
 
 // Create creates a new block storage volume
@@ -151,7 +151,7 @@ func (c *volumesClientImpl) Create(ctx context.Context, projectID string, body t
 	}
 	defer httpResp.Body.Close()
 
-	return types.ParseResponseBody[types.BlockStorageResponse](httpResp)
+	return types.ParseResponseBody[types.BlockStorageResponse](httpResp, c.client.Logger())
 }
 
 // Delete deletes a block storage volume by ID
@@ -181,5 +181,5 @@ func (c *volumesClientImpl) Delete(ctx context.Context, projectID string, volume
 	}
 	defer httpResp.Body.Close()
 
-	return types.ParseResponseBody[any](httpResp)
+	return types.ParseResponseBody[any](httpResp, c.client.Logger())
 }

--- a/internal/clients/storage/restore.go
+++ b/internal/clients/storage/restore.go
@@ -55,7 +55,7 @@ func (c *restoreClientImpl) List(ctx context.Context, projectID string, backupID
 	}
 	defer httpResp.Body.Close()
 
-	return types.ParseResponseBody[types.RestoreList](httpResp)
+	return types.ParseResponseBody[types.RestoreList](httpResp, c.client.Logger())
 }
 
 // Get retrieves a specific Restore by ID
@@ -87,7 +87,7 @@ func (c *restoreClientImpl) Get(ctx context.Context, projectID string, backupID 
 	}
 	defer httpResp.Body.Close()
 
-	return types.ParseResponseBody[types.RestoreResponse](httpResp)
+	return types.ParseResponseBody[types.RestoreResponse](httpResp, c.client.Logger())
 }
 
 // Create creates a new Restore
@@ -246,5 +246,5 @@ func (c *restoreClientImpl) Delete(ctx context.Context, projectID string, backup
 	}
 	defer httpResp.Body.Close()
 
-	return types.ParseResponseBody[any](httpResp)
+	return types.ParseResponseBody[any](httpResp, c.client.Logger())
 }

--- a/internal/clients/storage/snapshot.go
+++ b/internal/clients/storage/snapshot.go
@@ -50,7 +50,7 @@ func (c *snapshotsClientImpl) Update(ctx context.Context, projectID string, snap
 	}
 	defer httpResp.Body.Close()
 
-	return types.ParseResponseBody[types.SnapshotResponse](httpResp)
+	return types.ParseResponseBody[types.SnapshotResponse](httpResp, c.client.Logger())
 }
 
 // NewSnapshotsClientImpl creates a new unified Storage service
@@ -91,7 +91,7 @@ func (c *snapshotsClientImpl) List(ctx context.Context, projectID string, params
 	}
 	defer httpResp.Body.Close()
 
-	return types.ParseResponseBody[types.SnapshotList](httpResp)
+	return types.ParseResponseBody[types.SnapshotList](httpResp, c.client.Logger())
 }
 
 // Get retrieves a specific snapshot by ID
@@ -121,7 +121,7 @@ func (c *snapshotsClientImpl) Get(ctx context.Context, projectID string, snapsho
 	}
 	defer httpResp.Body.Close()
 
-	return types.ParseResponseBody[types.SnapshotResponse](httpResp)
+	return types.ParseResponseBody[types.SnapshotResponse](httpResp, c.client.Logger())
 }
 
 // Create creates a new snapshot
@@ -171,7 +171,7 @@ func (c *snapshotsClientImpl) Create(ctx context.Context, projectID string, body
 	}
 	defer httpResp.Body.Close()
 
-	return types.ParseResponseBody[types.SnapshotResponse](httpResp)
+	return types.ParseResponseBody[types.SnapshotResponse](httpResp, c.client.Logger())
 }
 
 // Delete deletes a snapshot by ID
@@ -201,7 +201,7 @@ func (c *snapshotsClientImpl) Delete(ctx context.Context, projectID string, snap
 	}
 	defer httpResp.Body.Close()
 
-	return types.ParseResponseBody[any](httpResp)
+	return types.ParseResponseBody[any](httpResp, c.client.Logger())
 }
 
 // extractVolumeIDFromURI extracts the volume ID from a volume URI

--- a/pkg/types/utils.go
+++ b/pkg/types/utils.go
@@ -7,11 +7,20 @@ import (
 	"net/http"
 )
 
+// DebugLogger is the minimal logging interface required by ParseResponseBody.
+// It is satisfied by internal/ports/logger.Logger and any type that implements Debugf,
+// so pkg/types does not need to import the internal logger package.
+type DebugLogger interface {
+	Debugf(format string, args ...interface{})
+}
+
 // ParseResponseBody reads and parses the HTTP response body into the Response struct.
 // For 2xx responses, it unmarshals into Data field.
 // For 4xx/5xx responses, it unmarshals into Error field.
 // Always stores the raw body in RawBody field.
-func ParseResponseBody[T any](httpResp *http.Response) (*Response[T], error) {
+// When the error body cannot be parsed as JSON, a DEBUG message is emitted via logger;
+// this is expected behaviour for APIs that return non-JSON bodies (e.g. proxy HTML pages).
+func ParseResponseBody[T any](httpResp *http.Response, logger DebugLogger) (*Response[T], error) {
 	if httpResp == nil {
 		return nil, fmt.Errorf("http response is nil")
 	}
@@ -39,7 +48,9 @@ func ParseResponseBody[T any](httpResp *http.Response) (*Response[T], error) {
 		response.Data = &data
 	} else if response.IsError() && len(bodyBytes) > 0 {
 		var errorResp ErrorResponse
-		if err := json.Unmarshal(bodyBytes, &errorResp); err == nil {
+		if err := json.Unmarshal(bodyBytes, &errorResp); err != nil {
+			logger.Debugf("ParseResponseBody: failed to unmarshal error body (status %d): %v; inspect RawBody for the raw response", httpResp.StatusCode, err)
+		} else {
 			response.Error = &errorResp
 		}
 	}

--- a/pkg/types/utils_test.go
+++ b/pkg/types/utils_test.go
@@ -1,0 +1,103 @@
+package types
+
+import (
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+)
+
+// captureLogger records Debugf calls for assertion in tests.
+type captureLogger struct {
+	msgs []string
+}
+
+func (l *captureLogger) Debugf(format string, args ...interface{}) {
+	l.msgs = append(l.msgs, fmt.Sprintf(format, args...))
+}
+
+func makeHTTPResponse(statusCode int, body string) *http.Response {
+	return &http.Response{
+		StatusCode: statusCode,
+		Body:       io.NopCloser(strings.NewReader(body)),
+		Header:     http.Header{},
+	}
+}
+
+func TestParseResponseBody(t *testing.T) {
+	t.Run("2xx with valid JSON sets Data, no debug message", func(t *testing.T) {
+		logger := &captureLogger{}
+		resp, err := ParseResponseBody[map[string]string](
+			makeHTTPResponse(200, `{"key":"value"}`),
+			logger,
+		)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if resp.Data == nil || (*resp.Data)["key"] != "value" {
+			t.Errorf("expected Data to be set with parsed JSON")
+		}
+		if resp.Error != nil {
+			t.Errorf("expected Error to be nil for 2xx response")
+		}
+		if len(logger.msgs) != 0 {
+			t.Errorf("expected no debug messages, got %d: %v", len(logger.msgs), logger.msgs)
+		}
+	})
+
+	t.Run("4xx with valid JSON error body sets Error, no debug message", func(t *testing.T) {
+		logger := &captureLogger{}
+		body := `{"code":"NOT_FOUND","message":"resource not found"}`
+		resp, err := ParseResponseBody[map[string]string](
+			makeHTTPResponse(404, body),
+			logger,
+		)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if resp.Error == nil {
+			t.Errorf("expected Error to be set for 4xx response with valid JSON")
+		}
+		if resp.Data != nil {
+			t.Errorf("expected Data to be nil for 4xx response")
+		}
+		if len(logger.msgs) != 0 {
+			t.Errorf("expected no debug messages, got %d: %v", len(logger.msgs), logger.msgs)
+		}
+	})
+
+	t.Run("4xx with non-JSON body leaves Error nil and emits one debug message", func(t *testing.T) {
+		logger := &captureLogger{}
+		resp, err := ParseResponseBody[map[string]string](
+			makeHTTPResponse(502, "<html><body>Bad Gateway</body></html>"),
+			logger,
+		)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if resp.Error != nil {
+			t.Errorf("expected Error to be nil when body is not JSON")
+		}
+		if len(resp.RawBody) == 0 {
+			t.Errorf("expected RawBody to be set even when JSON parse fails")
+		}
+		if len(logger.msgs) != 1 {
+			t.Fatalf("expected exactly 1 debug message, got %d: %v", len(logger.msgs), logger.msgs)
+		}
+		if !strings.Contains(logger.msgs[0], "502") {
+			t.Errorf("expected debug message to mention status code 502, got: %s", logger.msgs[0])
+		}
+	})
+
+	t.Run("nil httpResp returns error without panic", func(t *testing.T) {
+		logger := &captureLogger{}
+		resp, err := ParseResponseBody[map[string]string](nil, logger)
+		if err == nil {
+			t.Fatal("expected error for nil httpResp")
+		}
+		if resp != nil {
+			t.Errorf("expected nil response for nil httpResp")
+		}
+	})
+}


### PR DESCRIPTION
## Summary

Closes #121 (TD-011).

`ParseResponseBody` silently discarded the JSON unmarshal error when a 4xx/5xx response body could not be parsed, leaving `response.Error == nil` with no signal to callers.

## Fix

Log at **DEBUG** level when JSON unmarshal fails on an error body. The issue proposed WARN, but the user clarified that non-JSON error bodies (HTML from a proxy, plain-text 502s) are **expected behaviour** from this API — not programmer errors — so DEBUG is more appropriate.

## Design

`ParseResponseBody` is in `pkg/types`, which has no logger. Rather than importing `internal/ports/logger` into a types package, a minimal `DebugLogger` interface (one method: `Debugf`) is defined locally in `pkg/types`. Any type implementing `Debugf` satisfies it, including the existing `internal/ports/logger.Logger` that every client accesses via `c.client.Logger()`.

The logger is a **required** (non-variadic) parameter so the compiler enforces completeness — every missed call site is a build error. All 31 call-site files across `internal/clients/` were updated to pass their logger.

## Changes

- `pkg/types/utils.go` — `DebugLogger` interface + updated `ParseResponseBody` signature + debug log on unmarshal failure
- `pkg/types/utils_test.go` — 4 new tests (2xx success, 4xx valid JSON, 4xx non-JSON with debug message assertion, nil response)
- 31 `internal/clients/**/*.go` files — mechanical addition of `, c.client.Logger()` at each call site
- `ai/TECH_DEBT.md` — TD-011 moved to Resolved

## Test plan

- [x] `go test -v -run TestParseResponseBody ./pkg/types/...` — all 4 subtests pass
- [x] `go build ./...` — clean (confirmed all 31 call sites updated by compiler)
- [x] `make verify` — full lint + race-enabled suite passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)