### PR TITLE
test(network): migrate VPC graph boilerplate to testutil and add error matrix

### DIFF
--- a/internal/clients/network/subnet_test.go
+++ b/internal/clients/network/subnet_test.go
@@ -9,65 +9,19 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/Arubacloud/sdk-go/internal/impl/interceptor/standard"
-	"github.com/Arubacloud/sdk-go/internal/impl/logger/noop"
-	"github.com/Arubacloud/sdk-go/internal/restclient"
+	"github.com/Arubacloud/sdk-go/internal/testutil"
 	"github.com/Arubacloud/sdk-go/pkg/types"
 )
 
 func TestListSubnets(t *testing.T) {
 	t.Run("successful list", func(t *testing.T) {
-		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			if r.URL.Path == "/token" {
-				w.Header().Set("Content-Type", "application/json")
-				w.WriteHeader(http.StatusOK)
-				w.Write([]byte(`{"access_token":"test-token","token_type":"Bearer","expires_in":3600}`))
-				return
-			}
-
+		server := testutil.NewMockServer(t, func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
 			w.WriteHeader(http.StatusOK)
-			resp := types.SubnetList{
-				ListResponse: types.ListResponse{Total: 1},
-				Values: []types.SubnetResponse{
-					{
-						Metadata: types.ResourceMetadataResponse{Name: types.StringPtr("subnet-1")},
-						Properties: types.SubnetPropertiesResponse{
-							Type: types.SubnetTypeBasic,
-							Network: &types.SubnetNetwork{
-								Address: "192.168.1.0/24",
-							},
-							DHCP: &types.SubnetDHCP{
-								Enabled: true,
-								Range: &types.SubnetDHCPRange{
-									Start: "192.168.1.10",
-									Count: 50,
-								},
-								Routes: []types.SubnetDHCPRoute{
-									{
-										Address: "0.0.0.0/0",
-										Gateway: "192.168.1.1",
-									},
-								},
-								DNS: []string{"8.8.8.8"},
-							},
-						},
-					},
-				},
-			}
-			json.NewEncoder(w).Encode(resp)
-		}))
-		defer server.Close()
-
-		var (
-			baseURL    = server.URL
-			httpClient = http.DefaultClient
-			logger     = &noop.NoOpLogger{}
-		)
-
-		c := restclient.NewClient(baseURL, httpClient, standard.NewInterceptor(), logger)
-
+			fmt.Fprint(w, `{"total":1,"values":[{"metadata":{"name":"subnet-1"}}]}`)
+		})
+		c := testutil.NewClient(t, server.URL)
 		svc := NewSubnetsClientImpl(c, NewVPCsClientImpl(c))
-
 		resp, err := svc.List(context.Background(), "test-project", "vpc-123", nil)
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
@@ -76,67 +30,216 @@ func TestListSubnets(t *testing.T) {
 			t.Errorf("expected total 1, got %d", resp.Data.Total)
 		}
 	})
+
+	t.Run("empty project", func(t *testing.T) {
+		c := testutil.NewClient(t, "http://unused.invalid")
+		svc := NewSubnetsClientImpl(c, NewVPCsClientImpl(c))
+		_, err := svc.List(context.Background(), "", "vpc-123", nil)
+		if err == nil {
+			t.Fatal("expected validation error, got nil")
+		}
+	})
+
+	t.Run("empty vpcID", func(t *testing.T) {
+		c := testutil.NewClient(t, "http://unused.invalid")
+		svc := NewSubnetsClientImpl(c, NewVPCsClientImpl(c))
+		_, err := svc.List(context.Background(), "test-project", "", nil)
+		if err == nil {
+			t.Fatal("expected validation error, got nil")
+		}
+	})
+
+	t.Run("not found", func(t *testing.T) {
+		server := testutil.NewMockServer(t, func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusNotFound)
+			fmt.Fprint(w, testutil.ErrorBodyJSON("Not Found", "resource not found", 404))
+		})
+		c := testutil.NewClient(t, server.URL)
+		svc := NewSubnetsClientImpl(c, NewVPCsClientImpl(c))
+		resp, err := svc.List(context.Background(), "test-project", "vpc-123", nil)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if resp.StatusCode != http.StatusNotFound {
+			t.Errorf("expected status 404, got %d", resp.StatusCode)
+		}
+		if resp.Error == nil || resp.Error.Title == nil || *resp.Error.Title != "Not Found" {
+			t.Errorf("expected error title 'Not Found', got %v", resp.Error)
+		}
+	})
+
+	t.Run("bad gateway non-json", func(t *testing.T) {
+		server := testutil.NewMockServer(t, func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusBadGateway)
+			fmt.Fprint(w, "Bad Gateway")
+		})
+		c := testutil.NewClient(t, server.URL)
+		svc := NewSubnetsClientImpl(c, NewVPCsClientImpl(c))
+		resp, err := svc.List(context.Background(), "test-project", "vpc-123", nil)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if resp.StatusCode != http.StatusBadGateway {
+			t.Errorf("expected status 502, got %d", resp.StatusCode)
+		}
+		if resp.Error != nil {
+			t.Errorf("expected nil Error, got %v", resp.Error)
+		}
+		if string(resp.RawBody) != "Bad Gateway" {
+			t.Errorf("expected raw body 'Bad Gateway', got %q", string(resp.RawBody))
+		}
+	})
+
+	t.Run("network error", func(t *testing.T) {
+		c := testutil.NewBrokenClient(t, "http://unused.invalid")
+		svc := NewSubnetsClientImpl(c, NewVPCsClientImpl(c))
+		_, err := svc.List(context.Background(), "test-project", "vpc-123", nil)
+		if err == nil {
+			t.Fatal("expected transport error, got nil")
+		}
+	})
+
+	t.Run("nil params injects default api-version", func(t *testing.T) {
+		server := testutil.NewMockServer(t, func(w http.ResponseWriter, r *http.Request) {
+			if got := r.URL.Query().Get("api-version"); got != "1.0" {
+				t.Errorf("expected api-version=1.0, got %q", got)
+			}
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusOK)
+			fmt.Fprint(w, `{"total":0,"values":[]}`)
+		})
+		c := testutil.NewClient(t, server.URL)
+		svc := NewSubnetsClientImpl(c, NewVPCsClientImpl(c))
+		resp, err := svc.List(context.Background(), "test-project", "vpc-123", nil)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if resp.StatusCode != http.StatusOK {
+			t.Errorf("expected status 200, got %d", resp.StatusCode)
+		}
+	})
 }
 
 func TestGetSubnet(t *testing.T) {
 	t.Run("successful get", func(t *testing.T) {
-		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			if r.URL.Path == "/token" {
-				w.Header().Set("Content-Type", "application/json")
-				w.WriteHeader(http.StatusOK)
-				w.Write([]byte(`{"access_token":"test-token","token_type":"Bearer","expires_in":3600}`))
-				return
-			}
-
+		server := testutil.NewMockServer(t, func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
 			w.WriteHeader(http.StatusOK)
-			resp := types.SubnetResponse{
-				Metadata: types.ResourceMetadataResponse{Name: types.StringPtr("my-subnet")},
-				Properties: types.SubnetPropertiesResponse{
-					Type: types.SubnetTypeAdvanced,
-					Network: &types.SubnetNetwork{
-						Address: "192.168.1.0/25",
-					},
-					DHCP: &types.SubnetDHCP{
-						Enabled: true,
-						Range: &types.SubnetDHCPRange{
-							Start: "192.168.1.10",
-							Count: 50,
-						},
-						Routes: []types.SubnetDHCPRoute{
-							{
-								Address: "0.0.0.0/0",
-								Gateway: "192.168.1.1",
-							},
-						},
-						DNS: []string{"8.8.8.8", "8.8.4.4"},
-					},
-				},
-			}
-			json.NewEncoder(w).Encode(resp)
-		}))
-		defer server.Close()
-
-		var (
-			baseURL    = server.URL
-			httpClient = http.DefaultClient
-			logger     = &noop.NoOpLogger{}
-		)
-
-		c := restclient.NewClient(baseURL, httpClient, standard.NewInterceptor(), logger)
-
+			fmt.Fprint(w, `{"metadata":{"name":"my-subnet"}}`)
+		})
+		c := testutil.NewClient(t, server.URL)
 		svc := NewSubnetsClientImpl(c, NewVPCsClientImpl(c))
-
 		resp, err := svc.Get(context.Background(), "test-project", "vpc-123", "subnet-456", nil)
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
 		if resp.Data.Metadata.Name == nil || *resp.Data.Metadata.Name != "my-subnet" {
-			t.Errorf("expected name 'my-subnet', got '%v'", resp.Data.Metadata.Name)
+			t.Errorf("expected name 'my-subnet', got %v", resp.Data.Metadata.Name)
+		}
+	})
+
+	t.Run("empty project", func(t *testing.T) {
+		c := testutil.NewClient(t, "http://unused.invalid")
+		svc := NewSubnetsClientImpl(c, NewVPCsClientImpl(c))
+		_, err := svc.Get(context.Background(), "", "vpc-123", "subnet-456", nil)
+		if err == nil {
+			t.Fatal("expected validation error, got nil")
+		}
+	})
+
+	t.Run("empty vpcID", func(t *testing.T) {
+		c := testutil.NewClient(t, "http://unused.invalid")
+		svc := NewSubnetsClientImpl(c, NewVPCsClientImpl(c))
+		_, err := svc.Get(context.Background(), "test-project", "", "subnet-456", nil)
+		if err == nil {
+			t.Fatal("expected validation error, got nil")
+		}
+	})
+
+	t.Run("empty subnetID", func(t *testing.T) {
+		c := testutil.NewClient(t, "http://unused.invalid")
+		svc := NewSubnetsClientImpl(c, NewVPCsClientImpl(c))
+		_, err := svc.Get(context.Background(), "test-project", "vpc-123", "", nil)
+		if err == nil {
+			t.Fatal("expected validation error, got nil")
+		}
+	})
+
+	t.Run("not found", func(t *testing.T) {
+		server := testutil.NewMockServer(t, func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusNotFound)
+			fmt.Fprint(w, testutil.ErrorBodyJSON("Not Found", "resource not found", 404))
+		})
+		c := testutil.NewClient(t, server.URL)
+		svc := NewSubnetsClientImpl(c, NewVPCsClientImpl(c))
+		resp, err := svc.Get(context.Background(), "test-project", "vpc-123", "subnet-456", nil)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if resp.StatusCode != http.StatusNotFound {
+			t.Errorf("expected status 404, got %d", resp.StatusCode)
+		}
+		if resp.Error == nil || resp.Error.Title == nil || *resp.Error.Title != "Not Found" {
+			t.Errorf("expected error title 'Not Found', got %v", resp.Error)
+		}
+	})
+
+	t.Run("bad gateway non-json", func(t *testing.T) {
+		server := testutil.NewMockServer(t, func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusBadGateway)
+			fmt.Fprint(w, "Bad Gateway")
+		})
+		c := testutil.NewClient(t, server.URL)
+		svc := NewSubnetsClientImpl(c, NewVPCsClientImpl(c))
+		resp, err := svc.Get(context.Background(), "test-project", "vpc-123", "subnet-456", nil)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if resp.StatusCode != http.StatusBadGateway {
+			t.Errorf("expected status 502, got %d", resp.StatusCode)
+		}
+		if resp.Error != nil {
+			t.Errorf("expected nil Error, got %v", resp.Error)
+		}
+		if string(resp.RawBody) != "Bad Gateway" {
+			t.Errorf("expected raw body 'Bad Gateway', got %q", string(resp.RawBody))
+		}
+	})
+
+	t.Run("network error", func(t *testing.T) {
+		c := testutil.NewBrokenClient(t, "http://unused.invalid")
+		svc := NewSubnetsClientImpl(c, NewVPCsClientImpl(c))
+		_, err := svc.Get(context.Background(), "test-project", "vpc-123", "subnet-456", nil)
+		if err == nil {
+			t.Fatal("expected transport error, got nil")
+		}
+	})
+
+	t.Run("nil params injects default api-version", func(t *testing.T) {
+		server := testutil.NewMockServer(t, func(w http.ResponseWriter, r *http.Request) {
+			if got := r.URL.Query().Get("api-version"); got != "1.0" {
+				t.Errorf("expected api-version=1.0, got %q", got)
+			}
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusOK)
+			fmt.Fprint(w, `{}`)
+		})
+		c := testutil.NewClient(t, server.URL)
+		svc := NewSubnetsClientImpl(c, NewVPCsClientImpl(c))
+		resp, err := svc.Get(context.Background(), "test-project", "vpc-123", "subnet-456", nil)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if resp.StatusCode != http.StatusOK {
+			t.Errorf("expected status 200, got %d", resp.StatusCode)
 		}
 	})
 }
 
 func TestCreateSubnet(t *testing.T) {
+	// TODO(TD-020): unskip once VPC-active polling is mockable.
 	t.Skip("Skipping CreateSubnet test - requires complex VPC polling mock setup")
 	// NOTE: CreateSubnet calls waitForVPCActive() which polls the VPC status
 	// To properly test this, you need to mock the VPC GET endpoint to return "active" status
@@ -214,13 +317,7 @@ func TestCreateSubnet(t *testing.T) {
 		}))
 		defer server.Close()
 
-		var (
-			baseURL    = server.URL
-			httpClient = http.DefaultClient
-			logger     = &noop.NoOpLogger{}
-		)
-
-		c := restclient.NewClient(baseURL, httpClient, standard.NewInterceptor(), logger)
+		c := testutil.NewClient(t, server.URL)
 
 		svc := NewSubnetsClientImpl(c, NewVPCsClientImpl(c))
 
@@ -240,33 +337,231 @@ func TestCreateSubnet(t *testing.T) {
 	})
 }
 
+func TestUpdateSubnet(t *testing.T) {
+	t.Run("successful update", func(t *testing.T) {
+		server := testutil.NewMockServer(t, func(w http.ResponseWriter, r *http.Request) {
+			if r.Method != http.MethodPut {
+				t.Errorf("expected PUT, got %s", r.Method)
+			}
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusOK)
+			fmt.Fprint(w, `{"metadata":{"name":"updated-subnet"}}`)
+		})
+		c := testutil.NewClient(t, server.URL)
+		svc := NewSubnetsClientImpl(c, NewVPCsClientImpl(c))
+		resp, err := svc.Update(context.Background(), "test-project", "vpc-123", "subnet-456", types.SubnetRequest{}, nil)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if resp.StatusCode != http.StatusOK {
+			t.Errorf("expected status 200, got %d", resp.StatusCode)
+		}
+	})
+
+	t.Run("empty project", func(t *testing.T) {
+		c := testutil.NewClient(t, "http://unused.invalid")
+		svc := NewSubnetsClientImpl(c, NewVPCsClientImpl(c))
+		_, err := svc.Update(context.Background(), "", "vpc-123", "subnet-456", types.SubnetRequest{}, nil)
+		if err == nil {
+			t.Fatal("expected validation error, got nil")
+		}
+	})
+
+	t.Run("empty vpcID", func(t *testing.T) {
+		c := testutil.NewClient(t, "http://unused.invalid")
+		svc := NewSubnetsClientImpl(c, NewVPCsClientImpl(c))
+		_, err := svc.Update(context.Background(), "test-project", "", "subnet-456", types.SubnetRequest{}, nil)
+		if err == nil {
+			t.Fatal("expected validation error, got nil")
+		}
+	})
+
+	t.Run("empty subnetID", func(t *testing.T) {
+		c := testutil.NewClient(t, "http://unused.invalid")
+		svc := NewSubnetsClientImpl(c, NewVPCsClientImpl(c))
+		_, err := svc.Update(context.Background(), "test-project", "vpc-123", "", types.SubnetRequest{}, nil)
+		if err == nil {
+			t.Fatal("expected validation error, got nil")
+		}
+	})
+
+	t.Run("not found", func(t *testing.T) {
+		server := testutil.NewMockServer(t, func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusNotFound)
+			fmt.Fprint(w, testutil.ErrorBodyJSON("Not Found", "resource not found", 404))
+		})
+		c := testutil.NewClient(t, server.URL)
+		svc := NewSubnetsClientImpl(c, NewVPCsClientImpl(c))
+		resp, err := svc.Update(context.Background(), "test-project", "vpc-123", "subnet-456", types.SubnetRequest{}, nil)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if resp.StatusCode != http.StatusNotFound {
+			t.Errorf("expected status 404, got %d", resp.StatusCode)
+		}
+		if resp.Error == nil || resp.Error.Title == nil || *resp.Error.Title != "Not Found" {
+			t.Errorf("expected error title 'Not Found', got %v", resp.Error)
+		}
+	})
+
+	t.Run("bad gateway non-json", func(t *testing.T) {
+		// TODO(TD-010): Create/Update's manual response build silently swallows non-JSON
+		// unmarshal errors (diverges from ParseResponseBody which logs at DEBUG).
+		server := testutil.NewMockServer(t, func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusBadGateway)
+			fmt.Fprint(w, "Bad Gateway")
+		})
+		c := testutil.NewClient(t, server.URL)
+		svc := NewSubnetsClientImpl(c, NewVPCsClientImpl(c))
+		resp, err := svc.Update(context.Background(), "test-project", "vpc-123", "subnet-456", types.SubnetRequest{}, nil)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if resp.StatusCode != http.StatusBadGateway {
+			t.Errorf("expected status 502, got %d", resp.StatusCode)
+		}
+		if resp.Error != nil {
+			t.Errorf("expected nil Error, got %v", resp.Error)
+		}
+		if string(resp.RawBody) != "Bad Gateway" {
+			t.Errorf("expected raw body 'Bad Gateway', got %q", string(resp.RawBody))
+		}
+	})
+
+	t.Run("network error", func(t *testing.T) {
+		c := testutil.NewBrokenClient(t, "http://unused.invalid")
+		svc := NewSubnetsClientImpl(c, NewVPCsClientImpl(c))
+		_, err := svc.Update(context.Background(), "test-project", "vpc-123", "subnet-456", types.SubnetRequest{}, nil)
+		if err == nil {
+			t.Fatal("expected transport error, got nil")
+		}
+	})
+
+	t.Run("nil params injects default api-version", func(t *testing.T) {
+		server := testutil.NewMockServer(t, func(w http.ResponseWriter, r *http.Request) {
+			if got := r.URL.Query().Get("api-version"); got != "1.0" {
+				t.Errorf("expected api-version=1.0, got %q", got)
+			}
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusOK)
+			fmt.Fprint(w, `{}`)
+		})
+		c := testutil.NewClient(t, server.URL)
+		svc := NewSubnetsClientImpl(c, NewVPCsClientImpl(c))
+		resp, err := svc.Update(context.Background(), "test-project", "vpc-123", "subnet-456", types.SubnetRequest{}, nil)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if resp.StatusCode != http.StatusOK {
+			t.Errorf("expected status 200, got %d", resp.StatusCode)
+		}
+	})
+}
+
 func TestDeleteSubnet(t *testing.T) {
 	t.Run("successful delete", func(t *testing.T) {
-		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			if r.URL.Path == "/token" {
-				w.Header().Set("Content-Type", "application/json")
-				w.WriteHeader(http.StatusOK)
-				w.Write([]byte(`{"access_token":"test-token","token_type":"Bearer","expires_in":3600}`))
-				return
-			}
-
+		server := testutil.NewMockServer(t, func(w http.ResponseWriter, r *http.Request) {
 			if r.Method != http.MethodDelete {
 				t.Errorf("expected DELETE, got %s", r.Method)
 			}
 			w.WriteHeader(http.StatusNoContent)
-		}))
-		defer server.Close()
-
-		var (
-			baseURL    = server.URL
-			httpClient = http.DefaultClient
-			logger     = &noop.NoOpLogger{}
-		)
-
-		c := restclient.NewClient(baseURL, httpClient, standard.NewInterceptor(), logger)
-
+		})
+		c := testutil.NewClient(t, server.URL)
 		svc := NewSubnetsClientImpl(c, NewVPCsClientImpl(c))
+		_, err := svc.Delete(context.Background(), "test-project", "vpc-123", "subnet-456", nil)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
 
+	t.Run("empty project", func(t *testing.T) {
+		c := testutil.NewClient(t, "http://unused.invalid")
+		svc := NewSubnetsClientImpl(c, NewVPCsClientImpl(c))
+		_, err := svc.Delete(context.Background(), "", "vpc-123", "subnet-456", nil)
+		if err == nil {
+			t.Fatal("expected validation error, got nil")
+		}
+	})
+
+	t.Run("empty vpcID", func(t *testing.T) {
+		c := testutil.NewClient(t, "http://unused.invalid")
+		svc := NewSubnetsClientImpl(c, NewVPCsClientImpl(c))
+		_, err := svc.Delete(context.Background(), "test-project", "", "subnet-456", nil)
+		if err == nil {
+			t.Fatal("expected validation error, got nil")
+		}
+	})
+
+	t.Run("empty subnetID", func(t *testing.T) {
+		c := testutil.NewClient(t, "http://unused.invalid")
+		svc := NewSubnetsClientImpl(c, NewVPCsClientImpl(c))
+		_, err := svc.Delete(context.Background(), "test-project", "vpc-123", "", nil)
+		if err == nil {
+			t.Fatal("expected validation error, got nil")
+		}
+	})
+
+	t.Run("not found", func(t *testing.T) {
+		server := testutil.NewMockServer(t, func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusNotFound)
+			fmt.Fprint(w, testutil.ErrorBodyJSON("Not Found", "resource not found", 404))
+		})
+		c := testutil.NewClient(t, server.URL)
+		svc := NewSubnetsClientImpl(c, NewVPCsClientImpl(c))
+		resp, err := svc.Delete(context.Background(), "test-project", "vpc-123", "subnet-456", nil)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if resp.StatusCode != http.StatusNotFound {
+			t.Errorf("expected status 404, got %d", resp.StatusCode)
+		}
+		if resp.Error == nil || resp.Error.Title == nil || *resp.Error.Title != "Not Found" {
+			t.Errorf("expected error title 'Not Found', got %v", resp.Error)
+		}
+	})
+
+	t.Run("bad gateway non-json", func(t *testing.T) {
+		server := testutil.NewMockServer(t, func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusBadGateway)
+			fmt.Fprint(w, "Bad Gateway")
+		})
+		c := testutil.NewClient(t, server.URL)
+		svc := NewSubnetsClientImpl(c, NewVPCsClientImpl(c))
+		resp, err := svc.Delete(context.Background(), "test-project", "vpc-123", "subnet-456", nil)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if resp.StatusCode != http.StatusBadGateway {
+			t.Errorf("expected status 502, got %d", resp.StatusCode)
+		}
+		if resp.Error != nil {
+			t.Errorf("expected nil Error, got %v", resp.Error)
+		}
+		if string(resp.RawBody) != "Bad Gateway" {
+			t.Errorf("expected raw body 'Bad Gateway', got %q", string(resp.RawBody))
+		}
+	})
+
+	t.Run("network error", func(t *testing.T) {
+		c := testutil.NewBrokenClient(t, "http://unused.invalid")
+		svc := NewSubnetsClientImpl(c, NewVPCsClientImpl(c))
+		_, err := svc.Delete(context.Background(), "test-project", "vpc-123", "subnet-456", nil)
+		if err == nil {
+			t.Fatal("expected transport error, got nil")
+		}
+	})
+
+	t.Run("nil params injects default api-version", func(t *testing.T) {
+		server := testutil.NewMockServer(t, func(w http.ResponseWriter, r *http.Request) {
+			if got := r.URL.Query().Get("api-version"); got != "1.0" {
+				t.Errorf("expected api-version=1.0, got %q", got)
+			}
+			w.WriteHeader(http.StatusNoContent)
+		})
+		c := testutil.NewClient(t, server.URL)
+		svc := NewSubnetsClientImpl(c, NewVPCsClientImpl(c))
 		_, err := svc.Delete(context.Background(), "test-project", "vpc-123", "subnet-456", nil)
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)

--- a/internal/clients/network/vpc-peering-route_test.go
+++ b/internal/clients/network/vpc-peering-route_test.go
@@ -2,150 +2,625 @@ package network
 
 import (
 	"context"
-	"encoding/json"
+	"fmt"
 	"net/http"
-	"net/http/httptest"
 	"testing"
 
-	"github.com/Arubacloud/sdk-go/internal/impl/interceptor/standard"
-	"github.com/Arubacloud/sdk-go/internal/impl/logger/noop"
-	"github.com/Arubacloud/sdk-go/internal/restclient"
+	"github.com/Arubacloud/sdk-go/internal/testutil"
 	"github.com/Arubacloud/sdk-go/pkg/types"
 )
 
 func TestListVpcPeeringRoutes(t *testing.T) {
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.URL.Path == "/token" {
+	t.Run("successful list", func(t *testing.T) {
+		server := testutil.NewMockServer(t, func(w http.ResponseWriter, r *http.Request) {
 			w.Header().Set("Content-Type", "application/json")
 			w.WriteHeader(http.StatusOK)
-			w.Write([]byte(`{"access_token":"test-token","token_type":"Bearer","expires_in":3600}`))
-			return
+			fmt.Fprint(w, `{"total":1,"values":[{"metadata":{"name":"route-1"},"properties":{"localNetworkAddress":"10.0.0.0/16","remoteNetworkAddress":"10.1.0.0/16"}}]}`)
+		})
+		c := testutil.NewClient(t, server.URL)
+		svc := NewVPCPeeringRoutesClientImpl(c)
+		resp, err := svc.List(context.Background(), "test-project", "vpc-123", "peering-1", nil)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
 		}
+		if resp == nil || resp.Data == nil || len(resp.Data.Values) != 1 {
+			t.Errorf("expected 1 vpc peering route")
+		}
+	})
 
-		if r.Method == "GET" && r.URL.Path == "/projects/test-project/providers/Aruba.Network/vpcs/vpc-123/vpcPeerings/peering-1/routes" {
-			w.WriteHeader(http.StatusOK)
-			resp := types.VPCPeeringRouteList{
-				ListResponse: types.ListResponse{Total: 1},
-				Values: []types.VPCPeeringRouteResponse{
-					{
-						Metadata: types.RegionalResourceMetadataRequest{
-							ResourceMetadataRequest: types.ResourceMetadataRequest{
-								Name: "route-1",
-							},
-						},
-						Properties: types.VPCPeeringRoutePropertiesResponse{
-							LocalNetworkAddress:  "10.0.0.0/16",
-							RemoteNetworkAddress: "10.1.0.0/16",
-						},
-					},
-				},
+	t.Run("empty project", func(t *testing.T) {
+		c := testutil.NewClient(t, "http://unused.invalid")
+		svc := NewVPCPeeringRoutesClientImpl(c)
+		_, err := svc.List(context.Background(), "", "vpc-123", "peering-1", nil)
+		if err == nil {
+			t.Fatal("expected validation error, got nil")
+		}
+	})
+
+	t.Run("empty vpcID", func(t *testing.T) {
+		c := testutil.NewClient(t, "http://unused.invalid")
+		svc := NewVPCPeeringRoutesClientImpl(c)
+		_, err := svc.List(context.Background(), "test-project", "", "peering-1", nil)
+		if err == nil {
+			t.Fatal("expected validation error, got nil")
+		}
+	})
+
+	t.Run("empty vpcPeeringID", func(t *testing.T) {
+		c := testutil.NewClient(t, "http://unused.invalid")
+		svc := NewVPCPeeringRoutesClientImpl(c)
+		_, err := svc.List(context.Background(), "test-project", "vpc-123", "", nil)
+		if err == nil {
+			t.Fatal("expected validation error, got nil")
+		}
+	})
+
+	t.Run("not found", func(t *testing.T) {
+		server := testutil.NewMockServer(t, func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusNotFound)
+			fmt.Fprint(w, testutil.ErrorBodyJSON("Not Found", "resource not found", 404))
+		})
+		c := testutil.NewClient(t, server.URL)
+		svc := NewVPCPeeringRoutesClientImpl(c)
+		resp, err := svc.List(context.Background(), "test-project", "vpc-123", "peering-1", nil)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if resp.StatusCode != http.StatusNotFound {
+			t.Errorf("expected status 404, got %d", resp.StatusCode)
+		}
+		if resp.Error == nil || resp.Error.Title == nil || *resp.Error.Title != "Not Found" {
+			t.Errorf("expected error title 'Not Found', got %v", resp.Error)
+		}
+	})
+
+	t.Run("bad gateway non-json", func(t *testing.T) {
+		server := testutil.NewMockServer(t, func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusBadGateway)
+			fmt.Fprint(w, "Bad Gateway")
+		})
+		c := testutil.NewClient(t, server.URL)
+		svc := NewVPCPeeringRoutesClientImpl(c)
+		resp, err := svc.List(context.Background(), "test-project", "vpc-123", "peering-1", nil)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if resp.StatusCode != http.StatusBadGateway {
+			t.Errorf("expected status 502, got %d", resp.StatusCode)
+		}
+		if resp.Error != nil {
+			t.Errorf("expected nil Error, got %v", resp.Error)
+		}
+		if string(resp.RawBody) != "Bad Gateway" {
+			t.Errorf("expected raw body 'Bad Gateway', got %q", string(resp.RawBody))
+		}
+	})
+
+	t.Run("network error", func(t *testing.T) {
+		c := testutil.NewBrokenClient(t, "http://unused.invalid")
+		svc := NewVPCPeeringRoutesClientImpl(c)
+		_, err := svc.List(context.Background(), "test-project", "vpc-123", "peering-1", nil)
+		if err == nil {
+			t.Fatal("expected transport error, got nil")
+		}
+	})
+
+	t.Run("nil params injects default api-version", func(t *testing.T) {
+		server := testutil.NewMockServer(t, func(w http.ResponseWriter, r *http.Request) {
+			if got := r.URL.Query().Get("api-version"); got != "1.0" {
+				t.Errorf("expected api-version=1.0, got %q", got)
 			}
-			json.NewEncoder(w).Encode(resp)
-			return
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusOK)
+			fmt.Fprint(w, `{"total":0,"values":[]}`)
+		})
+		c := testutil.NewClient(t, server.URL)
+		svc := NewVPCPeeringRoutesClientImpl(c)
+		resp, err := svc.List(context.Background(), "test-project", "vpc-123", "peering-1", nil)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
 		}
-
-		http.NotFound(w, r)
-	}))
-	defer server.Close()
-
-	var (
-		baseURL    = server.URL
-		httpClient = http.DefaultClient
-		logger     = &noop.NoOpLogger{}
-	)
-
-	c := restclient.NewClient(baseURL, httpClient, standard.NewInterceptor(), logger)
-
-	svc := NewVPCPeeringRoutesClientImpl(c)
-
-	resp, err := svc.List(context.Background(), "test-project", "vpc-123", "peering-1", nil)
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-	if resp == nil || resp.Data == nil || len(resp.Data.Values) != 1 {
-		t.Errorf("expected 1 vpc peering route")
-	}
+		if resp.StatusCode != http.StatusOK {
+			t.Errorf("expected status 200, got %d", resp.StatusCode)
+		}
+	})
 }
 
 func TestGetVpcPeeringRoute(t *testing.T) {
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.URL.Path == "/token" {
+	t.Run("successful get", func(t *testing.T) {
+		server := testutil.NewMockServer(t, func(w http.ResponseWriter, r *http.Request) {
 			w.Header().Set("Content-Type", "application/json")
 			w.WriteHeader(http.StatusOK)
-			w.Write([]byte(`{"access_token":"test-token","token_type":"Bearer","expires_in":3600}`))
-			return
+			fmt.Fprint(w, `{"metadata":{"name":"route-1"},"properties":{"localNetworkAddress":"10.0.0.0/16","remoteNetworkAddress":"10.1.0.0/16"}}`)
+		})
+		c := testutil.NewClient(t, server.URL)
+		svc := NewVPCPeeringRoutesClientImpl(c)
+		resp, err := svc.Get(context.Background(), "test-project", "vpc-123", "peering-1", "route-1", nil)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
 		}
+		if resp.Data.Metadata.Name != "route-1" {
+			t.Errorf("expected route name 'route-1', got %q", resp.Data.Metadata.Name)
+		}
+	})
 
-		if r.Method == "GET" && r.URL.Path == "/projects/test-project/providers/Aruba.Network/vpcs/vpc-123/vpcPeerings/peering-1/routes/route-1" {
-			w.WriteHeader(http.StatusOK)
-			resp := types.VPCPeeringRouteResponse{
-				Metadata: types.RegionalResourceMetadataRequest{
-					ResourceMetadataRequest: types.ResourceMetadataRequest{
-						Name: "route-1",
-					},
-				},
-				Properties: types.VPCPeeringRoutePropertiesResponse{
-					LocalNetworkAddress:  "10.0.0.0/16",
-					RemoteNetworkAddress: "10.1.0.0/16",
-				},
+	t.Run("empty project", func(t *testing.T) {
+		c := testutil.NewClient(t, "http://unused.invalid")
+		svc := NewVPCPeeringRoutesClientImpl(c)
+		_, err := svc.Get(context.Background(), "", "vpc-123", "peering-1", "route-1", nil)
+		if err == nil {
+			t.Fatal("expected validation error, got nil")
+		}
+	})
+
+	t.Run("empty vpcID", func(t *testing.T) {
+		c := testutil.NewClient(t, "http://unused.invalid")
+		svc := NewVPCPeeringRoutesClientImpl(c)
+		_, err := svc.Get(context.Background(), "test-project", "", "peering-1", "route-1", nil)
+		if err == nil {
+			t.Fatal("expected validation error, got nil")
+		}
+	})
+
+	t.Run("empty vpcPeeringID", func(t *testing.T) {
+		c := testutil.NewClient(t, "http://unused.invalid")
+		svc := NewVPCPeeringRoutesClientImpl(c)
+		_, err := svc.Get(context.Background(), "test-project", "vpc-123", "", "route-1", nil)
+		if err == nil {
+			t.Fatal("expected validation error, got nil")
+		}
+	})
+
+	t.Run("empty vpcPeeringRouteID", func(t *testing.T) {
+		c := testutil.NewClient(t, "http://unused.invalid")
+		svc := NewVPCPeeringRoutesClientImpl(c)
+		_, err := svc.Get(context.Background(), "test-project", "vpc-123", "peering-1", "", nil)
+		if err == nil {
+			t.Fatal("expected validation error, got nil")
+		}
+	})
+
+	t.Run("not found", func(t *testing.T) {
+		server := testutil.NewMockServer(t, func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusNotFound)
+			fmt.Fprint(w, testutil.ErrorBodyJSON("Not Found", "resource not found", 404))
+		})
+		c := testutil.NewClient(t, server.URL)
+		svc := NewVPCPeeringRoutesClientImpl(c)
+		resp, err := svc.Get(context.Background(), "test-project", "vpc-123", "peering-1", "route-1", nil)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if resp.StatusCode != http.StatusNotFound {
+			t.Errorf("expected status 404, got %d", resp.StatusCode)
+		}
+		if resp.Error == nil || resp.Error.Title == nil || *resp.Error.Title != "Not Found" {
+			t.Errorf("expected error title 'Not Found', got %v", resp.Error)
+		}
+	})
+
+	t.Run("bad gateway non-json", func(t *testing.T) {
+		server := testutil.NewMockServer(t, func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusBadGateway)
+			fmt.Fprint(w, "Bad Gateway")
+		})
+		c := testutil.NewClient(t, server.URL)
+		svc := NewVPCPeeringRoutesClientImpl(c)
+		resp, err := svc.Get(context.Background(), "test-project", "vpc-123", "peering-1", "route-1", nil)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if resp.StatusCode != http.StatusBadGateway {
+			t.Errorf("expected status 502, got %d", resp.StatusCode)
+		}
+		if resp.Error != nil {
+			t.Errorf("expected nil Error, got %v", resp.Error)
+		}
+		if string(resp.RawBody) != "Bad Gateway" {
+			t.Errorf("expected raw body 'Bad Gateway', got %q", string(resp.RawBody))
+		}
+	})
+
+	t.Run("network error", func(t *testing.T) {
+		c := testutil.NewBrokenClient(t, "http://unused.invalid")
+		svc := NewVPCPeeringRoutesClientImpl(c)
+		_, err := svc.Get(context.Background(), "test-project", "vpc-123", "peering-1", "route-1", nil)
+		if err == nil {
+			t.Fatal("expected transport error, got nil")
+		}
+	})
+
+	t.Run("nil params injects default api-version", func(t *testing.T) {
+		server := testutil.NewMockServer(t, func(w http.ResponseWriter, r *http.Request) {
+			if got := r.URL.Query().Get("api-version"); got != "1.0" {
+				t.Errorf("expected api-version=1.0, got %q", got)
 			}
-			json.NewEncoder(w).Encode(resp)
-			return
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusOK)
+			fmt.Fprint(w, `{}`)
+		})
+		c := testutil.NewClient(t, server.URL)
+		svc := NewVPCPeeringRoutesClientImpl(c)
+		resp, err := svc.Get(context.Background(), "test-project", "vpc-123", "peering-1", "route-1", nil)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
 		}
+		if resp.StatusCode != http.StatusOK {
+			t.Errorf("expected status 200, got %d", resp.StatusCode)
+		}
+	})
+}
 
-		http.NotFound(w, r)
-	}))
-	defer server.Close()
+func TestCreateVpcPeeringRoute(t *testing.T) {
+	t.Run("successful create", func(t *testing.T) {
+		server := testutil.NewMockServer(t, func(w http.ResponseWriter, r *http.Request) {
+			if r.Method != http.MethodPost {
+				t.Errorf("expected POST, got %s", r.Method)
+			}
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusCreated)
+			fmt.Fprint(w, `{"metadata":{"name":"new-route"}}`)
+		})
+		c := testutil.NewClient(t, server.URL)
+		svc := NewVPCPeeringRoutesClientImpl(c)
+		resp, err := svc.Create(context.Background(), "test-project", "vpc-123", "peering-1", types.VPCPeeringRouteRequest{}, nil)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if resp.StatusCode != http.StatusCreated {
+			t.Errorf("expected status 201, got %d", resp.StatusCode)
+		}
+	})
 
-	var (
-		baseURL    = server.URL
-		httpClient = http.DefaultClient
-		logger     = &noop.NoOpLogger{}
-	)
+	t.Run("empty project", func(t *testing.T) {
+		c := testutil.NewClient(t, "http://unused.invalid")
+		svc := NewVPCPeeringRoutesClientImpl(c)
+		_, err := svc.Create(context.Background(), "", "vpc-123", "peering-1", types.VPCPeeringRouteRequest{}, nil)
+		if err == nil {
+			t.Fatal("expected validation error, got nil")
+		}
+	})
 
-	c := restclient.NewClient(baseURL, httpClient, standard.NewInterceptor(), logger)
+	t.Run("empty vpcID", func(t *testing.T) {
+		c := testutil.NewClient(t, "http://unused.invalid")
+		svc := NewVPCPeeringRoutesClientImpl(c)
+		_, err := svc.Create(context.Background(), "test-project", "", "peering-1", types.VPCPeeringRouteRequest{}, nil)
+		if err == nil {
+			t.Fatal("expected validation error, got nil")
+		}
+	})
 
-	svc := NewVPCPeeringRoutesClientImpl(c)
+	t.Run("empty vpcPeeringID", func(t *testing.T) {
+		c := testutil.NewClient(t, "http://unused.invalid")
+		svc := NewVPCPeeringRoutesClientImpl(c)
+		_, err := svc.Create(context.Background(), "test-project", "vpc-123", "", types.VPCPeeringRouteRequest{}, nil)
+		if err == nil {
+			t.Fatal("expected validation error, got nil")
+		}
+	})
 
-	resp, err := svc.Get(context.Background(), "test-project", "vpc-123", "peering-1", "route-1", nil)
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-	if resp == nil || resp.Data == nil || resp.Data.Metadata.Name != "route-1" {
-		t.Errorf("expected route name 'route-1'")
-	}
+	t.Run("not found", func(t *testing.T) {
+		server := testutil.NewMockServer(t, func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusNotFound)
+			fmt.Fprint(w, testutil.ErrorBodyJSON("Not Found", "resource not found", 404))
+		})
+		c := testutil.NewClient(t, server.URL)
+		svc := NewVPCPeeringRoutesClientImpl(c)
+		resp, err := svc.Create(context.Background(), "test-project", "vpc-123", "peering-1", types.VPCPeeringRouteRequest{}, nil)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if resp.StatusCode != http.StatusNotFound {
+			t.Errorf("expected status 404, got %d", resp.StatusCode)
+		}
+		if resp.Error == nil || resp.Error.Title == nil || *resp.Error.Title != "Not Found" {
+			t.Errorf("expected error title 'Not Found', got %v", resp.Error)
+		}
+	})
+
+	t.Run("bad gateway non-json", func(t *testing.T) {
+		// TODO(TD-010): Create/Update's manual response build silently swallows non-JSON
+		// unmarshal errors (diverges from ParseResponseBody which logs at DEBUG).
+		server := testutil.NewMockServer(t, func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusBadGateway)
+			fmt.Fprint(w, "Bad Gateway")
+		})
+		c := testutil.NewClient(t, server.URL)
+		svc := NewVPCPeeringRoutesClientImpl(c)
+		resp, err := svc.Create(context.Background(), "test-project", "vpc-123", "peering-1", types.VPCPeeringRouteRequest{}, nil)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if resp.StatusCode != http.StatusBadGateway {
+			t.Errorf("expected status 502, got %d", resp.StatusCode)
+		}
+		if resp.Error != nil {
+			t.Errorf("expected nil Error, got %v", resp.Error)
+		}
+		if string(resp.RawBody) != "Bad Gateway" {
+			t.Errorf("expected raw body 'Bad Gateway', got %q", string(resp.RawBody))
+		}
+	})
+
+	t.Run("network error", func(t *testing.T) {
+		c := testutil.NewBrokenClient(t, "http://unused.invalid")
+		svc := NewVPCPeeringRoutesClientImpl(c)
+		_, err := svc.Create(context.Background(), "test-project", "vpc-123", "peering-1", types.VPCPeeringRouteRequest{}, nil)
+		if err == nil {
+			t.Fatal("expected transport error, got nil")
+		}
+	})
+
+	t.Run("nil params injects default api-version", func(t *testing.T) {
+		server := testutil.NewMockServer(t, func(w http.ResponseWriter, r *http.Request) {
+			if got := r.URL.Query().Get("api-version"); got != "1.0" {
+				t.Errorf("expected api-version=1.0, got %q", got)
+			}
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusCreated)
+			fmt.Fprint(w, `{}`)
+		})
+		c := testutil.NewClient(t, server.URL)
+		svc := NewVPCPeeringRoutesClientImpl(c)
+		resp, err := svc.Create(context.Background(), "test-project", "vpc-123", "peering-1", types.VPCPeeringRouteRequest{}, nil)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if resp.StatusCode != http.StatusCreated {
+			t.Errorf("expected status 201, got %d", resp.StatusCode)
+		}
+	})
+}
+
+func TestUpdateVpcPeeringRoute(t *testing.T) {
+	t.Run("successful update", func(t *testing.T) {
+		server := testutil.NewMockServer(t, func(w http.ResponseWriter, r *http.Request) {
+			if r.Method != http.MethodPut {
+				t.Errorf("expected PUT, got %s", r.Method)
+			}
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusOK)
+			fmt.Fprint(w, `{"metadata":{"name":"updated-route"}}`)
+		})
+		c := testutil.NewClient(t, server.URL)
+		svc := NewVPCPeeringRoutesClientImpl(c)
+		resp, err := svc.Update(context.Background(), "test-project", "vpc-123", "peering-1", "route-1", types.VPCPeeringRouteRequest{}, nil)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if resp.StatusCode != http.StatusOK {
+			t.Errorf("expected status 200, got %d", resp.StatusCode)
+		}
+	})
+
+	t.Run("empty project", func(t *testing.T) {
+		c := testutil.NewClient(t, "http://unused.invalid")
+		svc := NewVPCPeeringRoutesClientImpl(c)
+		_, err := svc.Update(context.Background(), "", "vpc-123", "peering-1", "route-1", types.VPCPeeringRouteRequest{}, nil)
+		if err == nil {
+			t.Fatal("expected validation error, got nil")
+		}
+	})
+
+	t.Run("empty vpcID", func(t *testing.T) {
+		c := testutil.NewClient(t, "http://unused.invalid")
+		svc := NewVPCPeeringRoutesClientImpl(c)
+		_, err := svc.Update(context.Background(), "test-project", "", "peering-1", "route-1", types.VPCPeeringRouteRequest{}, nil)
+		if err == nil {
+			t.Fatal("expected validation error, got nil")
+		}
+	})
+
+	t.Run("empty vpcPeeringID", func(t *testing.T) {
+		c := testutil.NewClient(t, "http://unused.invalid")
+		svc := NewVPCPeeringRoutesClientImpl(c)
+		_, err := svc.Update(context.Background(), "test-project", "vpc-123", "", "route-1", types.VPCPeeringRouteRequest{}, nil)
+		if err == nil {
+			t.Fatal("expected validation error, got nil")
+		}
+	})
+
+	t.Run("empty vpcPeeringRouteID", func(t *testing.T) {
+		c := testutil.NewClient(t, "http://unused.invalid")
+		svc := NewVPCPeeringRoutesClientImpl(c)
+		_, err := svc.Update(context.Background(), "test-project", "vpc-123", "peering-1", "", types.VPCPeeringRouteRequest{}, nil)
+		if err == nil {
+			t.Fatal("expected validation error, got nil")
+		}
+	})
+
+	t.Run("not found", func(t *testing.T) {
+		server := testutil.NewMockServer(t, func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusNotFound)
+			fmt.Fprint(w, testutil.ErrorBodyJSON("Not Found", "resource not found", 404))
+		})
+		c := testutil.NewClient(t, server.URL)
+		svc := NewVPCPeeringRoutesClientImpl(c)
+		resp, err := svc.Update(context.Background(), "test-project", "vpc-123", "peering-1", "route-1", types.VPCPeeringRouteRequest{}, nil)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if resp.StatusCode != http.StatusNotFound {
+			t.Errorf("expected status 404, got %d", resp.StatusCode)
+		}
+		if resp.Error == nil || resp.Error.Title == nil || *resp.Error.Title != "Not Found" {
+			t.Errorf("expected error title 'Not Found', got %v", resp.Error)
+		}
+	})
+
+	t.Run("bad gateway non-json", func(t *testing.T) {
+		// TODO(TD-010): Create/Update's manual response build silently swallows non-JSON
+		// unmarshal errors (diverges from ParseResponseBody which logs at DEBUG).
+		server := testutil.NewMockServer(t, func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusBadGateway)
+			fmt.Fprint(w, "Bad Gateway")
+		})
+		c := testutil.NewClient(t, server.URL)
+		svc := NewVPCPeeringRoutesClientImpl(c)
+		resp, err := svc.Update(context.Background(), "test-project", "vpc-123", "peering-1", "route-1", types.VPCPeeringRouteRequest{}, nil)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if resp.StatusCode != http.StatusBadGateway {
+			t.Errorf("expected status 502, got %d", resp.StatusCode)
+		}
+		if resp.Error != nil {
+			t.Errorf("expected nil Error, got %v", resp.Error)
+		}
+		if string(resp.RawBody) != "Bad Gateway" {
+			t.Errorf("expected raw body 'Bad Gateway', got %q", string(resp.RawBody))
+		}
+	})
+
+	t.Run("network error", func(t *testing.T) {
+		c := testutil.NewBrokenClient(t, "http://unused.invalid")
+		svc := NewVPCPeeringRoutesClientImpl(c)
+		_, err := svc.Update(context.Background(), "test-project", "vpc-123", "peering-1", "route-1", types.VPCPeeringRouteRequest{}, nil)
+		if err == nil {
+			t.Fatal("expected transport error, got nil")
+		}
+	})
+
+	t.Run("nil params injects default api-version", func(t *testing.T) {
+		server := testutil.NewMockServer(t, func(w http.ResponseWriter, r *http.Request) {
+			if got := r.URL.Query().Get("api-version"); got != "1.0" {
+				t.Errorf("expected api-version=1.0, got %q", got)
+			}
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusOK)
+			fmt.Fprint(w, `{}`)
+		})
+		c := testutil.NewClient(t, server.URL)
+		svc := NewVPCPeeringRoutesClientImpl(c)
+		resp, err := svc.Update(context.Background(), "test-project", "vpc-123", "peering-1", "route-1", types.VPCPeeringRouteRequest{}, nil)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if resp.StatusCode != http.StatusOK {
+			t.Errorf("expected status 200, got %d", resp.StatusCode)
+		}
+	})
 }
 
 func TestDeleteVpcPeeringRoute(t *testing.T) {
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.URL.Path == "/token" {
-			w.Header().Set("Content-Type", "application/json")
-			w.WriteHeader(http.StatusOK)
-			w.Write([]byte(`{"access_token":"test-token","token_type":"Bearer","expires_in":3600}`))
-			return
-		}
-
-		if r.Method == "DELETE" && r.URL.Path == "/projects/test-project/providers/Aruba.Network/vpcs/vpc-123/vpcPeerings/peering-1/routes/route-1" {
+	t.Run("successful delete", func(t *testing.T) {
+		server := testutil.NewMockServer(t, func(w http.ResponseWriter, r *http.Request) {
+			if r.Method != http.MethodDelete {
+				t.Errorf("expected DELETE, got %s", r.Method)
+			}
 			w.WriteHeader(http.StatusNoContent)
-			return
+		})
+		c := testutil.NewClient(t, server.URL)
+		svc := NewVPCPeeringRoutesClientImpl(c)
+		_, err := svc.Delete(context.Background(), "test-project", "vpc-123", "peering-1", "route-1", nil)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
 		}
+	})
 
-		http.NotFound(w, r)
-	}))
-	defer server.Close()
+	t.Run("empty project", func(t *testing.T) {
+		c := testutil.NewClient(t, "http://unused.invalid")
+		svc := NewVPCPeeringRoutesClientImpl(c)
+		_, err := svc.Delete(context.Background(), "", "vpc-123", "peering-1", "route-1", nil)
+		if err == nil {
+			t.Fatal("expected validation error, got nil")
+		}
+	})
 
-	var (
-		baseURL    = server.URL
-		httpClient = http.DefaultClient
-		logger     = &noop.NoOpLogger{}
-	)
+	t.Run("empty vpcID", func(t *testing.T) {
+		c := testutil.NewClient(t, "http://unused.invalid")
+		svc := NewVPCPeeringRoutesClientImpl(c)
+		_, err := svc.Delete(context.Background(), "test-project", "", "peering-1", "route-1", nil)
+		if err == nil {
+			t.Fatal("expected validation error, got nil")
+		}
+	})
 
-	c := restclient.NewClient(baseURL, httpClient, standard.NewInterceptor(), logger)
+	t.Run("empty vpcPeeringID", func(t *testing.T) {
+		c := testutil.NewClient(t, "http://unused.invalid")
+		svc := NewVPCPeeringRoutesClientImpl(c)
+		_, err := svc.Delete(context.Background(), "test-project", "vpc-123", "", "route-1", nil)
+		if err == nil {
+			t.Fatal("expected validation error, got nil")
+		}
+	})
 
-	svc := NewVPCPeeringRoutesClientImpl(c)
+	t.Run("empty vpcPeeringRouteID", func(t *testing.T) {
+		c := testutil.NewClient(t, "http://unused.invalid")
+		svc := NewVPCPeeringRoutesClientImpl(c)
+		_, err := svc.Delete(context.Background(), "test-project", "vpc-123", "peering-1", "", nil)
+		if err == nil {
+			t.Fatal("expected validation error, got nil")
+		}
+	})
 
-	_, err := svc.Delete(context.Background(), "test-project", "vpc-123", "peering-1", "route-1", nil)
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
+	t.Run("not found", func(t *testing.T) {
+		server := testutil.NewMockServer(t, func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusNotFound)
+			fmt.Fprint(w, testutil.ErrorBodyJSON("Not Found", "resource not found", 404))
+		})
+		c := testutil.NewClient(t, server.URL)
+		svc := NewVPCPeeringRoutesClientImpl(c)
+		resp, err := svc.Delete(context.Background(), "test-project", "vpc-123", "peering-1", "route-1", nil)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if resp.StatusCode != http.StatusNotFound {
+			t.Errorf("expected status 404, got %d", resp.StatusCode)
+		}
+		if resp.Error == nil || resp.Error.Title == nil || *resp.Error.Title != "Not Found" {
+			t.Errorf("expected error title 'Not Found', got %v", resp.Error)
+		}
+	})
+
+	t.Run("bad gateway non-json", func(t *testing.T) {
+		server := testutil.NewMockServer(t, func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusBadGateway)
+			fmt.Fprint(w, "Bad Gateway")
+		})
+		c := testutil.NewClient(t, server.URL)
+		svc := NewVPCPeeringRoutesClientImpl(c)
+		resp, err := svc.Delete(context.Background(), "test-project", "vpc-123", "peering-1", "route-1", nil)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if resp.StatusCode != http.StatusBadGateway {
+			t.Errorf("expected status 502, got %d", resp.StatusCode)
+		}
+		if resp.Error != nil {
+			t.Errorf("expected nil Error, got %v", resp.Error)
+		}
+		if string(resp.RawBody) != "Bad Gateway" {
+			t.Errorf("expected raw body 'Bad Gateway', got %q", string(resp.RawBody))
+		}
+	})
+
+	t.Run("network error", func(t *testing.T) {
+		c := testutil.NewBrokenClient(t, "http://unused.invalid")
+		svc := NewVPCPeeringRoutesClientImpl(c)
+		_, err := svc.Delete(context.Background(), "test-project", "vpc-123", "peering-1", "route-1", nil)
+		if err == nil {
+			t.Fatal("expected transport error, got nil")
+		}
+	})
+
+	t.Run("nil params injects default api-version", func(t *testing.T) {
+		server := testutil.NewMockServer(t, func(w http.ResponseWriter, r *http.Request) {
+			if got := r.URL.Query().Get("api-version"); got != "1.0" {
+				t.Errorf("expected api-version=1.0, got %q", got)
+			}
+			w.WriteHeader(http.StatusNoContent)
+		})
+		c := testutil.NewClient(t, server.URL)
+		svc := NewVPCPeeringRoutesClientImpl(c)
+		_, err := svc.Delete(context.Background(), "test-project", "vpc-123", "peering-1", "route-1", nil)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
 }

--- a/internal/clients/network/vpc-peering_test.go
+++ b/internal/clients/network/vpc-peering_test.go
@@ -2,132 +2,580 @@ package network
 
 import (
 	"context"
-	"encoding/json"
+	"fmt"
 	"net/http"
-	"net/http/httptest"
 	"testing"
 
-	"github.com/Arubacloud/sdk-go/internal/impl/interceptor/standard"
-	"github.com/Arubacloud/sdk-go/internal/impl/logger/noop"
-	"github.com/Arubacloud/sdk-go/internal/restclient"
+	"github.com/Arubacloud/sdk-go/internal/testutil"
 	"github.com/Arubacloud/sdk-go/pkg/types"
 )
 
 func TestListVpcPeerings(t *testing.T) {
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.URL.Path == "/token" {
+	t.Run("successful list", func(t *testing.T) {
+		server := testutil.NewMockServer(t, func(w http.ResponseWriter, r *http.Request) {
 			w.Header().Set("Content-Type", "application/json")
 			w.WriteHeader(http.StatusOK)
-			w.Write([]byte(`{"access_token":"test-token","token_type":"Bearer","expires_in":3600}`))
-			return
+			fmt.Fprint(w, `{"total":1,"values":[{"metadata":{"name":"test-peering"}}]}`)
+		})
+		c := testutil.NewClient(t, server.URL)
+		svc := NewVPCPeeringsClientImpl(c)
+		resp, err := svc.List(context.Background(), "test-project", "vpc-123", nil)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
 		}
+		if resp == nil || resp.Data == nil || len(resp.Data.Values) != 1 {
+			t.Errorf("expected 1 peering")
+		}
+	})
 
-		if r.Method == "GET" && r.URL.Path == "/projects/test-project/providers/Aruba.Network/vpcs/vpc-123/vpcPeerings" {
-			w.WriteHeader(http.StatusOK)
-			resp := types.VPCPeeringList{
-				ListResponse: types.ListResponse{Total: 1},
-				Values: []types.VPCPeeringResponse{
-					{Metadata: types.ResourceMetadataResponse{Name: types.StringPtr("test-peering")}},
-				},
+	t.Run("empty project", func(t *testing.T) {
+		c := testutil.NewClient(t, "http://unused.invalid")
+		svc := NewVPCPeeringsClientImpl(c)
+		_, err := svc.List(context.Background(), "", "vpc-123", nil)
+		if err == nil {
+			t.Fatal("expected validation error, got nil")
+		}
+	})
+
+	t.Run("empty vpcID", func(t *testing.T) {
+		c := testutil.NewClient(t, "http://unused.invalid")
+		svc := NewVPCPeeringsClientImpl(c)
+		_, err := svc.List(context.Background(), "test-project", "", nil)
+		if err == nil {
+			t.Fatal("expected validation error, got nil")
+		}
+	})
+
+	t.Run("not found", func(t *testing.T) {
+		server := testutil.NewMockServer(t, func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusNotFound)
+			fmt.Fprint(w, testutil.ErrorBodyJSON("Not Found", "resource not found", 404))
+		})
+		c := testutil.NewClient(t, server.URL)
+		svc := NewVPCPeeringsClientImpl(c)
+		resp, err := svc.List(context.Background(), "test-project", "vpc-123", nil)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if resp.StatusCode != http.StatusNotFound {
+			t.Errorf("expected status 404, got %d", resp.StatusCode)
+		}
+		if resp.Error == nil || resp.Error.Title == nil || *resp.Error.Title != "Not Found" {
+			t.Errorf("expected error title 'Not Found', got %v", resp.Error)
+		}
+	})
+
+	t.Run("bad gateway non-json", func(t *testing.T) {
+		server := testutil.NewMockServer(t, func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusBadGateway)
+			fmt.Fprint(w, "Bad Gateway")
+		})
+		c := testutil.NewClient(t, server.URL)
+		svc := NewVPCPeeringsClientImpl(c)
+		resp, err := svc.List(context.Background(), "test-project", "vpc-123", nil)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if resp.StatusCode != http.StatusBadGateway {
+			t.Errorf("expected status 502, got %d", resp.StatusCode)
+		}
+		if resp.Error != nil {
+			t.Errorf("expected nil Error, got %v", resp.Error)
+		}
+		if string(resp.RawBody) != "Bad Gateway" {
+			t.Errorf("expected raw body 'Bad Gateway', got %q", string(resp.RawBody))
+		}
+	})
+
+	t.Run("network error", func(t *testing.T) {
+		c := testutil.NewBrokenClient(t, "http://unused.invalid")
+		svc := NewVPCPeeringsClientImpl(c)
+		_, err := svc.List(context.Background(), "test-project", "vpc-123", nil)
+		if err == nil {
+			t.Fatal("expected transport error, got nil")
+		}
+	})
+
+	t.Run("nil params injects default api-version", func(t *testing.T) {
+		server := testutil.NewMockServer(t, func(w http.ResponseWriter, r *http.Request) {
+			if got := r.URL.Query().Get("api-version"); got != "1.0" {
+				t.Errorf("expected api-version=1.0, got %q", got)
 			}
-			json.NewEncoder(w).Encode(resp)
-			return
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusOK)
+			fmt.Fprint(w, `{"total":0,"values":[]}`)
+		})
+		c := testutil.NewClient(t, server.URL)
+		svc := NewVPCPeeringsClientImpl(c)
+		resp, err := svc.List(context.Background(), "test-project", "vpc-123", nil)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
 		}
-
-		http.NotFound(w, r)
-	}))
-	defer server.Close()
-
-	var (
-		baseURL    = server.URL
-		httpClient = http.DefaultClient
-		logger     = &noop.NoOpLogger{}
-	)
-
-	c := restclient.NewClient(baseURL, httpClient, standard.NewInterceptor(), logger)
-
-	svc := NewVPCPeeringsClientImpl(c)
-
-	resp, err := svc.List(context.Background(), "test-project", "vpc-123", nil)
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-	if resp == nil || resp.Data == nil || len(resp.Data.Values) != 1 {
-		t.Errorf("expected 1 peering")
-	}
+		if resp.StatusCode != http.StatusOK {
+			t.Errorf("expected status 200, got %d", resp.StatusCode)
+		}
+	})
 }
 
 func TestGetVpcPeering(t *testing.T) {
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.URL.Path == "/token" {
+	t.Run("successful get", func(t *testing.T) {
+		server := testutil.NewMockServer(t, func(w http.ResponseWriter, r *http.Request) {
 			w.Header().Set("Content-Type", "application/json")
 			w.WriteHeader(http.StatusOK)
-			w.Write([]byte(`{"access_token":"test-token","token_type":"Bearer","expires_in":3600}`))
-			return
+			fmt.Fprint(w, `{"metadata":{"name":"test-peering"}}`)
+		})
+		c := testutil.NewClient(t, server.URL)
+		svc := NewVPCPeeringsClientImpl(c)
+		resp, err := svc.Get(context.Background(), "test-project", "vpc-123", "peering-1", nil)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
 		}
+		if resp.Data.Metadata.Name == nil || *resp.Data.Metadata.Name != "test-peering" {
+			t.Errorf("expected peering name 'test-peering'")
+		}
+	})
 
-		if r.Method == "GET" && r.URL.Path == "/projects/test-project/providers/Aruba.Network/vpcs/vpc-123/vpcPeerings/peering-1" {
-			w.WriteHeader(http.StatusOK)
-			resp := types.VPCPeeringResponse{
-				Metadata: types.ResourceMetadataResponse{Name: types.StringPtr("test-peering")},
+	t.Run("empty project", func(t *testing.T) {
+		c := testutil.NewClient(t, "http://unused.invalid")
+		svc := NewVPCPeeringsClientImpl(c)
+		_, err := svc.Get(context.Background(), "", "vpc-123", "peering-1", nil)
+		if err == nil {
+			t.Fatal("expected validation error, got nil")
+		}
+	})
+
+	t.Run("empty vpcID", func(t *testing.T) {
+		c := testutil.NewClient(t, "http://unused.invalid")
+		svc := NewVPCPeeringsClientImpl(c)
+		_, err := svc.Get(context.Background(), "test-project", "", "peering-1", nil)
+		if err == nil {
+			t.Fatal("expected validation error, got nil")
+		}
+	})
+
+	t.Run("empty vpcPeeringID", func(t *testing.T) {
+		c := testutil.NewClient(t, "http://unused.invalid")
+		svc := NewVPCPeeringsClientImpl(c)
+		_, err := svc.Get(context.Background(), "test-project", "vpc-123", "", nil)
+		if err == nil {
+			t.Fatal("expected validation error, got nil")
+		}
+	})
+
+	t.Run("not found", func(t *testing.T) {
+		server := testutil.NewMockServer(t, func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusNotFound)
+			fmt.Fprint(w, testutil.ErrorBodyJSON("Not Found", "resource not found", 404))
+		})
+		c := testutil.NewClient(t, server.URL)
+		svc := NewVPCPeeringsClientImpl(c)
+		resp, err := svc.Get(context.Background(), "test-project", "vpc-123", "peering-1", nil)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if resp.StatusCode != http.StatusNotFound {
+			t.Errorf("expected status 404, got %d", resp.StatusCode)
+		}
+		if resp.Error == nil || resp.Error.Title == nil || *resp.Error.Title != "Not Found" {
+			t.Errorf("expected error title 'Not Found', got %v", resp.Error)
+		}
+	})
+
+	t.Run("bad gateway non-json", func(t *testing.T) {
+		server := testutil.NewMockServer(t, func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusBadGateway)
+			fmt.Fprint(w, "Bad Gateway")
+		})
+		c := testutil.NewClient(t, server.URL)
+		svc := NewVPCPeeringsClientImpl(c)
+		resp, err := svc.Get(context.Background(), "test-project", "vpc-123", "peering-1", nil)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if resp.StatusCode != http.StatusBadGateway {
+			t.Errorf("expected status 502, got %d", resp.StatusCode)
+		}
+		if resp.Error != nil {
+			t.Errorf("expected nil Error, got %v", resp.Error)
+		}
+		if string(resp.RawBody) != "Bad Gateway" {
+			t.Errorf("expected raw body 'Bad Gateway', got %q", string(resp.RawBody))
+		}
+	})
+
+	t.Run("network error", func(t *testing.T) {
+		c := testutil.NewBrokenClient(t, "http://unused.invalid")
+		svc := NewVPCPeeringsClientImpl(c)
+		_, err := svc.Get(context.Background(), "test-project", "vpc-123", "peering-1", nil)
+		if err == nil {
+			t.Fatal("expected transport error, got nil")
+		}
+	})
+
+	t.Run("nil params injects default api-version", func(t *testing.T) {
+		server := testutil.NewMockServer(t, func(w http.ResponseWriter, r *http.Request) {
+			if got := r.URL.Query().Get("api-version"); got != "1.0" {
+				t.Errorf("expected api-version=1.0, got %q", got)
 			}
-			json.NewEncoder(w).Encode(resp)
-			return
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusOK)
+			fmt.Fprint(w, `{}`)
+		})
+		c := testutil.NewClient(t, server.URL)
+		svc := NewVPCPeeringsClientImpl(c)
+		resp, err := svc.Get(context.Background(), "test-project", "vpc-123", "peering-1", nil)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
 		}
+		if resp.StatusCode != http.StatusOK {
+			t.Errorf("expected status 200, got %d", resp.StatusCode)
+		}
+	})
+}
 
-		http.NotFound(w, r)
-	}))
-	defer server.Close()
+func TestCreateVpcPeering(t *testing.T) {
+	t.Run("successful create", func(t *testing.T) {
+		server := testutil.NewMockServer(t, func(w http.ResponseWriter, r *http.Request) {
+			if r.Method != http.MethodPost {
+				t.Errorf("expected POST, got %s", r.Method)
+			}
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusCreated)
+			fmt.Fprint(w, `{"metadata":{"name":"new-peering"}}`)
+		})
+		c := testutil.NewClient(t, server.URL)
+		svc := NewVPCPeeringsClientImpl(c)
+		resp, err := svc.Create(context.Background(), "test-project", "vpc-123", types.VPCPeeringRequest{}, nil)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if resp.StatusCode != http.StatusCreated {
+			t.Errorf("expected status 201, got %d", resp.StatusCode)
+		}
+	})
 
-	var (
-		baseURL    = server.URL
-		httpClient = http.DefaultClient
-		logger     = &noop.NoOpLogger{}
-	)
+	t.Run("empty project", func(t *testing.T) {
+		c := testutil.NewClient(t, "http://unused.invalid")
+		svc := NewVPCPeeringsClientImpl(c)
+		_, err := svc.Create(context.Background(), "", "vpc-123", types.VPCPeeringRequest{}, nil)
+		if err == nil {
+			t.Fatal("expected validation error, got nil")
+		}
+	})
 
-	c := restclient.NewClient(baseURL, httpClient, standard.NewInterceptor(), logger)
+	t.Run("empty vpcID", func(t *testing.T) {
+		c := testutil.NewClient(t, "http://unused.invalid")
+		svc := NewVPCPeeringsClientImpl(c)
+		_, err := svc.Create(context.Background(), "test-project", "", types.VPCPeeringRequest{}, nil)
+		if err == nil {
+			t.Fatal("expected validation error, got nil")
+		}
+	})
 
-	svc := NewVPCPeeringsClientImpl(c)
+	t.Run("not found", func(t *testing.T) {
+		server := testutil.NewMockServer(t, func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusNotFound)
+			fmt.Fprint(w, testutil.ErrorBodyJSON("Not Found", "resource not found", 404))
+		})
+		c := testutil.NewClient(t, server.URL)
+		svc := NewVPCPeeringsClientImpl(c)
+		resp, err := svc.Create(context.Background(), "test-project", "vpc-123", types.VPCPeeringRequest{}, nil)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if resp.StatusCode != http.StatusNotFound {
+			t.Errorf("expected status 404, got %d", resp.StatusCode)
+		}
+		if resp.Error == nil || resp.Error.Title == nil || *resp.Error.Title != "Not Found" {
+			t.Errorf("expected error title 'Not Found', got %v", resp.Error)
+		}
+	})
 
-	resp, err := svc.Get(context.Background(), "test-project", "vpc-123", "peering-1", nil)
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-	if resp == nil || resp.Data == nil || resp.Data.Metadata.Name == nil || *resp.Data.Metadata.Name != "test-peering" {
-		t.Errorf("expected peering name 'test-peering'")
-	}
+	t.Run("bad gateway non-json", func(t *testing.T) {
+		// TODO(TD-010): Create/Update's manual response build silently swallows non-JSON
+		// unmarshal errors (diverges from ParseResponseBody which logs at DEBUG).
+		server := testutil.NewMockServer(t, func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusBadGateway)
+			fmt.Fprint(w, "Bad Gateway")
+		})
+		c := testutil.NewClient(t, server.URL)
+		svc := NewVPCPeeringsClientImpl(c)
+		resp, err := svc.Create(context.Background(), "test-project", "vpc-123", types.VPCPeeringRequest{}, nil)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if resp.StatusCode != http.StatusBadGateway {
+			t.Errorf("expected status 502, got %d", resp.StatusCode)
+		}
+		if resp.Error != nil {
+			t.Errorf("expected nil Error, got %v", resp.Error)
+		}
+		if string(resp.RawBody) != "Bad Gateway" {
+			t.Errorf("expected raw body 'Bad Gateway', got %q", string(resp.RawBody))
+		}
+	})
+
+	t.Run("network error", func(t *testing.T) {
+		c := testutil.NewBrokenClient(t, "http://unused.invalid")
+		svc := NewVPCPeeringsClientImpl(c)
+		_, err := svc.Create(context.Background(), "test-project", "vpc-123", types.VPCPeeringRequest{}, nil)
+		if err == nil {
+			t.Fatal("expected transport error, got nil")
+		}
+	})
+
+	t.Run("nil params injects default api-version", func(t *testing.T) {
+		server := testutil.NewMockServer(t, func(w http.ResponseWriter, r *http.Request) {
+			if got := r.URL.Query().Get("api-version"); got != "1.0" {
+				t.Errorf("expected api-version=1.0, got %q", got)
+			}
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusCreated)
+			fmt.Fprint(w, `{}`)
+		})
+		c := testutil.NewClient(t, server.URL)
+		svc := NewVPCPeeringsClientImpl(c)
+		resp, err := svc.Create(context.Background(), "test-project", "vpc-123", types.VPCPeeringRequest{}, nil)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if resp.StatusCode != http.StatusCreated {
+			t.Errorf("expected status 201, got %d", resp.StatusCode)
+		}
+	})
+}
+
+func TestUpdateVpcPeering(t *testing.T) {
+	t.Run("successful update", func(t *testing.T) {
+		server := testutil.NewMockServer(t, func(w http.ResponseWriter, r *http.Request) {
+			if r.Method != http.MethodPut {
+				t.Errorf("expected PUT, got %s", r.Method)
+			}
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusOK)
+			fmt.Fprint(w, `{"metadata":{"name":"updated-peering"}}`)
+		})
+		c := testutil.NewClient(t, server.URL)
+		svc := NewVPCPeeringsClientImpl(c)
+		resp, err := svc.Update(context.Background(), "test-project", "vpc-123", "peering-1", types.VPCPeeringRequest{}, nil)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if resp.StatusCode != http.StatusOK {
+			t.Errorf("expected status 200, got %d", resp.StatusCode)
+		}
+	})
+
+	t.Run("empty project", func(t *testing.T) {
+		c := testutil.NewClient(t, "http://unused.invalid")
+		svc := NewVPCPeeringsClientImpl(c)
+		_, err := svc.Update(context.Background(), "", "vpc-123", "peering-1", types.VPCPeeringRequest{}, nil)
+		if err == nil {
+			t.Fatal("expected validation error, got nil")
+		}
+	})
+
+	t.Run("empty vpcID", func(t *testing.T) {
+		c := testutil.NewClient(t, "http://unused.invalid")
+		svc := NewVPCPeeringsClientImpl(c)
+		_, err := svc.Update(context.Background(), "test-project", "", "peering-1", types.VPCPeeringRequest{}, nil)
+		if err == nil {
+			t.Fatal("expected validation error, got nil")
+		}
+	})
+
+	t.Run("empty vpcPeeringID", func(t *testing.T) {
+		c := testutil.NewClient(t, "http://unused.invalid")
+		svc := NewVPCPeeringsClientImpl(c)
+		_, err := svc.Update(context.Background(), "test-project", "vpc-123", "", types.VPCPeeringRequest{}, nil)
+		if err == nil {
+			t.Fatal("expected validation error, got nil")
+		}
+	})
+
+	t.Run("not found", func(t *testing.T) {
+		server := testutil.NewMockServer(t, func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusNotFound)
+			fmt.Fprint(w, testutil.ErrorBodyJSON("Not Found", "resource not found", 404))
+		})
+		c := testutil.NewClient(t, server.URL)
+		svc := NewVPCPeeringsClientImpl(c)
+		resp, err := svc.Update(context.Background(), "test-project", "vpc-123", "peering-1", types.VPCPeeringRequest{}, nil)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if resp.StatusCode != http.StatusNotFound {
+			t.Errorf("expected status 404, got %d", resp.StatusCode)
+		}
+		if resp.Error == nil || resp.Error.Title == nil || *resp.Error.Title != "Not Found" {
+			t.Errorf("expected error title 'Not Found', got %v", resp.Error)
+		}
+	})
+
+	t.Run("bad gateway non-json", func(t *testing.T) {
+		// TODO(TD-010): Create/Update's manual response build silently swallows non-JSON
+		// unmarshal errors (diverges from ParseResponseBody which logs at DEBUG).
+		server := testutil.NewMockServer(t, func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusBadGateway)
+			fmt.Fprint(w, "Bad Gateway")
+		})
+		c := testutil.NewClient(t, server.URL)
+		svc := NewVPCPeeringsClientImpl(c)
+		resp, err := svc.Update(context.Background(), "test-project", "vpc-123", "peering-1", types.VPCPeeringRequest{}, nil)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if resp.StatusCode != http.StatusBadGateway {
+			t.Errorf("expected status 502, got %d", resp.StatusCode)
+		}
+		if resp.Error != nil {
+			t.Errorf("expected nil Error, got %v", resp.Error)
+		}
+		if string(resp.RawBody) != "Bad Gateway" {
+			t.Errorf("expected raw body 'Bad Gateway', got %q", string(resp.RawBody))
+		}
+	})
+
+	t.Run("network error", func(t *testing.T) {
+		c := testutil.NewBrokenClient(t, "http://unused.invalid")
+		svc := NewVPCPeeringsClientImpl(c)
+		_, err := svc.Update(context.Background(), "test-project", "vpc-123", "peering-1", types.VPCPeeringRequest{}, nil)
+		if err == nil {
+			t.Fatal("expected transport error, got nil")
+		}
+	})
+
+	t.Run("nil params injects default api-version", func(t *testing.T) {
+		server := testutil.NewMockServer(t, func(w http.ResponseWriter, r *http.Request) {
+			if got := r.URL.Query().Get("api-version"); got != "1.0" {
+				t.Errorf("expected api-version=1.0, got %q", got)
+			}
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusOK)
+			fmt.Fprint(w, `{}`)
+		})
+		c := testutil.NewClient(t, server.URL)
+		svc := NewVPCPeeringsClientImpl(c)
+		resp, err := svc.Update(context.Background(), "test-project", "vpc-123", "peering-1", types.VPCPeeringRequest{}, nil)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if resp.StatusCode != http.StatusOK {
+			t.Errorf("expected status 200, got %d", resp.StatusCode)
+		}
+	})
 }
 
 func TestDeleteVpcPeering(t *testing.T) {
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.URL.Path == "/token" {
-			w.Header().Set("Content-Type", "application/json")
-			w.WriteHeader(http.StatusOK)
-			w.Write([]byte(`{"access_token":"test-token","token_type":"Bearer","expires_in":3600}`))
-			return
-		}
-
-		if r.Method == "DELETE" && r.URL.Path == "/projects/test-project/providers/Aruba.Network/vpcs/vpc-123/vpcPeerings/peering-1" {
+	t.Run("successful delete", func(t *testing.T) {
+		server := testutil.NewMockServer(t, func(w http.ResponseWriter, r *http.Request) {
+			if r.Method != http.MethodDelete {
+				t.Errorf("expected DELETE, got %s", r.Method)
+			}
 			w.WriteHeader(http.StatusNoContent)
-			return
+		})
+		c := testutil.NewClient(t, server.URL)
+		svc := NewVPCPeeringsClientImpl(c)
+		_, err := svc.Delete(context.Background(), "test-project", "vpc-123", "peering-1", nil)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
 		}
+	})
 
-		http.NotFound(w, r)
-	}))
-	defer server.Close()
+	t.Run("empty project", func(t *testing.T) {
+		c := testutil.NewClient(t, "http://unused.invalid")
+		svc := NewVPCPeeringsClientImpl(c)
+		_, err := svc.Delete(context.Background(), "", "vpc-123", "peering-1", nil)
+		if err == nil {
+			t.Fatal("expected validation error, got nil")
+		}
+	})
 
-	var (
-		baseURL    = server.URL
-		httpClient = http.DefaultClient
-		logger     = &noop.NoOpLogger{}
-	)
+	t.Run("empty vpcID", func(t *testing.T) {
+		c := testutil.NewClient(t, "http://unused.invalid")
+		svc := NewVPCPeeringsClientImpl(c)
+		_, err := svc.Delete(context.Background(), "test-project", "", "peering-1", nil)
+		if err == nil {
+			t.Fatal("expected validation error, got nil")
+		}
+	})
 
-	c := restclient.NewClient(baseURL, httpClient, standard.NewInterceptor(), logger)
+	t.Run("empty vpcPeeringID", func(t *testing.T) {
+		c := testutil.NewClient(t, "http://unused.invalid")
+		svc := NewVPCPeeringsClientImpl(c)
+		_, err := svc.Delete(context.Background(), "test-project", "vpc-123", "", nil)
+		if err == nil {
+			t.Fatal("expected validation error, got nil")
+		}
+	})
 
-	svc := NewVPCPeeringsClientImpl(c)
+	t.Run("not found", func(t *testing.T) {
+		server := testutil.NewMockServer(t, func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusNotFound)
+			fmt.Fprint(w, testutil.ErrorBodyJSON("Not Found", "resource not found", 404))
+		})
+		c := testutil.NewClient(t, server.URL)
+		svc := NewVPCPeeringsClientImpl(c)
+		resp, err := svc.Delete(context.Background(), "test-project", "vpc-123", "peering-1", nil)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if resp.StatusCode != http.StatusNotFound {
+			t.Errorf("expected status 404, got %d", resp.StatusCode)
+		}
+		if resp.Error == nil || resp.Error.Title == nil || *resp.Error.Title != "Not Found" {
+			t.Errorf("expected error title 'Not Found', got %v", resp.Error)
+		}
+	})
 
-	_, err := svc.Delete(context.Background(), "test-project", "vpc-123", "peering-1", nil)
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
+	t.Run("bad gateway non-json", func(t *testing.T) {
+		server := testutil.NewMockServer(t, func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusBadGateway)
+			fmt.Fprint(w, "Bad Gateway")
+		})
+		c := testutil.NewClient(t, server.URL)
+		svc := NewVPCPeeringsClientImpl(c)
+		resp, err := svc.Delete(context.Background(), "test-project", "vpc-123", "peering-1", nil)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if resp.StatusCode != http.StatusBadGateway {
+			t.Errorf("expected status 502, got %d", resp.StatusCode)
+		}
+		if resp.Error != nil {
+			t.Errorf("expected nil Error, got %v", resp.Error)
+		}
+		if string(resp.RawBody) != "Bad Gateway" {
+			t.Errorf("expected raw body 'Bad Gateway', got %q", string(resp.RawBody))
+		}
+	})
+
+	t.Run("network error", func(t *testing.T) {
+		c := testutil.NewBrokenClient(t, "http://unused.invalid")
+		svc := NewVPCPeeringsClientImpl(c)
+		_, err := svc.Delete(context.Background(), "test-project", "vpc-123", "peering-1", nil)
+		if err == nil {
+			t.Fatal("expected transport error, got nil")
+		}
+	})
+
+	t.Run("nil params injects default api-version", func(t *testing.T) {
+		server := testutil.NewMockServer(t, func(w http.ResponseWriter, r *http.Request) {
+			if got := r.URL.Query().Get("api-version"); got != "1.0" {
+				t.Errorf("expected api-version=1.0, got %q", got)
+			}
+			w.WriteHeader(http.StatusNoContent)
+		})
+		c := testutil.NewClient(t, server.URL)
+		svc := NewVPCPeeringsClientImpl(c)
+		_, err := svc.Delete(context.Background(), "test-project", "vpc-123", "peering-1", nil)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
 }

--- a/internal/clients/network/vpc_test.go
+++ b/internal/clients/network/vpc_test.go
@@ -2,48 +2,23 @@ package network
 
 import (
 	"context"
-	"encoding/json"
+	"fmt"
 	"net/http"
-	"net/http/httptest"
 	"testing"
 
-	"github.com/Arubacloud/sdk-go/internal/impl/interceptor/standard"
-	"github.com/Arubacloud/sdk-go/internal/impl/logger/noop"
-	"github.com/Arubacloud/sdk-go/internal/restclient"
+	"github.com/Arubacloud/sdk-go/internal/testutil"
 	"github.com/Arubacloud/sdk-go/pkg/types"
 )
 
 func TestListVPCs(t *testing.T) {
 	t.Run("successful list", func(t *testing.T) {
-		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			if r.URL.Path == "/token" {
-				w.Header().Set("Content-Type", "application/json")
-				w.WriteHeader(http.StatusOK)
-				w.Write([]byte(`{"access_token":"test-token","token_type":"Bearer","expires_in":3600}`))
-				return
-			}
-
+		server := testutil.NewMockServer(t, func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
 			w.WriteHeader(http.StatusOK)
-			resp := types.VPCList{
-				ListResponse: types.ListResponse{Total: 1},
-				Values: []types.VPCResponse{
-					{Metadata: types.ResourceMetadataResponse{Name: types.StringPtr("vpc-1")}},
-				},
-			}
-			json.NewEncoder(w).Encode(resp)
-		}))
-		defer server.Close()
-
-		var (
-			baseURL    = server.URL
-			httpClient = http.DefaultClient
-			logger     = &noop.NoOpLogger{}
-		)
-
-		c := restclient.NewClient(baseURL, httpClient, standard.NewInterceptor(), logger)
-
+			fmt.Fprint(w, `{"total":1,"values":[{"metadata":{"name":"vpc-1"}}]}`)
+		})
+		c := testutil.NewClient(t, server.URL)
 		svc := NewVPCsClientImpl(c)
-
 		resp, err := svc.List(context.Background(), "test-project", nil)
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
@@ -52,86 +27,297 @@ func TestListVPCs(t *testing.T) {
 			t.Errorf("expected total 1, got %d", resp.Data.Total)
 		}
 	})
+
+	t.Run("empty project", func(t *testing.T) {
+		c := testutil.NewClient(t, "http://unused.invalid")
+		svc := NewVPCsClientImpl(c)
+		_, err := svc.List(context.Background(), "", nil)
+		if err == nil {
+			t.Fatal("expected validation error, got nil")
+		}
+	})
+
+	t.Run("not found", func(t *testing.T) {
+		server := testutil.NewMockServer(t, func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusNotFound)
+			fmt.Fprint(w, testutil.ErrorBodyJSON("Not Found", "resource not found", 404))
+		})
+		c := testutil.NewClient(t, server.URL)
+		svc := NewVPCsClientImpl(c)
+		resp, err := svc.List(context.Background(), "test-project", nil)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if resp.StatusCode != http.StatusNotFound {
+			t.Errorf("expected status 404, got %d", resp.StatusCode)
+		}
+		if resp.Error == nil || resp.Error.Title == nil || *resp.Error.Title != "Not Found" {
+			t.Errorf("expected error title 'Not Found', got %v", resp.Error)
+		}
+	})
+
+	t.Run("bad gateway non-json", func(t *testing.T) {
+		server := testutil.NewMockServer(t, func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusBadGateway)
+			fmt.Fprint(w, "Bad Gateway")
+		})
+		c := testutil.NewClient(t, server.URL)
+		svc := NewVPCsClientImpl(c)
+		resp, err := svc.List(context.Background(), "test-project", nil)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if resp.StatusCode != http.StatusBadGateway {
+			t.Errorf("expected status 502, got %d", resp.StatusCode)
+		}
+		if resp.Error != nil {
+			t.Errorf("expected nil Error, got %v", resp.Error)
+		}
+		if string(resp.RawBody) != "Bad Gateway" {
+			t.Errorf("expected raw body 'Bad Gateway', got %q", string(resp.RawBody))
+		}
+	})
+
+	t.Run("network error", func(t *testing.T) {
+		c := testutil.NewBrokenClient(t, "http://unused.invalid")
+		svc := NewVPCsClientImpl(c)
+		_, err := svc.List(context.Background(), "test-project", nil)
+		if err == nil {
+			t.Fatal("expected transport error, got nil")
+		}
+	})
+
+	t.Run("nil params injects default api-version", func(t *testing.T) {
+		server := testutil.NewMockServer(t, func(w http.ResponseWriter, r *http.Request) {
+			if got := r.URL.Query().Get("api-version"); got != "1.0" {
+				t.Errorf("expected api-version=1.0, got %q", got)
+			}
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusOK)
+			fmt.Fprint(w, `{"total":0,"values":[]}`)
+		})
+		c := testutil.NewClient(t, server.URL)
+		svc := NewVPCsClientImpl(c)
+		resp, err := svc.List(context.Background(), "test-project", nil)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if resp.StatusCode != http.StatusOK {
+			t.Errorf("expected status 200, got %d", resp.StatusCode)
+		}
+	})
 }
 
 func TestGetVPC(t *testing.T) {
 	t.Run("successful get", func(t *testing.T) {
-		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			if r.URL.Path == "/token" {
-				w.Header().Set("Content-Type", "application/json")
-				w.WriteHeader(http.StatusOK)
-				w.Write([]byte(`{"access_token":"test-token","token_type":"Bearer","expires_in":3600}`))
-				return
-			}
-
+		server := testutil.NewMockServer(t, func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
 			w.WriteHeader(http.StatusOK)
-			resp := types.VPCResponse{
-				Metadata: types.ResourceMetadataResponse{Name: types.StringPtr("my-vpc")},
-			}
-			json.NewEncoder(w).Encode(resp)
-		}))
-		defer server.Close()
-
-		var (
-			baseURL    = server.URL
-			httpClient = http.DefaultClient
-			logger     = &noop.NoOpLogger{}
-		)
-
-		c := restclient.NewClient(baseURL, httpClient, standard.NewInterceptor(), logger)
-
+			fmt.Fprint(w, `{"metadata":{"name":"my-vpc"}}`)
+		})
+		c := testutil.NewClient(t, server.URL)
 		svc := NewVPCsClientImpl(c)
-
 		resp, err := svc.Get(context.Background(), "test-project", "vpc-123", nil)
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
 		if resp.Data.Metadata.Name == nil || *resp.Data.Metadata.Name != "my-vpc" {
-			t.Errorf("expected name 'my-vpc', got '%v'", resp.Data.Metadata.Name)
+			t.Errorf("expected name 'my-vpc', got %v", resp.Data.Metadata.Name)
+		}
+	})
+
+	t.Run("empty project", func(t *testing.T) {
+		c := testutil.NewClient(t, "http://unused.invalid")
+		svc := NewVPCsClientImpl(c)
+		_, err := svc.Get(context.Background(), "", "vpc-123", nil)
+		if err == nil {
+			t.Fatal("expected validation error, got nil")
+		}
+	})
+
+	t.Run("empty vpcID", func(t *testing.T) {
+		c := testutil.NewClient(t, "http://unused.invalid")
+		svc := NewVPCsClientImpl(c)
+		_, err := svc.Get(context.Background(), "test-project", "", nil)
+		if err == nil {
+			t.Fatal("expected validation error, got nil")
+		}
+	})
+
+	t.Run("not found", func(t *testing.T) {
+		server := testutil.NewMockServer(t, func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusNotFound)
+			fmt.Fprint(w, testutil.ErrorBodyJSON("Not Found", "resource not found", 404))
+		})
+		c := testutil.NewClient(t, server.URL)
+		svc := NewVPCsClientImpl(c)
+		resp, err := svc.Get(context.Background(), "test-project", "vpc-123", nil)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if resp.StatusCode != http.StatusNotFound {
+			t.Errorf("expected status 404, got %d", resp.StatusCode)
+		}
+		if resp.Error == nil || resp.Error.Title == nil || *resp.Error.Title != "Not Found" {
+			t.Errorf("expected error title 'Not Found', got %v", resp.Error)
+		}
+	})
+
+	t.Run("bad gateway non-json", func(t *testing.T) {
+		server := testutil.NewMockServer(t, func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusBadGateway)
+			fmt.Fprint(w, "Bad Gateway")
+		})
+		c := testutil.NewClient(t, server.URL)
+		svc := NewVPCsClientImpl(c)
+		resp, err := svc.Get(context.Background(), "test-project", "vpc-123", nil)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if resp.StatusCode != http.StatusBadGateway {
+			t.Errorf("expected status 502, got %d", resp.StatusCode)
+		}
+		if resp.Error != nil {
+			t.Errorf("expected nil Error, got %v", resp.Error)
+		}
+		if string(resp.RawBody) != "Bad Gateway" {
+			t.Errorf("expected raw body 'Bad Gateway', got %q", string(resp.RawBody))
+		}
+	})
+
+	t.Run("network error", func(t *testing.T) {
+		c := testutil.NewBrokenClient(t, "http://unused.invalid")
+		svc := NewVPCsClientImpl(c)
+		_, err := svc.Get(context.Background(), "test-project", "vpc-123", nil)
+		if err == nil {
+			t.Fatal("expected transport error, got nil")
+		}
+	})
+
+	t.Run("nil params injects default api-version", func(t *testing.T) {
+		server := testutil.NewMockServer(t, func(w http.ResponseWriter, r *http.Request) {
+			if got := r.URL.Query().Get("api-version"); got != "1.0" {
+				t.Errorf("expected api-version=1.0, got %q", got)
+			}
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusOK)
+			fmt.Fprint(w, `{}`)
+		})
+		c := testutil.NewClient(t, server.URL)
+		svc := NewVPCsClientImpl(c)
+		resp, err := svc.Get(context.Background(), "test-project", "vpc-123", nil)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if resp.StatusCode != http.StatusOK {
+			t.Errorf("expected status 200, got %d", resp.StatusCode)
 		}
 	})
 }
 
 func TestCreateVPC(t *testing.T) {
-	// VPC Create doesn't require waiting, so this test should work fine
 	t.Run("successful create", func(t *testing.T) {
-		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			if r.URL.Path == "/token" {
-				w.Header().Set("Content-Type", "application/json")
-				w.WriteHeader(http.StatusOK)
-				w.Write([]byte(`{"access_token":"test-token","token_type":"Bearer","expires_in":3600}`))
-				return
-			}
-
+		server := testutil.NewMockServer(t, func(w http.ResponseWriter, r *http.Request) {
 			if r.Method != http.MethodPost {
 				t.Errorf("expected POST, got %s", r.Method)
 			}
+			w.Header().Set("Content-Type", "application/json")
 			w.WriteHeader(http.StatusCreated)
-			resp := types.VPCResponse{
-				Metadata: types.ResourceMetadataResponse{Name: types.StringPtr("new-vpc")},
-			}
-			json.NewEncoder(w).Encode(resp)
-		}))
-		defer server.Close()
-
-		var (
-			baseURL    = server.URL
-			httpClient = http.DefaultClient
-			logger     = &noop.NoOpLogger{}
-		)
-
-		c := restclient.NewClient(baseURL, httpClient, standard.NewInterceptor(), logger)
-
+			fmt.Fprint(w, `{"metadata":{"name":"new-vpc"}}`)
+		})
+		c := testutil.NewClient(t, server.URL)
 		svc := NewVPCsClientImpl(c)
-
 		req := types.VPCRequest{
 			Metadata: types.RegionalResourceMetadataRequest{
 				ResourceMetadataRequest: types.ResourceMetadataRequest{Name: "new-vpc"},
 				Location:                types.LocationRequest{Value: "ITBG-Bergamo"},
 			},
 		}
-
 		resp, err := svc.Create(context.Background(), "test-project", req, nil)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if resp.StatusCode != http.StatusCreated {
+			t.Errorf("expected status 201, got %d", resp.StatusCode)
+		}
+	})
+
+	t.Run("empty project", func(t *testing.T) {
+		c := testutil.NewClient(t, "http://unused.invalid")
+		svc := NewVPCsClientImpl(c)
+		_, err := svc.Create(context.Background(), "", types.VPCRequest{}, nil)
+		if err == nil {
+			t.Fatal("expected validation error, got nil")
+		}
+	})
+
+	t.Run("not found", func(t *testing.T) {
+		server := testutil.NewMockServer(t, func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusNotFound)
+			fmt.Fprint(w, testutil.ErrorBodyJSON("Not Found", "resource not found", 404))
+		})
+		c := testutil.NewClient(t, server.URL)
+		svc := NewVPCsClientImpl(c)
+		resp, err := svc.Create(context.Background(), "test-project", types.VPCRequest{}, nil)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if resp.StatusCode != http.StatusNotFound {
+			t.Errorf("expected status 404, got %d", resp.StatusCode)
+		}
+		if resp.Error == nil || resp.Error.Title == nil || *resp.Error.Title != "Not Found" {
+			t.Errorf("expected error title 'Not Found', got %v", resp.Error)
+		}
+	})
+
+	t.Run("bad gateway non-json", func(t *testing.T) {
+		// TODO(TD-010): Create/Update's manual response build silently swallows non-JSON
+		// unmarshal errors (diverges from ParseResponseBody which logs at DEBUG).
+		server := testutil.NewMockServer(t, func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusBadGateway)
+			fmt.Fprint(w, "Bad Gateway")
+		})
+		c := testutil.NewClient(t, server.URL)
+		svc := NewVPCsClientImpl(c)
+		resp, err := svc.Create(context.Background(), "test-project", types.VPCRequest{}, nil)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if resp.StatusCode != http.StatusBadGateway {
+			t.Errorf("expected status 502, got %d", resp.StatusCode)
+		}
+		if resp.Error != nil {
+			t.Errorf("expected nil Error, got %v", resp.Error)
+		}
+		if string(resp.RawBody) != "Bad Gateway" {
+			t.Errorf("expected raw body 'Bad Gateway', got %q", string(resp.RawBody))
+		}
+	})
+
+	t.Run("network error", func(t *testing.T) {
+		c := testutil.NewBrokenClient(t, "http://unused.invalid")
+		svc := NewVPCsClientImpl(c)
+		_, err := svc.Create(context.Background(), "test-project", types.VPCRequest{}, nil)
+		if err == nil {
+			t.Fatal("expected transport error, got nil")
+		}
+	})
+
+	t.Run("nil params injects default api-version", func(t *testing.T) {
+		server := testutil.NewMockServer(t, func(w http.ResponseWriter, r *http.Request) {
+			if got := r.URL.Query().Get("api-version"); got != "1.0" {
+				t.Errorf("expected api-version=1.0, got %q", got)
+			}
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusCreated)
+			fmt.Fprint(w, `{}`)
+		})
+		c := testutil.NewClient(t, server.URL)
+		svc := NewVPCsClientImpl(c)
+		resp, err := svc.Create(context.Background(), "test-project", types.VPCRequest{}, nil)
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -141,33 +327,213 @@ func TestCreateVPC(t *testing.T) {
 	})
 }
 
+func TestUpdateVPC(t *testing.T) {
+	t.Run("successful update", func(t *testing.T) {
+		server := testutil.NewMockServer(t, func(w http.ResponseWriter, r *http.Request) {
+			if r.Method != http.MethodPut {
+				t.Errorf("expected PUT, got %s", r.Method)
+			}
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusOK)
+			fmt.Fprint(w, `{"metadata":{"name":"updated-vpc"}}`)
+		})
+		c := testutil.NewClient(t, server.URL)
+		svc := NewVPCsClientImpl(c)
+		resp, err := svc.Update(context.Background(), "test-project", "vpc-123", types.VPCRequest{}, nil)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if resp.StatusCode != http.StatusOK {
+			t.Errorf("expected status 200, got %d", resp.StatusCode)
+		}
+	})
+
+	t.Run("empty project", func(t *testing.T) {
+		c := testutil.NewClient(t, "http://unused.invalid")
+		svc := NewVPCsClientImpl(c)
+		_, err := svc.Update(context.Background(), "", "vpc-123", types.VPCRequest{}, nil)
+		if err == nil {
+			t.Fatal("expected validation error, got nil")
+		}
+	})
+
+	t.Run("empty vpcID", func(t *testing.T) {
+		c := testutil.NewClient(t, "http://unused.invalid")
+		svc := NewVPCsClientImpl(c)
+		_, err := svc.Update(context.Background(), "test-project", "", types.VPCRequest{}, nil)
+		if err == nil {
+			t.Fatal("expected validation error, got nil")
+		}
+	})
+
+	t.Run("not found", func(t *testing.T) {
+		server := testutil.NewMockServer(t, func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusNotFound)
+			fmt.Fprint(w, testutil.ErrorBodyJSON("Not Found", "resource not found", 404))
+		})
+		c := testutil.NewClient(t, server.URL)
+		svc := NewVPCsClientImpl(c)
+		resp, err := svc.Update(context.Background(), "test-project", "vpc-123", types.VPCRequest{}, nil)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if resp.StatusCode != http.StatusNotFound {
+			t.Errorf("expected status 404, got %d", resp.StatusCode)
+		}
+		if resp.Error == nil || resp.Error.Title == nil || *resp.Error.Title != "Not Found" {
+			t.Errorf("expected error title 'Not Found', got %v", resp.Error)
+		}
+	})
+
+	t.Run("bad gateway non-json", func(t *testing.T) {
+		// TODO(TD-010): Create/Update's manual response build silently swallows non-JSON
+		// unmarshal errors (diverges from ParseResponseBody which logs at DEBUG).
+		server := testutil.NewMockServer(t, func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusBadGateway)
+			fmt.Fprint(w, "Bad Gateway")
+		})
+		c := testutil.NewClient(t, server.URL)
+		svc := NewVPCsClientImpl(c)
+		resp, err := svc.Update(context.Background(), "test-project", "vpc-123", types.VPCRequest{}, nil)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if resp.StatusCode != http.StatusBadGateway {
+			t.Errorf("expected status 502, got %d", resp.StatusCode)
+		}
+		if resp.Error != nil {
+			t.Errorf("expected nil Error, got %v", resp.Error)
+		}
+		if string(resp.RawBody) != "Bad Gateway" {
+			t.Errorf("expected raw body 'Bad Gateway', got %q", string(resp.RawBody))
+		}
+	})
+
+	t.Run("network error", func(t *testing.T) {
+		c := testutil.NewBrokenClient(t, "http://unused.invalid")
+		svc := NewVPCsClientImpl(c)
+		_, err := svc.Update(context.Background(), "test-project", "vpc-123", types.VPCRequest{}, nil)
+		if err == nil {
+			t.Fatal("expected transport error, got nil")
+		}
+	})
+
+	t.Run("nil params injects default api-version", func(t *testing.T) {
+		server := testutil.NewMockServer(t, func(w http.ResponseWriter, r *http.Request) {
+			if got := r.URL.Query().Get("api-version"); got != "1.0" {
+				t.Errorf("expected api-version=1.0, got %q", got)
+			}
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusOK)
+			fmt.Fprint(w, `{}`)
+		})
+		c := testutil.NewClient(t, server.URL)
+		svc := NewVPCsClientImpl(c)
+		resp, err := svc.Update(context.Background(), "test-project", "vpc-123", types.VPCRequest{}, nil)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if resp.StatusCode != http.StatusOK {
+			t.Errorf("expected status 200, got %d", resp.StatusCode)
+		}
+	})
+}
+
 func TestDeleteVPC(t *testing.T) {
 	t.Run("successful delete", func(t *testing.T) {
-		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			if r.URL.Path == "/token" {
-				w.Header().Set("Content-Type", "application/json")
-				w.WriteHeader(http.StatusOK)
-				w.Write([]byte(`{"access_token":"test-token","token_type":"Bearer","expires_in":3600}`))
-				return
-			}
-
+		server := testutil.NewMockServer(t, func(w http.ResponseWriter, r *http.Request) {
 			if r.Method != http.MethodDelete {
 				t.Errorf("expected DELETE, got %s", r.Method)
 			}
 			w.WriteHeader(http.StatusNoContent)
-		}))
-		defer server.Close()
-
-		var (
-			baseURL    = server.URL
-			httpClient = http.DefaultClient
-			logger     = &noop.NoOpLogger{}
-		)
-
-		c := restclient.NewClient(baseURL, httpClient, standard.NewInterceptor(), logger)
-
+		})
+		c := testutil.NewClient(t, server.URL)
 		svc := NewVPCsClientImpl(c)
+		_, err := svc.Delete(context.Background(), "test-project", "vpc-123", nil)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
 
+	t.Run("empty project", func(t *testing.T) {
+		c := testutil.NewClient(t, "http://unused.invalid")
+		svc := NewVPCsClientImpl(c)
+		_, err := svc.Delete(context.Background(), "", "vpc-123", nil)
+		if err == nil {
+			t.Fatal("expected validation error, got nil")
+		}
+	})
+
+	t.Run("empty vpcID", func(t *testing.T) {
+		c := testutil.NewClient(t, "http://unused.invalid")
+		svc := NewVPCsClientImpl(c)
+		_, err := svc.Delete(context.Background(), "test-project", "", nil)
+		if err == nil {
+			t.Fatal("expected validation error, got nil")
+		}
+	})
+
+	t.Run("not found", func(t *testing.T) {
+		server := testutil.NewMockServer(t, func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusNotFound)
+			fmt.Fprint(w, testutil.ErrorBodyJSON("Not Found", "resource not found", 404))
+		})
+		c := testutil.NewClient(t, server.URL)
+		svc := NewVPCsClientImpl(c)
+		resp, err := svc.Delete(context.Background(), "test-project", "vpc-123", nil)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if resp.StatusCode != http.StatusNotFound {
+			t.Errorf("expected status 404, got %d", resp.StatusCode)
+		}
+		if resp.Error == nil || resp.Error.Title == nil || *resp.Error.Title != "Not Found" {
+			t.Errorf("expected error title 'Not Found', got %v", resp.Error)
+		}
+	})
+
+	t.Run("bad gateway non-json", func(t *testing.T) {
+		server := testutil.NewMockServer(t, func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusBadGateway)
+			fmt.Fprint(w, "Bad Gateway")
+		})
+		c := testutil.NewClient(t, server.URL)
+		svc := NewVPCsClientImpl(c)
+		resp, err := svc.Delete(context.Background(), "test-project", "vpc-123", nil)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if resp.StatusCode != http.StatusBadGateway {
+			t.Errorf("expected status 502, got %d", resp.StatusCode)
+		}
+		if resp.Error != nil {
+			t.Errorf("expected nil Error, got %v", resp.Error)
+		}
+		if string(resp.RawBody) != "Bad Gateway" {
+			t.Errorf("expected raw body 'Bad Gateway', got %q", string(resp.RawBody))
+		}
+	})
+
+	t.Run("network error", func(t *testing.T) {
+		c := testutil.NewBrokenClient(t, "http://unused.invalid")
+		svc := NewVPCsClientImpl(c)
+		_, err := svc.Delete(context.Background(), "test-project", "vpc-123", nil)
+		if err == nil {
+			t.Fatal("expected transport error, got nil")
+		}
+	})
+
+	t.Run("nil params injects default api-version", func(t *testing.T) {
+		server := testutil.NewMockServer(t, func(w http.ResponseWriter, r *http.Request) {
+			if got := r.URL.Query().Get("api-version"); got != "1.0" {
+				t.Errorf("expected api-version=1.0, got %q", got)
+			}
+			w.WriteHeader(http.StatusNoContent)
+		})
+		c := testutil.NewClient(t, server.URL)
+		svc := NewVPCsClientImpl(c)
 		_, err := svc.Delete(context.Background(), "test-project", "vpc-123", nil)
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)


### PR DESCRIPTION
## Summary

- Rewrites 4 test files (`vpc_test.go`, `subnet_test.go`, `vpc-peering_test.go`, `vpc-peering-route_test.go`) to use `testutil` helpers instead of inline `httptest` + `/token` boilerplate
- Adds the standard 4-scenario error matrix to every non-skipped method: `not found`, `bad gateway non-json`, `network error`, `nil params injects default api-version`
- Adds empty-ID validation subtests per validator arg (`ValidateProject` → 1, `ValidateProjectAndResource` → 2, `ValidateVPCResource` → 3, `ValidateVPCPeeringRoute` → 4)
- Adds net-new test functions for previously untested verbs: `TestUpdateVPC`, `TestUpdateSubnet`, `TestCreateVpcPeering`, `TestUpdateVpcPeering`, `TestCreateVpcPeeringRoute`, `TestUpdateVpcPeeringRoute`
- Preserves `TestCreateSubnet` (skipped, adds `TODO(TD-020)` comment) and `TestNewSubnetsClientImpl_panicsOnNilVPCClient` unchanged

Closes #154 · Part of #130 · Follows shape set by #162 / #164 / #165 / #166 / #167

🤖 Generated with [Claude Code](https://claude.com/claude-code)