### PR TITLE
test(project): migrate to testutil and add error-path coverage (TD-020, #149)

### DIFF
--- a/internal/clients/project/project_test.go
+++ b/internal/clients/project/project_test.go
@@ -3,27 +3,18 @@ package project
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"net/http"
-	"net/http/httptest"
 	"testing"
 
-	"github.com/Arubacloud/sdk-go/internal/impl/interceptor/standard"
-	"github.com/Arubacloud/sdk-go/internal/impl/logger/noop"
-	"github.com/Arubacloud/sdk-go/internal/restclient"
+	"github.com/Arubacloud/sdk-go/internal/testutil"
 	"github.com/Arubacloud/sdk-go/pkg/types"
 )
 
 func TestListProjects(t *testing.T) {
 	t.Run("successful list", func(t *testing.T) {
-		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			if r.URL.Path == "/token" {
-				w.Header().Set("Content-Type", "application/json")
-				w.WriteHeader(http.StatusOK)
-				w.Write([]byte(`{"access_token":"test-token","token_type":"Bearer","expires_in":3600}`))
-				return
-			}
-
-			if r.Method == "GET" && r.URL.Path == "/projects" {
+		server := testutil.NewMockServer(t, func(w http.ResponseWriter, r *http.Request) {
+			if r.Method == http.MethodGet && r.URL.Path == "/projects" {
 				w.WriteHeader(http.StatusOK)
 				resp := types.ProjectList{
 					ListResponse: types.ListResponse{Total: 2},
@@ -55,19 +46,9 @@ func TestListProjects(t *testing.T) {
 				json.NewEncoder(w).Encode(resp)
 				return
 			}
-
 			http.NotFound(w, r)
-		}))
-		defer server.Close()
-
-		var (
-			baseURL    = server.URL
-			httpClient = http.DefaultClient
-			logger     = &noop.NoOpLogger{}
-		)
-
-		c := restclient.NewClient(baseURL, httpClient, standard.NewInterceptor(), logger)
-
+		})
+		c := testutil.NewClient(t, server.URL)
 		svc := NewProjectsClientImpl(c)
 
 		resp, err := svc.List(context.Background(), nil)
@@ -87,19 +68,85 @@ func TestListProjects(t *testing.T) {
 			t.Errorf("expected 10 resources, got %d", resp.Data.Values[0].Properties.ResourcesNumber)
 		}
 	})
+
+	t.Run("not found", func(t *testing.T) {
+		server := testutil.NewMockServer(t, func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusNotFound)
+			fmt.Fprint(w, testutil.ErrorBodyJSON("Not Found", "project list not found", 404))
+		})
+		c := testutil.NewClient(t, server.URL)
+		svc := NewProjectsClientImpl(c)
+
+		resp, err := svc.List(context.Background(), nil)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if resp == nil || resp.StatusCode != http.StatusNotFound {
+			t.Fatalf("expected 404 response")
+		}
+		if resp.Error == nil {
+			t.Fatalf("expected resp.Error to be populated")
+		}
+		if resp.Error.Title == nil || *resp.Error.Title != "Not Found" {
+			t.Errorf("expected title 'Not Found', got %v", resp.Error.Title)
+		}
+	})
+
+	t.Run("bad gateway non-json", func(t *testing.T) {
+		server := testutil.NewMockServer(t, func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusBadGateway)
+			fmt.Fprint(w, "Bad Gateway")
+		})
+		c := testutil.NewClient(t, server.URL)
+		svc := NewProjectsClientImpl(c)
+
+		resp, err := svc.List(context.Background(), nil)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if resp == nil || resp.StatusCode != http.StatusBadGateway {
+			t.Fatalf("expected 502 response")
+		}
+		if resp.Error != nil {
+			t.Errorf("expected resp.Error to be nil for non-JSON body, got %+v", resp.Error)
+		}
+		if string(resp.RawBody) != "Bad Gateway" {
+			t.Errorf("expected RawBody 'Bad Gateway', got %q", string(resp.RawBody))
+		}
+	})
+
+	t.Run("network error", func(t *testing.T) {
+		c := testutil.NewBrokenClient(t, "http://unused.invalid")
+		svc := NewProjectsClientImpl(c)
+
+		_, err := svc.List(context.Background(), nil)
+		if err == nil {
+			t.Fatal("expected a network error, got nil")
+		}
+	})
+
+	t.Run("nil params injects default api-version", func(t *testing.T) {
+		server := testutil.NewMockServer(t, func(w http.ResponseWriter, r *http.Request) {
+			if got := r.URL.Query().Get("api-version"); got != "1.0" {
+				t.Errorf("expected api-version=1.0, got %q", got)
+			}
+			w.WriteHeader(http.StatusOK)
+			fmt.Fprint(w, `{"total":0,"values":[]}`)
+		})
+		c := testutil.NewClient(t, server.URL)
+		svc := NewProjectsClientImpl(c)
+
+		if _, err := svc.List(context.Background(), nil); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
 }
 
 func TestGetProject(t *testing.T) {
 	t.Run("successful get", func(t *testing.T) {
-		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			if r.URL.Path == "/token" {
-				w.Header().Set("Content-Type", "application/json")
-				w.WriteHeader(http.StatusOK)
-				w.Write([]byte(`{"access_token":"test-token","token_type":"Bearer","expires_in":3600}`))
-				return
-			}
-
-			if r.Method == "GET" && r.URL.Path == "/projects/project-123" {
+		server := testutil.NewMockServer(t, func(w http.ResponseWriter, r *http.Request) {
+			if r.Method == http.MethodGet && r.URL.Path == "/projects/project-123" {
 				w.WriteHeader(http.StatusOK)
 				resp := types.ProjectResponse{
 					Metadata: types.ResourceMetadataResponse{
@@ -115,19 +162,9 @@ func TestGetProject(t *testing.T) {
 				json.NewEncoder(w).Encode(resp)
 				return
 			}
-
 			http.NotFound(w, r)
-		}))
-		defer server.Close()
-
-		var (
-			baseURL    = server.URL
-			httpClient = http.DefaultClient
-			logger     = &noop.NoOpLogger{}
-		)
-
-		c := restclient.NewClient(baseURL, httpClient, standard.NewInterceptor(), logger)
-
+		})
+		c := testutil.NewClient(t, server.URL)
 		svc := NewProjectsClientImpl(c)
 
 		resp, err := svc.Get(context.Background(), "project-123", nil)
@@ -147,19 +184,106 @@ func TestGetProject(t *testing.T) {
 			t.Errorf("expected project to not be default")
 		}
 	})
+
+	t.Run("not found", func(t *testing.T) {
+		server := testutil.NewMockServer(t, func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusNotFound)
+			fmt.Fprint(w, testutil.ErrorBodyJSON("Not Found", "project not found", 404))
+		})
+		c := testutil.NewClient(t, server.URL)
+		svc := NewProjectsClientImpl(c)
+
+		resp, err := svc.Get(context.Background(), "project-123", nil)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if resp == nil || resp.StatusCode != http.StatusNotFound {
+			t.Fatalf("expected 404 response")
+		}
+		if resp.Error == nil {
+			t.Fatalf("expected resp.Error to be populated")
+		}
+		if resp.Error.Title == nil || *resp.Error.Title != "Not Found" {
+			t.Errorf("expected title 'Not Found', got %v", resp.Error.Title)
+		}
+	})
+
+	t.Run("bad gateway non-json", func(t *testing.T) {
+		server := testutil.NewMockServer(t, func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusBadGateway)
+			fmt.Fprint(w, "Bad Gateway")
+		})
+		c := testutil.NewClient(t, server.URL)
+		svc := NewProjectsClientImpl(c)
+
+		resp, err := svc.Get(context.Background(), "project-123", nil)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if resp == nil || resp.StatusCode != http.StatusBadGateway {
+			t.Fatalf("expected 502 response")
+		}
+		if resp.Error != nil {
+			t.Errorf("expected resp.Error to be nil for non-JSON body, got %+v", resp.Error)
+		}
+		if string(resp.RawBody) != "Bad Gateway" {
+			t.Errorf("expected RawBody 'Bad Gateway', got %q", string(resp.RawBody))
+		}
+	})
+
+	t.Run("network error", func(t *testing.T) {
+		c := testutil.NewBrokenClient(t, "http://unused.invalid")
+		svc := NewProjectsClientImpl(c)
+
+		_, err := svc.Get(context.Background(), "project-123", nil)
+		if err == nil {
+			t.Fatal("expected a network error, got nil")
+		}
+	})
+
+	t.Run("nil params injects default api-version", func(t *testing.T) {
+		server := testutil.NewMockServer(t, func(w http.ResponseWriter, r *http.Request) {
+			if got := r.URL.Query().Get("api-version"); got != "1.0" {
+				t.Errorf("expected api-version=1.0, got %q", got)
+			}
+			w.WriteHeader(http.StatusOK)
+			resp := types.ProjectResponse{
+				Metadata: types.ResourceMetadataResponse{
+					Name: types.StringPtr("my-project"),
+					ID:   types.StringPtr("project-123"),
+				},
+				Properties: types.ProjectPropertiesResponse{
+					Description:     types.StringPtr("My test project"),
+					Default:         false,
+					ResourcesNumber: 15,
+				},
+			}
+			json.NewEncoder(w).Encode(resp)
+		})
+		c := testutil.NewClient(t, server.URL)
+		svc := NewProjectsClientImpl(c)
+
+		if _, err := svc.Get(context.Background(), "project-123", nil); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
+
+	t.Run("empty project ID", func(t *testing.T) {
+		c := testutil.NewClient(t, "http://unused.invalid")
+		svc := NewProjectsClientImpl(c)
+
+		_, err := svc.Get(context.Background(), "", nil)
+		if err == nil {
+			t.Fatal("expected an error for empty project ID")
+		}
+	})
 }
 
 func TestCreateProject(t *testing.T) {
 	t.Run("successful create", func(t *testing.T) {
-		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			if r.URL.Path == "/token" {
-				w.Header().Set("Content-Type", "application/json")
-				w.WriteHeader(http.StatusOK)
-				w.Write([]byte(`{"access_token":"test-token","token_type":"Bearer","expires_in":3600}`))
-				return
-			}
-
-			if r.Method == "POST" && r.URL.Path == "/projects" {
+		server := testutil.NewMockServer(t, func(w http.ResponseWriter, r *http.Request) {
+			if r.Method == http.MethodPost && r.URL.Path == "/projects" {
 				w.WriteHeader(http.StatusCreated)
 				resp := types.ProjectResponse{
 					Metadata: types.ResourceMetadataResponse{
@@ -175,19 +299,9 @@ func TestCreateProject(t *testing.T) {
 				json.NewEncoder(w).Encode(resp)
 				return
 			}
-
 			http.NotFound(w, r)
-		}))
-		defer server.Close()
-
-		var (
-			baseURL    = server.URL
-			httpClient = http.DefaultClient
-			logger     = &noop.NoOpLogger{}
-		)
-
-		c := restclient.NewClient(baseURL, httpClient, standard.NewInterceptor(), logger)
-
+		})
+		c := testutil.NewClient(t, server.URL)
 		svc := NewProjectsClientImpl(c)
 
 		body := types.ProjectRequest{
@@ -211,19 +325,117 @@ func TestCreateProject(t *testing.T) {
 			t.Errorf("expected name 'new-project'")
 		}
 	})
+
+	t.Run("not found", func(t *testing.T) {
+		server := testutil.NewMockServer(t, func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusNotFound)
+			fmt.Fprint(w, testutil.ErrorBodyJSON("Not Found", "project not found", 404))
+		})
+		c := testutil.NewClient(t, server.URL)
+		svc := NewProjectsClientImpl(c)
+
+		body := types.ProjectRequest{
+			Metadata: types.ResourceMetadataRequest{Name: "new-project"},
+		}
+
+		resp, err := svc.Create(context.Background(), body, nil)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if resp == nil || resp.StatusCode != http.StatusNotFound {
+			t.Fatalf("expected 404 response")
+		}
+		if resp.Error == nil {
+			t.Fatalf("expected resp.Error to be populated")
+		}
+		if resp.Error.Title == nil || *resp.Error.Title != "Not Found" {
+			t.Errorf("expected title 'Not Found', got %v", resp.Error.Title)
+		}
+	})
+
+	t.Run("bad gateway non-json", func(t *testing.T) {
+		server := testutil.NewMockServer(t, func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusBadGateway)
+			fmt.Fprint(w, "Bad Gateway")
+		})
+		c := testutil.NewClient(t, server.URL)
+		svc := NewProjectsClientImpl(c)
+
+		body := types.ProjectRequest{
+			Metadata: types.ResourceMetadataRequest{Name: "new-project"},
+		}
+
+		resp, err := svc.Create(context.Background(), body, nil)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if resp == nil || resp.StatusCode != http.StatusBadGateway {
+			t.Fatalf("expected 502 response")
+		}
+		// TD-010: Create swallows unmarshal failures for non-JSON error bodies; RawBody is the contract here.
+		if resp.Error != nil {
+			t.Errorf("expected resp.Error to be nil for non-JSON body, got %+v", resp.Error)
+		}
+		if string(resp.RawBody) != "Bad Gateway" {
+			t.Errorf("expected RawBody 'Bad Gateway', got %q", string(resp.RawBody))
+		}
+	})
+
+	t.Run("network error", func(t *testing.T) {
+		c := testutil.NewBrokenClient(t, "http://unused.invalid")
+		svc := NewProjectsClientImpl(c)
+
+		body := types.ProjectRequest{
+			Metadata: types.ResourceMetadataRequest{Name: "new-project"},
+		}
+
+		_, err := svc.Create(context.Background(), body, nil)
+		if err == nil {
+			t.Fatal("expected a network error, got nil")
+		}
+	})
+
+	t.Run("nil params injects default api-version", func(t *testing.T) {
+		server := testutil.NewMockServer(t, func(w http.ResponseWriter, r *http.Request) {
+			if got := r.URL.Query().Get("api-version"); got != "1.0" {
+				t.Errorf("expected api-version=1.0, got %q", got)
+			}
+			w.WriteHeader(http.StatusCreated)
+			resp := types.ProjectResponse{
+				Metadata: types.ResourceMetadataResponse{
+					Name: types.StringPtr("new-project"),
+					ID:   types.StringPtr("project-789"),
+				},
+				Properties: types.ProjectPropertiesResponse{
+					Description:     types.StringPtr("A new project"),
+					Default:         false,
+					ResourcesNumber: 0,
+				},
+			}
+			json.NewEncoder(w).Encode(resp)
+		})
+		c := testutil.NewClient(t, server.URL)
+		svc := NewProjectsClientImpl(c)
+
+		body := types.ProjectRequest{
+			Metadata: types.ResourceMetadataRequest{Name: "new-project"},
+			Properties: types.ProjectPropertiesRequest{
+				Description: types.StringPtr("A new project"),
+				Default:     false,
+			},
+		}
+
+		if _, err := svc.Create(context.Background(), body, nil); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
 }
 
 func TestUpdateProject(t *testing.T) {
 	t.Run("successful update", func(t *testing.T) {
-		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			if r.URL.Path == "/token" {
-				w.Header().Set("Content-Type", "application/json")
-				w.WriteHeader(http.StatusOK)
-				w.Write([]byte(`{"access_token":"test-token","token_type":"Bearer","expires_in":3600}`))
-				return
-			}
-
-			if r.Method == "PUT" && r.URL.Path == "/projects/project-123" {
+		server := testutil.NewMockServer(t, func(w http.ResponseWriter, r *http.Request) {
+			if r.Method == http.MethodPut && r.URL.Path == "/projects/project-123" {
 				w.WriteHeader(http.StatusOK)
 				resp := types.ProjectResponse{
 					Metadata: types.ResourceMetadataResponse{
@@ -239,19 +451,9 @@ func TestUpdateProject(t *testing.T) {
 				json.NewEncoder(w).Encode(resp)
 				return
 			}
-
 			http.NotFound(w, r)
-		}))
-		defer server.Close()
-
-		var (
-			baseURL    = server.URL
-			httpClient = http.DefaultClient
-			logger     = &noop.NoOpLogger{}
-		)
-
-		c := restclient.NewClient(baseURL, httpClient, standard.NewInterceptor(), logger)
-
+		})
+		c := testutil.NewClient(t, server.URL)
 		svc := NewProjectsClientImpl(c)
 
 		body := types.ProjectRequest{
@@ -278,40 +480,224 @@ func TestUpdateProject(t *testing.T) {
 			t.Errorf("expected description 'Updated description'")
 		}
 	})
+
+	t.Run("not found", func(t *testing.T) {
+		server := testutil.NewMockServer(t, func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusNotFound)
+			fmt.Fprint(w, testutil.ErrorBodyJSON("Not Found", "project not found", 404))
+		})
+		c := testutil.NewClient(t, server.URL)
+		svc := NewProjectsClientImpl(c)
+
+		body := types.ProjectRequest{
+			Metadata: types.ResourceMetadataRequest{Name: "updated-project"},
+		}
+
+		resp, err := svc.Update(context.Background(), "project-123", body, nil)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if resp == nil || resp.StatusCode != http.StatusNotFound {
+			t.Fatalf("expected 404 response")
+		}
+		if resp.Error == nil {
+			t.Fatalf("expected resp.Error to be populated")
+		}
+		if resp.Error.Title == nil || *resp.Error.Title != "Not Found" {
+			t.Errorf("expected title 'Not Found', got %v", resp.Error.Title)
+		}
+	})
+
+	t.Run("bad gateway non-json", func(t *testing.T) {
+		server := testutil.NewMockServer(t, func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusBadGateway)
+			fmt.Fprint(w, "Bad Gateway")
+		})
+		c := testutil.NewClient(t, server.URL)
+		svc := NewProjectsClientImpl(c)
+
+		body := types.ProjectRequest{
+			Metadata: types.ResourceMetadataRequest{Name: "updated-project"},
+		}
+
+		resp, err := svc.Update(context.Background(), "project-123", body, nil)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if resp == nil || resp.StatusCode != http.StatusBadGateway {
+			t.Fatalf("expected 502 response")
+		}
+		// TD-010: Update swallows unmarshal failures for non-JSON error bodies; RawBody is the contract here.
+		if resp.Error != nil {
+			t.Errorf("expected resp.Error to be nil for non-JSON body, got %+v", resp.Error)
+		}
+		if string(resp.RawBody) != "Bad Gateway" {
+			t.Errorf("expected RawBody 'Bad Gateway', got %q", string(resp.RawBody))
+		}
+	})
+
+	t.Run("network error", func(t *testing.T) {
+		c := testutil.NewBrokenClient(t, "http://unused.invalid")
+		svc := NewProjectsClientImpl(c)
+
+		body := types.ProjectRequest{
+			Metadata: types.ResourceMetadataRequest{Name: "updated-project"},
+		}
+
+		_, err := svc.Update(context.Background(), "project-123", body, nil)
+		if err == nil {
+			t.Fatal("expected a network error, got nil")
+		}
+	})
+
+	t.Run("nil params injects default api-version", func(t *testing.T) {
+		server := testutil.NewMockServer(t, func(w http.ResponseWriter, r *http.Request) {
+			if got := r.URL.Query().Get("api-version"); got != "1.0" {
+				t.Errorf("expected api-version=1.0, got %q", got)
+			}
+			w.WriteHeader(http.StatusOK)
+			resp := types.ProjectResponse{
+				Metadata: types.ResourceMetadataResponse{
+					Name: types.StringPtr("updated-project"),
+					ID:   types.StringPtr("project-123"),
+				},
+				Properties: types.ProjectPropertiesResponse{
+					Description:     types.StringPtr("Updated description"),
+					Default:         false,
+					ResourcesNumber: 15,
+				},
+			}
+			json.NewEncoder(w).Encode(resp)
+		})
+		c := testutil.NewClient(t, server.URL)
+		svc := NewProjectsClientImpl(c)
+
+		body := types.ProjectRequest{
+			Metadata: types.ResourceMetadataRequest{Name: "updated-project"},
+			Properties: types.ProjectPropertiesRequest{
+				Description: types.StringPtr("Updated description"),
+				Default:     false,
+			},
+		}
+
+		if _, err := svc.Update(context.Background(), "project-123", body, nil); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
+
+	t.Run("empty project ID", func(t *testing.T) {
+		c := testutil.NewClient(t, "http://unused.invalid")
+		svc := NewProjectsClientImpl(c)
+
+		body := types.ProjectRequest{
+			Metadata: types.ResourceMetadataRequest{Name: "updated-project"},
+		}
+
+		_, err := svc.Update(context.Background(), "", body, nil)
+		if err == nil {
+			t.Fatal("expected an error for empty project ID")
+		}
+	})
 }
 
 func TestDeleteProject(t *testing.T) {
 	t.Run("successful delete", func(t *testing.T) {
-		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			if r.URL.Path == "/token" {
-				w.Header().Set("Content-Type", "application/json")
-				w.WriteHeader(http.StatusOK)
-				w.Write([]byte(`{"access_token":"test-token","token_type":"Bearer","expires_in":3600}`))
-				return
-			}
-
-			if r.Method == "DELETE" && r.URL.Path == "/projects/project-123" {
+		server := testutil.NewMockServer(t, func(w http.ResponseWriter, r *http.Request) {
+			if r.Method == http.MethodDelete && r.URL.Path == "/projects/project-123" {
 				w.WriteHeader(http.StatusNoContent)
 				return
 			}
-
 			http.NotFound(w, r)
-		}))
-		defer server.Close()
-
-		var (
-			baseURL    = server.URL
-			httpClient = http.DefaultClient
-			logger     = &noop.NoOpLogger{}
-		)
-
-		c := restclient.NewClient(baseURL, httpClient, standard.NewInterceptor(), logger)
-
+		})
+		c := testutil.NewClient(t, server.URL)
 		svc := NewProjectsClientImpl(c)
 
 		_, err := svc.Delete(context.Background(), "project-123", nil)
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
+		}
+	})
+
+	t.Run("not found", func(t *testing.T) {
+		server := testutil.NewMockServer(t, func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusNotFound)
+			fmt.Fprint(w, testutil.ErrorBodyJSON("Not Found", "project not found", 404))
+		})
+		c := testutil.NewClient(t, server.URL)
+		svc := NewProjectsClientImpl(c)
+
+		resp, err := svc.Delete(context.Background(), "project-123", nil)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if resp == nil || resp.StatusCode != http.StatusNotFound {
+			t.Fatalf("expected 404 response")
+		}
+		if resp.Error != nil {
+			t.Errorf("expected resp.Error to be nil because Delete does not parse error bodies, got %+v", resp.Error)
+		}
+		if string(resp.RawBody) != testutil.ErrorBodyJSON("Not Found", "project not found", 404) {
+			t.Errorf("expected RawBody to preserve the JSON error payload, got %q", string(resp.RawBody))
+		}
+	})
+
+	t.Run("bad gateway non-json", func(t *testing.T) {
+		server := testutil.NewMockServer(t, func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusBadGateway)
+			fmt.Fprint(w, "Bad Gateway")
+		})
+		c := testutil.NewClient(t, server.URL)
+		svc := NewProjectsClientImpl(c)
+
+		resp, err := svc.Delete(context.Background(), "project-123", nil)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if resp == nil || resp.StatusCode != http.StatusBadGateway {
+			t.Fatalf("expected 502 response")
+		}
+		if resp.Error != nil {
+			t.Errorf("expected resp.Error to be nil because Delete does not parse error bodies, got %+v", resp.Error)
+		}
+		if string(resp.RawBody) != "Bad Gateway" {
+			t.Errorf("expected RawBody 'Bad Gateway', got %q", string(resp.RawBody))
+		}
+	})
+
+	t.Run("network error", func(t *testing.T) {
+		c := testutil.NewBrokenClient(t, "http://unused.invalid")
+		svc := NewProjectsClientImpl(c)
+
+		_, err := svc.Delete(context.Background(), "project-123", nil)
+		if err == nil {
+			t.Fatal("expected a network error, got nil")
+		}
+	})
+
+	t.Run("nil params injects default api-version", func(t *testing.T) {
+		server := testutil.NewMockServer(t, func(w http.ResponseWriter, r *http.Request) {
+			if got := r.URL.Query().Get("api-version"); got != "1.0" {
+				t.Errorf("expected api-version=1.0, got %q", got)
+			}
+			w.WriteHeader(http.StatusNoContent)
+		})
+		c := testutil.NewClient(t, server.URL)
+		svc := NewProjectsClientImpl(c)
+
+		if _, err := svc.Delete(context.Background(), "project-123", nil); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
+
+	t.Run("empty project ID", func(t *testing.T) {
+		c := testutil.NewClient(t, "http://unused.invalid")
+		svc := NewProjectsClientImpl(c)
+
+		_, err := svc.Delete(context.Background(), "", nil)
+		if err == nil {
+			t.Fatal("expected an error for empty project ID")
 		}
 	})
 }


### PR DESCRIPTION
## Summary

Closes #157. Migrates `internal/clients/project/project_test.go` off its inline `httptest.NewServer` + `/token` + `standard.NewInterceptor()` boilerplate onto the shared `internal/testutil` helpers, and adds the TD-020 standard error matrix to every verb (List / Get / Create / Update / Delete).

## Why this matters

The issue spells out the subtask exactly: mirror the canonical shape you landed in `db96bde test(audit): migrate to testutil and add error-path coverage (TD-020, #149)`. That change established the template — `testutil.NewMockServer`, `testutil.NewClient`, `testutil.NewBrokenClient`, `testutil.ErrorBodyJSON`, and the same five-subtest pattern per verb. This PR applies the template to `project` without touching production code.

Two references in the issue body called out:

- `project.go:129-134` silently swallows the unmarshal error for non-JSON 4xx/5xx bodies. The `bad gateway non-json` subtests on `TestCreateProject` and `TestUpdateProject` include the requested `// TD-010` comment documenting this divergence from `ParseResponseBody`.
- `Get`, `Update`, and `Delete` take a `projectID`, so each picks up the additional `empty project ID` subtest on top of the four standard ones.

## Changes

One file touched: `internal/clients/project/project_test.go` (+493 / -107).

Per-verb subtest coverage after this PR:

| Verb | successful | not found | bad gateway non-json | network error | nil params | empty project ID |
|------|:---:|:---:|:---:|:---:|:---:|:---:|
| List    | ✓ | ✓ | ✓ | ✓ | ✓ | — |
| Get     | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ |
| Create  | ✓ | ✓ | ✓ (TD-010) | ✓ | ✓ | — |
| Update  | ✓ | ✓ | ✓ (TD-010) | ✓ | ✓ | ✓ |
| Delete  | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ |

Happy-path assertions carried over from the existing tests; nothing removed.

## Testing

- `go test ./internal/clients/project/... -count=1 -race` - ok.
- `go test ./internal/clients/project/... -cover` - ok, coverage 84.3% of statements.
- `go vet ./internal/clients/project/...` - clean.
- `gofmt -l internal/clients/project/project_test.go` - no diffs.

Closes #157

_This contribution was developed with AI assistance (Codex)._
