### PR TITLE
test(security): migrate kms_test to testutil and add error-path coverage

### DIFF
--- a/internal/clients/security/kms_test.go
+++ b/internal/clients/security/kms_test.go
@@ -2,319 +2,549 @@ package security
 
 import (
 	"context"
-	"encoding/json"
+	"fmt"
 	"net/http"
-	"net/http/httptest"
 	"testing"
 
-	"github.com/Arubacloud/sdk-go/internal/impl/interceptor/standard"
-	"github.com/Arubacloud/sdk-go/internal/impl/logger/noop"
-	"github.com/Arubacloud/sdk-go/internal/restclient"
+	"github.com/Arubacloud/sdk-go/internal/testutil"
 	"github.com/Arubacloud/sdk-go/pkg/types"
 )
 
 func TestListKMSKeys(t *testing.T) {
-	t.Run("successful_list", func(t *testing.T) {
-		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			if r.URL.Path == "/token" {
-				w.Header().Set("Content-Type", "application/json")
-				w.WriteHeader(http.StatusOK)
-				w.Write([]byte(`{"access_token":"test-token","token_type":"Bearer","expires_in":3600}`))
-				return
-			}
-
-			if r.Method == "GET" && r.URL.Path == "/projects/test-project/providers/Aruba.Security/kms" {
-				w.WriteHeader(http.StatusOK)
-				resp := types.KmsList{
-					ListResponse: types.ListResponse{Total: 2},
-					Values: []types.KmsResponse{
-						{
-							Metadata: types.ResourceMetadataResponse{
-								Name: types.StringPtr("encryption-key-1"),
-								ID:   types.StringPtr("kms-123"),
-							},
-							Properties: types.KmsPropertiesResponse{
-								BillingPeriod: "Month",
-							},
-							Status: types.ResourceStatus{
-								State: types.StringPtr("active"),
-							},
-						},
-						{
-							Metadata: types.ResourceMetadataResponse{
-								Name: types.StringPtr("encryption-key-2"),
-								ID:   types.StringPtr("kms-456"),
-							},
-							Properties: types.KmsPropertiesResponse{
-								BillingPeriod: "Month",
-							},
-							Status: types.ResourceStatus{
-								State: types.StringPtr("active"),
-							},
-						},
-					},
-				}
-				json.NewEncoder(w).Encode(resp)
-				return
-			}
-
-			http.NotFound(w, r)
-		}))
-		defer server.Close()
-
-		var (
-			baseURL    = server.URL
-			httpClient = http.DefaultClient
-			logger     = &noop.NoOpLogger{}
-		)
-
-		c := restclient.NewClient(baseURL, httpClient, standard.NewInterceptor(), logger)
-
+	t.Run("successful list", func(t *testing.T) {
+		server := testutil.NewMockServer(t, func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusOK)
+			fmt.Fprint(w, `{"total":2,"values":[{"metadata":{"name":"encryption-key-1","id":"kms-123"},"properties":{"billingPeriod":"Month"},"status":{"state":"active"}},{"metadata":{"name":"encryption-key-2","id":"kms-456"},"properties":{"billingPeriod":"Month"},"status":{"state":"active"}}]}`)
+		})
+		c := testutil.NewClient(t, server.URL)
 		svc := NewKMSClientImpl(c)
-
 		resp, err := svc.List(context.Background(), "test-project", nil)
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
-		if resp == nil || resp.Data == nil || len(resp.Data.Values) != 2 {
-			t.Errorf("expected 2 KMS keys")
+		if len(resp.Data.Values) != 2 {
+			t.Errorf("expected 2 KMS keys, got %d", len(resp.Data.Values))
 		}
 		if resp.Data.Values[0].Metadata.Name == nil || *resp.Data.Values[0].Metadata.Name != "encryption-key-1" {
-			t.Errorf("expected name 'encryption-key-1'")
+			t.Errorf("expected name 'encryption-key-1', got %v", resp.Data.Values[0].Metadata.Name)
+		}
+	})
+
+	t.Run("empty project", func(t *testing.T) {
+		c := testutil.NewClient(t, "http://unused.invalid")
+		svc := NewKMSClientImpl(c)
+		_, err := svc.List(context.Background(), "", nil)
+		if err == nil {
+			t.Fatal("expected validation error, got nil")
+		}
+	})
+
+	t.Run("not found", func(t *testing.T) {
+		server := testutil.NewMockServer(t, func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusNotFound)
+			fmt.Fprint(w, testutil.ErrorBodyJSON("Not Found", "resource not found", 404))
+		})
+		c := testutil.NewClient(t, server.URL)
+		svc := NewKMSClientImpl(c)
+		resp, err := svc.List(context.Background(), "test-project", nil)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if resp.StatusCode != http.StatusNotFound {
+			t.Errorf("expected status 404, got %d", resp.StatusCode)
+		}
+		if resp.Error == nil || resp.Error.Title == nil || *resp.Error.Title != "Not Found" {
+			t.Errorf("expected error title 'Not Found', got %v", resp.Error)
+		}
+	})
+
+	t.Run("bad gateway non-json", func(t *testing.T) {
+		server := testutil.NewMockServer(t, func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusBadGateway)
+			fmt.Fprint(w, "Bad Gateway")
+		})
+		c := testutil.NewClient(t, server.URL)
+		svc := NewKMSClientImpl(c)
+		resp, err := svc.List(context.Background(), "test-project", nil)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if resp.StatusCode != http.StatusBadGateway {
+			t.Errorf("expected status 502, got %d", resp.StatusCode)
+		}
+		if resp.Error != nil {
+			t.Errorf("expected nil Error, got %v", resp.Error)
+		}
+		if string(resp.RawBody) != "Bad Gateway" {
+			t.Errorf("expected raw body 'Bad Gateway', got %q", string(resp.RawBody))
+		}
+	})
+
+	t.Run("network error", func(t *testing.T) {
+		c := testutil.NewBrokenClient(t, "http://unused.invalid")
+		svc := NewKMSClientImpl(c)
+		_, err := svc.List(context.Background(), "test-project", nil)
+		if err == nil {
+			t.Fatal("expected transport error, got nil")
+		}
+	})
+
+	t.Run("nil params injects default api-version", func(t *testing.T) {
+		server := testutil.NewMockServer(t, func(w http.ResponseWriter, r *http.Request) {
+			if got := r.URL.Query().Get("api-version"); got != "1.0" {
+				t.Errorf("expected api-version=1.0, got %q", got)
+			}
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusOK)
+			fmt.Fprint(w, `{"total":0,"values":[]}`)
+		})
+		c := testutil.NewClient(t, server.URL)
+		svc := NewKMSClientImpl(c)
+		resp, err := svc.List(context.Background(), "test-project", nil)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if resp.StatusCode != http.StatusOK {
+			t.Errorf("expected status 200, got %d", resp.StatusCode)
 		}
 	})
 }
 
 func TestGetKMSKey(t *testing.T) {
-	t.Run("successful_get", func(t *testing.T) {
-		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			if r.URL.Path == "/token" {
-				w.Header().Set("Content-Type", "application/json")
-				w.WriteHeader(http.StatusOK)
-				w.Write([]byte(`{"access_token":"test-token","token_type":"Bearer","expires_in":3600}`))
-				return
-			}
-
-			if r.Method == "GET" && r.URL.Path == "/projects/test-project/providers/Aruba.Security/kms/kms-123" {
-				w.WriteHeader(http.StatusOK)
-				resp := types.KmsResponse{
-					Metadata: types.ResourceMetadataResponse{
-						Name: types.StringPtr("my-encryption-key"),
-						ID:   types.StringPtr("kms-123"),
-					},
-					Properties: types.KmsPropertiesResponse{
-						BillingPeriod: "Month",
-					},
-					Status: types.ResourceStatus{
-						State: types.StringPtr("active"),
-					},
-				}
-				json.NewEncoder(w).Encode(resp)
-				return
-			}
-
-			http.NotFound(w, r)
-		}))
-		defer server.Close()
-
-		var (
-			baseURL    = server.URL
-			httpClient = http.DefaultClient
-			logger     = &noop.NoOpLogger{}
-		)
-
-		c := restclient.NewClient(baseURL, httpClient, standard.NewInterceptor(), logger)
-
+	t.Run("successful get", func(t *testing.T) {
+		server := testutil.NewMockServer(t, func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusOK)
+			fmt.Fprint(w, `{"metadata":{"name":"my-encryption-key","id":"kms-123"},"properties":{"billingPeriod":"Month"},"status":{"state":"active"}}`)
+		})
+		c := testutil.NewClient(t, server.URL)
 		svc := NewKMSClientImpl(c)
-
 		resp, err := svc.Get(context.Background(), "test-project", "kms-123", nil)
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
-		if resp == nil || resp.Data == nil {
-			t.Fatalf("expected response data")
-		}
 		if resp.Data.Metadata.Name == nil || *resp.Data.Metadata.Name != "my-encryption-key" {
-			t.Errorf("expected name 'my-encryption-key'")
+			t.Errorf("expected name 'my-encryption-key', got %v", resp.Data.Metadata.Name)
 		}
 		if resp.Data.Properties.BillingPeriod != "Month" {
-			t.Errorf("expected billing period 'Month'")
+			t.Errorf("expected billing period 'Month', got %q", resp.Data.Properties.BillingPeriod)
+		}
+	})
+
+	t.Run("empty project", func(t *testing.T) {
+		c := testutil.NewClient(t, "http://unused.invalid")
+		svc := NewKMSClientImpl(c)
+		_, err := svc.Get(context.Background(), "", "kms-123", nil)
+		if err == nil {
+			t.Fatal("expected validation error, got nil")
+		}
+	})
+
+	t.Run("empty KMS ID", func(t *testing.T) {
+		c := testutil.NewClient(t, "http://unused.invalid")
+		svc := NewKMSClientImpl(c)
+		_, err := svc.Get(context.Background(), "test-project", "", nil)
+		if err == nil {
+			t.Fatal("expected validation error, got nil")
+		}
+	})
+
+	t.Run("not found", func(t *testing.T) {
+		server := testutil.NewMockServer(t, func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusNotFound)
+			fmt.Fprint(w, testutil.ErrorBodyJSON("Not Found", "resource not found", 404))
+		})
+		c := testutil.NewClient(t, server.URL)
+		svc := NewKMSClientImpl(c)
+		resp, err := svc.Get(context.Background(), "test-project", "kms-123", nil)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if resp.StatusCode != http.StatusNotFound {
+			t.Errorf("expected status 404, got %d", resp.StatusCode)
+		}
+		if resp.Error == nil || resp.Error.Title == nil || *resp.Error.Title != "Not Found" {
+			t.Errorf("expected error title 'Not Found', got %v", resp.Error)
+		}
+	})
+
+	t.Run("bad gateway non-json", func(t *testing.T) {
+		server := testutil.NewMockServer(t, func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusBadGateway)
+			fmt.Fprint(w, "Bad Gateway")
+		})
+		c := testutil.NewClient(t, server.URL)
+		svc := NewKMSClientImpl(c)
+		resp, err := svc.Get(context.Background(), "test-project", "kms-123", nil)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if resp.StatusCode != http.StatusBadGateway {
+			t.Errorf("expected status 502, got %d", resp.StatusCode)
+		}
+		if resp.Error != nil {
+			t.Errorf("expected nil Error, got %v", resp.Error)
+		}
+		if string(resp.RawBody) != "Bad Gateway" {
+			t.Errorf("expected raw body 'Bad Gateway', got %q", string(resp.RawBody))
+		}
+	})
+
+	t.Run("network error", func(t *testing.T) {
+		c := testutil.NewBrokenClient(t, "http://unused.invalid")
+		svc := NewKMSClientImpl(c)
+		_, err := svc.Get(context.Background(), "test-project", "kms-123", nil)
+		if err == nil {
+			t.Fatal("expected transport error, got nil")
+		}
+	})
+
+	t.Run("nil params injects default api-version", func(t *testing.T) {
+		server := testutil.NewMockServer(t, func(w http.ResponseWriter, r *http.Request) {
+			if got := r.URL.Query().Get("api-version"); got != "1.0" {
+				t.Errorf("expected api-version=1.0, got %q", got)
+			}
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusOK)
+			fmt.Fprint(w, `{"metadata":{"name":"x"}}`)
+		})
+		c := testutil.NewClient(t, server.URL)
+		svc := NewKMSClientImpl(c)
+		resp, err := svc.Get(context.Background(), "test-project", "kms-123", nil)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if resp.StatusCode != http.StatusOK {
+			t.Errorf("expected status 200, got %d", resp.StatusCode)
 		}
 	})
 }
 
 func TestCreateKMSKey(t *testing.T) {
-	t.Run("successful_create", func(t *testing.T) {
-		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			if r.URL.Path == "/token" {
-				w.Header().Set("Content-Type", "application/json")
-				w.WriteHeader(http.StatusOK)
-				w.Write([]byte(`{"access_token":"test-token","token_type":"Bearer","expires_in":3600}`))
-				return
-			}
-
-			if r.Method == "POST" && r.URL.Path == "/projects/test-project/providers/Aruba.Security/kms" {
-				w.WriteHeader(http.StatusCreated)
-				resp := types.KmsResponse{
-					Metadata: types.ResourceMetadataResponse{
-						Name: types.StringPtr("new-encryption-key"),
-						ID:   types.StringPtr("kms-789"),
-					},
-					Properties: types.KmsPropertiesResponse{
-						BillingPeriod: "Month",
-					},
-					Status: types.ResourceStatus{
-						State: types.StringPtr("creating"),
-					},
-				}
-				json.NewEncoder(w).Encode(resp)
-				return
-			}
-
-			http.NotFound(w, r)
-		}))
-		defer server.Close()
-
-		var (
-			baseURL    = server.URL
-			httpClient = http.DefaultClient
-			logger     = &noop.NoOpLogger{}
-		)
-
-		c := restclient.NewClient(baseURL, httpClient, standard.NewInterceptor(), logger)
-
+	t.Run("successful create", func(t *testing.T) {
+		server := testutil.NewMockServer(t, func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusCreated)
+			fmt.Fprint(w, `{"metadata":{"name":"new-encryption-key","id":"kms-789"},"properties":{"billingPeriod":"Month"},"status":{"state":"creating"}}`)
+		})
+		c := testutil.NewClient(t, server.URL)
 		svc := NewKMSClientImpl(c)
-
 		body := types.KmsRequest{
 			Metadata: types.RegionalResourceMetadataRequest{
-				ResourceMetadataRequest: types.ResourceMetadataRequest{
-					Name: "new-encryption-key",
-				},
-				Location: types.LocationRequest{Value: "it-eur"},
+				ResourceMetadataRequest: types.ResourceMetadataRequest{Name: "new-encryption-key"},
+				Location:                types.LocationRequest{Value: "it-eur"},
 			},
-			Properties: types.KmsPropertiesRequest{
-				BillingPeriod: "Month",
-			},
+			Properties: types.KmsPropertiesRequest{BillingPeriod: "Month"},
 		}
-
 		resp, err := svc.Create(context.Background(), "test-project", body, nil)
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
-		if resp == nil || resp.Data == nil {
-			t.Fatalf("expected response data")
-		}
 		if resp.Data.Metadata.Name == nil || *resp.Data.Metadata.Name != "new-encryption-key" {
-			t.Errorf("expected name 'new-encryption-key'")
+			t.Errorf("expected name 'new-encryption-key', got %v", resp.Data.Metadata.Name)
 		}
 		if resp.Data.Status.State == nil || *resp.Data.Status.State != "creating" {
-			t.Errorf("expected state 'creating'")
+			t.Errorf("expected state 'creating', got %v", resp.Data.Status.State)
+		}
+	})
+
+	t.Run("empty project", func(t *testing.T) {
+		c := testutil.NewClient(t, "http://unused.invalid")
+		svc := NewKMSClientImpl(c)
+		_, err := svc.Create(context.Background(), "", types.KmsRequest{}, nil)
+		if err == nil {
+			t.Fatal("expected validation error, got nil")
+		}
+	})
+
+	t.Run("not found", func(t *testing.T) {
+		server := testutil.NewMockServer(t, func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusNotFound)
+			fmt.Fprint(w, testutil.ErrorBodyJSON("Not Found", "resource not found", 404))
+		})
+		c := testutil.NewClient(t, server.URL)
+		svc := NewKMSClientImpl(c)
+		resp, err := svc.Create(context.Background(), "test-project", types.KmsRequest{}, nil)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if resp.StatusCode != http.StatusNotFound {
+			t.Errorf("expected status 404, got %d", resp.StatusCode)
+		}
+		if resp.Error == nil || resp.Error.Title == nil || *resp.Error.Title != "Not Found" {
+			t.Errorf("expected error title 'Not Found', got %v", resp.Error)
+		}
+	})
+
+	// TODO(TD-010): Create uses the manual response-build flow and silently swallows
+	// non-JSON unmarshal errors; resp.Error will be nil even though the body is non-JSON.
+	t.Run("bad gateway non-json", func(t *testing.T) {
+		server := testutil.NewMockServer(t, func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusBadGateway)
+			fmt.Fprint(w, "Bad Gateway")
+		})
+		c := testutil.NewClient(t, server.URL)
+		svc := NewKMSClientImpl(c)
+		resp, err := svc.Create(context.Background(), "test-project", types.KmsRequest{}, nil)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if resp.StatusCode != http.StatusBadGateway {
+			t.Errorf("expected status 502, got %d", resp.StatusCode)
+		}
+		if string(resp.RawBody) != "Bad Gateway" {
+			t.Errorf("expected raw body 'Bad Gateway', got %q", string(resp.RawBody))
+		}
+	})
+
+	t.Run("network error", func(t *testing.T) {
+		c := testutil.NewBrokenClient(t, "http://unused.invalid")
+		svc := NewKMSClientImpl(c)
+		_, err := svc.Create(context.Background(), "test-project", types.KmsRequest{}, nil)
+		if err == nil {
+			t.Fatal("expected transport error, got nil")
+		}
+	})
+
+	t.Run("nil params injects default api-version", func(t *testing.T) {
+		server := testutil.NewMockServer(t, func(w http.ResponseWriter, r *http.Request) {
+			if got := r.URL.Query().Get("api-version"); got != "1.0" {
+				t.Errorf("expected api-version=1.0, got %q", got)
+			}
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusCreated)
+			fmt.Fprint(w, `{"metadata":{"name":"x"}}`)
+		})
+		c := testutil.NewClient(t, server.URL)
+		svc := NewKMSClientImpl(c)
+		resp, err := svc.Create(context.Background(), "test-project", types.KmsRequest{}, nil)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if resp.StatusCode != http.StatusCreated {
+			t.Errorf("expected status 201, got %d", resp.StatusCode)
 		}
 	})
 }
 
 func TestUpdateKMSKey(t *testing.T) {
-	t.Run("successful_update", func(t *testing.T) {
-		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			if r.URL.Path == "/token" {
-				w.Header().Set("Content-Type", "application/json")
-				w.WriteHeader(http.StatusOK)
-				w.Write([]byte(`{"access_token":"test-token","token_type":"Bearer","expires_in":3600}`))
-				return
-			}
-
-			if r.Method == "PUT" && r.URL.Path == "/projects/test-project/providers/Aruba.Security/kms/kms-123" {
-				w.WriteHeader(http.StatusOK)
-				resp := types.KmsResponse{
-					Metadata: types.ResourceMetadataResponse{
-						Name: types.StringPtr("updated-encryption-key"),
-						ID:   types.StringPtr("kms-123"),
-					},
-					Properties: types.KmsPropertiesResponse{
-						BillingPeriod: "Year",
-					},
-					Status: types.ResourceStatus{
-						State: types.StringPtr("active"),
-					},
-				}
-				json.NewEncoder(w).Encode(resp)
-				return
-			}
-
-			http.NotFound(w, r)
-		}))
-		defer server.Close()
-
-		var (
-			baseURL    = server.URL
-			httpClient = http.DefaultClient
-			logger     = &noop.NoOpLogger{}
-		)
-
-		c := restclient.NewClient(baseURL, httpClient, standard.NewInterceptor(), logger)
-
+	t.Run("successful update", func(t *testing.T) {
+		server := testutil.NewMockServer(t, func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusOK)
+			fmt.Fprint(w, `{"metadata":{"name":"updated-encryption-key","id":"kms-123"},"properties":{"billingPeriod":"Year"},"status":{"state":"active"}}`)
+		})
+		c := testutil.NewClient(t, server.URL)
 		svc := NewKMSClientImpl(c)
-
 		body := types.KmsRequest{
 			Metadata: types.RegionalResourceMetadataRequest{
-				ResourceMetadataRequest: types.ResourceMetadataRequest{
-					Name: "updated-encryption-key",
-				},
-				Location: types.LocationRequest{Value: "it-eur"},
+				ResourceMetadataRequest: types.ResourceMetadataRequest{Name: "updated-encryption-key"},
+				Location:                types.LocationRequest{Value: "it-eur"},
 			},
-			Properties: types.KmsPropertiesRequest{
-				BillingPeriod: "Year",
-			},
+			Properties: types.KmsPropertiesRequest{BillingPeriod: "Year"},
 		}
-
 		resp, err := svc.Update(context.Background(), "test-project", "kms-123", body, nil)
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
-		if resp == nil || resp.Data == nil {
-			t.Fatalf("expected response data")
-		}
 		if resp.Data.Metadata.Name == nil || *resp.Data.Metadata.Name != "updated-encryption-key" {
-			t.Errorf("expected name 'updated-encryption-key'")
+			t.Errorf("expected name 'updated-encryption-key', got %v", resp.Data.Metadata.Name)
 		}
 		if resp.Data.Properties.BillingPeriod != "Year" {
-			t.Errorf("expected billing period 'Year'")
+			t.Errorf("expected billing period 'Year', got %q", resp.Data.Properties.BillingPeriod)
+		}
+	})
+
+	t.Run("empty project", func(t *testing.T) {
+		c := testutil.NewClient(t, "http://unused.invalid")
+		svc := NewKMSClientImpl(c)
+		_, err := svc.Update(context.Background(), "", "kms-123", types.KmsRequest{}, nil)
+		if err == nil {
+			t.Fatal("expected validation error, got nil")
+		}
+	})
+
+	t.Run("empty KMS ID", func(t *testing.T) {
+		c := testutil.NewClient(t, "http://unused.invalid")
+		svc := NewKMSClientImpl(c)
+		_, err := svc.Update(context.Background(), "test-project", "", types.KmsRequest{}, nil)
+		if err == nil {
+			t.Fatal("expected validation error, got nil")
+		}
+	})
+
+	t.Run("not found", func(t *testing.T) {
+		server := testutil.NewMockServer(t, func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusNotFound)
+			fmt.Fprint(w, testutil.ErrorBodyJSON("Not Found", "resource not found", 404))
+		})
+		c := testutil.NewClient(t, server.URL)
+		svc := NewKMSClientImpl(c)
+		resp, err := svc.Update(context.Background(), "test-project", "kms-123", types.KmsRequest{}, nil)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if resp.StatusCode != http.StatusNotFound {
+			t.Errorf("expected status 404, got %d", resp.StatusCode)
+		}
+		if resp.Error == nil || resp.Error.Title == nil || *resp.Error.Title != "Not Found" {
+			t.Errorf("expected error title 'Not Found', got %v", resp.Error)
+		}
+	})
+
+	// TODO(TD-010): Update uses the manual response-build flow and silently swallows
+	// non-JSON unmarshal errors; resp.Error will be nil even though the body is non-JSON.
+	t.Run("bad gateway non-json", func(t *testing.T) {
+		server := testutil.NewMockServer(t, func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusBadGateway)
+			fmt.Fprint(w, "Bad Gateway")
+		})
+		c := testutil.NewClient(t, server.URL)
+		svc := NewKMSClientImpl(c)
+		resp, err := svc.Update(context.Background(), "test-project", "kms-123", types.KmsRequest{}, nil)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if resp.StatusCode != http.StatusBadGateway {
+			t.Errorf("expected status 502, got %d", resp.StatusCode)
+		}
+		if string(resp.RawBody) != "Bad Gateway" {
+			t.Errorf("expected raw body 'Bad Gateway', got %q", string(resp.RawBody))
+		}
+	})
+
+	t.Run("network error", func(t *testing.T) {
+		c := testutil.NewBrokenClient(t, "http://unused.invalid")
+		svc := NewKMSClientImpl(c)
+		_, err := svc.Update(context.Background(), "test-project", "kms-123", types.KmsRequest{}, nil)
+		if err == nil {
+			t.Fatal("expected transport error, got nil")
+		}
+	})
+
+	t.Run("nil params injects default api-version", func(t *testing.T) {
+		server := testutil.NewMockServer(t, func(w http.ResponseWriter, r *http.Request) {
+			if got := r.URL.Query().Get("api-version"); got != "1.0" {
+				t.Errorf("expected api-version=1.0, got %q", got)
+			}
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusOK)
+			fmt.Fprint(w, `{"metadata":{"name":"x"}}`)
+		})
+		c := testutil.NewClient(t, server.URL)
+		svc := NewKMSClientImpl(c)
+		resp, err := svc.Update(context.Background(), "test-project", "kms-123", types.KmsRequest{}, nil)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if resp.StatusCode != http.StatusOK {
+			t.Errorf("expected status 200, got %d", resp.StatusCode)
 		}
 	})
 }
 
 func TestDeleteKMSKey(t *testing.T) {
-	t.Run("successful_delete", func(t *testing.T) {
-		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			if r.URL.Path == "/token" {
-				w.Header().Set("Content-Type", "application/json")
-				w.WriteHeader(http.StatusOK)
-				w.Write([]byte(`{"access_token":"test-token","token_type":"Bearer","expires_in":3600}`))
-				return
-			}
-
-			if r.Method == "DELETE" && r.URL.Path == "/projects/test-project/providers/Aruba.Security/kms/kms-123" {
-				w.WriteHeader(http.StatusNoContent)
-				return
-			}
-
-			http.NotFound(w, r)
-		}))
-		defer server.Close()
-
-		var (
-			baseURL    = server.URL
-			httpClient = http.DefaultClient
-			logger     = &noop.NoOpLogger{}
-		)
-
-		c := restclient.NewClient(baseURL, httpClient, standard.NewInterceptor(), logger)
-
+	t.Run("successful delete", func(t *testing.T) {
+		server := testutil.NewMockServer(t, func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusNoContent)
+		})
+		c := testutil.NewClient(t, server.URL)
 		svc := NewKMSClientImpl(c)
-
 		_, err := svc.Delete(context.Background(), "test-project", "kms-123", nil)
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
+		}
+	})
+
+	t.Run("empty project", func(t *testing.T) {
+		c := testutil.NewClient(t, "http://unused.invalid")
+		svc := NewKMSClientImpl(c)
+		_, err := svc.Delete(context.Background(), "", "kms-123", nil)
+		if err == nil {
+			t.Fatal("expected validation error, got nil")
+		}
+	})
+
+	t.Run("empty KMS ID", func(t *testing.T) {
+		c := testutil.NewClient(t, "http://unused.invalid")
+		svc := NewKMSClientImpl(c)
+		_, err := svc.Delete(context.Background(), "test-project", "", nil)
+		if err == nil {
+			t.Fatal("expected validation error, got nil")
+		}
+	})
+
+	t.Run("not found", func(t *testing.T) {
+		server := testutil.NewMockServer(t, func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusNotFound)
+			fmt.Fprint(w, testutil.ErrorBodyJSON("Not Found", "resource not found", 404))
+		})
+		c := testutil.NewClient(t, server.URL)
+		svc := NewKMSClientImpl(c)
+		resp, err := svc.Delete(context.Background(), "test-project", "kms-123", nil)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if resp.StatusCode != http.StatusNotFound {
+			t.Errorf("expected status 404, got %d", resp.StatusCode)
+		}
+		if resp.Error == nil || resp.Error.Title == nil || *resp.Error.Title != "Not Found" {
+			t.Errorf("expected error title 'Not Found', got %v", resp.Error)
+		}
+	})
+
+	t.Run("bad gateway non-json", func(t *testing.T) {
+		server := testutil.NewMockServer(t, func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusBadGateway)
+			fmt.Fprint(w, "Bad Gateway")
+		})
+		c := testutil.NewClient(t, server.URL)
+		svc := NewKMSClientImpl(c)
+		resp, err := svc.Delete(context.Background(), "test-project", "kms-123", nil)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if resp.StatusCode != http.StatusBadGateway {
+			t.Errorf("expected status 502, got %d", resp.StatusCode)
+		}
+		if resp.Error != nil {
+			t.Errorf("expected nil Error, got %v", resp.Error)
+		}
+		if string(resp.RawBody) != "Bad Gateway" {
+			t.Errorf("expected raw body 'Bad Gateway', got %q", string(resp.RawBody))
+		}
+	})
+
+	t.Run("network error", func(t *testing.T) {
+		c := testutil.NewBrokenClient(t, "http://unused.invalid")
+		svc := NewKMSClientImpl(c)
+		_, err := svc.Delete(context.Background(), "test-project", "kms-123", nil)
+		if err == nil {
+			t.Fatal("expected transport error, got nil")
+		}
+	})
+
+	t.Run("nil params injects default api-version", func(t *testing.T) {
+		server := testutil.NewMockServer(t, func(w http.ResponseWriter, r *http.Request) {
+			if got := r.URL.Query().Get("api-version"); got != "1.0" {
+				t.Errorf("expected api-version=1.0, got %q", got)
+			}
+			w.WriteHeader(http.StatusNoContent)
+		})
+		c := testutil.NewClient(t, server.URL)
+		svc := NewKMSClientImpl(c)
+		resp, err := svc.Delete(context.Background(), "test-project", "kms-123", nil)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if resp.StatusCode != http.StatusNoContent {
+			t.Errorf("expected status 204, got %d", resp.StatusCode)
 		}
 	})
 }


### PR DESCRIPTION
## Summary

- Rewrites `internal/clients/security/kms_test.go` to use `testutil` helpers (`NewMockServer`, `NewClient`, `NewBrokenClient`, `ErrorBodyJSON`)
- Adds the standard error matrix for all 5 verbs: 404 JSON, non-JSON 5xx, transport error, `api-version` injection
- Adds empty-ID validation subtests (`empty project` for List/Create; `empty project` + `empty KMS ID` for Get/Update/Delete)
- Documents the manual response-build flow on Create/Update `bad gateway non-json` subtests with `TODO(TD-010)` comments
- Total: 5 test functions, 33 subtests, 0 skipped

## Test plan

- [x] `go test ./internal/clients/security/... -count=1 -race -v` — all 33 subtests pass
- [x] `go test ./...` — no regressions
- [x] `golangci-lint run` — 0 issues

Closes #159 · Part of #130 · Follows shape set by #162 / #164 / #165 / #166 / #167 / #168 / #169 / #170 / #171 / #172

🤖 Generated with [Claude Code](https://claude.com/claude-code)