### PR TITLE
test(database): add full coverage from scratch with testutil helpers

### DIFF
--- a/internal/clients/database/backup_test.go
+++ b/internal/clients/database/backup_test.go
@@ -1,0 +1,513 @@
+package database
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"testing"
+
+	"github.com/Arubacloud/sdk-go/internal/testutil"
+	"github.com/Arubacloud/sdk-go/pkg/types"
+)
+
+func TestListBackups(t *testing.T) {
+	t.Run("successful list", func(t *testing.T) {
+		server := testutil.NewMockServer(t, func(w http.ResponseWriter, r *http.Request) {
+			if r.Method == "GET" && r.URL.Path == "/projects/test-project/providers/Aruba.Database/backups" {
+				w.WriteHeader(http.StatusOK)
+				resp := types.BackupList{
+					ListResponse: types.ListResponse{Total: 1},
+					Values: []types.BackupResponse{
+						{
+							Metadata: types.ResourceMetadataResponse{
+								Name: types.StringPtr("backup-1"),
+								ID:   types.StringPtr("bk-123"),
+							},
+							Properties: types.BackupPropertiesResponse{
+								Zone:        "ITBG-1",
+								DBaaS:       types.ReferenceResource{URI: "/projects/test-project/providers/Aruba.Database/dbaas/dbaas-1"},
+								Database:    types.ReferenceResource{URI: "/projects/test-project/providers/Aruba.Database/dbaas/dbaas-1/databases/db-1"},
+								BillingPlan: types.BillingPeriodResource{BillingPeriod: "Hour"},
+								Storage:     types.BackupStorageResponse{Size: 10},
+							},
+							Status: types.ResourceStatus{State: types.StringPtr("active")},
+						},
+					},
+				}
+				json.NewEncoder(w).Encode(resp)
+				return
+			}
+			http.NotFound(w, r)
+		})
+		c := testutil.NewClient(t, server.URL)
+		svc := NewBackupsClientImpl(c)
+
+		resp, err := svc.List(context.Background(), "test-project", nil)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if resp == nil || resp.Data == nil || len(resp.Data.Values) != 1 {
+			t.Fatalf("expected 1 backup")
+		}
+		if resp.Data.Values[0].Metadata.Name == nil || *resp.Data.Values[0].Metadata.Name != "backup-1" {
+			t.Errorf("expected name 'backup-1'")
+		}
+		if resp.Data.Values[0].Properties.Zone != "ITBG-1" {
+			t.Errorf("expected zone 'ITBG-1', got %s", resp.Data.Values[0].Properties.Zone)
+		}
+	})
+
+	t.Run("empty project", func(t *testing.T) {
+		c := testutil.NewClient(t, "http://unused.invalid")
+		svc := NewBackupsClientImpl(c)
+		_, err := svc.List(context.Background(), "", nil)
+		if err == nil {
+			t.Fatal("expected validation error, got nil")
+		}
+	})
+
+	t.Run("not found", func(t *testing.T) {
+		server := testutil.NewMockServer(t, func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusNotFound)
+			fmt.Fprint(w, testutil.ErrorBodyJSON("Not Found", "resource not found", 404))
+		})
+		c := testutil.NewClient(t, server.URL)
+		svc := NewBackupsClientImpl(c)
+
+		resp, err := svc.List(context.Background(), "test-project", nil)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if resp == nil || resp.StatusCode != http.StatusNotFound {
+			t.Fatalf("expected 404 response")
+		}
+		if resp.Error == nil {
+			t.Fatalf("expected resp.Error to be populated")
+		}
+		if resp.Error.Title == nil || *resp.Error.Title != "Not Found" {
+			t.Errorf("expected title 'Not Found', got %v", resp.Error.Title)
+		}
+	})
+
+	t.Run("bad gateway non-json", func(t *testing.T) {
+		server := testutil.NewMockServer(t, func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusBadGateway)
+			fmt.Fprint(w, "Bad Gateway")
+		})
+		c := testutil.NewClient(t, server.URL)
+		svc := NewBackupsClientImpl(c)
+
+		resp, err := svc.List(context.Background(), "test-project", nil)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if resp == nil || resp.StatusCode != http.StatusBadGateway {
+			t.Fatalf("expected 502 response")
+		}
+		if resp.Error != nil {
+			t.Errorf("expected resp.Error to be nil for non-JSON body, got %+v", resp.Error)
+		}
+		if string(resp.RawBody) != "Bad Gateway" {
+			t.Errorf("expected RawBody 'Bad Gateway', got %q", string(resp.RawBody))
+		}
+	})
+
+	t.Run("network error", func(t *testing.T) {
+		c := testutil.NewBrokenClient(t, "http://unused.invalid")
+		svc := NewBackupsClientImpl(c)
+		_, err := svc.List(context.Background(), "test-project", nil)
+		if err == nil {
+			t.Fatal("expected a network error, got nil")
+		}
+	})
+
+	t.Run("nil params injects default api-version", func(t *testing.T) {
+		server := testutil.NewMockServer(t, func(w http.ResponseWriter, r *http.Request) {
+			if got := r.URL.Query().Get("api-version"); got != "1.0" {
+				t.Errorf("expected api-version=1.0, got %q", got)
+			}
+			w.WriteHeader(http.StatusOK)
+			fmt.Fprint(w, `{"total":0,"values":[]}`)
+		})
+		c := testutil.NewClient(t, server.URL)
+		svc := NewBackupsClientImpl(c)
+		if _, err := svc.List(context.Background(), "test-project", nil); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
+}
+
+func TestGetBackup(t *testing.T) {
+	t.Run("successful get", func(t *testing.T) {
+		server := testutil.NewMockServer(t, func(w http.ResponseWriter, r *http.Request) {
+			if r.Method == "GET" && r.URL.Path == "/projects/test-project/providers/Aruba.Database/backups/bk-123" {
+				w.WriteHeader(http.StatusOK)
+				resp := types.BackupResponse{
+					Metadata: types.ResourceMetadataResponse{
+						Name: types.StringPtr("backup-1"),
+						ID:   types.StringPtr("bk-123"),
+					},
+					Properties: types.BackupPropertiesResponse{
+						Zone:        "ITBG-1",
+						DBaaS:       types.ReferenceResource{URI: "/projects/test-project/providers/Aruba.Database/dbaas/dbaas-1"},
+						Database:    types.ReferenceResource{URI: "/projects/test-project/providers/Aruba.Database/dbaas/dbaas-1/databases/db-1"},
+						BillingPlan: types.BillingPeriodResource{BillingPeriod: "Hour"},
+						Storage:     types.BackupStorageResponse{Size: 10},
+					},
+					Status: types.ResourceStatus{State: types.StringPtr("active")},
+				}
+				json.NewEncoder(w).Encode(resp)
+				return
+			}
+			http.NotFound(w, r)
+		})
+		c := testutil.NewClient(t, server.URL)
+		svc := NewBackupsClientImpl(c)
+
+		resp, err := svc.Get(context.Background(), "test-project", "bk-123", nil)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if resp == nil || resp.Data == nil {
+			t.Fatalf("expected response data")
+		}
+		if resp.Data.Metadata.Name == nil || *resp.Data.Metadata.Name != "backup-1" {
+			t.Errorf("expected name 'backup-1'")
+		}
+		if resp.Data.Properties.Zone != "ITBG-1" {
+			t.Errorf("expected zone 'ITBG-1', got %s", resp.Data.Properties.Zone)
+		}
+	})
+
+	t.Run("empty project", func(t *testing.T) {
+		c := testutil.NewClient(t, "http://unused.invalid")
+		svc := NewBackupsClientImpl(c)
+		_, err := svc.Get(context.Background(), "", "bk-123", nil)
+		if err == nil {
+			t.Fatal("expected validation error, got nil")
+		}
+	})
+
+	t.Run("empty backup ID", func(t *testing.T) {
+		c := testutil.NewClient(t, "http://unused.invalid")
+		svc := NewBackupsClientImpl(c)
+		_, err := svc.Get(context.Background(), "test-project", "", nil)
+		if err == nil {
+			t.Fatal("expected validation error, got nil")
+		}
+	})
+
+	t.Run("not found", func(t *testing.T) {
+		server := testutil.NewMockServer(t, func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusNotFound)
+			fmt.Fprint(w, testutil.ErrorBodyJSON("Not Found", "resource not found", 404))
+		})
+		c := testutil.NewClient(t, server.URL)
+		svc := NewBackupsClientImpl(c)
+
+		resp, err := svc.Get(context.Background(), "test-project", "bk-123", nil)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if resp == nil || resp.StatusCode != http.StatusNotFound {
+			t.Fatalf("expected 404 response")
+		}
+		if resp.Error == nil {
+			t.Fatalf("expected resp.Error to be populated")
+		}
+		if resp.Error.Title == nil || *resp.Error.Title != "Not Found" {
+			t.Errorf("expected title 'Not Found', got %v", resp.Error.Title)
+		}
+	})
+
+	t.Run("bad gateway non-json", func(t *testing.T) {
+		server := testutil.NewMockServer(t, func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusBadGateway)
+			fmt.Fprint(w, "Bad Gateway")
+		})
+		c := testutil.NewClient(t, server.URL)
+		svc := NewBackupsClientImpl(c)
+
+		resp, err := svc.Get(context.Background(), "test-project", "bk-123", nil)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if resp == nil || resp.StatusCode != http.StatusBadGateway {
+			t.Fatalf("expected 502 response")
+		}
+		if resp.Error != nil {
+			t.Errorf("expected resp.Error to be nil for non-JSON body, got %+v", resp.Error)
+		}
+		if string(resp.RawBody) != "Bad Gateway" {
+			t.Errorf("expected RawBody 'Bad Gateway', got %q", string(resp.RawBody))
+		}
+	})
+
+	t.Run("network error", func(t *testing.T) {
+		c := testutil.NewBrokenClient(t, "http://unused.invalid")
+		svc := NewBackupsClientImpl(c)
+		_, err := svc.Get(context.Background(), "test-project", "bk-123", nil)
+		if err == nil {
+			t.Fatal("expected a network error, got nil")
+		}
+	})
+
+	t.Run("nil params injects default api-version", func(t *testing.T) {
+		server := testutil.NewMockServer(t, func(w http.ResponseWriter, r *http.Request) {
+			if got := r.URL.Query().Get("api-version"); got != "1.0" {
+				t.Errorf("expected api-version=1.0, got %q", got)
+			}
+			w.WriteHeader(http.StatusOK)
+			fmt.Fprint(w, `{}`)
+		})
+		c := testutil.NewClient(t, server.URL)
+		svc := NewBackupsClientImpl(c)
+		if _, err := svc.Get(context.Background(), "test-project", "bk-123", nil); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
+}
+
+func TestCreateBackup(t *testing.T) {
+	t.Run("successful create", func(t *testing.T) {
+		server := testutil.NewMockServer(t, func(w http.ResponseWriter, r *http.Request) {
+			if r.Method == "POST" && r.URL.Path == "/projects/test-project/providers/Aruba.Database/backups" {
+				w.WriteHeader(http.StatusCreated)
+				resp := types.BackupResponse{
+					Metadata: types.ResourceMetadataResponse{
+						Name: types.StringPtr("backup-1"),
+						ID:   types.StringPtr("bk-123"),
+					},
+					Properties: types.BackupPropertiesResponse{
+						Zone:        "ITBG-1",
+						DBaaS:       types.ReferenceResource{URI: "/projects/test-project/providers/Aruba.Database/dbaas/dbaas-1"},
+						Database:    types.ReferenceResource{URI: "/projects/test-project/providers/Aruba.Database/dbaas/dbaas-1/databases/db-1"},
+						BillingPlan: types.BillingPeriodResource{BillingPeriod: "Hour"},
+					},
+					Status: types.ResourceStatus{State: types.StringPtr("creating")},
+				}
+				json.NewEncoder(w).Encode(resp)
+				return
+			}
+			http.NotFound(w, r)
+		})
+		c := testutil.NewClient(t, server.URL)
+		svc := NewBackupsClientImpl(c)
+
+		body := types.BackupRequest{
+			Metadata: types.RegionalResourceMetadataRequest{
+				ResourceMetadataRequest: types.ResourceMetadataRequest{Name: "backup-1"},
+			},
+			Properties: types.BackupPropertiesRequest{
+				Zone:        "ITBG-1",
+				DBaaS:       types.ReferenceResource{URI: "/projects/test-project/providers/Aruba.Database/dbaas/dbaas-1"},
+				Database:    types.ReferenceResource{URI: "/projects/test-project/providers/Aruba.Database/dbaas/dbaas-1/databases/db-1"},
+				BillingPlan: types.BillingPeriodResource{BillingPeriod: "Hour"},
+			},
+		}
+
+		resp, err := svc.Create(context.Background(), "test-project", body, nil)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if resp == nil || resp.Data == nil {
+			t.Fatalf("expected response data")
+		}
+		if resp.Data.Metadata.Name == nil || *resp.Data.Metadata.Name != "backup-1" {
+			t.Errorf("expected name 'backup-1'")
+		}
+		if resp.Data.Status.State == nil || *resp.Data.Status.State != "creating" {
+			t.Errorf("expected state 'creating'")
+		}
+	})
+
+	t.Run("empty project", func(t *testing.T) {
+		c := testutil.NewClient(t, "http://unused.invalid")
+		svc := NewBackupsClientImpl(c)
+		_, err := svc.Create(context.Background(), "", types.BackupRequest{}, nil)
+		if err == nil {
+			t.Fatal("expected validation error, got nil")
+		}
+	})
+
+	t.Run("not found", func(t *testing.T) {
+		server := testutil.NewMockServer(t, func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusNotFound)
+			fmt.Fprint(w, testutil.ErrorBodyJSON("Not Found", "resource not found", 404))
+		})
+		c := testutil.NewClient(t, server.URL)
+		svc := NewBackupsClientImpl(c)
+
+		resp, err := svc.Create(context.Background(), "test-project", types.BackupRequest{}, nil)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if resp == nil || resp.StatusCode != http.StatusNotFound {
+			t.Fatalf("expected 404 response")
+		}
+		if resp.Error == nil {
+			t.Fatalf("expected resp.Error to be populated")
+		}
+		if resp.Error.Title == nil || *resp.Error.Title != "Not Found" {
+			t.Errorf("expected title 'Not Found', got %v", resp.Error.Title)
+		}
+	})
+
+	t.Run("bad gateway non-json", func(t *testing.T) {
+		server := testutil.NewMockServer(t, func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusBadGateway)
+			fmt.Fprint(w, "Bad Gateway")
+		})
+		c := testutil.NewClient(t, server.URL)
+		svc := NewBackupsClientImpl(c)
+
+		resp, err := svc.Create(context.Background(), "test-project", types.BackupRequest{}, nil)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if resp == nil || resp.StatusCode != http.StatusBadGateway {
+			t.Fatalf("expected 502 response")
+		}
+		if resp.Error != nil {
+			t.Errorf("expected resp.Error to be nil for non-JSON body, got %+v", resp.Error)
+		}
+		if string(resp.RawBody) != "Bad Gateway" {
+			t.Errorf("expected RawBody 'Bad Gateway', got %q", string(resp.RawBody))
+		}
+	})
+
+	t.Run("network error", func(t *testing.T) {
+		c := testutil.NewBrokenClient(t, "http://unused.invalid")
+		svc := NewBackupsClientImpl(c)
+		_, err := svc.Create(context.Background(), "test-project", types.BackupRequest{}, nil)
+		if err == nil {
+			t.Fatal("expected a network error, got nil")
+		}
+	})
+
+	t.Run("nil params injects default api-version", func(t *testing.T) {
+		server := testutil.NewMockServer(t, func(w http.ResponseWriter, r *http.Request) {
+			if got := r.URL.Query().Get("api-version"); got != "1.0" {
+				t.Errorf("expected api-version=1.0, got %q", got)
+			}
+			w.WriteHeader(http.StatusCreated)
+			fmt.Fprint(w, `{}`)
+		})
+		c := testutil.NewClient(t, server.URL)
+		svc := NewBackupsClientImpl(c)
+		if _, err := svc.Create(context.Background(), "test-project", types.BackupRequest{}, nil); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
+}
+
+func TestDeleteBackup(t *testing.T) {
+	t.Run("successful delete", func(t *testing.T) {
+		server := testutil.NewMockServer(t, func(w http.ResponseWriter, r *http.Request) {
+			if r.Method == "DELETE" && r.URL.Path == "/projects/test-project/providers/Aruba.Database/backups/bk-123" {
+				w.WriteHeader(http.StatusNoContent)
+				return
+			}
+			http.NotFound(w, r)
+		})
+		c := testutil.NewClient(t, server.URL)
+		svc := NewBackupsClientImpl(c)
+
+		_, err := svc.Delete(context.Background(), "test-project", "bk-123", nil)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
+
+	t.Run("empty project", func(t *testing.T) {
+		c := testutil.NewClient(t, "http://unused.invalid")
+		svc := NewBackupsClientImpl(c)
+		_, err := svc.Delete(context.Background(), "", "bk-123", nil)
+		if err == nil {
+			t.Fatal("expected validation error, got nil")
+		}
+	})
+
+	t.Run("empty backup ID", func(t *testing.T) {
+		c := testutil.NewClient(t, "http://unused.invalid")
+		svc := NewBackupsClientImpl(c)
+		_, err := svc.Delete(context.Background(), "test-project", "", nil)
+		if err == nil {
+			t.Fatal("expected validation error, got nil")
+		}
+	})
+
+	t.Run("not found", func(t *testing.T) {
+		server := testutil.NewMockServer(t, func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusNotFound)
+			fmt.Fprint(w, testutil.ErrorBodyJSON("Not Found", "resource not found", 404))
+		})
+		c := testutil.NewClient(t, server.URL)
+		svc := NewBackupsClientImpl(c)
+
+		resp, err := svc.Delete(context.Background(), "test-project", "bk-123", nil)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if resp == nil || resp.StatusCode != http.StatusNotFound {
+			t.Fatalf("expected 404 response")
+		}
+		if resp.Error == nil {
+			t.Fatalf("expected resp.Error to be populated")
+		}
+		if resp.Error.Title == nil || *resp.Error.Title != "Not Found" {
+			t.Errorf("expected title 'Not Found', got %v", resp.Error.Title)
+		}
+	})
+
+	t.Run("bad gateway non-json", func(t *testing.T) {
+		server := testutil.NewMockServer(t, func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusBadGateway)
+			fmt.Fprint(w, "Bad Gateway")
+		})
+		c := testutil.NewClient(t, server.URL)
+		svc := NewBackupsClientImpl(c)
+
+		resp, err := svc.Delete(context.Background(), "test-project", "bk-123", nil)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if resp == nil || resp.StatusCode != http.StatusBadGateway {
+			t.Fatalf("expected 502 response")
+		}
+		if resp.Error != nil {
+			t.Errorf("expected resp.Error to be nil for non-JSON body, got %+v", resp.Error)
+		}
+		if string(resp.RawBody) != "Bad Gateway" {
+			t.Errorf("expected RawBody 'Bad Gateway', got %q", string(resp.RawBody))
+		}
+	})
+
+	t.Run("network error", func(t *testing.T) {
+		c := testutil.NewBrokenClient(t, "http://unused.invalid")
+		svc := NewBackupsClientImpl(c)
+		_, err := svc.Delete(context.Background(), "test-project", "bk-123", nil)
+		if err == nil {
+			t.Fatal("expected a network error, got nil")
+		}
+	})
+
+	t.Run("nil params injects default api-version", func(t *testing.T) {
+		server := testutil.NewMockServer(t, func(w http.ResponseWriter, r *http.Request) {
+			if got := r.URL.Query().Get("api-version"); got != "1.0" {
+				t.Errorf("expected api-version=1.0, got %q", got)
+			}
+			w.WriteHeader(http.StatusNoContent)
+		})
+		c := testutil.NewClient(t, server.URL)
+		svc := NewBackupsClientImpl(c)
+		if _, err := svc.Delete(context.Background(), "test-project", "bk-123", nil); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
+}

--- a/internal/clients/database/database_test.go
+++ b/internal/clients/database/database_test.go
@@ -1,0 +1,619 @@
+package database
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"testing"
+
+	"github.com/Arubacloud/sdk-go/internal/testutil"
+	"github.com/Arubacloud/sdk-go/pkg/types"
+)
+
+func TestListDatabases(t *testing.T) {
+	t.Run("successful list", func(t *testing.T) {
+		server := testutil.NewMockServer(t, func(w http.ResponseWriter, r *http.Request) {
+			if r.Method == "GET" && r.URL.Path == "/projects/test-project/providers/Aruba.Database/dbaas/dbaas-123/databases" {
+				w.WriteHeader(http.StatusOK)
+				resp := types.DatabaseList{
+					ListResponse: types.ListResponse{Total: 1},
+					Values: []types.DatabaseResponse{
+						{Name: "my-db"},
+					},
+				}
+				json.NewEncoder(w).Encode(resp)
+				return
+			}
+			http.NotFound(w, r)
+		})
+		c := testutil.NewClient(t, server.URL)
+		svc := NewDatabasesClientImpl(c)
+
+		resp, err := svc.List(context.Background(), "test-project", "dbaas-123", nil)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if resp == nil || resp.Data == nil || len(resp.Data.Values) != 1 {
+			t.Fatalf("expected 1 database")
+		}
+		if resp.Data.Values[0].Name != "my-db" {
+			t.Errorf("expected name 'my-db', got %s", resp.Data.Values[0].Name)
+		}
+	})
+
+	t.Run("empty project", func(t *testing.T) {
+		c := testutil.NewClient(t, "http://unused.invalid")
+		svc := NewDatabasesClientImpl(c)
+		_, err := svc.List(context.Background(), "", "dbaas-123", nil)
+		if err == nil {
+			t.Fatal("expected validation error, got nil")
+		}
+	})
+
+	t.Run("empty DBaaS ID", func(t *testing.T) {
+		c := testutil.NewClient(t, "http://unused.invalid")
+		svc := NewDatabasesClientImpl(c)
+		_, err := svc.List(context.Background(), "test-project", "", nil)
+		if err == nil {
+			t.Fatal("expected validation error, got nil")
+		}
+	})
+
+	t.Run("not found", func(t *testing.T) {
+		server := testutil.NewMockServer(t, func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusNotFound)
+			fmt.Fprint(w, testutil.ErrorBodyJSON("Not Found", "resource not found", 404))
+		})
+		c := testutil.NewClient(t, server.URL)
+		svc := NewDatabasesClientImpl(c)
+
+		resp, err := svc.List(context.Background(), "test-project", "dbaas-123", nil)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if resp == nil || resp.StatusCode != http.StatusNotFound {
+			t.Fatalf("expected 404 response")
+		}
+		if resp.Error == nil {
+			t.Fatalf("expected resp.Error to be populated")
+		}
+		if resp.Error.Title == nil || *resp.Error.Title != "Not Found" {
+			t.Errorf("expected title 'Not Found', got %v", resp.Error.Title)
+		}
+	})
+
+	t.Run("bad gateway non-json", func(t *testing.T) {
+		server := testutil.NewMockServer(t, func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusBadGateway)
+			fmt.Fprint(w, "Bad Gateway")
+		})
+		c := testutil.NewClient(t, server.URL)
+		svc := NewDatabasesClientImpl(c)
+
+		resp, err := svc.List(context.Background(), "test-project", "dbaas-123", nil)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if resp == nil || resp.StatusCode != http.StatusBadGateway {
+			t.Fatalf("expected 502 response")
+		}
+		if resp.Error != nil {
+			t.Errorf("expected resp.Error to be nil for non-JSON body, got %+v", resp.Error)
+		}
+		if string(resp.RawBody) != "Bad Gateway" {
+			t.Errorf("expected RawBody 'Bad Gateway', got %q", string(resp.RawBody))
+		}
+	})
+
+	t.Run("network error", func(t *testing.T) {
+		c := testutil.NewBrokenClient(t, "http://unused.invalid")
+		svc := NewDatabasesClientImpl(c)
+		_, err := svc.List(context.Background(), "test-project", "dbaas-123", nil)
+		if err == nil {
+			t.Fatal("expected a network error, got nil")
+		}
+	})
+
+	t.Run("nil params injects default api-version", func(t *testing.T) {
+		server := testutil.NewMockServer(t, func(w http.ResponseWriter, r *http.Request) {
+			if got := r.URL.Query().Get("api-version"); got != "1.0" {
+				t.Errorf("expected api-version=1.0, got %q", got)
+			}
+			w.WriteHeader(http.StatusOK)
+			fmt.Fprint(w, `{"total":0,"values":[]}`)
+		})
+		c := testutil.NewClient(t, server.URL)
+		svc := NewDatabasesClientImpl(c)
+		if _, err := svc.List(context.Background(), "test-project", "dbaas-123", nil); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
+}
+
+func TestGetDatabase(t *testing.T) {
+	t.Run("successful get", func(t *testing.T) {
+		server := testutil.NewMockServer(t, func(w http.ResponseWriter, r *http.Request) {
+			if r.Method == "GET" && r.URL.Path == "/projects/test-project/providers/Aruba.Database/dbaas/dbaas-123/databases/db-456" {
+				w.WriteHeader(http.StatusOK)
+				resp := types.DatabaseResponse{Name: "my-db"}
+				json.NewEncoder(w).Encode(resp)
+				return
+			}
+			http.NotFound(w, r)
+		})
+		c := testutil.NewClient(t, server.URL)
+		svc := NewDatabasesClientImpl(c)
+
+		resp, err := svc.Get(context.Background(), "test-project", "dbaas-123", "db-456", nil)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if resp == nil || resp.Data == nil {
+			t.Fatalf("expected response data")
+		}
+		if resp.Data.Name != "my-db" {
+			t.Errorf("expected name 'my-db', got %s", resp.Data.Name)
+		}
+	})
+
+	t.Run("empty project", func(t *testing.T) {
+		c := testutil.NewClient(t, "http://unused.invalid")
+		svc := NewDatabasesClientImpl(c)
+		_, err := svc.Get(context.Background(), "", "dbaas-123", "db-456", nil)
+		if err == nil {
+			t.Fatal("expected validation error, got nil")
+		}
+	})
+
+	t.Run("empty DBaaS ID", func(t *testing.T) {
+		c := testutil.NewClient(t, "http://unused.invalid")
+		svc := NewDatabasesClientImpl(c)
+		_, err := svc.Get(context.Background(), "test-project", "", "db-456", nil)
+		if err == nil {
+			t.Fatal("expected validation error, got nil")
+		}
+	})
+
+	t.Run("empty database ID", func(t *testing.T) {
+		c := testutil.NewClient(t, "http://unused.invalid")
+		svc := NewDatabasesClientImpl(c)
+		_, err := svc.Get(context.Background(), "test-project", "dbaas-123", "", nil)
+		if err == nil {
+			t.Fatal("expected validation error, got nil")
+		}
+	})
+
+	t.Run("not found", func(t *testing.T) {
+		server := testutil.NewMockServer(t, func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusNotFound)
+			fmt.Fprint(w, testutil.ErrorBodyJSON("Not Found", "resource not found", 404))
+		})
+		c := testutil.NewClient(t, server.URL)
+		svc := NewDatabasesClientImpl(c)
+
+		resp, err := svc.Get(context.Background(), "test-project", "dbaas-123", "db-456", nil)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if resp == nil || resp.StatusCode != http.StatusNotFound {
+			t.Fatalf("expected 404 response")
+		}
+		if resp.Error == nil {
+			t.Fatalf("expected resp.Error to be populated")
+		}
+		if resp.Error.Title == nil || *resp.Error.Title != "Not Found" {
+			t.Errorf("expected title 'Not Found', got %v", resp.Error.Title)
+		}
+	})
+
+	t.Run("bad gateway non-json", func(t *testing.T) {
+		server := testutil.NewMockServer(t, func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusBadGateway)
+			fmt.Fprint(w, "Bad Gateway")
+		})
+		c := testutil.NewClient(t, server.URL)
+		svc := NewDatabasesClientImpl(c)
+
+		resp, err := svc.Get(context.Background(), "test-project", "dbaas-123", "db-456", nil)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if resp == nil || resp.StatusCode != http.StatusBadGateway {
+			t.Fatalf("expected 502 response")
+		}
+		if resp.Error != nil {
+			t.Errorf("expected resp.Error to be nil for non-JSON body, got %+v", resp.Error)
+		}
+		if string(resp.RawBody) != "Bad Gateway" {
+			t.Errorf("expected RawBody 'Bad Gateway', got %q", string(resp.RawBody))
+		}
+	})
+
+	t.Run("network error", func(t *testing.T) {
+		c := testutil.NewBrokenClient(t, "http://unused.invalid")
+		svc := NewDatabasesClientImpl(c)
+		_, err := svc.Get(context.Background(), "test-project", "dbaas-123", "db-456", nil)
+		if err == nil {
+			t.Fatal("expected a network error, got nil")
+		}
+	})
+
+	t.Run("nil params injects default api-version", func(t *testing.T) {
+		server := testutil.NewMockServer(t, func(w http.ResponseWriter, r *http.Request) {
+			if got := r.URL.Query().Get("api-version"); got != "1.0" {
+				t.Errorf("expected api-version=1.0, got %q", got)
+			}
+			w.WriteHeader(http.StatusOK)
+			fmt.Fprint(w, `{}`)
+		})
+		c := testutil.NewClient(t, server.URL)
+		svc := NewDatabasesClientImpl(c)
+		if _, err := svc.Get(context.Background(), "test-project", "dbaas-123", "db-456", nil); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
+}
+
+func TestCreateDatabase(t *testing.T) {
+	t.Run("successful create", func(t *testing.T) {
+		server := testutil.NewMockServer(t, func(w http.ResponseWriter, r *http.Request) {
+			if r.Method == "POST" && r.URL.Path == "/projects/test-project/providers/Aruba.Database/dbaas/dbaas-123/databases" {
+				w.WriteHeader(http.StatusCreated)
+				resp := types.DatabaseResponse{Name: "my-db"}
+				json.NewEncoder(w).Encode(resp)
+				return
+			}
+			http.NotFound(w, r)
+		})
+		c := testutil.NewClient(t, server.URL)
+		svc := NewDatabasesClientImpl(c)
+
+		resp, err := svc.Create(context.Background(), "test-project", "dbaas-123", types.DatabaseRequest{Name: "my-db"}, nil)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if resp == nil || resp.Data == nil {
+			t.Fatalf("expected response data")
+		}
+		if resp.Data.Name != "my-db" {
+			t.Errorf("expected name 'my-db', got %s", resp.Data.Name)
+		}
+	})
+
+	t.Run("empty project", func(t *testing.T) {
+		c := testutil.NewClient(t, "http://unused.invalid")
+		svc := NewDatabasesClientImpl(c)
+		_, err := svc.Create(context.Background(), "", "dbaas-123", types.DatabaseRequest{}, nil)
+		if err == nil {
+			t.Fatal("expected validation error, got nil")
+		}
+	})
+
+	t.Run("empty DBaaS ID", func(t *testing.T) {
+		c := testutil.NewClient(t, "http://unused.invalid")
+		svc := NewDatabasesClientImpl(c)
+		_, err := svc.Create(context.Background(), "test-project", "", types.DatabaseRequest{}, nil)
+		if err == nil {
+			t.Fatal("expected validation error, got nil")
+		}
+	})
+
+	t.Run("not found", func(t *testing.T) {
+		server := testutil.NewMockServer(t, func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusNotFound)
+			fmt.Fprint(w, testutil.ErrorBodyJSON("Not Found", "resource not found", 404))
+		})
+		c := testutil.NewClient(t, server.URL)
+		svc := NewDatabasesClientImpl(c)
+
+		resp, err := svc.Create(context.Background(), "test-project", "dbaas-123", types.DatabaseRequest{}, nil)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if resp == nil || resp.StatusCode != http.StatusNotFound {
+			t.Fatalf("expected 404 response")
+		}
+		if resp.Error == nil {
+			t.Fatalf("expected resp.Error to be populated")
+		}
+		if resp.Error.Title == nil || *resp.Error.Title != "Not Found" {
+			t.Errorf("expected title 'Not Found', got %v", resp.Error.Title)
+		}
+	})
+
+	t.Run("bad gateway non-json", func(t *testing.T) {
+		// TODO(TD-010): Create's manual response build silently swallows non-JSON
+		// unmarshal errors (diverges from ParseResponseBody which logs at DEBUG).
+		server := testutil.NewMockServer(t, func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusBadGateway)
+			fmt.Fprint(w, "Bad Gateway")
+		})
+		c := testutil.NewClient(t, server.URL)
+		svc := NewDatabasesClientImpl(c)
+
+		resp, err := svc.Create(context.Background(), "test-project", "dbaas-123", types.DatabaseRequest{}, nil)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if resp == nil || resp.StatusCode != http.StatusBadGateway {
+			t.Fatalf("expected 502 response")
+		}
+		if resp.Error != nil {
+			t.Errorf("expected resp.Error to be nil for non-JSON body, got %+v", resp.Error)
+		}
+		if string(resp.RawBody) != "Bad Gateway" {
+			t.Errorf("expected RawBody 'Bad Gateway', got %q", string(resp.RawBody))
+		}
+	})
+
+	t.Run("network error", func(t *testing.T) {
+		c := testutil.NewBrokenClient(t, "http://unused.invalid")
+		svc := NewDatabasesClientImpl(c)
+		_, err := svc.Create(context.Background(), "test-project", "dbaas-123", types.DatabaseRequest{}, nil)
+		if err == nil {
+			t.Fatal("expected a network error, got nil")
+		}
+	})
+
+	t.Run("nil params injects default api-version", func(t *testing.T) {
+		server := testutil.NewMockServer(t, func(w http.ResponseWriter, r *http.Request) {
+			if got := r.URL.Query().Get("api-version"); got != "1.0" {
+				t.Errorf("expected api-version=1.0, got %q", got)
+			}
+			w.WriteHeader(http.StatusCreated)
+			fmt.Fprint(w, `{}`)
+		})
+		c := testutil.NewClient(t, server.URL)
+		svc := NewDatabasesClientImpl(c)
+		if _, err := svc.Create(context.Background(), "test-project", "dbaas-123", types.DatabaseRequest{}, nil); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
+}
+
+func TestUpdateDatabase(t *testing.T) {
+	t.Run("successful update", func(t *testing.T) {
+		server := testutil.NewMockServer(t, func(w http.ResponseWriter, r *http.Request) {
+			if r.Method == "PUT" && r.URL.Path == "/projects/test-project/providers/Aruba.Database/dbaas/dbaas-123/databases/db-456" {
+				w.WriteHeader(http.StatusOK)
+				resp := types.DatabaseResponse{Name: "my-db-updated"}
+				json.NewEncoder(w).Encode(resp)
+				return
+			}
+			http.NotFound(w, r)
+		})
+		c := testutil.NewClient(t, server.URL)
+		svc := NewDatabasesClientImpl(c)
+
+		resp, err := svc.Update(context.Background(), "test-project", "dbaas-123", "db-456", types.DatabaseRequest{Name: "my-db-updated"}, nil)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if resp == nil || resp.Data == nil {
+			t.Fatalf("expected response data")
+		}
+		if resp.Data.Name != "my-db-updated" {
+			t.Errorf("expected name 'my-db-updated', got %s", resp.Data.Name)
+		}
+	})
+
+	t.Run("empty project", func(t *testing.T) {
+		c := testutil.NewClient(t, "http://unused.invalid")
+		svc := NewDatabasesClientImpl(c)
+		_, err := svc.Update(context.Background(), "", "dbaas-123", "db-456", types.DatabaseRequest{}, nil)
+		if err == nil {
+			t.Fatal("expected validation error, got nil")
+		}
+	})
+
+	t.Run("empty DBaaS ID", func(t *testing.T) {
+		c := testutil.NewClient(t, "http://unused.invalid")
+		svc := NewDatabasesClientImpl(c)
+		_, err := svc.Update(context.Background(), "test-project", "", "db-456", types.DatabaseRequest{}, nil)
+		if err == nil {
+			t.Fatal("expected validation error, got nil")
+		}
+	})
+
+	t.Run("empty database ID", func(t *testing.T) {
+		c := testutil.NewClient(t, "http://unused.invalid")
+		svc := NewDatabasesClientImpl(c)
+		_, err := svc.Update(context.Background(), "test-project", "dbaas-123", "", types.DatabaseRequest{}, nil)
+		if err == nil {
+			t.Fatal("expected validation error, got nil")
+		}
+	})
+
+	t.Run("not found", func(t *testing.T) {
+		server := testutil.NewMockServer(t, func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusNotFound)
+			fmt.Fprint(w, testutil.ErrorBodyJSON("Not Found", "resource not found", 404))
+		})
+		c := testutil.NewClient(t, server.URL)
+		svc := NewDatabasesClientImpl(c)
+
+		resp, err := svc.Update(context.Background(), "test-project", "dbaas-123", "db-456", types.DatabaseRequest{}, nil)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if resp == nil || resp.StatusCode != http.StatusNotFound {
+			t.Fatalf("expected 404 response")
+		}
+		if resp.Error == nil {
+			t.Fatalf("expected resp.Error to be populated")
+		}
+		if resp.Error.Title == nil || *resp.Error.Title != "Not Found" {
+			t.Errorf("expected title 'Not Found', got %v", resp.Error.Title)
+		}
+	})
+
+	t.Run("bad gateway non-json", func(t *testing.T) {
+		// TODO(TD-010): Update's manual response build silently swallows non-JSON
+		// unmarshal errors (diverges from ParseResponseBody which logs at DEBUG).
+		server := testutil.NewMockServer(t, func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusBadGateway)
+			fmt.Fprint(w, "Bad Gateway")
+		})
+		c := testutil.NewClient(t, server.URL)
+		svc := NewDatabasesClientImpl(c)
+
+		resp, err := svc.Update(context.Background(), "test-project", "dbaas-123", "db-456", types.DatabaseRequest{}, nil)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if resp == nil || resp.StatusCode != http.StatusBadGateway {
+			t.Fatalf("expected 502 response")
+		}
+		if resp.Error != nil {
+			t.Errorf("expected resp.Error to be nil for non-JSON body, got %+v", resp.Error)
+		}
+		if string(resp.RawBody) != "Bad Gateway" {
+			t.Errorf("expected RawBody 'Bad Gateway', got %q", string(resp.RawBody))
+		}
+	})
+
+	t.Run("network error", func(t *testing.T) {
+		c := testutil.NewBrokenClient(t, "http://unused.invalid")
+		svc := NewDatabasesClientImpl(c)
+		_, err := svc.Update(context.Background(), "test-project", "dbaas-123", "db-456", types.DatabaseRequest{}, nil)
+		if err == nil {
+			t.Fatal("expected a network error, got nil")
+		}
+	})
+
+	t.Run("nil params injects default api-version", func(t *testing.T) {
+		server := testutil.NewMockServer(t, func(w http.ResponseWriter, r *http.Request) {
+			if got := r.URL.Query().Get("api-version"); got != "1.0" {
+				t.Errorf("expected api-version=1.0, got %q", got)
+			}
+			w.WriteHeader(http.StatusOK)
+			fmt.Fprint(w, `{}`)
+		})
+		c := testutil.NewClient(t, server.URL)
+		svc := NewDatabasesClientImpl(c)
+		if _, err := svc.Update(context.Background(), "test-project", "dbaas-123", "db-456", types.DatabaseRequest{}, nil); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
+}
+
+func TestDeleteDatabase(t *testing.T) {
+	t.Run("successful delete", func(t *testing.T) {
+		server := testutil.NewMockServer(t, func(w http.ResponseWriter, r *http.Request) {
+			if r.Method == "DELETE" && r.URL.Path == "/projects/test-project/providers/Aruba.Database/dbaas/dbaas-123/databases/db-456" {
+				w.WriteHeader(http.StatusNoContent)
+				return
+			}
+			http.NotFound(w, r)
+		})
+		c := testutil.NewClient(t, server.URL)
+		svc := NewDatabasesClientImpl(c)
+
+		_, err := svc.Delete(context.Background(), "test-project", "dbaas-123", "db-456", nil)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
+
+	t.Run("empty project", func(t *testing.T) {
+		c := testutil.NewClient(t, "http://unused.invalid")
+		svc := NewDatabasesClientImpl(c)
+		_, err := svc.Delete(context.Background(), "", "dbaas-123", "db-456", nil)
+		if err == nil {
+			t.Fatal("expected validation error, got nil")
+		}
+	})
+
+	t.Run("empty DBaaS ID", func(t *testing.T) {
+		c := testutil.NewClient(t, "http://unused.invalid")
+		svc := NewDatabasesClientImpl(c)
+		_, err := svc.Delete(context.Background(), "test-project", "", "db-456", nil)
+		if err == nil {
+			t.Fatal("expected validation error, got nil")
+		}
+	})
+
+	t.Run("empty database ID", func(t *testing.T) {
+		c := testutil.NewClient(t, "http://unused.invalid")
+		svc := NewDatabasesClientImpl(c)
+		_, err := svc.Delete(context.Background(), "test-project", "dbaas-123", "", nil)
+		if err == nil {
+			t.Fatal("expected validation error, got nil")
+		}
+	})
+
+	t.Run("not found", func(t *testing.T) {
+		server := testutil.NewMockServer(t, func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusNotFound)
+			fmt.Fprint(w, testutil.ErrorBodyJSON("Not Found", "resource not found", 404))
+		})
+		c := testutil.NewClient(t, server.URL)
+		svc := NewDatabasesClientImpl(c)
+
+		resp, err := svc.Delete(context.Background(), "test-project", "dbaas-123", "db-456", nil)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if resp == nil || resp.StatusCode != http.StatusNotFound {
+			t.Fatalf("expected 404 response")
+		}
+		if resp.Error == nil {
+			t.Fatalf("expected resp.Error to be populated")
+		}
+		if resp.Error.Title == nil || *resp.Error.Title != "Not Found" {
+			t.Errorf("expected title 'Not Found', got %v", resp.Error.Title)
+		}
+	})
+
+	t.Run("bad gateway non-json", func(t *testing.T) {
+		server := testutil.NewMockServer(t, func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusBadGateway)
+			fmt.Fprint(w, "Bad Gateway")
+		})
+		c := testutil.NewClient(t, server.URL)
+		svc := NewDatabasesClientImpl(c)
+
+		resp, err := svc.Delete(context.Background(), "test-project", "dbaas-123", "db-456", nil)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if resp == nil || resp.StatusCode != http.StatusBadGateway {
+			t.Fatalf("expected 502 response")
+		}
+		if resp.Error != nil {
+			t.Errorf("expected resp.Error to be nil for non-JSON body, got %+v", resp.Error)
+		}
+		if string(resp.RawBody) != "Bad Gateway" {
+			t.Errorf("expected RawBody 'Bad Gateway', got %q", string(resp.RawBody))
+		}
+	})
+
+	t.Run("network error", func(t *testing.T) {
+		c := testutil.NewBrokenClient(t, "http://unused.invalid")
+		svc := NewDatabasesClientImpl(c)
+		_, err := svc.Delete(context.Background(), "test-project", "dbaas-123", "db-456", nil)
+		if err == nil {
+			t.Fatal("expected a network error, got nil")
+		}
+	})
+
+	t.Run("nil params injects default api-version", func(t *testing.T) {
+		server := testutil.NewMockServer(t, func(w http.ResponseWriter, r *http.Request) {
+			if got := r.URL.Query().Get("api-version"); got != "1.0" {
+				t.Errorf("expected api-version=1.0, got %q", got)
+			}
+			w.WriteHeader(http.StatusNoContent)
+		})
+		c := testutil.NewClient(t, server.URL)
+		svc := NewDatabasesClientImpl(c)
+		if _, err := svc.Delete(context.Background(), "test-project", "dbaas-123", "db-456", nil); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
+}

--- a/internal/clients/database/dbaas_test.go
+++ b/internal/clients/database/dbaas_test.go
@@ -1,0 +1,642 @@
+package database
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"testing"
+
+	"github.com/Arubacloud/sdk-go/internal/testutil"
+	"github.com/Arubacloud/sdk-go/pkg/types"
+)
+
+func TestListDBaaS(t *testing.T) {
+	t.Run("successful list", func(t *testing.T) {
+		server := testutil.NewMockServer(t, func(w http.ResponseWriter, r *http.Request) {
+			if r.Method == "GET" && r.URL.Path == "/projects/test-project/providers/Aruba.Database/dbaas" {
+				w.WriteHeader(http.StatusOK)
+				resp := types.DBaaSList{
+					ListResponse: types.ListResponse{Total: 1},
+					Values: []types.DBaaSResponse{
+						{
+							Metadata: types.ResourceMetadataResponse{
+								Name: types.StringPtr("dbaas-1"),
+								ID:   types.StringPtr("dbaas-123"),
+							},
+							Properties: types.DBaaSPropertiesResponse{
+								Engine: &types.DBaaSEngineResponse{
+									Type:    types.StringPtr("MySQL"),
+									Version: types.StringPtr("8.0"),
+								},
+							},
+							Status: types.ResourceStatus{State: types.StringPtr("active")},
+						},
+					},
+				}
+				json.NewEncoder(w).Encode(resp)
+				return
+			}
+			http.NotFound(w, r)
+		})
+		c := testutil.NewClient(t, server.URL)
+		svc := NewDBaaSClientImpl(c)
+
+		resp, err := svc.List(context.Background(), "test-project", nil)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if resp == nil || resp.Data == nil || len(resp.Data.Values) != 1 {
+			t.Fatalf("expected 1 DBaaS")
+		}
+		if resp.Data.Values[0].Metadata.Name == nil || *resp.Data.Values[0].Metadata.Name != "dbaas-1" {
+			t.Errorf("expected name 'dbaas-1'")
+		}
+	})
+
+	t.Run("empty project", func(t *testing.T) {
+		c := testutil.NewClient(t, "http://unused.invalid")
+		svc := NewDBaaSClientImpl(c)
+		_, err := svc.List(context.Background(), "", nil)
+		if err == nil {
+			t.Fatal("expected validation error, got nil")
+		}
+	})
+
+	t.Run("not found", func(t *testing.T) {
+		server := testutil.NewMockServer(t, func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusNotFound)
+			fmt.Fprint(w, testutil.ErrorBodyJSON("Not Found", "resource not found", 404))
+		})
+		c := testutil.NewClient(t, server.URL)
+		svc := NewDBaaSClientImpl(c)
+
+		resp, err := svc.List(context.Background(), "test-project", nil)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if resp == nil || resp.StatusCode != http.StatusNotFound {
+			t.Fatalf("expected 404 response")
+		}
+		if resp.Error == nil {
+			t.Fatalf("expected resp.Error to be populated")
+		}
+		if resp.Error.Title == nil || *resp.Error.Title != "Not Found" {
+			t.Errorf("expected title 'Not Found', got %v", resp.Error.Title)
+		}
+	})
+
+	t.Run("bad gateway non-json", func(t *testing.T) {
+		server := testutil.NewMockServer(t, func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusBadGateway)
+			fmt.Fprint(w, "Bad Gateway")
+		})
+		c := testutil.NewClient(t, server.URL)
+		svc := NewDBaaSClientImpl(c)
+
+		resp, err := svc.List(context.Background(), "test-project", nil)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if resp == nil || resp.StatusCode != http.StatusBadGateway {
+			t.Fatalf("expected 502 response")
+		}
+		if resp.Error != nil {
+			t.Errorf("expected resp.Error to be nil for non-JSON body, got %+v", resp.Error)
+		}
+		if string(resp.RawBody) != "Bad Gateway" {
+			t.Errorf("expected RawBody 'Bad Gateway', got %q", string(resp.RawBody))
+		}
+	})
+
+	t.Run("network error", func(t *testing.T) {
+		c := testutil.NewBrokenClient(t, "http://unused.invalid")
+		svc := NewDBaaSClientImpl(c)
+		_, err := svc.List(context.Background(), "test-project", nil)
+		if err == nil {
+			t.Fatal("expected a network error, got nil")
+		}
+	})
+
+	t.Run("nil params injects default api-version", func(t *testing.T) {
+		server := testutil.NewMockServer(t, func(w http.ResponseWriter, r *http.Request) {
+			if got := r.URL.Query().Get("api-version"); got != "1.0" {
+				t.Errorf("expected api-version=1.0, got %q", got)
+			}
+			w.WriteHeader(http.StatusOK)
+			fmt.Fprint(w, `{"total":0,"values":[]}`)
+		})
+		c := testutil.NewClient(t, server.URL)
+		svc := NewDBaaSClientImpl(c)
+		if _, err := svc.List(context.Background(), "test-project", nil); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
+}
+
+func TestGetDBaaS(t *testing.T) {
+	t.Run("successful get", func(t *testing.T) {
+		server := testutil.NewMockServer(t, func(w http.ResponseWriter, r *http.Request) {
+			if r.Method == "GET" && r.URL.Path == "/projects/test-project/providers/Aruba.Database/dbaas/dbaas-123" {
+				w.WriteHeader(http.StatusOK)
+				resp := types.DBaaSResponse{
+					Metadata: types.ResourceMetadataResponse{
+						Name: types.StringPtr("dbaas-1"),
+						ID:   types.StringPtr("dbaas-123"),
+					},
+					Properties: types.DBaaSPropertiesResponse{
+						Engine: &types.DBaaSEngineResponse{
+							Type:    types.StringPtr("MySQL"),
+							Version: types.StringPtr("8.0"),
+						},
+						Flavor: &types.DBaaSFlavorResponse{
+							Name: types.StringPtr("M4-8"),
+						},
+					},
+					Status: types.ResourceStatus{State: types.StringPtr("active")},
+				}
+				json.NewEncoder(w).Encode(resp)
+				return
+			}
+			http.NotFound(w, r)
+		})
+		c := testutil.NewClient(t, server.URL)
+		svc := NewDBaaSClientImpl(c)
+
+		resp, err := svc.Get(context.Background(), "test-project", "dbaas-123", nil)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if resp == nil || resp.Data == nil {
+			t.Fatalf("expected response data")
+		}
+		if resp.Data.Metadata.Name == nil || *resp.Data.Metadata.Name != "dbaas-1" {
+			t.Errorf("expected name 'dbaas-1'")
+		}
+		if resp.Data.Status.State == nil || *resp.Data.Status.State != "active" {
+			t.Errorf("expected state 'active'")
+		}
+	})
+
+	t.Run("empty project", func(t *testing.T) {
+		c := testutil.NewClient(t, "http://unused.invalid")
+		svc := NewDBaaSClientImpl(c)
+		_, err := svc.Get(context.Background(), "", "dbaas-123", nil)
+		if err == nil {
+			t.Fatal("expected validation error, got nil")
+		}
+	})
+
+	t.Run("empty DBaaS ID", func(t *testing.T) {
+		c := testutil.NewClient(t, "http://unused.invalid")
+		svc := NewDBaaSClientImpl(c)
+		_, err := svc.Get(context.Background(), "test-project", "", nil)
+		if err == nil {
+			t.Fatal("expected validation error, got nil")
+		}
+	})
+
+	t.Run("not found", func(t *testing.T) {
+		server := testutil.NewMockServer(t, func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusNotFound)
+			fmt.Fprint(w, testutil.ErrorBodyJSON("Not Found", "resource not found", 404))
+		})
+		c := testutil.NewClient(t, server.URL)
+		svc := NewDBaaSClientImpl(c)
+
+		resp, err := svc.Get(context.Background(), "test-project", "dbaas-123", nil)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if resp == nil || resp.StatusCode != http.StatusNotFound {
+			t.Fatalf("expected 404 response")
+		}
+		if resp.Error == nil {
+			t.Fatalf("expected resp.Error to be populated")
+		}
+		if resp.Error.Title == nil || *resp.Error.Title != "Not Found" {
+			t.Errorf("expected title 'Not Found', got %v", resp.Error.Title)
+		}
+	})
+
+	t.Run("bad gateway non-json", func(t *testing.T) {
+		server := testutil.NewMockServer(t, func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusBadGateway)
+			fmt.Fprint(w, "Bad Gateway")
+		})
+		c := testutil.NewClient(t, server.URL)
+		svc := NewDBaaSClientImpl(c)
+
+		resp, err := svc.Get(context.Background(), "test-project", "dbaas-123", nil)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if resp == nil || resp.StatusCode != http.StatusBadGateway {
+			t.Fatalf("expected 502 response")
+		}
+		if resp.Error != nil {
+			t.Errorf("expected resp.Error to be nil for non-JSON body, got %+v", resp.Error)
+		}
+		if string(resp.RawBody) != "Bad Gateway" {
+			t.Errorf("expected RawBody 'Bad Gateway', got %q", string(resp.RawBody))
+		}
+	})
+
+	t.Run("network error", func(t *testing.T) {
+		c := testutil.NewBrokenClient(t, "http://unused.invalid")
+		svc := NewDBaaSClientImpl(c)
+		_, err := svc.Get(context.Background(), "test-project", "dbaas-123", nil)
+		if err == nil {
+			t.Fatal("expected a network error, got nil")
+		}
+	})
+
+	t.Run("nil params injects default api-version", func(t *testing.T) {
+		server := testutil.NewMockServer(t, func(w http.ResponseWriter, r *http.Request) {
+			if got := r.URL.Query().Get("api-version"); got != "1.0" {
+				t.Errorf("expected api-version=1.0, got %q", got)
+			}
+			w.WriteHeader(http.StatusOK)
+			fmt.Fprint(w, `{}`)
+		})
+		c := testutil.NewClient(t, server.URL)
+		svc := NewDBaaSClientImpl(c)
+		if _, err := svc.Get(context.Background(), "test-project", "dbaas-123", nil); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
+}
+
+func TestCreateDBaaS(t *testing.T) {
+	t.Run("successful create", func(t *testing.T) {
+		server := testutil.NewMockServer(t, func(w http.ResponseWriter, r *http.Request) {
+			if r.Method == "POST" && r.URL.Path == "/projects/test-project/providers/Aruba.Database/dbaas" {
+				w.WriteHeader(http.StatusCreated)
+				resp := types.DBaaSResponse{
+					Metadata: types.ResourceMetadataResponse{
+						Name: types.StringPtr("dbaas-1"),
+						ID:   types.StringPtr("dbaas-123"),
+					},
+					Properties: types.DBaaSPropertiesResponse{
+						Engine: &types.DBaaSEngineResponse{Type: types.StringPtr("MySQL")},
+					},
+					Status: types.ResourceStatus{State: types.StringPtr("creating")},
+				}
+				json.NewEncoder(w).Encode(resp)
+				return
+			}
+			http.NotFound(w, r)
+		})
+		c := testutil.NewClient(t, server.URL)
+		svc := NewDBaaSClientImpl(c)
+
+		body := types.DBaaSRequest{
+			Metadata: types.RegionalResourceMetadataRequest{
+				ResourceMetadataRequest: types.ResourceMetadataRequest{Name: "dbaas-1"},
+			},
+			Properties: types.DBaaSPropertiesRequest{},
+		}
+
+		resp, err := svc.Create(context.Background(), "test-project", body, nil)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if resp == nil || resp.Data == nil {
+			t.Fatalf("expected response data")
+		}
+		if resp.Data.Metadata.Name == nil || *resp.Data.Metadata.Name != "dbaas-1" {
+			t.Errorf("expected name 'dbaas-1'")
+		}
+		if resp.Data.Status.State == nil || *resp.Data.Status.State != "creating" {
+			t.Errorf("expected state 'creating'")
+		}
+	})
+
+	t.Run("empty project", func(t *testing.T) {
+		c := testutil.NewClient(t, "http://unused.invalid")
+		svc := NewDBaaSClientImpl(c)
+		_, err := svc.Create(context.Background(), "", types.DBaaSRequest{}, nil)
+		if err == nil {
+			t.Fatal("expected validation error, got nil")
+		}
+	})
+
+	t.Run("not found", func(t *testing.T) {
+		server := testutil.NewMockServer(t, func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusNotFound)
+			fmt.Fprint(w, testutil.ErrorBodyJSON("Not Found", "resource not found", 404))
+		})
+		c := testutil.NewClient(t, server.URL)
+		svc := NewDBaaSClientImpl(c)
+
+		resp, err := svc.Create(context.Background(), "test-project", types.DBaaSRequest{}, nil)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if resp == nil || resp.StatusCode != http.StatusNotFound {
+			t.Fatalf("expected 404 response")
+		}
+		if resp.Error == nil {
+			t.Fatalf("expected resp.Error to be populated")
+		}
+		if resp.Error.Title == nil || *resp.Error.Title != "Not Found" {
+			t.Errorf("expected title 'Not Found', got %v", resp.Error.Title)
+		}
+	})
+
+	t.Run("bad gateway non-json", func(t *testing.T) {
+		// TODO(TD-010): Create's manual response build silently swallows non-JSON
+		// unmarshal errors (diverges from ParseResponseBody which logs at DEBUG).
+		server := testutil.NewMockServer(t, func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusBadGateway)
+			fmt.Fprint(w, "Bad Gateway")
+		})
+		c := testutil.NewClient(t, server.URL)
+		svc := NewDBaaSClientImpl(c)
+
+		resp, err := svc.Create(context.Background(), "test-project", types.DBaaSRequest{}, nil)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if resp == nil || resp.StatusCode != http.StatusBadGateway {
+			t.Fatalf("expected 502 response")
+		}
+		if resp.Error != nil {
+			t.Errorf("expected resp.Error to be nil for non-JSON body, got %+v", resp.Error)
+		}
+		if string(resp.RawBody) != "Bad Gateway" {
+			t.Errorf("expected RawBody 'Bad Gateway', got %q", string(resp.RawBody))
+		}
+	})
+
+	t.Run("network error", func(t *testing.T) {
+		c := testutil.NewBrokenClient(t, "http://unused.invalid")
+		svc := NewDBaaSClientImpl(c)
+		_, err := svc.Create(context.Background(), "test-project", types.DBaaSRequest{}, nil)
+		if err == nil {
+			t.Fatal("expected a network error, got nil")
+		}
+	})
+
+	t.Run("nil params injects default api-version", func(t *testing.T) {
+		server := testutil.NewMockServer(t, func(w http.ResponseWriter, r *http.Request) {
+			if got := r.URL.Query().Get("api-version"); got != "1.0" {
+				t.Errorf("expected api-version=1.0, got %q", got)
+			}
+			w.WriteHeader(http.StatusCreated)
+			fmt.Fprint(w, `{}`)
+		})
+		c := testutil.NewClient(t, server.URL)
+		svc := NewDBaaSClientImpl(c)
+		if _, err := svc.Create(context.Background(), "test-project", types.DBaaSRequest{}, nil); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
+}
+
+func TestUpdateDBaaS(t *testing.T) {
+	t.Run("successful update", func(t *testing.T) {
+		server := testutil.NewMockServer(t, func(w http.ResponseWriter, r *http.Request) {
+			if r.Method == "PUT" && r.URL.Path == "/projects/test-project/providers/Aruba.Database/dbaas/dbaas-123" {
+				w.WriteHeader(http.StatusOK)
+				resp := types.DBaaSResponse{
+					Metadata: types.ResourceMetadataResponse{
+						Name: types.StringPtr("dbaas-updated"),
+						ID:   types.StringPtr("dbaas-123"),
+					},
+					Properties: types.DBaaSPropertiesResponse{
+						Engine: &types.DBaaSEngineResponse{Type: types.StringPtr("MySQL")},
+					},
+					Status: types.ResourceStatus{State: types.StringPtr("updating")},
+				}
+				json.NewEncoder(w).Encode(resp)
+				return
+			}
+			http.NotFound(w, r)
+		})
+		c := testutil.NewClient(t, server.URL)
+		svc := NewDBaaSClientImpl(c)
+
+		body := types.DBaaSRequest{
+			Metadata: types.RegionalResourceMetadataRequest{
+				ResourceMetadataRequest: types.ResourceMetadataRequest{Name: "dbaas-updated"},
+			},
+			Properties: types.DBaaSPropertiesRequest{},
+		}
+
+		resp, err := svc.Update(context.Background(), "test-project", "dbaas-123", body, nil)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if resp == nil || resp.Data == nil {
+			t.Fatalf("expected response data")
+		}
+		if resp.Data.Metadata.Name == nil || *resp.Data.Metadata.Name != "dbaas-updated" {
+			t.Errorf("expected name 'dbaas-updated'")
+		}
+		if resp.Data.Status.State == nil || *resp.Data.Status.State != "updating" {
+			t.Errorf("expected state 'updating'")
+		}
+	})
+
+	t.Run("empty project", func(t *testing.T) {
+		c := testutil.NewClient(t, "http://unused.invalid")
+		svc := NewDBaaSClientImpl(c)
+		_, err := svc.Update(context.Background(), "", "dbaas-123", types.DBaaSRequest{}, nil)
+		if err == nil {
+			t.Fatal("expected validation error, got nil")
+		}
+	})
+
+	t.Run("empty DBaaS ID", func(t *testing.T) {
+		c := testutil.NewClient(t, "http://unused.invalid")
+		svc := NewDBaaSClientImpl(c)
+		_, err := svc.Update(context.Background(), "test-project", "", types.DBaaSRequest{}, nil)
+		if err == nil {
+			t.Fatal("expected validation error, got nil")
+		}
+	})
+
+	t.Run("not found", func(t *testing.T) {
+		server := testutil.NewMockServer(t, func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusNotFound)
+			fmt.Fprint(w, testutil.ErrorBodyJSON("Not Found", "resource not found", 404))
+		})
+		c := testutil.NewClient(t, server.URL)
+		svc := NewDBaaSClientImpl(c)
+
+		resp, err := svc.Update(context.Background(), "test-project", "dbaas-123", types.DBaaSRequest{}, nil)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if resp == nil || resp.StatusCode != http.StatusNotFound {
+			t.Fatalf("expected 404 response")
+		}
+		if resp.Error == nil {
+			t.Fatalf("expected resp.Error to be populated")
+		}
+		if resp.Error.Title == nil || *resp.Error.Title != "Not Found" {
+			t.Errorf("expected title 'Not Found', got %v", resp.Error.Title)
+		}
+	})
+
+	t.Run("bad gateway non-json", func(t *testing.T) {
+		// TODO(TD-010): Update's manual response build silently swallows non-JSON
+		// unmarshal errors (diverges from ParseResponseBody which logs at DEBUG).
+		server := testutil.NewMockServer(t, func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusBadGateway)
+			fmt.Fprint(w, "Bad Gateway")
+		})
+		c := testutil.NewClient(t, server.URL)
+		svc := NewDBaaSClientImpl(c)
+
+		resp, err := svc.Update(context.Background(), "test-project", "dbaas-123", types.DBaaSRequest{}, nil)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if resp == nil || resp.StatusCode != http.StatusBadGateway {
+			t.Fatalf("expected 502 response")
+		}
+		if resp.Error != nil {
+			t.Errorf("expected resp.Error to be nil for non-JSON body, got %+v", resp.Error)
+		}
+		if string(resp.RawBody) != "Bad Gateway" {
+			t.Errorf("expected RawBody 'Bad Gateway', got %q", string(resp.RawBody))
+		}
+	})
+
+	t.Run("network error", func(t *testing.T) {
+		c := testutil.NewBrokenClient(t, "http://unused.invalid")
+		svc := NewDBaaSClientImpl(c)
+		_, err := svc.Update(context.Background(), "test-project", "dbaas-123", types.DBaaSRequest{}, nil)
+		if err == nil {
+			t.Fatal("expected a network error, got nil")
+		}
+	})
+
+	t.Run("nil params injects default api-version", func(t *testing.T) {
+		server := testutil.NewMockServer(t, func(w http.ResponseWriter, r *http.Request) {
+			if got := r.URL.Query().Get("api-version"); got != "1.0" {
+				t.Errorf("expected api-version=1.0, got %q", got)
+			}
+			w.WriteHeader(http.StatusOK)
+			fmt.Fprint(w, `{}`)
+		})
+		c := testutil.NewClient(t, server.URL)
+		svc := NewDBaaSClientImpl(c)
+		if _, err := svc.Update(context.Background(), "test-project", "dbaas-123", types.DBaaSRequest{}, nil); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
+}
+
+func TestDeleteDBaaS(t *testing.T) {
+	t.Run("successful delete", func(t *testing.T) {
+		server := testutil.NewMockServer(t, func(w http.ResponseWriter, r *http.Request) {
+			if r.Method == "DELETE" && r.URL.Path == "/projects/test-project/providers/Aruba.Database/dbaas/dbaas-123" {
+				w.WriteHeader(http.StatusNoContent)
+				return
+			}
+			http.NotFound(w, r)
+		})
+		c := testutil.NewClient(t, server.URL)
+		svc := NewDBaaSClientImpl(c)
+
+		_, err := svc.Delete(context.Background(), "test-project", "dbaas-123", nil)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
+
+	t.Run("empty project", func(t *testing.T) {
+		c := testutil.NewClient(t, "http://unused.invalid")
+		svc := NewDBaaSClientImpl(c)
+		_, err := svc.Delete(context.Background(), "", "dbaas-123", nil)
+		if err == nil {
+			t.Fatal("expected validation error, got nil")
+		}
+	})
+
+	t.Run("empty DBaaS ID", func(t *testing.T) {
+		c := testutil.NewClient(t, "http://unused.invalid")
+		svc := NewDBaaSClientImpl(c)
+		_, err := svc.Delete(context.Background(), "test-project", "", nil)
+		if err == nil {
+			t.Fatal("expected validation error, got nil")
+		}
+	})
+
+	t.Run("not found", func(t *testing.T) {
+		server := testutil.NewMockServer(t, func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusNotFound)
+			fmt.Fprint(w, testutil.ErrorBodyJSON("Not Found", "resource not found", 404))
+		})
+		c := testutil.NewClient(t, server.URL)
+		svc := NewDBaaSClientImpl(c)
+
+		resp, err := svc.Delete(context.Background(), "test-project", "dbaas-123", nil)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if resp == nil || resp.StatusCode != http.StatusNotFound {
+			t.Fatalf("expected 404 response")
+		}
+		if resp.Error == nil {
+			t.Fatalf("expected resp.Error to be populated")
+		}
+		if resp.Error.Title == nil || *resp.Error.Title != "Not Found" {
+			t.Errorf("expected title 'Not Found', got %v", resp.Error.Title)
+		}
+	})
+
+	t.Run("bad gateway non-json", func(t *testing.T) {
+		server := testutil.NewMockServer(t, func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusBadGateway)
+			fmt.Fprint(w, "Bad Gateway")
+		})
+		c := testutil.NewClient(t, server.URL)
+		svc := NewDBaaSClientImpl(c)
+
+		resp, err := svc.Delete(context.Background(), "test-project", "dbaas-123", nil)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if resp == nil || resp.StatusCode != http.StatusBadGateway {
+			t.Fatalf("expected 502 response")
+		}
+		if resp.Error != nil {
+			t.Errorf("expected resp.Error to be nil for non-JSON body, got %+v", resp.Error)
+		}
+		if string(resp.RawBody) != "Bad Gateway" {
+			t.Errorf("expected RawBody 'Bad Gateway', got %q", string(resp.RawBody))
+		}
+	})
+
+	t.Run("network error", func(t *testing.T) {
+		c := testutil.NewBrokenClient(t, "http://unused.invalid")
+		svc := NewDBaaSClientImpl(c)
+		_, err := svc.Delete(context.Background(), "test-project", "dbaas-123", nil)
+		if err == nil {
+			t.Fatal("expected a network error, got nil")
+		}
+	})
+
+	t.Run("nil params injects default api-version", func(t *testing.T) {
+		server := testutil.NewMockServer(t, func(w http.ResponseWriter, r *http.Request) {
+			if got := r.URL.Query().Get("api-version"); got != "1.0" {
+				t.Errorf("expected api-version=1.0, got %q", got)
+			}
+			w.WriteHeader(http.StatusNoContent)
+		})
+		c := testutil.NewClient(t, server.URL)
+		svc := NewDBaaSClientImpl(c)
+		if _, err := svc.Delete(context.Background(), "test-project", "dbaas-123", nil); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
+}

--- a/internal/clients/database/grant_test.go
+++ b/internal/clients/database/grant_test.go
@@ -1,0 +1,699 @@
+package database
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"testing"
+
+	"github.com/Arubacloud/sdk-go/internal/testutil"
+	"github.com/Arubacloud/sdk-go/pkg/types"
+)
+
+func TestListGrants(t *testing.T) {
+	t.Run("successful list", func(t *testing.T) {
+		server := testutil.NewMockServer(t, func(w http.ResponseWriter, r *http.Request) {
+			if r.Method == "GET" && r.URL.Path == "/projects/test-project/providers/Aruba.Database/dbaas/dbaas-123/databases/db-456/grants" {
+				w.WriteHeader(http.StatusOK)
+				resp := types.GrantList{
+					ListResponse: types.ListResponse{Total: 1},
+					Values: []types.GrantResponse{
+						{
+							User: types.GrantUser{Username: "alice"},
+							Role: types.GrantRole{Name: "read"},
+							Database: types.GrantDatabaseResponse{Name: "my-db"},
+						},
+					},
+				}
+				json.NewEncoder(w).Encode(resp)
+				return
+			}
+			http.NotFound(w, r)
+		})
+		c := testutil.NewClient(t, server.URL)
+		svc := NewGrantsClientImpl(c)
+
+		resp, err := svc.List(context.Background(), "test-project", "dbaas-123", "db-456", nil)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if resp == nil || resp.Data == nil || len(resp.Data.Values) != 1 {
+			t.Fatalf("expected 1 grant")
+		}
+		if resp.Data.Values[0].User.Username != "alice" {
+			t.Errorf("expected username 'alice', got %s", resp.Data.Values[0].User.Username)
+		}
+		if resp.Data.Values[0].Role.Name != "read" {
+			t.Errorf("expected role 'read', got %s", resp.Data.Values[0].Role.Name)
+		}
+	})
+
+	t.Run("empty project", func(t *testing.T) {
+		c := testutil.NewClient(t, "http://unused.invalid")
+		svc := NewGrantsClientImpl(c)
+		_, err := svc.List(context.Background(), "", "dbaas-123", "db-456", nil)
+		if err == nil {
+			t.Fatal("expected validation error, got nil")
+		}
+	})
+
+	t.Run("empty DBaaS ID", func(t *testing.T) {
+		c := testutil.NewClient(t, "http://unused.invalid")
+		svc := NewGrantsClientImpl(c)
+		_, err := svc.List(context.Background(), "test-project", "", "db-456", nil)
+		if err == nil {
+			t.Fatal("expected validation error, got nil")
+		}
+	})
+
+	t.Run("empty database ID", func(t *testing.T) {
+		c := testutil.NewClient(t, "http://unused.invalid")
+		svc := NewGrantsClientImpl(c)
+		_, err := svc.List(context.Background(), "test-project", "dbaas-123", "", nil)
+		if err == nil {
+			t.Fatal("expected validation error, got nil")
+		}
+	})
+
+	t.Run("not found", func(t *testing.T) {
+		server := testutil.NewMockServer(t, func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusNotFound)
+			fmt.Fprint(w, testutil.ErrorBodyJSON("Not Found", "resource not found", 404))
+		})
+		c := testutil.NewClient(t, server.URL)
+		svc := NewGrantsClientImpl(c)
+
+		resp, err := svc.List(context.Background(), "test-project", "dbaas-123", "db-456", nil)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if resp == nil || resp.StatusCode != http.StatusNotFound {
+			t.Fatalf("expected 404 response")
+		}
+		if resp.Error == nil {
+			t.Fatalf("expected resp.Error to be populated")
+		}
+		if resp.Error.Title == nil || *resp.Error.Title != "Not Found" {
+			t.Errorf("expected title 'Not Found', got %v", resp.Error.Title)
+		}
+	})
+
+	t.Run("bad gateway non-json", func(t *testing.T) {
+		server := testutil.NewMockServer(t, func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusBadGateway)
+			fmt.Fprint(w, "Bad Gateway")
+		})
+		c := testutil.NewClient(t, server.URL)
+		svc := NewGrantsClientImpl(c)
+
+		resp, err := svc.List(context.Background(), "test-project", "dbaas-123", "db-456", nil)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if resp == nil || resp.StatusCode != http.StatusBadGateway {
+			t.Fatalf("expected 502 response")
+		}
+		if resp.Error != nil {
+			t.Errorf("expected resp.Error to be nil for non-JSON body, got %+v", resp.Error)
+		}
+		if string(resp.RawBody) != "Bad Gateway" {
+			t.Errorf("expected RawBody 'Bad Gateway', got %q", string(resp.RawBody))
+		}
+	})
+
+	t.Run("network error", func(t *testing.T) {
+		c := testutil.NewBrokenClient(t, "http://unused.invalid")
+		svc := NewGrantsClientImpl(c)
+		_, err := svc.List(context.Background(), "test-project", "dbaas-123", "db-456", nil)
+		if err == nil {
+			t.Fatal("expected a network error, got nil")
+		}
+	})
+
+	t.Run("nil params injects default api-version", func(t *testing.T) {
+		server := testutil.NewMockServer(t, func(w http.ResponseWriter, r *http.Request) {
+			if got := r.URL.Query().Get("api-version"); got != "1.0" {
+				t.Errorf("expected api-version=1.0, got %q", got)
+			}
+			w.WriteHeader(http.StatusOK)
+			fmt.Fprint(w, `{"total":0,"values":[]}`)
+		})
+		c := testutil.NewClient(t, server.URL)
+		svc := NewGrantsClientImpl(c)
+		if _, err := svc.List(context.Background(), "test-project", "dbaas-123", "db-456", nil); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
+}
+
+func TestGetGrant(t *testing.T) {
+	t.Run("successful get", func(t *testing.T) {
+		server := testutil.NewMockServer(t, func(w http.ResponseWriter, r *http.Request) {
+			if r.Method == "GET" && r.URL.Path == "/projects/test-project/providers/Aruba.Database/dbaas/dbaas-123/databases/db-456/grants/grant-789" {
+				w.WriteHeader(http.StatusOK)
+				resp := types.GrantResponse{
+					User:     types.GrantUser{Username: "alice"},
+					Role:     types.GrantRole{Name: "read"},
+					Database: types.GrantDatabaseResponse{Name: "my-db"},
+				}
+				json.NewEncoder(w).Encode(resp)
+				return
+			}
+			http.NotFound(w, r)
+		})
+		c := testutil.NewClient(t, server.URL)
+		svc := NewGrantsClientImpl(c)
+
+		resp, err := svc.Get(context.Background(), "test-project", "dbaas-123", "db-456", "grant-789", nil)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if resp == nil || resp.Data == nil {
+			t.Fatalf("expected response data")
+		}
+		if resp.Data.User.Username != "alice" {
+			t.Errorf("expected username 'alice', got %s", resp.Data.User.Username)
+		}
+		if resp.Data.Role.Name != "read" {
+			t.Errorf("expected role 'read', got %s", resp.Data.Role.Name)
+		}
+	})
+
+	t.Run("empty project", func(t *testing.T) {
+		c := testutil.NewClient(t, "http://unused.invalid")
+		svc := NewGrantsClientImpl(c)
+		_, err := svc.Get(context.Background(), "", "dbaas-123", "db-456", "grant-789", nil)
+		if err == nil {
+			t.Fatal("expected validation error, got nil")
+		}
+	})
+
+	t.Run("empty DBaaS ID", func(t *testing.T) {
+		c := testutil.NewClient(t, "http://unused.invalid")
+		svc := NewGrantsClientImpl(c)
+		_, err := svc.Get(context.Background(), "test-project", "", "db-456", "grant-789", nil)
+		if err == nil {
+			t.Fatal("expected validation error, got nil")
+		}
+	})
+
+	t.Run("empty database ID", func(t *testing.T) {
+		c := testutil.NewClient(t, "http://unused.invalid")
+		svc := NewGrantsClientImpl(c)
+		_, err := svc.Get(context.Background(), "test-project", "dbaas-123", "", "grant-789", nil)
+		if err == nil {
+			t.Fatal("expected validation error, got nil")
+		}
+	})
+
+	t.Run("empty grant ID", func(t *testing.T) {
+		c := testutil.NewClient(t, "http://unused.invalid")
+		svc := NewGrantsClientImpl(c)
+		_, err := svc.Get(context.Background(), "test-project", "dbaas-123", "db-456", "", nil)
+		if err == nil {
+			t.Fatal("expected validation error, got nil")
+		}
+	})
+
+	t.Run("not found", func(t *testing.T) {
+		server := testutil.NewMockServer(t, func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusNotFound)
+			fmt.Fprint(w, testutil.ErrorBodyJSON("Not Found", "resource not found", 404))
+		})
+		c := testutil.NewClient(t, server.URL)
+		svc := NewGrantsClientImpl(c)
+
+		resp, err := svc.Get(context.Background(), "test-project", "dbaas-123", "db-456", "grant-789", nil)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if resp == nil || resp.StatusCode != http.StatusNotFound {
+			t.Fatalf("expected 404 response")
+		}
+		if resp.Error == nil {
+			t.Fatalf("expected resp.Error to be populated")
+		}
+		if resp.Error.Title == nil || *resp.Error.Title != "Not Found" {
+			t.Errorf("expected title 'Not Found', got %v", resp.Error.Title)
+		}
+	})
+
+	t.Run("bad gateway non-json", func(t *testing.T) {
+		server := testutil.NewMockServer(t, func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusBadGateway)
+			fmt.Fprint(w, "Bad Gateway")
+		})
+		c := testutil.NewClient(t, server.URL)
+		svc := NewGrantsClientImpl(c)
+
+		resp, err := svc.Get(context.Background(), "test-project", "dbaas-123", "db-456", "grant-789", nil)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if resp == nil || resp.StatusCode != http.StatusBadGateway {
+			t.Fatalf("expected 502 response")
+		}
+		if resp.Error != nil {
+			t.Errorf("expected resp.Error to be nil for non-JSON body, got %+v", resp.Error)
+		}
+		if string(resp.RawBody) != "Bad Gateway" {
+			t.Errorf("expected RawBody 'Bad Gateway', got %q", string(resp.RawBody))
+		}
+	})
+
+	t.Run("network error", func(t *testing.T) {
+		c := testutil.NewBrokenClient(t, "http://unused.invalid")
+		svc := NewGrantsClientImpl(c)
+		_, err := svc.Get(context.Background(), "test-project", "dbaas-123", "db-456", "grant-789", nil)
+		if err == nil {
+			t.Fatal("expected a network error, got nil")
+		}
+	})
+
+	t.Run("nil params injects default api-version", func(t *testing.T) {
+		server := testutil.NewMockServer(t, func(w http.ResponseWriter, r *http.Request) {
+			if got := r.URL.Query().Get("api-version"); got != "1.0" {
+				t.Errorf("expected api-version=1.0, got %q", got)
+			}
+			w.WriteHeader(http.StatusOK)
+			fmt.Fprint(w, `{}`)
+		})
+		c := testutil.NewClient(t, server.URL)
+		svc := NewGrantsClientImpl(c)
+		if _, err := svc.Get(context.Background(), "test-project", "dbaas-123", "db-456", "grant-789", nil); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
+}
+
+func TestCreateGrant(t *testing.T) {
+	t.Run("successful create", func(t *testing.T) {
+		server := testutil.NewMockServer(t, func(w http.ResponseWriter, r *http.Request) {
+			if r.Method == "POST" && r.URL.Path == "/projects/test-project/providers/Aruba.Database/dbaas/dbaas-123/databases/db-456/grants" {
+				w.WriteHeader(http.StatusCreated)
+				resp := types.GrantResponse{
+					User:     types.GrantUser{Username: "alice"},
+					Role:     types.GrantRole{Name: "read"},
+					Database: types.GrantDatabaseResponse{Name: "my-db"},
+				}
+				json.NewEncoder(w).Encode(resp)
+				return
+			}
+			http.NotFound(w, r)
+		})
+		c := testutil.NewClient(t, server.URL)
+		svc := NewGrantsClientImpl(c)
+
+		body := types.GrantRequest{
+			User: types.GrantUser{Username: "alice"},
+			Role: types.GrantRole{Name: "read"},
+		}
+
+		resp, err := svc.Create(context.Background(), "test-project", "dbaas-123", "db-456", body, nil)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if resp == nil || resp.Data == nil {
+			t.Fatalf("expected response data")
+		}
+		if resp.Data.User.Username != "alice" {
+			t.Errorf("expected username 'alice', got %s", resp.Data.User.Username)
+		}
+		if resp.Data.Role.Name != "read" {
+			t.Errorf("expected role 'read', got %s", resp.Data.Role.Name)
+		}
+	})
+
+	t.Run("empty project", func(t *testing.T) {
+		c := testutil.NewClient(t, "http://unused.invalid")
+		svc := NewGrantsClientImpl(c)
+		_, err := svc.Create(context.Background(), "", "dbaas-123", "db-456", types.GrantRequest{}, nil)
+		if err == nil {
+			t.Fatal("expected validation error, got nil")
+		}
+	})
+
+	t.Run("empty DBaaS ID", func(t *testing.T) {
+		c := testutil.NewClient(t, "http://unused.invalid")
+		svc := NewGrantsClientImpl(c)
+		_, err := svc.Create(context.Background(), "test-project", "", "db-456", types.GrantRequest{}, nil)
+		if err == nil {
+			t.Fatal("expected validation error, got nil")
+		}
+	})
+
+	t.Run("empty database ID", func(t *testing.T) {
+		c := testutil.NewClient(t, "http://unused.invalid")
+		svc := NewGrantsClientImpl(c)
+		_, err := svc.Create(context.Background(), "test-project", "dbaas-123", "", types.GrantRequest{}, nil)
+		if err == nil {
+			t.Fatal("expected validation error, got nil")
+		}
+	})
+
+	t.Run("not found", func(t *testing.T) {
+		server := testutil.NewMockServer(t, func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusNotFound)
+			fmt.Fprint(w, testutil.ErrorBodyJSON("Not Found", "resource not found", 404))
+		})
+		c := testutil.NewClient(t, server.URL)
+		svc := NewGrantsClientImpl(c)
+
+		resp, err := svc.Create(context.Background(), "test-project", "dbaas-123", "db-456", types.GrantRequest{}, nil)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if resp == nil || resp.StatusCode != http.StatusNotFound {
+			t.Fatalf("expected 404 response")
+		}
+		if resp.Error == nil {
+			t.Fatalf("expected resp.Error to be populated")
+		}
+		if resp.Error.Title == nil || *resp.Error.Title != "Not Found" {
+			t.Errorf("expected title 'Not Found', got %v", resp.Error.Title)
+		}
+	})
+
+	t.Run("bad gateway non-json", func(t *testing.T) {
+		// TODO(TD-010): Create's manual response build silently swallows non-JSON
+		// unmarshal errors (diverges from ParseResponseBody which logs at DEBUG).
+		server := testutil.NewMockServer(t, func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusBadGateway)
+			fmt.Fprint(w, "Bad Gateway")
+		})
+		c := testutil.NewClient(t, server.URL)
+		svc := NewGrantsClientImpl(c)
+
+		resp, err := svc.Create(context.Background(), "test-project", "dbaas-123", "db-456", types.GrantRequest{}, nil)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if resp == nil || resp.StatusCode != http.StatusBadGateway {
+			t.Fatalf("expected 502 response")
+		}
+		if resp.Error != nil {
+			t.Errorf("expected resp.Error to be nil for non-JSON body, got %+v", resp.Error)
+		}
+		if string(resp.RawBody) != "Bad Gateway" {
+			t.Errorf("expected RawBody 'Bad Gateway', got %q", string(resp.RawBody))
+		}
+	})
+
+	t.Run("network error", func(t *testing.T) {
+		c := testutil.NewBrokenClient(t, "http://unused.invalid")
+		svc := NewGrantsClientImpl(c)
+		_, err := svc.Create(context.Background(), "test-project", "dbaas-123", "db-456", types.GrantRequest{}, nil)
+		if err == nil {
+			t.Fatal("expected a network error, got nil")
+		}
+	})
+
+	t.Run("nil params injects default api-version", func(t *testing.T) {
+		server := testutil.NewMockServer(t, func(w http.ResponseWriter, r *http.Request) {
+			if got := r.URL.Query().Get("api-version"); got != "1.0" {
+				t.Errorf("expected api-version=1.0, got %q", got)
+			}
+			w.WriteHeader(http.StatusCreated)
+			fmt.Fprint(w, `{}`)
+		})
+		c := testutil.NewClient(t, server.URL)
+		svc := NewGrantsClientImpl(c)
+		if _, err := svc.Create(context.Background(), "test-project", "dbaas-123", "db-456", types.GrantRequest{}, nil); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
+}
+
+func TestUpdateGrant(t *testing.T) {
+	t.Run("successful update", func(t *testing.T) {
+		server := testutil.NewMockServer(t, func(w http.ResponseWriter, r *http.Request) {
+			if r.Method == "PUT" && r.URL.Path == "/projects/test-project/providers/Aruba.Database/dbaas/dbaas-123/databases/db-456/grants/grant-789" {
+				w.WriteHeader(http.StatusOK)
+				resp := types.GrantResponse{
+					User:     types.GrantUser{Username: "alice"},
+					Role:     types.GrantRole{Name: "write"},
+					Database: types.GrantDatabaseResponse{Name: "my-db"},
+				}
+				json.NewEncoder(w).Encode(resp)
+				return
+			}
+			http.NotFound(w, r)
+		})
+		c := testutil.NewClient(t, server.URL)
+		svc := NewGrantsClientImpl(c)
+
+		body := types.GrantRequest{
+			User: types.GrantUser{Username: "alice"},
+			Role: types.GrantRole{Name: "write"},
+		}
+
+		resp, err := svc.Update(context.Background(), "test-project", "dbaas-123", "db-456", "grant-789", body, nil)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if resp == nil || resp.Data == nil {
+			t.Fatalf("expected response data")
+		}
+		if resp.Data.Role.Name != "write" {
+			t.Errorf("expected role 'write', got %s", resp.Data.Role.Name)
+		}
+	})
+
+	t.Run("empty project", func(t *testing.T) {
+		c := testutil.NewClient(t, "http://unused.invalid")
+		svc := NewGrantsClientImpl(c)
+		_, err := svc.Update(context.Background(), "", "dbaas-123", "db-456", "grant-789", types.GrantRequest{}, nil)
+		if err == nil {
+			t.Fatal("expected validation error, got nil")
+		}
+	})
+
+	t.Run("empty DBaaS ID", func(t *testing.T) {
+		c := testutil.NewClient(t, "http://unused.invalid")
+		svc := NewGrantsClientImpl(c)
+		_, err := svc.Update(context.Background(), "test-project", "", "db-456", "grant-789", types.GrantRequest{}, nil)
+		if err == nil {
+			t.Fatal("expected validation error, got nil")
+		}
+	})
+
+	t.Run("empty database ID", func(t *testing.T) {
+		c := testutil.NewClient(t, "http://unused.invalid")
+		svc := NewGrantsClientImpl(c)
+		_, err := svc.Update(context.Background(), "test-project", "dbaas-123", "", "grant-789", types.GrantRequest{}, nil)
+		if err == nil {
+			t.Fatal("expected validation error, got nil")
+		}
+	})
+
+	t.Run("empty grant ID", func(t *testing.T) {
+		c := testutil.NewClient(t, "http://unused.invalid")
+		svc := NewGrantsClientImpl(c)
+		_, err := svc.Update(context.Background(), "test-project", "dbaas-123", "db-456", "", types.GrantRequest{}, nil)
+		if err == nil {
+			t.Fatal("expected validation error, got nil")
+		}
+	})
+
+	t.Run("not found", func(t *testing.T) {
+		server := testutil.NewMockServer(t, func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusNotFound)
+			fmt.Fprint(w, testutil.ErrorBodyJSON("Not Found", "resource not found", 404))
+		})
+		c := testutil.NewClient(t, server.URL)
+		svc := NewGrantsClientImpl(c)
+
+		resp, err := svc.Update(context.Background(), "test-project", "dbaas-123", "db-456", "grant-789", types.GrantRequest{}, nil)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if resp == nil || resp.StatusCode != http.StatusNotFound {
+			t.Fatalf("expected 404 response")
+		}
+		if resp.Error == nil {
+			t.Fatalf("expected resp.Error to be populated")
+		}
+		if resp.Error.Title == nil || *resp.Error.Title != "Not Found" {
+			t.Errorf("expected title 'Not Found', got %v", resp.Error.Title)
+		}
+	})
+
+	t.Run("bad gateway non-json", func(t *testing.T) {
+		// TODO(TD-010): Update's manual response build silently swallows non-JSON
+		// unmarshal errors (diverges from ParseResponseBody which logs at DEBUG).
+		server := testutil.NewMockServer(t, func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusBadGateway)
+			fmt.Fprint(w, "Bad Gateway")
+		})
+		c := testutil.NewClient(t, server.URL)
+		svc := NewGrantsClientImpl(c)
+
+		resp, err := svc.Update(context.Background(), "test-project", "dbaas-123", "db-456", "grant-789", types.GrantRequest{}, nil)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if resp == nil || resp.StatusCode != http.StatusBadGateway {
+			t.Fatalf("expected 502 response")
+		}
+		if resp.Error != nil {
+			t.Errorf("expected resp.Error to be nil for non-JSON body, got %+v", resp.Error)
+		}
+		if string(resp.RawBody) != "Bad Gateway" {
+			t.Errorf("expected RawBody 'Bad Gateway', got %q", string(resp.RawBody))
+		}
+	})
+
+	t.Run("network error", func(t *testing.T) {
+		c := testutil.NewBrokenClient(t, "http://unused.invalid")
+		svc := NewGrantsClientImpl(c)
+		_, err := svc.Update(context.Background(), "test-project", "dbaas-123", "db-456", "grant-789", types.GrantRequest{}, nil)
+		if err == nil {
+			t.Fatal("expected a network error, got nil")
+		}
+	})
+
+	t.Run("nil params injects default api-version", func(t *testing.T) {
+		server := testutil.NewMockServer(t, func(w http.ResponseWriter, r *http.Request) {
+			if got := r.URL.Query().Get("api-version"); got != "1.0" {
+				t.Errorf("expected api-version=1.0, got %q", got)
+			}
+			w.WriteHeader(http.StatusOK)
+			fmt.Fprint(w, `{}`)
+		})
+		c := testutil.NewClient(t, server.URL)
+		svc := NewGrantsClientImpl(c)
+		if _, err := svc.Update(context.Background(), "test-project", "dbaas-123", "db-456", "grant-789", types.GrantRequest{}, nil); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
+}
+
+func TestDeleteGrant(t *testing.T) {
+	t.Run("successful delete", func(t *testing.T) {
+		server := testutil.NewMockServer(t, func(w http.ResponseWriter, r *http.Request) {
+			if r.Method == "DELETE" && r.URL.Path == "/projects/test-project/providers/Aruba.Database/dbaas/dbaas-123/databases/db-456/grants/grant-789" {
+				w.WriteHeader(http.StatusNoContent)
+				return
+			}
+			http.NotFound(w, r)
+		})
+		c := testutil.NewClient(t, server.URL)
+		svc := NewGrantsClientImpl(c)
+
+		_, err := svc.Delete(context.Background(), "test-project", "dbaas-123", "db-456", "grant-789", nil)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
+
+	t.Run("empty project", func(t *testing.T) {
+		c := testutil.NewClient(t, "http://unused.invalid")
+		svc := NewGrantsClientImpl(c)
+		_, err := svc.Delete(context.Background(), "", "dbaas-123", "db-456", "grant-789", nil)
+		if err == nil {
+			t.Fatal("expected validation error, got nil")
+		}
+	})
+
+	t.Run("empty DBaaS ID", func(t *testing.T) {
+		c := testutil.NewClient(t, "http://unused.invalid")
+		svc := NewGrantsClientImpl(c)
+		_, err := svc.Delete(context.Background(), "test-project", "", "db-456", "grant-789", nil)
+		if err == nil {
+			t.Fatal("expected validation error, got nil")
+		}
+	})
+
+	t.Run("empty database ID", func(t *testing.T) {
+		c := testutil.NewClient(t, "http://unused.invalid")
+		svc := NewGrantsClientImpl(c)
+		_, err := svc.Delete(context.Background(), "test-project", "dbaas-123", "", "grant-789", nil)
+		if err == nil {
+			t.Fatal("expected validation error, got nil")
+		}
+	})
+
+	t.Run("empty grant ID", func(t *testing.T) {
+		c := testutil.NewClient(t, "http://unused.invalid")
+		svc := NewGrantsClientImpl(c)
+		_, err := svc.Delete(context.Background(), "test-project", "dbaas-123", "db-456", "", nil)
+		if err == nil {
+			t.Fatal("expected validation error, got nil")
+		}
+	})
+
+	t.Run("not found", func(t *testing.T) {
+		server := testutil.NewMockServer(t, func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusNotFound)
+			fmt.Fprint(w, testutil.ErrorBodyJSON("Not Found", "resource not found", 404))
+		})
+		c := testutil.NewClient(t, server.URL)
+		svc := NewGrantsClientImpl(c)
+
+		resp, err := svc.Delete(context.Background(), "test-project", "dbaas-123", "db-456", "grant-789", nil)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if resp == nil || resp.StatusCode != http.StatusNotFound {
+			t.Fatalf("expected 404 response")
+		}
+		if resp.Error == nil {
+			t.Fatalf("expected resp.Error to be populated")
+		}
+		if resp.Error.Title == nil || *resp.Error.Title != "Not Found" {
+			t.Errorf("expected title 'Not Found', got %v", resp.Error.Title)
+		}
+	})
+
+	t.Run("bad gateway non-json", func(t *testing.T) {
+		server := testutil.NewMockServer(t, func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusBadGateway)
+			fmt.Fprint(w, "Bad Gateway")
+		})
+		c := testutil.NewClient(t, server.URL)
+		svc := NewGrantsClientImpl(c)
+
+		resp, err := svc.Delete(context.Background(), "test-project", "dbaas-123", "db-456", "grant-789", nil)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if resp == nil || resp.StatusCode != http.StatusBadGateway {
+			t.Fatalf("expected 502 response")
+		}
+		if resp.Error != nil {
+			t.Errorf("expected resp.Error to be nil for non-JSON body, got %+v", resp.Error)
+		}
+		if string(resp.RawBody) != "Bad Gateway" {
+			t.Errorf("expected RawBody 'Bad Gateway', got %q", string(resp.RawBody))
+		}
+	})
+
+	t.Run("network error", func(t *testing.T) {
+		c := testutil.NewBrokenClient(t, "http://unused.invalid")
+		svc := NewGrantsClientImpl(c)
+		_, err := svc.Delete(context.Background(), "test-project", "dbaas-123", "db-456", "grant-789", nil)
+		if err == nil {
+			t.Fatal("expected a network error, got nil")
+		}
+	})
+
+	t.Run("nil params injects default api-version", func(t *testing.T) {
+		server := testutil.NewMockServer(t, func(w http.ResponseWriter, r *http.Request) {
+			if got := r.URL.Query().Get("api-version"); got != "1.0" {
+				t.Errorf("expected api-version=1.0, got %q", got)
+			}
+			w.WriteHeader(http.StatusNoContent)
+		})
+		c := testutil.NewClient(t, server.URL)
+		svc := NewGrantsClientImpl(c)
+		if _, err := svc.Delete(context.Background(), "test-project", "dbaas-123", "db-456", "grant-789", nil); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
+}

--- a/internal/clients/database/grant_test.go
+++ b/internal/clients/database/grant_test.go
@@ -20,8 +20,8 @@ func TestListGrants(t *testing.T) {
 					ListResponse: types.ListResponse{Total: 1},
 					Values: []types.GrantResponse{
 						{
-							User: types.GrantUser{Username: "alice"},
-							Role: types.GrantRole{Name: "read"},
+							User:     types.GrantUser{Username: "alice"},
+							Role:     types.GrantRole{Name: "read"},
 							Database: types.GrantDatabaseResponse{Name: "my-db"},
 						},
 					},

--- a/internal/clients/database/user_test.go
+++ b/internal/clients/database/user_test.go
@@ -1,0 +1,617 @@
+package database
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"testing"
+
+	"github.com/Arubacloud/sdk-go/internal/testutil"
+	"github.com/Arubacloud/sdk-go/pkg/types"
+)
+
+func TestListUsers(t *testing.T) {
+	t.Run("successful list", func(t *testing.T) {
+		server := testutil.NewMockServer(t, func(w http.ResponseWriter, r *http.Request) {
+			if r.Method == "GET" && r.URL.Path == "/projects/test-project/providers/Aruba.Database/dbaas/dbaas-123/users" {
+				w.WriteHeader(http.StatusOK)
+				resp := types.UserList{
+					ListResponse: types.ListResponse{Total: 1},
+					Values:       []types.UserResponse{{Username: "alice"}},
+				}
+				json.NewEncoder(w).Encode(resp)
+				return
+			}
+			http.NotFound(w, r)
+		})
+		c := testutil.NewClient(t, server.URL)
+		svc := NewUsersClientImpl(c)
+
+		resp, err := svc.List(context.Background(), "test-project", "dbaas-123", nil)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if resp == nil || resp.Data == nil || len(resp.Data.Values) != 1 {
+			t.Fatalf("expected 1 user")
+		}
+		if resp.Data.Values[0].Username != "alice" {
+			t.Errorf("expected username 'alice', got %s", resp.Data.Values[0].Username)
+		}
+	})
+
+	t.Run("empty project", func(t *testing.T) {
+		c := testutil.NewClient(t, "http://unused.invalid")
+		svc := NewUsersClientImpl(c)
+		_, err := svc.List(context.Background(), "", "dbaas-123", nil)
+		if err == nil {
+			t.Fatal("expected validation error, got nil")
+		}
+	})
+
+	t.Run("empty DBaaS ID", func(t *testing.T) {
+		c := testutil.NewClient(t, "http://unused.invalid")
+		svc := NewUsersClientImpl(c)
+		_, err := svc.List(context.Background(), "test-project", "", nil)
+		if err == nil {
+			t.Fatal("expected validation error, got nil")
+		}
+	})
+
+	t.Run("not found", func(t *testing.T) {
+		server := testutil.NewMockServer(t, func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusNotFound)
+			fmt.Fprint(w, testutil.ErrorBodyJSON("Not Found", "resource not found", 404))
+		})
+		c := testutil.NewClient(t, server.URL)
+		svc := NewUsersClientImpl(c)
+
+		resp, err := svc.List(context.Background(), "test-project", "dbaas-123", nil)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if resp == nil || resp.StatusCode != http.StatusNotFound {
+			t.Fatalf("expected 404 response")
+		}
+		if resp.Error == nil {
+			t.Fatalf("expected resp.Error to be populated")
+		}
+		if resp.Error.Title == nil || *resp.Error.Title != "Not Found" {
+			t.Errorf("expected title 'Not Found', got %v", resp.Error.Title)
+		}
+	})
+
+	t.Run("bad gateway non-json", func(t *testing.T) {
+		server := testutil.NewMockServer(t, func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusBadGateway)
+			fmt.Fprint(w, "Bad Gateway")
+		})
+		c := testutil.NewClient(t, server.URL)
+		svc := NewUsersClientImpl(c)
+
+		resp, err := svc.List(context.Background(), "test-project", "dbaas-123", nil)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if resp == nil || resp.StatusCode != http.StatusBadGateway {
+			t.Fatalf("expected 502 response")
+		}
+		if resp.Error != nil {
+			t.Errorf("expected resp.Error to be nil for non-JSON body, got %+v", resp.Error)
+		}
+		if string(resp.RawBody) != "Bad Gateway" {
+			t.Errorf("expected RawBody 'Bad Gateway', got %q", string(resp.RawBody))
+		}
+	})
+
+	t.Run("network error", func(t *testing.T) {
+		c := testutil.NewBrokenClient(t, "http://unused.invalid")
+		svc := NewUsersClientImpl(c)
+		_, err := svc.List(context.Background(), "test-project", "dbaas-123", nil)
+		if err == nil {
+			t.Fatal("expected a network error, got nil")
+		}
+	})
+
+	t.Run("nil params injects default api-version", func(t *testing.T) {
+		server := testutil.NewMockServer(t, func(w http.ResponseWriter, r *http.Request) {
+			if got := r.URL.Query().Get("api-version"); got != "1.0" {
+				t.Errorf("expected api-version=1.0, got %q", got)
+			}
+			w.WriteHeader(http.StatusOK)
+			fmt.Fprint(w, `{"total":0,"values":[]}`)
+		})
+		c := testutil.NewClient(t, server.URL)
+		svc := NewUsersClientImpl(c)
+		if _, err := svc.List(context.Background(), "test-project", "dbaas-123", nil); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
+}
+
+func TestGetUser(t *testing.T) {
+	t.Run("successful get", func(t *testing.T) {
+		server := testutil.NewMockServer(t, func(w http.ResponseWriter, r *http.Request) {
+			if r.Method == "GET" && r.URL.Path == "/projects/test-project/providers/Aruba.Database/dbaas/dbaas-123/users/alice" {
+				w.WriteHeader(http.StatusOK)
+				resp := types.UserResponse{Username: "alice"}
+				json.NewEncoder(w).Encode(resp)
+				return
+			}
+			http.NotFound(w, r)
+		})
+		c := testutil.NewClient(t, server.URL)
+		svc := NewUsersClientImpl(c)
+
+		resp, err := svc.Get(context.Background(), "test-project", "dbaas-123", "alice", nil)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if resp == nil || resp.Data == nil {
+			t.Fatalf("expected response data")
+		}
+		if resp.Data.Username != "alice" {
+			t.Errorf("expected username 'alice', got %s", resp.Data.Username)
+		}
+	})
+
+	t.Run("empty project", func(t *testing.T) {
+		c := testutil.NewClient(t, "http://unused.invalid")
+		svc := NewUsersClientImpl(c)
+		_, err := svc.Get(context.Background(), "", "dbaas-123", "alice", nil)
+		if err == nil {
+			t.Fatal("expected validation error, got nil")
+		}
+	})
+
+	t.Run("empty DBaaS ID", func(t *testing.T) {
+		c := testutil.NewClient(t, "http://unused.invalid")
+		svc := NewUsersClientImpl(c)
+		_, err := svc.Get(context.Background(), "test-project", "", "alice", nil)
+		if err == nil {
+			t.Fatal("expected validation error, got nil")
+		}
+	})
+
+	t.Run("empty user ID", func(t *testing.T) {
+		c := testutil.NewClient(t, "http://unused.invalid")
+		svc := NewUsersClientImpl(c)
+		_, err := svc.Get(context.Background(), "test-project", "dbaas-123", "", nil)
+		if err == nil {
+			t.Fatal("expected validation error, got nil")
+		}
+	})
+
+	t.Run("not found", func(t *testing.T) {
+		server := testutil.NewMockServer(t, func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusNotFound)
+			fmt.Fprint(w, testutil.ErrorBodyJSON("Not Found", "resource not found", 404))
+		})
+		c := testutil.NewClient(t, server.URL)
+		svc := NewUsersClientImpl(c)
+
+		resp, err := svc.Get(context.Background(), "test-project", "dbaas-123", "alice", nil)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if resp == nil || resp.StatusCode != http.StatusNotFound {
+			t.Fatalf("expected 404 response")
+		}
+		if resp.Error == nil {
+			t.Fatalf("expected resp.Error to be populated")
+		}
+		if resp.Error.Title == nil || *resp.Error.Title != "Not Found" {
+			t.Errorf("expected title 'Not Found', got %v", resp.Error.Title)
+		}
+	})
+
+	t.Run("bad gateway non-json", func(t *testing.T) {
+		server := testutil.NewMockServer(t, func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusBadGateway)
+			fmt.Fprint(w, "Bad Gateway")
+		})
+		c := testutil.NewClient(t, server.URL)
+		svc := NewUsersClientImpl(c)
+
+		resp, err := svc.Get(context.Background(), "test-project", "dbaas-123", "alice", nil)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if resp == nil || resp.StatusCode != http.StatusBadGateway {
+			t.Fatalf("expected 502 response")
+		}
+		if resp.Error != nil {
+			t.Errorf("expected resp.Error to be nil for non-JSON body, got %+v", resp.Error)
+		}
+		if string(resp.RawBody) != "Bad Gateway" {
+			t.Errorf("expected RawBody 'Bad Gateway', got %q", string(resp.RawBody))
+		}
+	})
+
+	t.Run("network error", func(t *testing.T) {
+		c := testutil.NewBrokenClient(t, "http://unused.invalid")
+		svc := NewUsersClientImpl(c)
+		_, err := svc.Get(context.Background(), "test-project", "dbaas-123", "alice", nil)
+		if err == nil {
+			t.Fatal("expected a network error, got nil")
+		}
+	})
+
+	t.Run("nil params injects default api-version", func(t *testing.T) {
+		server := testutil.NewMockServer(t, func(w http.ResponseWriter, r *http.Request) {
+			if got := r.URL.Query().Get("api-version"); got != "1.0" {
+				t.Errorf("expected api-version=1.0, got %q", got)
+			}
+			w.WriteHeader(http.StatusOK)
+			fmt.Fprint(w, `{}`)
+		})
+		c := testutil.NewClient(t, server.URL)
+		svc := NewUsersClientImpl(c)
+		if _, err := svc.Get(context.Background(), "test-project", "dbaas-123", "alice", nil); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
+}
+
+func TestCreateUser(t *testing.T) {
+	t.Run("successful create", func(t *testing.T) {
+		server := testutil.NewMockServer(t, func(w http.ResponseWriter, r *http.Request) {
+			if r.Method == "POST" && r.URL.Path == "/projects/test-project/providers/Aruba.Database/dbaas/dbaas-123/users" {
+				w.WriteHeader(http.StatusCreated)
+				resp := types.UserResponse{Username: "alice"}
+				json.NewEncoder(w).Encode(resp)
+				return
+			}
+			http.NotFound(w, r)
+		})
+		c := testutil.NewClient(t, server.URL)
+		svc := NewUsersClientImpl(c)
+
+		resp, err := svc.Create(context.Background(), "test-project", "dbaas-123", types.UserRequest{Username: "alice", Password: "pass"}, nil)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if resp == nil || resp.Data == nil {
+			t.Fatalf("expected response data")
+		}
+		if resp.Data.Username != "alice" {
+			t.Errorf("expected username 'alice', got %s", resp.Data.Username)
+		}
+	})
+
+	t.Run("empty project", func(t *testing.T) {
+		c := testutil.NewClient(t, "http://unused.invalid")
+		svc := NewUsersClientImpl(c)
+		_, err := svc.Create(context.Background(), "", "dbaas-123", types.UserRequest{}, nil)
+		if err == nil {
+			t.Fatal("expected validation error, got nil")
+		}
+	})
+
+	t.Run("empty DBaaS ID", func(t *testing.T) {
+		c := testutil.NewClient(t, "http://unused.invalid")
+		svc := NewUsersClientImpl(c)
+		_, err := svc.Create(context.Background(), "test-project", "", types.UserRequest{}, nil)
+		if err == nil {
+			t.Fatal("expected validation error, got nil")
+		}
+	})
+
+	t.Run("not found", func(t *testing.T) {
+		server := testutil.NewMockServer(t, func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusNotFound)
+			fmt.Fprint(w, testutil.ErrorBodyJSON("Not Found", "resource not found", 404))
+		})
+		c := testutil.NewClient(t, server.URL)
+		svc := NewUsersClientImpl(c)
+
+		resp, err := svc.Create(context.Background(), "test-project", "dbaas-123", types.UserRequest{}, nil)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if resp == nil || resp.StatusCode != http.StatusNotFound {
+			t.Fatalf("expected 404 response")
+		}
+		if resp.Error == nil {
+			t.Fatalf("expected resp.Error to be populated")
+		}
+		if resp.Error.Title == nil || *resp.Error.Title != "Not Found" {
+			t.Errorf("expected title 'Not Found', got %v", resp.Error.Title)
+		}
+	})
+
+	t.Run("bad gateway non-json", func(t *testing.T) {
+		// TODO(TD-010): Create's manual response build silently swallows non-JSON
+		// unmarshal errors (diverges from ParseResponseBody which logs at DEBUG).
+		server := testutil.NewMockServer(t, func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusBadGateway)
+			fmt.Fprint(w, "Bad Gateway")
+		})
+		c := testutil.NewClient(t, server.URL)
+		svc := NewUsersClientImpl(c)
+
+		resp, err := svc.Create(context.Background(), "test-project", "dbaas-123", types.UserRequest{}, nil)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if resp == nil || resp.StatusCode != http.StatusBadGateway {
+			t.Fatalf("expected 502 response")
+		}
+		if resp.Error != nil {
+			t.Errorf("expected resp.Error to be nil for non-JSON body, got %+v", resp.Error)
+		}
+		if string(resp.RawBody) != "Bad Gateway" {
+			t.Errorf("expected RawBody 'Bad Gateway', got %q", string(resp.RawBody))
+		}
+	})
+
+	t.Run("network error", func(t *testing.T) {
+		c := testutil.NewBrokenClient(t, "http://unused.invalid")
+		svc := NewUsersClientImpl(c)
+		_, err := svc.Create(context.Background(), "test-project", "dbaas-123", types.UserRequest{}, nil)
+		if err == nil {
+			t.Fatal("expected a network error, got nil")
+		}
+	})
+
+	t.Run("nil params injects default api-version", func(t *testing.T) {
+		server := testutil.NewMockServer(t, func(w http.ResponseWriter, r *http.Request) {
+			if got := r.URL.Query().Get("api-version"); got != "1.0" {
+				t.Errorf("expected api-version=1.0, got %q", got)
+			}
+			w.WriteHeader(http.StatusCreated)
+			fmt.Fprint(w, `{}`)
+		})
+		c := testutil.NewClient(t, server.URL)
+		svc := NewUsersClientImpl(c)
+		if _, err := svc.Create(context.Background(), "test-project", "dbaas-123", types.UserRequest{}, nil); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
+}
+
+func TestUpdateUser(t *testing.T) {
+	t.Run("successful update", func(t *testing.T) {
+		server := testutil.NewMockServer(t, func(w http.ResponseWriter, r *http.Request) {
+			if r.Method == "PUT" && r.URL.Path == "/projects/test-project/providers/Aruba.Database/dbaas/dbaas-123/users/alice" {
+				w.WriteHeader(http.StatusOK)
+				resp := types.UserResponse{Username: "alice"}
+				json.NewEncoder(w).Encode(resp)
+				return
+			}
+			http.NotFound(w, r)
+		})
+		c := testutil.NewClient(t, server.URL)
+		svc := NewUsersClientImpl(c)
+
+		resp, err := svc.Update(context.Background(), "test-project", "dbaas-123", "alice", types.UserRequest{Username: "alice", Password: "newpass"}, nil)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if resp == nil || resp.Data == nil {
+			t.Fatalf("expected response data")
+		}
+		if resp.Data.Username != "alice" {
+			t.Errorf("expected username 'alice', got %s", resp.Data.Username)
+		}
+	})
+
+	t.Run("empty project", func(t *testing.T) {
+		c := testutil.NewClient(t, "http://unused.invalid")
+		svc := NewUsersClientImpl(c)
+		_, err := svc.Update(context.Background(), "", "dbaas-123", "alice", types.UserRequest{}, nil)
+		if err == nil {
+			t.Fatal("expected validation error, got nil")
+		}
+	})
+
+	t.Run("empty DBaaS ID", func(t *testing.T) {
+		c := testutil.NewClient(t, "http://unused.invalid")
+		svc := NewUsersClientImpl(c)
+		_, err := svc.Update(context.Background(), "test-project", "", "alice", types.UserRequest{}, nil)
+		if err == nil {
+			t.Fatal("expected validation error, got nil")
+		}
+	})
+
+	t.Run("empty user ID", func(t *testing.T) {
+		c := testutil.NewClient(t, "http://unused.invalid")
+		svc := NewUsersClientImpl(c)
+		_, err := svc.Update(context.Background(), "test-project", "dbaas-123", "", types.UserRequest{}, nil)
+		if err == nil {
+			t.Fatal("expected validation error, got nil")
+		}
+	})
+
+	t.Run("not found", func(t *testing.T) {
+		server := testutil.NewMockServer(t, func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusNotFound)
+			fmt.Fprint(w, testutil.ErrorBodyJSON("Not Found", "resource not found", 404))
+		})
+		c := testutil.NewClient(t, server.URL)
+		svc := NewUsersClientImpl(c)
+
+		resp, err := svc.Update(context.Background(), "test-project", "dbaas-123", "alice", types.UserRequest{}, nil)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if resp == nil || resp.StatusCode != http.StatusNotFound {
+			t.Fatalf("expected 404 response")
+		}
+		if resp.Error == nil {
+			t.Fatalf("expected resp.Error to be populated")
+		}
+		if resp.Error.Title == nil || *resp.Error.Title != "Not Found" {
+			t.Errorf("expected title 'Not Found', got %v", resp.Error.Title)
+		}
+	})
+
+	t.Run("bad gateway non-json", func(t *testing.T) {
+		// TODO(TD-010): Update's manual response build silently swallows non-JSON
+		// unmarshal errors (diverges from ParseResponseBody which logs at DEBUG).
+		server := testutil.NewMockServer(t, func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusBadGateway)
+			fmt.Fprint(w, "Bad Gateway")
+		})
+		c := testutil.NewClient(t, server.URL)
+		svc := NewUsersClientImpl(c)
+
+		resp, err := svc.Update(context.Background(), "test-project", "dbaas-123", "alice", types.UserRequest{}, nil)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if resp == nil || resp.StatusCode != http.StatusBadGateway {
+			t.Fatalf("expected 502 response")
+		}
+		if resp.Error != nil {
+			t.Errorf("expected resp.Error to be nil for non-JSON body, got %+v", resp.Error)
+		}
+		if string(resp.RawBody) != "Bad Gateway" {
+			t.Errorf("expected RawBody 'Bad Gateway', got %q", string(resp.RawBody))
+		}
+	})
+
+	t.Run("network error", func(t *testing.T) {
+		c := testutil.NewBrokenClient(t, "http://unused.invalid")
+		svc := NewUsersClientImpl(c)
+		_, err := svc.Update(context.Background(), "test-project", "dbaas-123", "alice", types.UserRequest{}, nil)
+		if err == nil {
+			t.Fatal("expected a network error, got nil")
+		}
+	})
+
+	t.Run("nil params injects default api-version", func(t *testing.T) {
+		server := testutil.NewMockServer(t, func(w http.ResponseWriter, r *http.Request) {
+			if got := r.URL.Query().Get("api-version"); got != "1.0" {
+				t.Errorf("expected api-version=1.0, got %q", got)
+			}
+			w.WriteHeader(http.StatusOK)
+			fmt.Fprint(w, `{}`)
+		})
+		c := testutil.NewClient(t, server.URL)
+		svc := NewUsersClientImpl(c)
+		if _, err := svc.Update(context.Background(), "test-project", "dbaas-123", "alice", types.UserRequest{}, nil); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
+}
+
+func TestDeleteUser(t *testing.T) {
+	t.Run("successful delete", func(t *testing.T) {
+		server := testutil.NewMockServer(t, func(w http.ResponseWriter, r *http.Request) {
+			if r.Method == "DELETE" && r.URL.Path == "/projects/test-project/providers/Aruba.Database/dbaas/dbaas-123/users/alice" {
+				w.WriteHeader(http.StatusNoContent)
+				return
+			}
+			http.NotFound(w, r)
+		})
+		c := testutil.NewClient(t, server.URL)
+		svc := NewUsersClientImpl(c)
+
+		_, err := svc.Delete(context.Background(), "test-project", "dbaas-123", "alice", nil)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
+
+	t.Run("empty project", func(t *testing.T) {
+		c := testutil.NewClient(t, "http://unused.invalid")
+		svc := NewUsersClientImpl(c)
+		_, err := svc.Delete(context.Background(), "", "dbaas-123", "alice", nil)
+		if err == nil {
+			t.Fatal("expected validation error, got nil")
+		}
+	})
+
+	t.Run("empty DBaaS ID", func(t *testing.T) {
+		c := testutil.NewClient(t, "http://unused.invalid")
+		svc := NewUsersClientImpl(c)
+		_, err := svc.Delete(context.Background(), "test-project", "", "alice", nil)
+		if err == nil {
+			t.Fatal("expected validation error, got nil")
+		}
+	})
+
+	t.Run("empty user ID", func(t *testing.T) {
+		c := testutil.NewClient(t, "http://unused.invalid")
+		svc := NewUsersClientImpl(c)
+		_, err := svc.Delete(context.Background(), "test-project", "dbaas-123", "", nil)
+		if err == nil {
+			t.Fatal("expected validation error, got nil")
+		}
+	})
+
+	t.Run("not found", func(t *testing.T) {
+		server := testutil.NewMockServer(t, func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusNotFound)
+			fmt.Fprint(w, testutil.ErrorBodyJSON("Not Found", "resource not found", 404))
+		})
+		c := testutil.NewClient(t, server.URL)
+		svc := NewUsersClientImpl(c)
+
+		resp, err := svc.Delete(context.Background(), "test-project", "dbaas-123", "alice", nil)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if resp == nil || resp.StatusCode != http.StatusNotFound {
+			t.Fatalf("expected 404 response")
+		}
+		if resp.Error == nil {
+			t.Fatalf("expected resp.Error to be populated")
+		}
+		if resp.Error.Title == nil || *resp.Error.Title != "Not Found" {
+			t.Errorf("expected title 'Not Found', got %v", resp.Error.Title)
+		}
+	})
+
+	t.Run("bad gateway non-json", func(t *testing.T) {
+		server := testutil.NewMockServer(t, func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusBadGateway)
+			fmt.Fprint(w, "Bad Gateway")
+		})
+		c := testutil.NewClient(t, server.URL)
+		svc := NewUsersClientImpl(c)
+
+		resp, err := svc.Delete(context.Background(), "test-project", "dbaas-123", "alice", nil)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if resp == nil || resp.StatusCode != http.StatusBadGateway {
+			t.Fatalf("expected 502 response")
+		}
+		if resp.Error != nil {
+			t.Errorf("expected resp.Error to be nil for non-JSON body, got %+v", resp.Error)
+		}
+		if string(resp.RawBody) != "Bad Gateway" {
+			t.Errorf("expected RawBody 'Bad Gateway', got %q", string(resp.RawBody))
+		}
+	})
+
+	t.Run("network error", func(t *testing.T) {
+		c := testutil.NewBrokenClient(t, "http://unused.invalid")
+		svc := NewUsersClientImpl(c)
+		_, err := svc.Delete(context.Background(), "test-project", "dbaas-123", "alice", nil)
+		if err == nil {
+			t.Fatal("expected a network error, got nil")
+		}
+	})
+
+	t.Run("nil params injects default api-version", func(t *testing.T) {
+		server := testutil.NewMockServer(t, func(w http.ResponseWriter, r *http.Request) {
+			if got := r.URL.Query().Get("api-version"); got != "1.0" {
+				t.Errorf("expected api-version=1.0, got %q", got)
+			}
+			w.WriteHeader(http.StatusNoContent)
+		})
+		c := testutil.NewClient(t, server.URL)
+		svc := NewUsersClientImpl(c)
+		if _, err := svc.Delete(context.Background(), "test-project", "dbaas-123", "alice", nil); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
+}


### PR DESCRIPTION
## Summary

- Writes 5 new test files for the `database` package which previously had **zero test coverage**
- Covers all 24 test functions across 5 resources (Backup, DBaaS, Database, User, Grant) with the standard 6-subtest matrix per method: `successful <verb>`, N×`empty-<X>-ID`, `not found`, `bad gateway non-json`, `network error`, `nil params injects default api-version`
- Coverage increases from **0% → 85.3%** of statements
- Manual-flow `Create`/`Update` methods carry `TODO(TD-010)` comments flagging silent non-JSON error body swallowing vs. `ParseResponseBody`'s DEBUG-log path
- `backup.Create` is the only POST in this package using standard `ParseResponseBody` — no TD-010 comment there

Closes #152 · Part of #130 · Follows shape set by #162 (audit), #164 (compute), #165 (container)

## Test plan

- [x] `go test ./internal/clients/database/... -count=1 -race -v` — all subtests pass
- [x] `go test ./internal/clients/database/... -cover` — 85.3% coverage
- [x] CI lint passes (golangci-lint)

🤖 Generated with [Claude Code](https://claude.com/claude-code)