### PR TITLE
[TD-020] Subtask 0 — Introduce internal/testutil shared test helpers

### DIFF
--- a/internal/testutil/httpserver.go
+++ b/internal/testutil/httpserver.go
@@ -23,7 +23,7 @@ func NewMockServer(t *testing.T, handler http.HandlerFunc) *httptest.Server {
 		if r.URL.Path == "/token" {
 			w.Header().Set("Content-Type", "application/json")
 			w.WriteHeader(http.StatusOK)
-			fmt.Fprint(w, cannedToken)
+			_, _ = fmt.Fprint(w, cannedToken)
 			return
 		}
 		handler(w, r)
@@ -56,10 +56,13 @@ func NewBrokenClient(t *testing.T, baseURL string) *restclient.Client {
 // ErrorBodyJSON returns a well-formed types.ErrorResponse JSON string fixture.
 func ErrorBodyJSON(title, detail string, status int) string {
 	s := int32(status)
-	b, _ := json.Marshal(types.ErrorResponse{
+	b, err := json.Marshal(types.ErrorResponse{
 		Title:  &title,
 		Detail: &detail,
 		Status: &s,
 	})
+	if err != nil {
+		panic(fmt.Sprintf("testutil.ErrorBodyJSON: marshal failed: %v", err))
+	}
 	return string(b)
 }

--- a/internal/testutil/httpserver.go
+++ b/internal/testutil/httpserver.go
@@ -1,0 +1,65 @@
+package testutil
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/Arubacloud/sdk-go/internal/impl/interceptor/standard"
+	"github.com/Arubacloud/sdk-go/internal/impl/logger/noop"
+	"github.com/Arubacloud/sdk-go/internal/restclient"
+	"github.com/Arubacloud/sdk-go/pkg/types"
+)
+
+const cannedToken = `{"access_token":"test-token","token_type":"Bearer","expires_in":3600}`
+
+// NewMockServer starts an httptest.Server that handles /token (returning a canned bearer token)
+// and delegates all other paths to handler. Registers t.Cleanup(s.Close).
+func NewMockServer(t *testing.T, handler http.HandlerFunc) *httptest.Server {
+	t.Helper()
+	s := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/token" {
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusOK)
+			fmt.Fprint(w, cannedToken)
+			return
+		}
+		handler(w, r)
+	}))
+	t.Cleanup(s.Close)
+	return s
+}
+
+// NewClient builds a restclient.Client pointed at baseURL with standard interceptor and noop logger.
+func NewClient(t *testing.T, baseURL string) *restclient.Client {
+	t.Helper()
+	return restclient.NewClient(baseURL, http.DefaultClient, standard.NewInterceptor(), &noop.NoOpLogger{})
+}
+
+// ErrRoundTripper is an http.RoundTripper that returns Err on every call.
+type ErrRoundTripper struct{ Err error }
+
+func (e ErrRoundTripper) RoundTrip(*http.Request) (*http.Response, error) {
+	return nil, e.Err
+}
+
+// NewBrokenClient returns a client whose transport always returns an error, allowing
+// tests to verify network-error handling without racing a server.Close().
+func NewBrokenClient(t *testing.T, baseURL string) *restclient.Client {
+	t.Helper()
+	broken := &http.Client{Transport: ErrRoundTripper{Err: fmt.Errorf("connection refused")}}
+	return restclient.NewClient(baseURL, broken, standard.NewInterceptor(), &noop.NoOpLogger{})
+}
+
+// ErrorBodyJSON returns a well-formed types.ErrorResponse JSON string fixture.
+func ErrorBodyJSON(title, detail string, status int) string {
+	s := int32(status)
+	b, _ := json.Marshal(types.ErrorResponse{
+		Title:  &title,
+		Detail: &detail,
+		Status: &s,
+	})
+	return string(b)
+}

--- a/internal/testutil/httpserver.go
+++ b/internal/testutil/httpserver.go
@@ -23,7 +23,9 @@ func NewMockServer(t *testing.T, handler http.HandlerFunc) *httptest.Server {
 		if r.URL.Path == "/token" {
 			w.Header().Set("Content-Type", "application/json")
 			w.WriteHeader(http.StatusOK)
-			_, _ = fmt.Fprint(w, cannedToken)
+			if _, err := fmt.Fprint(w, cannedToken); err != nil {
+				t.Errorf("mock server: failed to write token: %v", err)
+			}
 			return
 		}
 		handler(w, r)

--- a/internal/testutil/httpserver_test.go
+++ b/internal/testutil/httpserver_test.go
@@ -1,0 +1,58 @@
+package testutil
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"testing"
+
+	"github.com/Arubacloud/sdk-go/pkg/types"
+)
+
+func TestNewMockServer(t *testing.T) {
+	t.Run("token endpoint returns canned bearer token", func(t *testing.T) {
+		called := false
+		s := NewMockServer(t, func(w http.ResponseWriter, r *http.Request) {
+			called = true
+			w.WriteHeader(http.StatusOK)
+		})
+
+		c := NewClient(t, s.URL)
+		resp, err := c.DoRequest(context.Background(), http.MethodGet, "/anything", nil, nil, nil)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		resp.Body.Close()
+		if !called {
+			t.Error("handler was not called")
+		}
+	})
+
+	t.Run("NewBrokenClient returns network error", func(t *testing.T) {
+		s := NewMockServer(t, func(w http.ResponseWriter, r *http.Request) {})
+
+		c := NewBrokenClient(t, s.URL)
+		_, err := c.DoRequest(context.Background(), http.MethodGet, "/anything", nil, nil, nil)
+		if err == nil {
+			t.Fatal("expected an error from broken client, got nil")
+		}
+	})
+
+	t.Run("ErrorBodyJSON produces parseable ErrorResponse", func(t *testing.T) {
+		body := ErrorBodyJSON("Not Found", "resource does not exist", 404)
+		if body == "" {
+			t.Fatal("expected non-empty JSON")
+		}
+
+		var e types.ErrorResponse
+		if err := json.Unmarshal([]byte(body), &e); err != nil {
+			t.Fatalf("ErrorBodyJSON produced invalid JSON: %v", err)
+		}
+		if e.Title == nil || *e.Title != "Not Found" {
+			t.Errorf("unexpected title: %v", e.Title)
+		}
+		if e.Status == nil || *e.Status != 404 {
+			t.Errorf("unexpected status: %v", e.Status)
+		}
+	})
+}


### PR DESCRIPTION
## Summary
- Adds `internal/testutil/httpserver.go` with shared helpers for client error-path tests
- `NewMockServer` auto-intercepts `/token` with a canned bearer token and registers `t.Cleanup`
- `NewClient` centralises the `restclient.NewClient(...)` wiring (currently copy-pasted ~22 times)
- `NewBrokenClient` + `ErrRoundTripper` enable deterministic network-error testing
- `ErrorBodyJSON` produces a valid `types.ErrorResponse` JSON fixture for 4xx/5xx scenarios

## Test plan
- [ ] `go test ./internal/testutil/... -count=1 -race -v` — all 3 self-tests pass
- [ ] `go test ./... ` — full repo stays green

Closes #148 · Part of #130

🤖 Generated with [Claude Code](https://claude.com/claude-code)