### PR TITLE
[TD-020] Subtask 1 — Error-path coverage: audit

### DIFF
--- a/internal/clients/audit/event_test.go
+++ b/internal/clients/audit/event_test.go
@@ -3,27 +3,18 @@ package audit
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"net/http"
-	"net/http/httptest"
 	"testing"
 	"time"
 
-	"github.com/Arubacloud/sdk-go/internal/impl/interceptor/standard"
-	"github.com/Arubacloud/sdk-go/internal/impl/logger/noop"
-	"github.com/Arubacloud/sdk-go/internal/restclient"
+	"github.com/Arubacloud/sdk-go/internal/testutil"
 	"github.com/Arubacloud/sdk-go/pkg/types"
 )
 
 func TestListEvents(t *testing.T) {
 	t.Run("successful list", func(t *testing.T) {
-		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			if r.URL.Path == "/token" {
-				w.Header().Set("Content-Type", "application/json")
-				w.WriteHeader(http.StatusOK)
-				w.Write([]byte(`{"access_token":"test-token","token_type":"Bearer","expires_in":3600}`))
-				return
-			}
-
+		server := testutil.NewMockServer(t, func(w http.ResponseWriter, r *http.Request) {
 			if r.Method == "GET" && r.URL.Path == "/projects/test-project/providers/Aruba.Audit/events" {
 				w.WriteHeader(http.StatusOK)
 				resp := types.AuditEventListResponse{
@@ -69,19 +60,9 @@ func TestListEvents(t *testing.T) {
 				json.NewEncoder(w).Encode(resp)
 				return
 			}
-
 			http.NotFound(w, r)
-		}))
-		defer server.Close()
-
-		var (
-			baseURL    = server.URL
-			httpClient = http.DefaultClient
-			logger     = &noop.NoOpLogger{}
-		)
-
-		c := restclient.NewClient(baseURL, httpClient, standard.NewInterceptor(), logger)
-
+		})
+		c := testutil.NewClient(t, server.URL)
 		svc := NewEventsClientImpl(c)
 
 		resp, err := svc.List(context.Background(), "test-project", nil)
@@ -100,14 +81,7 @@ func TestListEvents(t *testing.T) {
 	})
 
 	t.Run("empty list", func(t *testing.T) {
-		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			if r.URL.Path == "/token" {
-				w.Header().Set("Content-Type", "application/json")
-				w.WriteHeader(http.StatusOK)
-				w.Write([]byte(`{"access_token":"test-token","token_type":"Bearer","expires_in":3600}`))
-				return
-			}
-
+		server := testutil.NewMockServer(t, func(w http.ResponseWriter, r *http.Request) {
 			if r.Method == "GET" && r.URL.Path == "/projects/test-project/providers/Aruba.Audit/events" {
 				w.WriteHeader(http.StatusOK)
 				resp := types.AuditEventListResponse{
@@ -117,19 +91,9 @@ func TestListEvents(t *testing.T) {
 				json.NewEncoder(w).Encode(resp)
 				return
 			}
-
 			http.NotFound(w, r)
-		}))
-		defer server.Close()
-
-		var (
-			baseURL    = server.URL
-			httpClient = http.DefaultClient
-			logger     = &noop.NoOpLogger{}
-		)
-
-		c := restclient.NewClient(baseURL, httpClient, standard.NewInterceptor(), logger)
-
+		})
+		c := testutil.NewClient(t, server.URL)
 		svc := NewEventsClientImpl(c)
 
 		resp, err := svc.List(context.Background(), "test-project", nil)
@@ -142,82 +106,43 @@ func TestListEvents(t *testing.T) {
 	})
 
 	t.Run("with pagination", func(t *testing.T) {
-		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			if r.URL.Path == "/token" {
-				w.Header().Set("Content-Type", "application/json")
-				w.WriteHeader(http.StatusOK)
-				w.Write([]byte(`{"access_token":"test-token","token_type":"Bearer","expires_in":3600}`))
-				return
-			}
-
+		server := testutil.NewMockServer(t, func(w http.ResponseWriter, r *http.Request) {
 			if r.Method == "GET" && r.URL.Path == "/projects/test-project/providers/Aruba.Audit/events" {
-				// Check pagination query params
 				limit := r.URL.Query().Get("limit")
 				offset := r.URL.Query().Get("offset")
-
 				if limit != "10" || offset != "5" {
 					t.Errorf("expected limit=10 and offset=5, got limit=%s and offset=%s", limit, offset)
 				}
-
 				w.WriteHeader(http.StatusOK)
 				resp := types.AuditEventListResponse{
-					ListResponse: types.ListResponse{
-						Total: 100,
-					},
+					ListResponse: types.ListResponse{Total: 100},
 					Values: []types.AuditEvent{
 						{
 							SeverityLevel: "Warning",
-							LogFormat: types.LogFormatVersion{
-								Version: "1.0",
-							},
-							Timestamp: time.Now(),
-							Operation: types.Operation{
-								ID: "test-operation",
-							},
-							Event: types.EventInfo{
-								ID:   "event-456",
-								Type: "operational",
-							},
-							Category: types.EventCategory{
-								Value: "Security",
-							},
-							Origin:  "system",
-							Channel: "Security",
-							Status: types.Status{
-								Value: "Failed",
-								Code:  types.Int32Ptr(403),
-							},
-							Identity: types.Identity{
-								Caller: types.Caller{
-									Subject: "system",
-								},
-							},
+							LogFormat:     types.LogFormatVersion{Version: "1.0"},
+							Timestamp:     time.Now(),
+							Operation:     types.Operation{ID: "test-operation"},
+							Event:         types.EventInfo{ID: "event-456", Type: "operational"},
+							Category:      types.EventCategory{Value: "Security"},
+							Origin:        "system",
+							Channel:       "Security",
+							Status:        types.Status{Value: "Failed", Code: types.Int32Ptr(403)},
+							Identity:      types.Identity{Caller: types.Caller{Subject: "system"}},
 						},
 					},
 				}
 				json.NewEncoder(w).Encode(resp)
 				return
 			}
-
 			http.NotFound(w, r)
-		}))
-		defer server.Close()
-
-		var (
-			baseURL    = server.URL
-			httpClient = http.DefaultClient
-			logger     = &noop.NoOpLogger{}
-		)
-
-		c := restclient.NewClient(baseURL, httpClient, standard.NewInterceptor(), logger)
-
+		})
+		c := testutil.NewClient(t, server.URL)
 		svc := NewEventsClientImpl(c)
 
 		params := &types.RequestParameters{
 			Limit:  types.Int32Ptr(10),
 			Offset: types.Int32Ptr(5),
 		}
-
 		resp, err := svc.List(context.Background(), "test-project", params)
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
@@ -230,6 +155,79 @@ func TestListEvents(t *testing.T) {
 		}
 		if len(resp.Data.Values) != 1 {
 			t.Errorf("expected 1 audit event, got %d", len(resp.Data.Values))
+		}
+	})
+
+	t.Run("not found", func(t *testing.T) {
+		server := testutil.NewMockServer(t, func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusNotFound)
+			fmt.Fprint(w, testutil.ErrorBodyJSON("Not Found", "project not found", 404))
+		})
+		c := testutil.NewClient(t, server.URL)
+		svc := NewEventsClientImpl(c)
+
+		resp, err := svc.List(context.Background(), "test-project", nil)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if resp == nil || resp.StatusCode != http.StatusNotFound {
+			t.Fatalf("expected 404 response")
+		}
+		if resp.Error == nil {
+			t.Fatalf("expected resp.Error to be populated")
+		}
+		if resp.Error.Title == nil || *resp.Error.Title != "Not Found" {
+			t.Errorf("expected title 'Not Found', got %v", resp.Error.Title)
+		}
+	})
+
+	t.Run("bad gateway non-json", func(t *testing.T) {
+		server := testutil.NewMockServer(t, func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusBadGateway)
+			fmt.Fprint(w, "Bad Gateway")
+		})
+		c := testutil.NewClient(t, server.URL)
+		svc := NewEventsClientImpl(c)
+
+		resp, err := svc.List(context.Background(), "test-project", nil)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if resp == nil || resp.StatusCode != http.StatusBadGateway {
+			t.Fatalf("expected 502 response")
+		}
+		if resp.Error != nil {
+			t.Errorf("expected resp.Error to be nil for non-JSON body, got %+v", resp.Error)
+		}
+		if string(resp.RawBody) != "Bad Gateway" {
+			t.Errorf("expected RawBody 'Bad Gateway', got %q", string(resp.RawBody))
+		}
+	})
+
+	t.Run("network error", func(t *testing.T) {
+		c := testutil.NewBrokenClient(t, "http://unused.invalid")
+		svc := NewEventsClientImpl(c)
+
+		_, err := svc.List(context.Background(), "test-project", nil)
+		if err == nil {
+			t.Fatal("expected a network error, got nil")
+		}
+	})
+
+	t.Run("nil params injects default api-version", func(t *testing.T) {
+		server := testutil.NewMockServer(t, func(w http.ResponseWriter, r *http.Request) {
+			if got := r.URL.Query().Get("api-version"); got != "1.0" {
+				t.Errorf("expected api-version=1.0, got %q", got)
+			}
+			w.WriteHeader(http.StatusOK)
+			fmt.Fprint(w, `{"total":0,"values":[]}`)
+		})
+		c := testutil.NewClient(t, server.URL)
+		svc := NewEventsClientImpl(c)
+
+		if _, err := svc.List(context.Background(), "test-project", nil); err != nil {
+			t.Fatalf("unexpected error: %v", err)
 		}
 	})
 }


### PR DESCRIPTION
## Summary
- Migrates 3× duplicated `/token` boilerplate in `event_test.go` to `testutil.NewMockServer` / `testutil.NewClient`
- Adds 4 error-path subtests to `TestListEvents`:
  - `not found` — 404 with JSON error body; asserts `resp.Error` is populated (TD-011 JSON branch)
  - `bad gateway non-json` — 502 with plain text; asserts `resp.Error == nil` and `resp.RawBody` preserved (TD-011 non-JSON branch)
  - `network error` — `testutil.NewBrokenClient`; asserts `err != nil`
  - `nil params injects default api-version` — asserts `api-version=1.0` reaches the server

This is the **template PR** for subtasks 2–10 — reviewers should use it as the canonical shape.

## Test plan
- [ ] `go test ./internal/clients/audit/... -count=1 -race -v` — 7 subtests pass (3 existing + 4 new)
- [ ] `go test ./internal/clients/audit/... -cover` — coverage increases vs. `main`
- [ ] `go test ./...` — full repo stays green

Closes #149 · Part of #130 · Depends on #148 (testutil — merged in #161)

🤖 Generated with [Claude Code](https://claude.com/claude-code)