### PR TITLE
[TD-020] Subtask 2 — Error-path coverage: compute

### DIFF
--- a/internal/clients/compute/cloudserver_test.go
+++ b/internal/clients/compute/cloudserver_test.go
@@ -4,52 +4,29 @@ import (
 	"context"
 	"encoding/base64"
 	"encoding/json"
+	"fmt"
 	"net/http"
-	"net/http/httptest"
 	"testing"
 
-	"github.com/Arubacloud/sdk-go/internal/impl/interceptor/standard"
-	"github.com/Arubacloud/sdk-go/internal/impl/logger/noop"
-	"github.com/Arubacloud/sdk-go/internal/restclient"
+	"github.com/Arubacloud/sdk-go/internal/testutil"
 	"github.com/Arubacloud/sdk-go/pkg/types"
 )
 
-// TestListCloudServers tests the ListCloudServers method
 func TestListCloudServers(t *testing.T) {
 	t.Run("successful list", func(t *testing.T) {
 		apiCalled := false
-
-		// Create mock server that handles both token and API calls
-		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			if r.URL.Path == "/token" {
-				w.Header().Set("Content-Type", "application/json")
-				w.WriteHeader(http.StatusOK)
-				w.Write([]byte(`{"access_token":"test-token","token_type":"Bearer","expires_in":3600}`))
-				return
-			}
-
+		server := testutil.NewMockServer(t, func(w http.ResponseWriter, r *http.Request) {
 			apiCalled = true
 			w.WriteHeader(http.StatusOK)
 			resp := types.CloudServerList{
 				ListResponse: types.ListResponse{Total: 2},
 				Values: []types.CloudServerResponse{
-					{Metadata: types.ResourceMetadataResponse{
-						Name: types.StringPtr("server-1"),
-					}},
+					{Metadata: types.ResourceMetadataResponse{Name: types.StringPtr("server-1")}},
 				},
 			}
 			json.NewEncoder(w).Encode(resp)
-		}))
-		defer server.Close()
-
-		var (
-			baseURL    = server.URL
-			httpClient = http.DefaultClient
-			logger     = &noop.NoOpLogger{}
-		)
-
-		c := restclient.NewClient(baseURL, httpClient, standard.NewInterceptor(), logger)
-
+		})
+		c := testutil.NewClient(t, server.URL)
 		svc := NewCloudServersClientImpl(c)
 
 		resp, err := svc.List(context.Background(), "test-project", nil)
@@ -65,61 +42,95 @@ func TestListCloudServers(t *testing.T) {
 	})
 
 	t.Run("empty project ID", func(t *testing.T) {
-		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			if r.URL.Path == "/token" {
-				w.Header().Set("Content-Type", "application/json")
-				w.WriteHeader(http.StatusOK)
-				w.Write([]byte(`{"access_token":"test-token","token_type":"Bearer","expires_in":3600}`))
-				return
-			}
-		}))
-		defer server.Close()
-
-		var (
-			baseURL    = server.URL
-			httpClient = http.DefaultClient
-			logger     = &noop.NoOpLogger{}
-		)
-
-		c := restclient.NewClient(baseURL, httpClient, standard.NewInterceptor(), logger)
-
+		c := testutil.NewClient(t, "http://unused.invalid")
 		svc := NewCloudServersClientImpl(c)
-
 		_, err := svc.List(context.Background(), "", nil)
 		if err == nil {
 			t.Error("expected error for empty project ID")
 		}
 	})
-} // TestGetCloudServer tests the GetCloudServer method
+
+	t.Run("not found", func(t *testing.T) {
+		server := testutil.NewMockServer(t, func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusNotFound)
+			fmt.Fprint(w, testutil.ErrorBodyJSON("Not Found", "resource not found", 404))
+		})
+		c := testutil.NewClient(t, server.URL)
+		svc := NewCloudServersClientImpl(c)
+		resp, err := svc.List(context.Background(), "test-project", nil)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if resp == nil || resp.StatusCode != http.StatusNotFound {
+			t.Fatalf("expected 404 response")
+		}
+		if resp.Error == nil {
+			t.Fatalf("expected resp.Error to be populated")
+		}
+		if resp.Error.Title == nil || *resp.Error.Title != "Not Found" {
+			t.Errorf("expected title 'Not Found', got %v", resp.Error.Title)
+		}
+	})
+
+	t.Run("bad gateway non-json", func(t *testing.T) {
+		server := testutil.NewMockServer(t, func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusBadGateway)
+			fmt.Fprint(w, "Bad Gateway")
+		})
+		c := testutil.NewClient(t, server.URL)
+		svc := NewCloudServersClientImpl(c)
+		resp, err := svc.List(context.Background(), "test-project", nil)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if resp == nil || resp.StatusCode != http.StatusBadGateway {
+			t.Fatalf("expected 502 response")
+		}
+		if resp.Error != nil {
+			t.Errorf("expected resp.Error to be nil for non-JSON body, got %+v", resp.Error)
+		}
+		if string(resp.RawBody) != "Bad Gateway" {
+			t.Errorf("expected RawBody 'Bad Gateway', got %q", string(resp.RawBody))
+		}
+	})
+
+	t.Run("network error", func(t *testing.T) {
+		c := testutil.NewBrokenClient(t, "http://unused.invalid")
+		svc := NewCloudServersClientImpl(c)
+		_, err := svc.List(context.Background(), "test-project", nil)
+		if err == nil {
+			t.Fatal("expected a network error, got nil")
+		}
+	})
+
+	t.Run("nil params injects default api-version", func(t *testing.T) {
+		server := testutil.NewMockServer(t, func(w http.ResponseWriter, r *http.Request) {
+			if got := r.URL.Query().Get("api-version"); got != "1.0" {
+				t.Errorf("expected api-version=1.0, got %q", got)
+			}
+			w.WriteHeader(http.StatusOK)
+			fmt.Fprint(w, `{"total":0,"values":[]}`)
+		})
+		c := testutil.NewClient(t, server.URL)
+		svc := NewCloudServersClientImpl(c)
+		if _, err := svc.List(context.Background(), "test-project", nil); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
+}
+
 func TestGetCloudServer(t *testing.T) {
 	t.Run("successful get", func(t *testing.T) {
-		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			if r.URL.Path == "/token" {
-				w.Header().Set("Content-Type", "application/json")
-				w.WriteHeader(http.StatusOK)
-				w.Write([]byte(`{"access_token":"test-token","token_type":"Bearer","expires_in":3600}`))
-				return
-			}
-
+		server := testutil.NewMockServer(t, func(w http.ResponseWriter, r *http.Request) {
 			w.WriteHeader(http.StatusOK)
 			resp := types.CloudServerResponse{
-				Metadata: types.ResourceMetadataResponse{
-					Name: types.StringPtr("my-server"),
-				},
+				Metadata:   types.ResourceMetadataResponse{Name: types.StringPtr("my-server")},
 				Properties: types.CloudServerPropertiesResult{Zone: "ITBG-1"},
 			}
 			json.NewEncoder(w).Encode(resp)
-		}))
-		defer server.Close()
-
-		var (
-			baseURL    = server.URL
-			httpClient = http.DefaultClient
-			logger     = &noop.NoOpLogger{}
-		)
-
-		c := restclient.NewClient(baseURL, httpClient, standard.NewInterceptor(), logger)
-
+		})
+		c := testutil.NewClient(t, server.URL)
 		svc := NewCloudServersClientImpl(c)
 
 		resp, err := svc.Get(context.Background(), "test-project", "server-123", nil)
@@ -132,83 +143,111 @@ func TestGetCloudServer(t *testing.T) {
 	})
 
 	t.Run("empty project ID", func(t *testing.T) {
-		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			if r.URL.Path == "/token" {
-				w.Header().Set("Content-Type", "application/json")
-				w.WriteHeader(http.StatusOK)
-				w.Write([]byte(`{"access_token":"test-token","token_type":"Bearer","expires_in":3600}`))
-				return
-			}
-		}))
-		defer server.Close()
-
-		var (
-			baseURL    = server.URL
-			httpClient = http.DefaultClient
-			logger     = &noop.NoOpLogger{}
-		)
-
-		c := restclient.NewClient(baseURL, httpClient, standard.NewInterceptor(), logger)
-
+		c := testutil.NewClient(t, "http://unused.invalid")
 		svc := NewCloudServersClientImpl(c)
-
 		_, err := svc.Get(context.Background(), "", "server-123", nil)
 		if err == nil {
 			t.Error("expected error for empty project ID")
 		}
 	})
+
+	t.Run("not found", func(t *testing.T) {
+		server := testutil.NewMockServer(t, func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusNotFound)
+			fmt.Fprint(w, testutil.ErrorBodyJSON("Not Found", "resource not found", 404))
+		})
+		c := testutil.NewClient(t, server.URL)
+		svc := NewCloudServersClientImpl(c)
+		resp, err := svc.Get(context.Background(), "test-project", "server-123", nil)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if resp == nil || resp.StatusCode != http.StatusNotFound {
+			t.Fatalf("expected 404 response")
+		}
+		if resp.Error == nil {
+			t.Fatalf("expected resp.Error to be populated")
+		}
+		if resp.Error.Title == nil || *resp.Error.Title != "Not Found" {
+			t.Errorf("expected title 'Not Found', got %v", resp.Error.Title)
+		}
+	})
+
+	t.Run("bad gateway non-json", func(t *testing.T) {
+		server := testutil.NewMockServer(t, func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusBadGateway)
+			fmt.Fprint(w, "Bad Gateway")
+		})
+		c := testutil.NewClient(t, server.URL)
+		svc := NewCloudServersClientImpl(c)
+		resp, err := svc.Get(context.Background(), "test-project", "server-123", nil)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if resp == nil || resp.StatusCode != http.StatusBadGateway {
+			t.Fatalf("expected 502 response")
+		}
+		if resp.Error != nil {
+			t.Errorf("expected resp.Error to be nil for non-JSON body, got %+v", resp.Error)
+		}
+		if string(resp.RawBody) != "Bad Gateway" {
+			t.Errorf("expected RawBody 'Bad Gateway', got %q", string(resp.RawBody))
+		}
+	})
+
+	t.Run("network error", func(t *testing.T) {
+		c := testutil.NewBrokenClient(t, "http://unused.invalid")
+		svc := NewCloudServersClientImpl(c)
+		_, err := svc.Get(context.Background(), "test-project", "server-123", nil)
+		if err == nil {
+			t.Fatal("expected a network error, got nil")
+		}
+	})
+
+	t.Run("nil params injects default api-version", func(t *testing.T) {
+		server := testutil.NewMockServer(t, func(w http.ResponseWriter, r *http.Request) {
+			if got := r.URL.Query().Get("api-version"); got != "1.0" {
+				t.Errorf("expected api-version=1.0, got %q", got)
+			}
+			w.WriteHeader(http.StatusOK)
+			fmt.Fprint(w, `{}`)
+		})
+		c := testutil.NewClient(t, server.URL)
+		svc := NewCloudServersClientImpl(c)
+		if _, err := svc.Get(context.Background(), "test-project", "server-123", nil); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
 }
 
-// TestCreateCloudServer tests the CreateCloudServer method
 func TestCreateCloudServer(t *testing.T) {
-	t.Run("successful create", func(t *testing.T) {
-		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			if r.URL.Path == "/token" {
-				w.Header().Set("Content-Type", "application/json")
-				w.WriteHeader(http.StatusOK)
-				w.Write([]byte(`{"access_token":"test-token","token_type":"Bearer","expires_in":3600}`))
-				return
-			}
+	cloudInitContent := "#cloud-config\npackage_update: true\n"
+	userData := base64.StdEncoding.EncodeToString([]byte(cloudInitContent))
+	req := types.CloudServerRequest{
+		Metadata: types.RegionalResourceMetadataRequest{
+			ResourceMetadataRequest: types.ResourceMetadataRequest{Name: "new-server"},
+			Location:                types.LocationRequest{Value: "ITBG-Bergamo"},
+		},
+		Properties: types.CloudServerPropertiesRequest{
+			Zone:     "ITBG-1",
+			UserData: types.StringPtr(userData),
+		},
+	}
 
+	t.Run("successful create", func(t *testing.T) {
+		server := testutil.NewMockServer(t, func(w http.ResponseWriter, r *http.Request) {
 			if r.Method != http.MethodPost {
 				t.Errorf("expected POST, got %s", r.Method)
 			}
 			w.WriteHeader(http.StatusCreated)
 			resp := types.CloudServerResponse{
-				Metadata: types.ResourceMetadataResponse{
-					Name: types.StringPtr("new-server"),
-				},
+				Metadata: types.ResourceMetadataResponse{Name: types.StringPtr("new-server")},
 			}
 			json.NewEncoder(w).Encode(resp)
-		}))
-		defer server.Close()
-
-		var (
-			baseURL    = server.URL
-			httpClient = http.DefaultClient
-			logger     = &noop.NoOpLogger{}
-		)
-
-		c := restclient.NewClient(baseURL, httpClient, standard.NewInterceptor(), logger)
-
+		})
+		c := testutil.NewClient(t, server.URL)
 		svc := NewCloudServersClientImpl(c)
-
-		// Example cloud-init content for testing
-		cloudInitContent := `#cloud-config
-package_update: true
-`
-		userData := base64.StdEncoding.EncodeToString([]byte(cloudInitContent))
-
-		req := types.CloudServerRequest{
-			Metadata: types.RegionalResourceMetadataRequest{
-				ResourceMetadataRequest: types.ResourceMetadataRequest{Name: "new-server"},
-				Location:                types.LocationRequest{Value: "ITBG-Bergamo"},
-			},
-			Properties: types.CloudServerPropertiesRequest{
-				Zone:     "ITBG-1",
-				UserData: types.StringPtr(userData),
-			},
-		}
 
 		resp, err := svc.Create(context.Background(), "test-project", req, nil)
 		if err != nil {
@@ -218,34 +257,88 @@ package_update: true
 			t.Errorf("expected status 201, got %d", resp.StatusCode)
 		}
 	})
+
+	t.Run("not found", func(t *testing.T) {
+		server := testutil.NewMockServer(t, func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusNotFound)
+			fmt.Fprint(w, testutil.ErrorBodyJSON("Not Found", "resource not found", 404))
+		})
+		c := testutil.NewClient(t, server.URL)
+		svc := NewCloudServersClientImpl(c)
+		resp, err := svc.Create(context.Background(), "test-project", req, nil)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if resp == nil || resp.StatusCode != http.StatusNotFound {
+			t.Fatalf("expected 404 response")
+		}
+		if resp.Error == nil {
+			t.Fatalf("expected resp.Error to be populated")
+		}
+		if resp.Error.Title == nil || *resp.Error.Title != "Not Found" {
+			t.Errorf("expected title 'Not Found', got %v", resp.Error.Title)
+		}
+	})
+
+	t.Run("bad gateway non-json", func(t *testing.T) {
+		// TODO(TD-010): Create's manual response build silently swallows non-JSON unmarshal
+		// errors (diverges from ParseResponseBody which logs at DEBUG).
+		server := testutil.NewMockServer(t, func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusBadGateway)
+			fmt.Fprint(w, "Bad Gateway")
+		})
+		c := testutil.NewClient(t, server.URL)
+		svc := NewCloudServersClientImpl(c)
+		resp, err := svc.Create(context.Background(), "test-project", req, nil)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if resp == nil || resp.StatusCode != http.StatusBadGateway {
+			t.Fatalf("expected 502 response")
+		}
+		if resp.Error != nil {
+			t.Errorf("expected resp.Error to be nil for non-JSON body, got %+v", resp.Error)
+		}
+		if string(resp.RawBody) != "Bad Gateway" {
+			t.Errorf("expected RawBody 'Bad Gateway', got %q", string(resp.RawBody))
+		}
+	})
+
+	t.Run("network error", func(t *testing.T) {
+		c := testutil.NewBrokenClient(t, "http://unused.invalid")
+		svc := NewCloudServersClientImpl(c)
+		_, err := svc.Create(context.Background(), "test-project", req, nil)
+		if err == nil {
+			t.Fatal("expected a network error, got nil")
+		}
+	})
+
+	t.Run("nil params injects default api-version", func(t *testing.T) {
+		server := testutil.NewMockServer(t, func(w http.ResponseWriter, r *http.Request) {
+			if got := r.URL.Query().Get("api-version"); got != "1.1" {
+				t.Errorf("expected api-version=1.1, got %q", got)
+			}
+			w.WriteHeader(http.StatusCreated)
+			fmt.Fprint(w, `{}`)
+		})
+		c := testutil.NewClient(t, server.URL)
+		svc := NewCloudServersClientImpl(c)
+		if _, err := svc.Create(context.Background(), "test-project", req, nil); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
 }
 
-// TestDeleteCloudServer tests the DeleteCloudServer method
 func TestDeleteCloudServer(t *testing.T) {
 	t.Run("successful delete", func(t *testing.T) {
-		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			if r.URL.Path == "/token" {
-				w.Header().Set("Content-Type", "application/json")
-				w.WriteHeader(http.StatusOK)
-				w.Write([]byte(`{"access_token":"test-token","token_type":"Bearer","expires_in":3600}`))
-				return
-			}
-
+		server := testutil.NewMockServer(t, func(w http.ResponseWriter, r *http.Request) {
 			if r.Method != http.MethodDelete {
 				t.Errorf("expected DELETE, got %s", r.Method)
 			}
 			w.WriteHeader(http.StatusNoContent)
-		}))
-		defer server.Close()
-
-		var (
-			baseURL    = server.URL
-			httpClient = http.DefaultClient
-			logger     = &noop.NoOpLogger{}
-		)
-
-		c := restclient.NewClient(baseURL, httpClient, standard.NewInterceptor(), logger)
-
+		})
+		c := testutil.NewClient(t, server.URL)
 		svc := NewCloudServersClientImpl(c)
 
 		_, err := svc.Delete(context.Background(), "test-project", "server-123", nil)
@@ -255,44 +348,86 @@ func TestDeleteCloudServer(t *testing.T) {
 	})
 
 	t.Run("empty project ID", func(t *testing.T) {
-		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			if r.URL.Path == "/token" {
-				w.Header().Set("Content-Type", "application/json")
-				w.WriteHeader(http.StatusOK)
-				w.Write([]byte(`{"access_token":"test-token","token_type":"Bearer","expires_in":3600}`))
-				return
-			}
-		}))
-		defer server.Close()
-
-		var (
-			baseURL    = server.URL
-			httpClient = http.DefaultClient
-			logger     = &noop.NoOpLogger{}
-		)
-
-		c := restclient.NewClient(baseURL, httpClient, standard.NewInterceptor(), logger)
-
+		c := testutil.NewClient(t, "http://unused.invalid")
 		svc := NewCloudServersClientImpl(c)
-
 		_, err := svc.Delete(context.Background(), "", "server-123", nil)
 		if err == nil {
 			t.Error("expected error for empty project ID")
 		}
 	})
+
+	t.Run("not found", func(t *testing.T) {
+		server := testutil.NewMockServer(t, func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusNotFound)
+			fmt.Fprint(w, testutil.ErrorBodyJSON("Not Found", "resource not found", 404))
+		})
+		c := testutil.NewClient(t, server.URL)
+		svc := NewCloudServersClientImpl(c)
+		resp, err := svc.Delete(context.Background(), "test-project", "server-123", nil)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if resp == nil || resp.StatusCode != http.StatusNotFound {
+			t.Fatalf("expected 404 response")
+		}
+		if resp.Error == nil {
+			t.Fatalf("expected resp.Error to be populated")
+		}
+		if resp.Error.Title == nil || *resp.Error.Title != "Not Found" {
+			t.Errorf("expected title 'Not Found', got %v", resp.Error.Title)
+		}
+	})
+
+	t.Run("bad gateway non-json", func(t *testing.T) {
+		server := testutil.NewMockServer(t, func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusBadGateway)
+			fmt.Fprint(w, "Bad Gateway")
+		})
+		c := testutil.NewClient(t, server.URL)
+		svc := NewCloudServersClientImpl(c)
+		resp, err := svc.Delete(context.Background(), "test-project", "server-123", nil)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if resp == nil || resp.StatusCode != http.StatusBadGateway {
+			t.Fatalf("expected 502 response")
+		}
+		if resp.Error != nil {
+			t.Errorf("expected resp.Error to be nil for non-JSON body, got %+v", resp.Error)
+		}
+		if string(resp.RawBody) != "Bad Gateway" {
+			t.Errorf("expected RawBody 'Bad Gateway', got %q", string(resp.RawBody))
+		}
+	})
+
+	t.Run("network error", func(t *testing.T) {
+		c := testutil.NewBrokenClient(t, "http://unused.invalid")
+		svc := NewCloudServersClientImpl(c)
+		_, err := svc.Delete(context.Background(), "test-project", "server-123", nil)
+		if err == nil {
+			t.Fatal("expected a network error, got nil")
+		}
+	})
+
+	t.Run("nil params injects default api-version", func(t *testing.T) {
+		server := testutil.NewMockServer(t, func(w http.ResponseWriter, r *http.Request) {
+			if got := r.URL.Query().Get("api-version"); got != "1.0" {
+				t.Errorf("expected api-version=1.0, got %q", got)
+			}
+			w.WriteHeader(http.StatusNoContent)
+		})
+		c := testutil.NewClient(t, server.URL)
+		svc := NewCloudServersClientImpl(c)
+		if _, err := svc.Delete(context.Background(), "test-project", "server-123", nil); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
 }
 
-// TestPowerOnCloudServer tests the PowerOn method
 func TestPowerOnCloudServer(t *testing.T) {
 	t.Run("successful power on", func(t *testing.T) {
-		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			if r.URL.Path == "/token" {
-				w.Header().Set("Content-Type", "application/json")
-				w.WriteHeader(http.StatusOK)
-				w.Write([]byte(`{"access_token":"test-token","token_type":"Bearer","expires_in":3600}`))
-				return
-			}
-
+		server := testutil.NewMockServer(t, func(w http.ResponseWriter, r *http.Request) {
 			if r.Method != http.MethodPost {
 				t.Errorf("expected POST, got %s", r.Method)
 			}
@@ -301,26 +436,13 @@ func TestPowerOnCloudServer(t *testing.T) {
 			}
 			w.WriteHeader(http.StatusOK)
 			resp := types.CloudServerResponse{
-				Metadata: types.ResourceMetadataResponse{
-					Name: types.StringPtr("my-server"),
-				},
+				Metadata:   types.ResourceMetadataResponse{Name: types.StringPtr("my-server")},
 				Properties: types.CloudServerPropertiesResult{Zone: "ITBG-1"},
-				Status: types.ResourceStatus{
-					State: types.StringPtr("active"),
-				},
+				Status:     types.ResourceStatus{State: types.StringPtr("active")},
 			}
 			json.NewEncoder(w).Encode(resp)
-		}))
-		defer server.Close()
-
-		var (
-			baseURL    = server.URL
-			httpClient = http.DefaultClient
-			logger     = &noop.NoOpLogger{}
-		)
-
-		c := restclient.NewClient(baseURL, httpClient, standard.NewInterceptor(), logger)
-
+		})
+		c := testutil.NewClient(t, server.URL)
 		svc := NewCloudServersClientImpl(c)
 
 		resp, err := svc.PowerOn(context.Background(), "test-project", "server-123", nil)
@@ -337,19 +459,80 @@ func TestPowerOnCloudServer(t *testing.T) {
 			t.Errorf("expected successful response, got status code %d", resp.StatusCode)
 		}
 	})
+
+	t.Run("not found", func(t *testing.T) {
+		server := testutil.NewMockServer(t, func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusNotFound)
+			fmt.Fprint(w, testutil.ErrorBodyJSON("Not Found", "resource not found", 404))
+		})
+		c := testutil.NewClient(t, server.URL)
+		svc := NewCloudServersClientImpl(c)
+		resp, err := svc.PowerOn(context.Background(), "test-project", "server-123", nil)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if resp == nil || resp.StatusCode != http.StatusNotFound {
+			t.Fatalf("expected 404 response")
+		}
+		if resp.Error == nil {
+			t.Fatalf("expected resp.Error to be populated")
+		}
+		if resp.Error.Title == nil || *resp.Error.Title != "Not Found" {
+			t.Errorf("expected title 'Not Found', got %v", resp.Error.Title)
+		}
+	})
+
+	t.Run("bad gateway non-json", func(t *testing.T) {
+		server := testutil.NewMockServer(t, func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusBadGateway)
+			fmt.Fprint(w, "Bad Gateway")
+		})
+		c := testutil.NewClient(t, server.URL)
+		svc := NewCloudServersClientImpl(c)
+		resp, err := svc.PowerOn(context.Background(), "test-project", "server-123", nil)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if resp == nil || resp.StatusCode != http.StatusBadGateway {
+			t.Fatalf("expected 502 response")
+		}
+		if resp.Error != nil {
+			t.Errorf("expected resp.Error to be nil for non-JSON body, got %+v", resp.Error)
+		}
+		if string(resp.RawBody) != "Bad Gateway" {
+			t.Errorf("expected RawBody 'Bad Gateway', got %q", string(resp.RawBody))
+		}
+	})
+
+	t.Run("network error", func(t *testing.T) {
+		c := testutil.NewBrokenClient(t, "http://unused.invalid")
+		svc := NewCloudServersClientImpl(c)
+		_, err := svc.PowerOn(context.Background(), "test-project", "server-123", nil)
+		if err == nil {
+			t.Fatal("expected a network error, got nil")
+		}
+	})
+
+	t.Run("nil params injects default api-version", func(t *testing.T) {
+		server := testutil.NewMockServer(t, func(w http.ResponseWriter, r *http.Request) {
+			if got := r.URL.Query().Get("api-version"); got != "1.0" {
+				t.Errorf("expected api-version=1.0, got %q", got)
+			}
+			w.WriteHeader(http.StatusOK)
+			fmt.Fprint(w, `{}`)
+		})
+		c := testutil.NewClient(t, server.URL)
+		svc := NewCloudServersClientImpl(c)
+		if _, err := svc.PowerOn(context.Background(), "test-project", "server-123", nil); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
 }
 
-// TestPowerOffCloudServer tests the PowerOff method
 func TestPowerOffCloudServer(t *testing.T) {
 	t.Run("successful power off", func(t *testing.T) {
-		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			if r.URL.Path == "/token" {
-				w.Header().Set("Content-Type", "application/json")
-				w.WriteHeader(http.StatusOK)
-				w.Write([]byte(`{"access_token":"test-token","token_type":"Bearer","expires_in":3600}`))
-				return
-			}
-
+		server := testutil.NewMockServer(t, func(w http.ResponseWriter, r *http.Request) {
 			if r.Method != http.MethodPost {
 				t.Errorf("expected POST, got %s", r.Method)
 			}
@@ -358,26 +541,13 @@ func TestPowerOffCloudServer(t *testing.T) {
 			}
 			w.WriteHeader(http.StatusOK)
 			resp := types.CloudServerResponse{
-				Metadata: types.ResourceMetadataResponse{
-					Name: types.StringPtr("my-server"),
-				},
+				Metadata:   types.ResourceMetadataResponse{Name: types.StringPtr("my-server")},
 				Properties: types.CloudServerPropertiesResult{Zone: "ITBG-1"},
-				Status: types.ResourceStatus{
-					State: types.StringPtr("stopped"),
-				},
+				Status:     types.ResourceStatus{State: types.StringPtr("stopped")},
 			}
 			json.NewEncoder(w).Encode(resp)
-		}))
-		defer server.Close()
-
-		var (
-			baseURL    = server.URL
-			httpClient = http.DefaultClient
-			logger     = &noop.NoOpLogger{}
-		)
-
-		c := restclient.NewClient(baseURL, httpClient, standard.NewInterceptor(), logger)
-
+		})
+		c := testutil.NewClient(t, server.URL)
 		svc := NewCloudServersClientImpl(c)
 
 		resp, err := svc.PowerOff(context.Background(), "test-project", "server-123", nil)
@@ -394,27 +564,88 @@ func TestPowerOffCloudServer(t *testing.T) {
 			t.Errorf("expected successful response, got status code %d", resp.StatusCode)
 		}
 	})
+
+	t.Run("not found", func(t *testing.T) {
+		server := testutil.NewMockServer(t, func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusNotFound)
+			fmt.Fprint(w, testutil.ErrorBodyJSON("Not Found", "resource not found", 404))
+		})
+		c := testutil.NewClient(t, server.URL)
+		svc := NewCloudServersClientImpl(c)
+		resp, err := svc.PowerOff(context.Background(), "test-project", "server-123", nil)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if resp == nil || resp.StatusCode != http.StatusNotFound {
+			t.Fatalf("expected 404 response")
+		}
+		if resp.Error == nil {
+			t.Fatalf("expected resp.Error to be populated")
+		}
+		if resp.Error.Title == nil || *resp.Error.Title != "Not Found" {
+			t.Errorf("expected title 'Not Found', got %v", resp.Error.Title)
+		}
+	})
+
+	t.Run("bad gateway non-json", func(t *testing.T) {
+		server := testutil.NewMockServer(t, func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusBadGateway)
+			fmt.Fprint(w, "Bad Gateway")
+		})
+		c := testutil.NewClient(t, server.URL)
+		svc := NewCloudServersClientImpl(c)
+		resp, err := svc.PowerOff(context.Background(), "test-project", "server-123", nil)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if resp == nil || resp.StatusCode != http.StatusBadGateway {
+			t.Fatalf("expected 502 response")
+		}
+		if resp.Error != nil {
+			t.Errorf("expected resp.Error to be nil for non-JSON body, got %+v", resp.Error)
+		}
+		if string(resp.RawBody) != "Bad Gateway" {
+			t.Errorf("expected RawBody 'Bad Gateway', got %q", string(resp.RawBody))
+		}
+	})
+
+	t.Run("network error", func(t *testing.T) {
+		c := testutil.NewBrokenClient(t, "http://unused.invalid")
+		svc := NewCloudServersClientImpl(c)
+		_, err := svc.PowerOff(context.Background(), "test-project", "server-123", nil)
+		if err == nil {
+			t.Fatal("expected a network error, got nil")
+		}
+	})
+
+	t.Run("nil params injects default api-version", func(t *testing.T) {
+		server := testutil.NewMockServer(t, func(w http.ResponseWriter, r *http.Request) {
+			if got := r.URL.Query().Get("api-version"); got != "1.0" {
+				t.Errorf("expected api-version=1.0, got %q", got)
+			}
+			w.WriteHeader(http.StatusOK)
+			fmt.Fprint(w, `{}`)
+		})
+		c := testutil.NewClient(t, server.URL)
+		svc := NewCloudServersClientImpl(c)
+		if _, err := svc.PowerOff(context.Background(), "test-project", "server-123", nil); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
 }
 
-// TestSetPasswordCloudServer tests the SetPassword method
 func TestSetPasswordCloudServer(t *testing.T) {
-	t.Run("successful set password", func(t *testing.T) {
-		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			if r.URL.Path == "/token" {
-				w.Header().Set("Content-Type", "application/json")
-				w.WriteHeader(http.StatusOK)
-				w.Write([]byte(`{"access_token":"test-token","token_type":"Bearer","expires_in":3600}`))
-				return
-			}
+	req := types.CloudServerPasswordRequest{Password: "newPassword123"}
 
+	t.Run("successful set password", func(t *testing.T) {
+		server := testutil.NewMockServer(t, func(w http.ResponseWriter, r *http.Request) {
 			if r.Method != http.MethodPost {
 				t.Errorf("expected POST, got %s", r.Method)
 			}
 			if r.URL.Path != "/projects/test-project/providers/Aruba.Compute/cloudServers/server-123/password" {
 				t.Errorf("expected password path, got %s", r.URL.Path)
 			}
-
-			// Verify request body
 			var reqBody types.CloudServerPasswordRequest
 			if err := json.NewDecoder(r.Body).Decode(&reqBody); err != nil {
 				t.Errorf("failed to decode request body: %v", err)
@@ -422,24 +653,10 @@ func TestSetPasswordCloudServer(t *testing.T) {
 			if reqBody.Password != "newPassword123" {
 				t.Errorf("expected password 'newPassword123', got '%s'", reqBody.Password)
 			}
-
 			w.WriteHeader(http.StatusOK)
-		}))
-		defer server.Close()
-
-		var (
-			baseURL    = server.URL
-			httpClient = http.DefaultClient
-			logger     = &noop.NoOpLogger{}
-		)
-
-		c := restclient.NewClient(baseURL, httpClient, standard.NewInterceptor(), logger)
-
+		})
+		c := testutil.NewClient(t, server.URL)
 		svc := NewCloudServersClientImpl(c)
-
-		req := types.CloudServerPasswordRequest{
-			Password: "newPassword123",
-		}
 
 		resp, err := svc.SetPassword(context.Background(), "test-project", "server-123", req, nil)
 		if err != nil {
@@ -451,33 +668,79 @@ func TestSetPasswordCloudServer(t *testing.T) {
 	})
 
 	t.Run("empty project ID", func(t *testing.T) {
-		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			if r.URL.Path == "/token" {
-				w.Header().Set("Content-Type", "application/json")
-				w.WriteHeader(http.StatusOK)
-				w.Write([]byte(`{"access_token":"test-token","token_type":"Bearer","expires_in":3600}`))
-				return
-			}
-		}))
-		defer server.Close()
-
-		var (
-			baseURL    = server.URL
-			httpClient = http.DefaultClient
-			logger     = &noop.NoOpLogger{}
-		)
-
-		c := restclient.NewClient(baseURL, httpClient, standard.NewInterceptor(), logger)
-
+		c := testutil.NewClient(t, "http://unused.invalid")
 		svc := NewCloudServersClientImpl(c)
-
-		req := types.CloudServerPasswordRequest{
-			Password: "newPassword123",
-		}
-
 		_, err := svc.SetPassword(context.Background(), "", "server-123", req, nil)
 		if err == nil {
 			t.Error("expected error for empty project ID")
+		}
+	})
+
+	t.Run("not found", func(t *testing.T) {
+		server := testutil.NewMockServer(t, func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusNotFound)
+			fmt.Fprint(w, testutil.ErrorBodyJSON("Not Found", "resource not found", 404))
+		})
+		c := testutil.NewClient(t, server.URL)
+		svc := NewCloudServersClientImpl(c)
+		resp, err := svc.SetPassword(context.Background(), "test-project", "server-123", req, nil)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if resp == nil || resp.StatusCode != http.StatusNotFound {
+			t.Fatalf("expected 404 response")
+		}
+		if resp.Error == nil {
+			t.Fatalf("expected resp.Error to be populated")
+		}
+		if resp.Error.Title == nil || *resp.Error.Title != "Not Found" {
+			t.Errorf("expected title 'Not Found', got %v", resp.Error.Title)
+		}
+	})
+
+	t.Run("bad gateway non-json", func(t *testing.T) {
+		server := testutil.NewMockServer(t, func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusBadGateway)
+			fmt.Fprint(w, "Bad Gateway")
+		})
+		c := testutil.NewClient(t, server.URL)
+		svc := NewCloudServersClientImpl(c)
+		resp, err := svc.SetPassword(context.Background(), "test-project", "server-123", req, nil)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if resp == nil || resp.StatusCode != http.StatusBadGateway {
+			t.Fatalf("expected 502 response")
+		}
+		if resp.Error != nil {
+			t.Errorf("expected resp.Error to be nil for non-JSON body, got %+v", resp.Error)
+		}
+		if string(resp.RawBody) != "Bad Gateway" {
+			t.Errorf("expected RawBody 'Bad Gateway', got %q", string(resp.RawBody))
+		}
+	})
+
+	t.Run("network error", func(t *testing.T) {
+		c := testutil.NewBrokenClient(t, "http://unused.invalid")
+		svc := NewCloudServersClientImpl(c)
+		_, err := svc.SetPassword(context.Background(), "test-project", "server-123", req, nil)
+		if err == nil {
+			t.Fatal("expected a network error, got nil")
+		}
+	})
+
+	t.Run("nil params injects default api-version", func(t *testing.T) {
+		server := testutil.NewMockServer(t, func(w http.ResponseWriter, r *http.Request) {
+			if got := r.URL.Query().Get("api-version"); got != "1.0" {
+				t.Errorf("expected api-version=1.0, got %q", got)
+			}
+			w.WriteHeader(http.StatusOK)
+		})
+		c := testutil.NewClient(t, server.URL)
+		svc := NewCloudServersClientImpl(c)
+		if _, err := svc.SetPassword(context.Background(), "test-project", "server-123", req, nil); err != nil {
+			t.Fatalf("unexpected error: %v", err)
 		}
 	})
 }

--- a/internal/clients/compute/keypair_test.go
+++ b/internal/clients/compute/keypair_test.go
@@ -3,48 +3,27 @@ package compute
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"net/http"
-	"net/http/httptest"
 	"testing"
 
-	"github.com/Arubacloud/sdk-go/internal/impl/interceptor/standard"
-	"github.com/Arubacloud/sdk-go/internal/impl/logger/noop"
-	"github.com/Arubacloud/sdk-go/internal/restclient"
+	"github.com/Arubacloud/sdk-go/internal/testutil"
 	"github.com/Arubacloud/sdk-go/pkg/types"
 )
 
-// TestListKeyPairs tests the ListKeyPairs method
 func TestListKeyPairs(t *testing.T) {
 	t.Run("successful list", func(t *testing.T) {
-		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			if r.URL.Path == "/token" {
-				w.Header().Set("Content-Type", "application/json")
-				w.WriteHeader(http.StatusOK)
-				w.Write([]byte(`{"access_token":"test-token","token_type":"Bearer","expires_in":3600}`))
-				return
-			}
-
+		server := testutil.NewMockServer(t, func(w http.ResponseWriter, r *http.Request) {
 			w.WriteHeader(http.StatusOK)
 			resp := types.KeyPairListResponse{
 				ListResponse: types.ListResponse{Total: 1},
 				Values: []types.KeyPairResponse{
-					{
-						Metadata: types.ResourceMetadataResponse{Name: types.StringPtr("my-keypair")},
-					},
+					{Metadata: types.ResourceMetadataResponse{Name: types.StringPtr("my-keypair")}},
 				},
 			}
 			json.NewEncoder(w).Encode(resp)
-		}))
-		defer server.Close()
-
-		var (
-			baseURL    = server.URL
-			httpClient = http.DefaultClient
-			logger     = &noop.NoOpLogger{}
-		)
-
-		c := restclient.NewClient(baseURL, httpClient, standard.NewInterceptor(), logger)
-
+		})
+		c := testutil.NewClient(t, server.URL)
 		svc := NewKeyPairsClientImpl(c)
 
 		resp, err := svc.List(context.Background(), "test-project", nil)
@@ -60,60 +39,94 @@ func TestListKeyPairs(t *testing.T) {
 	})
 
 	t.Run("empty project ID", func(t *testing.T) {
-		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			if r.URL.Path == "/token" {
-				w.Header().Set("Content-Type", "application/json")
-				w.WriteHeader(http.StatusOK)
-				w.Write([]byte(`{"access_token":"test-token","token_type":"Bearer","expires_in":3600}`))
-				return
-			}
-		}))
-		defer server.Close()
-
-		var (
-			baseURL    = server.URL
-			httpClient = http.DefaultClient
-			logger     = &noop.NoOpLogger{}
-		)
-
-		c := restclient.NewClient(baseURL, httpClient, standard.NewInterceptor(), logger)
-
+		c := testutil.NewClient(t, "http://unused.invalid")
 		svc := NewKeyPairsClientImpl(c)
-
 		_, err := svc.List(context.Background(), "", nil)
 		if err == nil {
 			t.Error("expected error for empty project ID")
 		}
 	})
+
+	t.Run("not found", func(t *testing.T) {
+		server := testutil.NewMockServer(t, func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusNotFound)
+			fmt.Fprint(w, testutil.ErrorBodyJSON("Not Found", "resource not found", 404))
+		})
+		c := testutil.NewClient(t, server.URL)
+		svc := NewKeyPairsClientImpl(c)
+		resp, err := svc.List(context.Background(), "test-project", nil)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if resp == nil || resp.StatusCode != http.StatusNotFound {
+			t.Fatalf("expected 404 response")
+		}
+		if resp.Error == nil {
+			t.Fatalf("expected resp.Error to be populated")
+		}
+		if resp.Error.Title == nil || *resp.Error.Title != "Not Found" {
+			t.Errorf("expected title 'Not Found', got %v", resp.Error.Title)
+		}
+	})
+
+	t.Run("bad gateway non-json", func(t *testing.T) {
+		server := testutil.NewMockServer(t, func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusBadGateway)
+			fmt.Fprint(w, "Bad Gateway")
+		})
+		c := testutil.NewClient(t, server.URL)
+		svc := NewKeyPairsClientImpl(c)
+		resp, err := svc.List(context.Background(), "test-project", nil)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if resp == nil || resp.StatusCode != http.StatusBadGateway {
+			t.Fatalf("expected 502 response")
+		}
+		if resp.Error != nil {
+			t.Errorf("expected resp.Error to be nil for non-JSON body, got %+v", resp.Error)
+		}
+		if string(resp.RawBody) != "Bad Gateway" {
+			t.Errorf("expected RawBody 'Bad Gateway', got %q", string(resp.RawBody))
+		}
+	})
+
+	t.Run("network error", func(t *testing.T) {
+		c := testutil.NewBrokenClient(t, "http://unused.invalid")
+		svc := NewKeyPairsClientImpl(c)
+		_, err := svc.List(context.Background(), "test-project", nil)
+		if err == nil {
+			t.Fatal("expected a network error, got nil")
+		}
+	})
+
+	t.Run("nil params injects default api-version", func(t *testing.T) {
+		server := testutil.NewMockServer(t, func(w http.ResponseWriter, r *http.Request) {
+			if got := r.URL.Query().Get("api-version"); got != "1.0" {
+				t.Errorf("expected api-version=1.0, got %q", got)
+			}
+			w.WriteHeader(http.StatusOK)
+			fmt.Fprint(w, `{"total":0,"values":[]}`)
+		})
+		c := testutil.NewClient(t, server.URL)
+		svc := NewKeyPairsClientImpl(c)
+		if _, err := svc.List(context.Background(), "test-project", nil); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
 }
 
-// TestGetKeyPair tests the GetKeyPair method
 func TestGetKeyPair(t *testing.T) {
 	t.Run("successful get", func(t *testing.T) {
-		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			if r.URL.Path == "/token" {
-				w.Header().Set("Content-Type", "application/json")
-				w.WriteHeader(http.StatusOK)
-				w.Write([]byte(`{"access_token":"test-token","token_type":"Bearer","expires_in":3600}`))
-				return
-			}
-
+		server := testutil.NewMockServer(t, func(w http.ResponseWriter, r *http.Request) {
 			w.WriteHeader(http.StatusOK)
 			resp := types.KeyPairResponse{
 				Metadata: types.ResourceMetadataResponse{Name: types.StringPtr("my-keypair")},
 			}
 			json.NewEncoder(w).Encode(resp)
-		}))
-		defer server.Close()
-
-		var (
-			baseURL    = server.URL
-			httpClient = http.DefaultClient
-			logger     = &noop.NoOpLogger{}
-		)
-
-		c := restclient.NewClient(baseURL, httpClient, standard.NewInterceptor(), logger)
-
+		})
+		c := testutil.NewClient(t, server.URL)
 		svc := NewKeyPairsClientImpl(c)
 
 		resp, err := svc.Get(context.Background(), "test-project", "keypair-123", nil)
@@ -126,44 +139,95 @@ func TestGetKeyPair(t *testing.T) {
 	})
 
 	t.Run("empty keypair ID", func(t *testing.T) {
-		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			if r.URL.Path == "/token" {
-				w.Header().Set("Content-Type", "application/json")
-				w.WriteHeader(http.StatusOK)
-				w.Write([]byte(`{"access_token":"test-token","token_type":"Bearer","expires_in":3600}`))
-				return
-			}
-		}))
-		defer server.Close()
-
-		var (
-			baseURL    = server.URL
-			httpClient = http.DefaultClient
-			logger     = &noop.NoOpLogger{}
-		)
-
-		c := restclient.NewClient(baseURL, httpClient, standard.NewInterceptor(), logger)
-
+		c := testutil.NewClient(t, "http://unused.invalid")
 		svc := NewKeyPairsClientImpl(c)
-
 		_, err := svc.Get(context.Background(), "test-project", "", nil)
 		if err == nil {
 			t.Error("expected error for empty keypair ID")
 		}
 	})
+
+	t.Run("not found", func(t *testing.T) {
+		server := testutil.NewMockServer(t, func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusNotFound)
+			fmt.Fprint(w, testutil.ErrorBodyJSON("Not Found", "resource not found", 404))
+		})
+		c := testutil.NewClient(t, server.URL)
+		svc := NewKeyPairsClientImpl(c)
+		resp, err := svc.Get(context.Background(), "test-project", "keypair-123", nil)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if resp == nil || resp.StatusCode != http.StatusNotFound {
+			t.Fatalf("expected 404 response")
+		}
+		if resp.Error == nil {
+			t.Fatalf("expected resp.Error to be populated")
+		}
+		if resp.Error.Title == nil || *resp.Error.Title != "Not Found" {
+			t.Errorf("expected title 'Not Found', got %v", resp.Error.Title)
+		}
+	})
+
+	t.Run("bad gateway non-json", func(t *testing.T) {
+		server := testutil.NewMockServer(t, func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusBadGateway)
+			fmt.Fprint(w, "Bad Gateway")
+		})
+		c := testutil.NewClient(t, server.URL)
+		svc := NewKeyPairsClientImpl(c)
+		resp, err := svc.Get(context.Background(), "test-project", "keypair-123", nil)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if resp == nil || resp.StatusCode != http.StatusBadGateway {
+			t.Fatalf("expected 502 response")
+		}
+		if resp.Error != nil {
+			t.Errorf("expected resp.Error to be nil for non-JSON body, got %+v", resp.Error)
+		}
+		if string(resp.RawBody) != "Bad Gateway" {
+			t.Errorf("expected RawBody 'Bad Gateway', got %q", string(resp.RawBody))
+		}
+	})
+
+	t.Run("network error", func(t *testing.T) {
+		c := testutil.NewBrokenClient(t, "http://unused.invalid")
+		svc := NewKeyPairsClientImpl(c)
+		_, err := svc.Get(context.Background(), "test-project", "keypair-123", nil)
+		if err == nil {
+			t.Fatal("expected a network error, got nil")
+		}
+	})
+
+	t.Run("nil params injects default api-version", func(t *testing.T) {
+		server := testutil.NewMockServer(t, func(w http.ResponseWriter, r *http.Request) {
+			if got := r.URL.Query().Get("api-version"); got != "1.0" {
+				t.Errorf("expected api-version=1.0, got %q", got)
+			}
+			w.WriteHeader(http.StatusOK)
+			fmt.Fprint(w, `{}`)
+		})
+		c := testutil.NewClient(t, server.URL)
+		svc := NewKeyPairsClientImpl(c)
+		if _, err := svc.Get(context.Background(), "test-project", "keypair-123", nil); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
 }
 
-// TestCreateKeyPair tests the CreateKeyPair method
 func TestCreateKeyPair(t *testing.T) {
-	t.Run("successful create", func(t *testing.T) {
-		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			if r.URL.Path == "/token" {
-				w.Header().Set("Content-Type", "application/json")
-				w.WriteHeader(http.StatusOK)
-				w.Write([]byte(`{"access_token":"test-token","token_type":"Bearer","expires_in":3600}`))
-				return
-			}
+	req := types.KeyPairRequest{
+		Metadata: types.RegionalResourceMetadataRequest{
+			ResourceMetadataRequest: types.ResourceMetadataRequest{Name: "new-keypair"},
+			Location:                types.LocationRequest{Value: "ITBG-Bergamo"},
+		},
+		Properties: types.KeyPairPropertiesRequest{Value: "ssh-rsa AAAAB3Nza..."},
+	}
 
+	t.Run("successful create", func(t *testing.T) {
+		server := testutil.NewMockServer(t, func(w http.ResponseWriter, r *http.Request) {
 			if r.Method != http.MethodPost {
 				t.Errorf("expected POST, got %s", r.Method)
 			}
@@ -172,26 +236,9 @@ func TestCreateKeyPair(t *testing.T) {
 				Metadata: types.ResourceMetadataResponse{Name: types.StringPtr("new-keypair")},
 			}
 			json.NewEncoder(w).Encode(resp)
-		}))
-		defer server.Close()
-
-		var (
-			baseURL    = server.URL
-			httpClient = http.DefaultClient
-			logger     = &noop.NoOpLogger{}
-		)
-
-		c := restclient.NewClient(baseURL, httpClient, standard.NewInterceptor(), logger)
-
+		})
+		c := testutil.NewClient(t, server.URL)
 		svc := NewKeyPairsClientImpl(c)
-
-		req := types.KeyPairRequest{
-			Metadata: types.RegionalResourceMetadataRequest{
-				ResourceMetadataRequest: types.ResourceMetadataRequest{Name: "new-keypair"},
-				Location:                types.LocationRequest{Value: "ITBG-Bergamo"},
-			},
-			Properties: types.KeyPairPropertiesRequest{Value: "ssh-rsa AAAAB3Nza..."},
-		}
 
 		resp, err := svc.Create(context.Background(), "test-project", req, nil)
 		if err != nil {
@@ -201,38 +248,160 @@ func TestCreateKeyPair(t *testing.T) {
 			t.Errorf("expected status 201, got %d", resp.StatusCode)
 		}
 	})
+
+	t.Run("not found", func(t *testing.T) {
+		server := testutil.NewMockServer(t, func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusNotFound)
+			fmt.Fprint(w, testutil.ErrorBodyJSON("Not Found", "resource not found", 404))
+		})
+		c := testutil.NewClient(t, server.URL)
+		svc := NewKeyPairsClientImpl(c)
+		resp, err := svc.Create(context.Background(), "test-project", req, nil)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if resp == nil || resp.StatusCode != http.StatusNotFound {
+			t.Fatalf("expected 404 response")
+		}
+		if resp.Error == nil {
+			t.Fatalf("expected resp.Error to be populated")
+		}
+		if resp.Error.Title == nil || *resp.Error.Title != "Not Found" {
+			t.Errorf("expected title 'Not Found', got %v", resp.Error.Title)
+		}
+	})
+
+	t.Run("bad gateway non-json", func(t *testing.T) {
+		// TODO(TD-010): Create's manual response build silently swallows non-JSON unmarshal
+		// errors (diverges from ParseResponseBody which logs at DEBUG).
+		server := testutil.NewMockServer(t, func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusBadGateway)
+			fmt.Fprint(w, "Bad Gateway")
+		})
+		c := testutil.NewClient(t, server.URL)
+		svc := NewKeyPairsClientImpl(c)
+		resp, err := svc.Create(context.Background(), "test-project", req, nil)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if resp == nil || resp.StatusCode != http.StatusBadGateway {
+			t.Fatalf("expected 502 response")
+		}
+		if resp.Error != nil {
+			t.Errorf("expected resp.Error to be nil for non-JSON body, got %+v", resp.Error)
+		}
+		if string(resp.RawBody) != "Bad Gateway" {
+			t.Errorf("expected RawBody 'Bad Gateway', got %q", string(resp.RawBody))
+		}
+	})
+
+	t.Run("network error", func(t *testing.T) {
+		c := testutil.NewBrokenClient(t, "http://unused.invalid")
+		svc := NewKeyPairsClientImpl(c)
+		_, err := svc.Create(context.Background(), "test-project", req, nil)
+		if err == nil {
+			t.Fatal("expected a network error, got nil")
+		}
+	})
+
+	t.Run("nil params injects default api-version", func(t *testing.T) {
+		server := testutil.NewMockServer(t, func(w http.ResponseWriter, r *http.Request) {
+			if got := r.URL.Query().Get("api-version"); got != "1.0" {
+				t.Errorf("expected api-version=1.0, got %q", got)
+			}
+			w.WriteHeader(http.StatusCreated)
+			fmt.Fprint(w, `{}`)
+		})
+		c := testutil.NewClient(t, server.URL)
+		svc := NewKeyPairsClientImpl(c)
+		if _, err := svc.Create(context.Background(), "test-project", req, nil); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
 }
 
-// TestDeleteKeyPair tests the DeleteKeyPair method
 func TestDeleteKeyPair(t *testing.T) {
 	t.Run("successful delete", func(t *testing.T) {
-		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			if r.URL.Path == "/token" {
-				w.Header().Set("Content-Type", "application/json")
-				w.WriteHeader(http.StatusOK)
-				w.Write([]byte(`{"access_token":"test-token","token_type":"Bearer","expires_in":3600}`))
-				return
-			}
-
+		server := testutil.NewMockServer(t, func(w http.ResponseWriter, r *http.Request) {
 			if r.Method != http.MethodDelete {
 				t.Errorf("expected DELETE, got %s", r.Method)
 			}
 			w.WriteHeader(http.StatusNoContent)
-		}))
-		defer server.Close()
-
-		var (
-			baseURL    = server.URL
-			httpClient = http.DefaultClient
-			logger     = &noop.NoOpLogger{}
-		)
-
-		c := restclient.NewClient(baseURL, httpClient, standard.NewInterceptor(), logger)
-
+		})
+		c := testutil.NewClient(t, server.URL)
 		svc := NewKeyPairsClientImpl(c)
 
 		_, err := svc.Delete(context.Background(), "test-project", "keypair-123", nil)
 		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
+
+	t.Run("not found", func(t *testing.T) {
+		server := testutil.NewMockServer(t, func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusNotFound)
+			fmt.Fprint(w, testutil.ErrorBodyJSON("Not Found", "resource not found", 404))
+		})
+		c := testutil.NewClient(t, server.URL)
+		svc := NewKeyPairsClientImpl(c)
+		resp, err := svc.Delete(context.Background(), "test-project", "keypair-123", nil)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if resp == nil || resp.StatusCode != http.StatusNotFound {
+			t.Fatalf("expected 404 response")
+		}
+		if resp.Error == nil {
+			t.Fatalf("expected resp.Error to be populated")
+		}
+		if resp.Error.Title == nil || *resp.Error.Title != "Not Found" {
+			t.Errorf("expected title 'Not Found', got %v", resp.Error.Title)
+		}
+	})
+
+	t.Run("bad gateway non-json", func(t *testing.T) {
+		server := testutil.NewMockServer(t, func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusBadGateway)
+			fmt.Fprint(w, "Bad Gateway")
+		})
+		c := testutil.NewClient(t, server.URL)
+		svc := NewKeyPairsClientImpl(c)
+		resp, err := svc.Delete(context.Background(), "test-project", "keypair-123", nil)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if resp == nil || resp.StatusCode != http.StatusBadGateway {
+			t.Fatalf("expected 502 response")
+		}
+		if resp.Error != nil {
+			t.Errorf("expected resp.Error to be nil for non-JSON body, got %+v", resp.Error)
+		}
+		if string(resp.RawBody) != "Bad Gateway" {
+			t.Errorf("expected RawBody 'Bad Gateway', got %q", string(resp.RawBody))
+		}
+	})
+
+	t.Run("network error", func(t *testing.T) {
+		c := testutil.NewBrokenClient(t, "http://unused.invalid")
+		svc := NewKeyPairsClientImpl(c)
+		_, err := svc.Delete(context.Background(), "test-project", "keypair-123", nil)
+		if err == nil {
+			t.Fatal("expected a network error, got nil")
+		}
+	})
+
+	t.Run("nil params injects default api-version", func(t *testing.T) {
+		server := testutil.NewMockServer(t, func(w http.ResponseWriter, r *http.Request) {
+			if got := r.URL.Query().Get("api-version"); got != "1.0" {
+				t.Errorf("expected api-version=1.0, got %q", got)
+			}
+			w.WriteHeader(http.StatusNoContent)
+		})
+		c := testutil.NewClient(t, server.URL)
+		svc := NewKeyPairsClientImpl(c)
+		if _, err := svc.Delete(context.Background(), "test-project", "keypair-123", nil); err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
 	})


### PR DESCRIPTION
## Summary
- Migrates all per-subtest `/token` boilerplate in `cloudserver_test.go` and `keypair_test.go` to `testutil.NewMockServer` / `testutil.NewClient`
- Adds 4-scenario error matrix to all **11 test functions** (7 cloudserver + 4 keypair):
  - `not found` — 404 JSON error body; `resp.Error` populated
  - `bad gateway non-json` — 502 plain text; `resp.Error == nil`, `resp.RawBody` preserved (TD-011)
  - `network error` — `testutil.NewBrokenClient`; `err != nil`
  - `nil params injects default api-version` — asserts correct `api-version` query param (Create uses `1.1`, all others `1.0`)
- Empty-ID subtests migrated to `testutil.NewClient` (no server needed — validation short-circuits before HTTP)
- `TestCreateCloudServer` and `TestCreateKeyPair` `bad gateway non-json` subtests annotated with `// TODO(TD-010)` — Create's manual response build silently swallows non-JSON unmarshal errors, diverging from `ParseResponseBody`

## Test plan
- [ ] `go test ./internal/clients/compute/... -count=1 -race -v` — all subtests pass
- [ ] `go test ./internal/clients/compute/... -cover` — coverage increases vs. `main`
- [ ] `go test ./...` — full repo stays green

Closes #150 · Part of #130 · Depends on #148 (merged in #161) · Follows shape set by #162

🤖 Generated with [Claude Code](https://claude.com/claude-code)