### PR TITLE
[TD-021] Validate ID/URI/Name on Create responses

### DIFF
--- a/ai/TECH_DEBT.md
+++ b/ai/TECH_DEBT.md
@@ -23,6 +23,7 @@ Issues are grouped by severity. Address Critical items before new features ship;
 | [TD-016](#td-016) | No structured logging | Medium | L | Medium |
 | [TD-017](#td-017) | `WARN` writes to stdout | Medium | XS | Low |
 | [TD-020](#td-020) | Test coverage gaps | Low | XL | High |
+| [TD-021](#td-021) | Create responses validate metadata ID/URI/Name | Low | M | Medium |
 
 ### Recommended execution order
 
@@ -32,7 +33,7 @@ Issues are grouped by severity. Address Critical items before new features ship;
 
 **Wave 3 — Medium fixes** (S effort, Medium/Low impact): *(all resolved)*
 
-**Wave 4 — Large refactors** (L/XL, plan separately): TD-010, TD-016, TD-020
+**Wave 4 — Large refactors** (L/XL, plan separately): TD-010, TD-016, TD-020, TD-021
 
 ---
 
@@ -242,6 +243,18 @@ Replace all manual implementations with calls to this helper.
 ---
 
 ## Low
+
+### TD-021 · Create responses do not contract-test resource ID exposure (Metadata.ID / URI) — [#175](https://github.com/Arubacloud/sdk-go/issues/175)
+
+All `*.Create` methods returned success even when the API response omitted required identity fields (`metadata.id`, `metadata.uri`, `metadata.name`). Downstream consumers (e.g., acloud-cli) silently received `nil` pointers and fell back to broken workarounds.
+
+**Fix:** Added `ResourceMetadataResponse.Validate()` (returns `*MetadataValidationError` if any of the three fields is absent) and called it in every Create method that returns a `ResourceMetadataResponse`-bearing type. Added `pkg/types/resource_test.go` unit tests for the validator and "missing id/uri/name" subtests in each Create test file.
+
+**Effort:** M — 21 impl files + 21 test files; mechanical but thorough.
+
+**Impact:** Medium — eliminates a class of silent nil-pointer bugs at the API boundary.
+
+---
 
 ### TD-020 · Test coverage limited to happy path and empty-ID validation — [#130](https://github.com/Arubacloud/sdk-go/issues/130)
 All `internal/clients/*/_test.go` files — existing tests cover successful responses and empty project/resource IDs. Missing: HTTP 4xx/5xx error responses, malformed JSON bodies, network-level errors, `nil` params handling, and request body marshaling failures.

--- a/internal/clients/compute/cloudserver.go
+++ b/internal/clients/compute/cloudserver.go
@@ -136,6 +136,9 @@ func (c *cloudServersClientImpl) Create(ctx context.Context, projectID string, b
 			return nil, fmt.Errorf("failed to parse response: %w", err)
 		}
 		response.Data = &data
+		if err := response.Data.Metadata.Validate(); err != nil {
+			return response, fmt.Errorf("invalid create response: %w", err)
+		}
 	} else if response.IsError() && len(respBytes) > 0 {
 		var errorResp types.ErrorResponse
 		if err := json.Unmarshal(respBytes, &errorResp); err == nil {

--- a/internal/clients/compute/cloudserver_test.go
+++ b/internal/clients/compute/cloudserver_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/base64"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net/http"
 	"testing"
@@ -240,11 +241,9 @@ func TestCreateCloudServer(t *testing.T) {
 			if r.Method != http.MethodPost {
 				t.Errorf("expected POST, got %s", r.Method)
 			}
+			w.Header().Set("Content-Type", "application/json")
 			w.WriteHeader(http.StatusCreated)
-			resp := types.CloudServerResponse{
-				Metadata: types.ResourceMetadataResponse{Name: types.StringPtr("new-server")},
-			}
-			json.NewEncoder(w).Encode(resp)
+			fmt.Fprint(w, `{"metadata":{"id":"res-123","uri":"/projects/test-project/providers/Aruba.Compute/cloudServers/res-123","name":"new-server"}}`)
 		})
 		c := testutil.NewClient(t, server.URL)
 		svc := NewCloudServersClientImpl(c)
@@ -255,6 +254,15 @@ func TestCreateCloudServer(t *testing.T) {
 		}
 		if resp.StatusCode != http.StatusCreated {
 			t.Errorf("expected status 201, got %d", resp.StatusCode)
+		}
+		if resp.Data.Metadata.ID == nil || *resp.Data.Metadata.ID != "res-123" {
+			t.Errorf("expected ID 'res-123', got %v", resp.Data.Metadata.ID)
+		}
+		if resp.Data.Metadata.URI == nil || *resp.Data.Metadata.URI != "/projects/test-project/providers/Aruba.Compute/cloudServers/res-123" {
+			t.Errorf("expected URI, got %v", resp.Data.Metadata.URI)
+		}
+		if resp.Data.Metadata.Name == nil || *resp.Data.Metadata.Name != "new-server" {
+			t.Errorf("expected name 'new-server', got %v", resp.Data.Metadata.Name)
 		}
 	})
 
@@ -320,12 +328,84 @@ func TestCreateCloudServer(t *testing.T) {
 				t.Errorf("expected api-version=1.1, got %q", got)
 			}
 			w.WriteHeader(http.StatusCreated)
-			fmt.Fprint(w, `{}`)
+			fmt.Fprint(w, `{"metadata":{"id":"x","uri":"/x","name":"x"}}`)
 		})
 		c := testutil.NewClient(t, server.URL)
 		svc := NewCloudServersClientImpl(c)
 		if _, err := svc.Create(context.Background(), "test-project", req, nil); err != nil {
 			t.Fatalf("unexpected error: %v", err)
+		}
+	})
+
+	t.Run("successful create missing id", func(t *testing.T) {
+		server := testutil.NewMockServer(t, func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusCreated)
+			fmt.Fprint(w, `{"metadata":{"uri":"/projects/test-project/providers/Aruba.Compute/cloudServers/res-123","name":"new-server"}}`)
+		})
+		c := testutil.NewClient(t, server.URL)
+		svc := NewCloudServersClientImpl(c)
+		resp, err := svc.Create(context.Background(), "test-project", types.CloudServerRequest{}, nil)
+		if err == nil {
+			t.Fatal("expected metadata validation error, got nil")
+		}
+		var mvErr *types.MetadataValidationError
+		if !errors.As(err, &mvErr) {
+			t.Fatalf("expected *types.MetadataValidationError, got %T: %v", err, err)
+		}
+		if len(mvErr.Missing) != 1 || mvErr.Missing[0] != "id" {
+			t.Errorf("expected missing=[id], got %v", mvErr.Missing)
+		}
+		if resp == nil {
+			t.Fatal("expected partial response alongside error")
+		}
+	})
+
+	t.Run("successful create missing uri", func(t *testing.T) {
+		server := testutil.NewMockServer(t, func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusCreated)
+			fmt.Fprint(w, `{"metadata":{"id":"res-123","name":"new-server"}}`)
+		})
+		c := testutil.NewClient(t, server.URL)
+		svc := NewCloudServersClientImpl(c)
+		resp, err := svc.Create(context.Background(), "test-project", types.CloudServerRequest{}, nil)
+		if err == nil {
+			t.Fatal("expected metadata validation error, got nil")
+		}
+		var mvErr *types.MetadataValidationError
+		if !errors.As(err, &mvErr) {
+			t.Fatalf("expected *types.MetadataValidationError, got %T: %v", err, err)
+		}
+		if len(mvErr.Missing) != 1 || mvErr.Missing[0] != "uri" {
+			t.Errorf("expected missing=[uri], got %v", mvErr.Missing)
+		}
+		if resp == nil {
+			t.Fatal("expected partial response alongside error")
+		}
+	})
+
+	t.Run("successful create missing name", func(t *testing.T) {
+		server := testutil.NewMockServer(t, func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusCreated)
+			fmt.Fprint(w, `{"metadata":{"id":"res-123","uri":"/projects/test-project/providers/Aruba.Compute/cloudServers/res-123"}}`)
+		})
+		c := testutil.NewClient(t, server.URL)
+		svc := NewCloudServersClientImpl(c)
+		resp, err := svc.Create(context.Background(), "test-project", types.CloudServerRequest{}, nil)
+		if err == nil {
+			t.Fatal("expected metadata validation error, got nil")
+		}
+		var mvErr *types.MetadataValidationError
+		if !errors.As(err, &mvErr) {
+			t.Fatalf("expected *types.MetadataValidationError, got %T: %v", err, err)
+		}
+		if len(mvErr.Missing) != 1 || mvErr.Missing[0] != "name" {
+			t.Errorf("expected missing=[name], got %v", mvErr.Missing)
+		}
+		if resp == nil {
+			t.Fatal("expected partial response alongside error")
 		}
 	})
 }

--- a/internal/clients/compute/keypair.go
+++ b/internal/clients/compute/keypair.go
@@ -136,6 +136,9 @@ func (c *keyPairsClientImpl) Create(ctx context.Context, projectID string, body 
 			return nil, fmt.Errorf("failed to parse response: %w", err)
 		}
 		response.Data = &data
+		if err := response.Data.Metadata.Validate(); err != nil {
+			return response, fmt.Errorf("invalid create response: %w", err)
+		}
 	} else if response.IsError() && len(respBytes) > 0 {
 		var errorResp types.ErrorResponse
 		if err := json.Unmarshal(respBytes, &errorResp); err == nil {

--- a/internal/clients/compute/keypair_test.go
+++ b/internal/clients/compute/keypair_test.go
@@ -3,6 +3,7 @@ package compute
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net/http"
 	"testing"
@@ -231,11 +232,9 @@ func TestCreateKeyPair(t *testing.T) {
 			if r.Method != http.MethodPost {
 				t.Errorf("expected POST, got %s", r.Method)
 			}
+			w.Header().Set("Content-Type", "application/json")
 			w.WriteHeader(http.StatusCreated)
-			resp := types.KeyPairResponse{
-				Metadata: types.ResourceMetadataResponse{Name: types.StringPtr("new-keypair")},
-			}
-			json.NewEncoder(w).Encode(resp)
+			fmt.Fprint(w, `{"metadata":{"id":"res-123","uri":"/projects/test-project/providers/Aruba.Compute/keyPairs/res-123","name":"new-keypair"}}`)
 		})
 		c := testutil.NewClient(t, server.URL)
 		svc := NewKeyPairsClientImpl(c)
@@ -246,6 +245,15 @@ func TestCreateKeyPair(t *testing.T) {
 		}
 		if resp.StatusCode != http.StatusCreated {
 			t.Errorf("expected status 201, got %d", resp.StatusCode)
+		}
+		if resp.Data.Metadata.ID == nil || *resp.Data.Metadata.ID != "res-123" {
+			t.Errorf("expected ID 'res-123', got %v", resp.Data.Metadata.ID)
+		}
+		if resp.Data.Metadata.URI == nil || *resp.Data.Metadata.URI != "/projects/test-project/providers/Aruba.Compute/keyPairs/res-123" {
+			t.Errorf("expected URI, got %v", resp.Data.Metadata.URI)
+		}
+		if resp.Data.Metadata.Name == nil || *resp.Data.Metadata.Name != "new-keypair" {
+			t.Errorf("expected name 'new-keypair', got %v", resp.Data.Metadata.Name)
 		}
 	})
 
@@ -311,12 +319,84 @@ func TestCreateKeyPair(t *testing.T) {
 				t.Errorf("expected api-version=1.0, got %q", got)
 			}
 			w.WriteHeader(http.StatusCreated)
-			fmt.Fprint(w, `{}`)
+			fmt.Fprint(w, `{"metadata":{"id":"x","uri":"/x","name":"x"}}`)
 		})
 		c := testutil.NewClient(t, server.URL)
 		svc := NewKeyPairsClientImpl(c)
 		if _, err := svc.Create(context.Background(), "test-project", req, nil); err != nil {
 			t.Fatalf("unexpected error: %v", err)
+		}
+	})
+
+	t.Run("successful create missing id", func(t *testing.T) {
+		server := testutil.NewMockServer(t, func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusCreated)
+			fmt.Fprint(w, `{"metadata":{"uri":"/projects/test-project/providers/Aruba.Compute/keyPairs/res-123","name":"new-keypair"}}`)
+		})
+		c := testutil.NewClient(t, server.URL)
+		svc := NewKeyPairsClientImpl(c)
+		resp, err := svc.Create(context.Background(), "test-project", types.KeyPairRequest{}, nil)
+		if err == nil {
+			t.Fatal("expected metadata validation error, got nil")
+		}
+		var mvErr *types.MetadataValidationError
+		if !errors.As(err, &mvErr) {
+			t.Fatalf("expected *types.MetadataValidationError, got %T: %v", err, err)
+		}
+		if len(mvErr.Missing) != 1 || mvErr.Missing[0] != "id" {
+			t.Errorf("expected missing=[id], got %v", mvErr.Missing)
+		}
+		if resp == nil {
+			t.Fatal("expected partial response alongside error")
+		}
+	})
+
+	t.Run("successful create missing uri", func(t *testing.T) {
+		server := testutil.NewMockServer(t, func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusCreated)
+			fmt.Fprint(w, `{"metadata":{"id":"res-123","name":"new-keypair"}}`)
+		})
+		c := testutil.NewClient(t, server.URL)
+		svc := NewKeyPairsClientImpl(c)
+		resp, err := svc.Create(context.Background(), "test-project", types.KeyPairRequest{}, nil)
+		if err == nil {
+			t.Fatal("expected metadata validation error, got nil")
+		}
+		var mvErr *types.MetadataValidationError
+		if !errors.As(err, &mvErr) {
+			t.Fatalf("expected *types.MetadataValidationError, got %T: %v", err, err)
+		}
+		if len(mvErr.Missing) != 1 || mvErr.Missing[0] != "uri" {
+			t.Errorf("expected missing=[uri], got %v", mvErr.Missing)
+		}
+		if resp == nil {
+			t.Fatal("expected partial response alongside error")
+		}
+	})
+
+	t.Run("successful create missing name", func(t *testing.T) {
+		server := testutil.NewMockServer(t, func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusCreated)
+			fmt.Fprint(w, `{"metadata":{"id":"res-123","uri":"/projects/test-project/providers/Aruba.Compute/keyPairs/res-123"}}`)
+		})
+		c := testutil.NewClient(t, server.URL)
+		svc := NewKeyPairsClientImpl(c)
+		resp, err := svc.Create(context.Background(), "test-project", types.KeyPairRequest{}, nil)
+		if err == nil {
+			t.Fatal("expected metadata validation error, got nil")
+		}
+		var mvErr *types.MetadataValidationError
+		if !errors.As(err, &mvErr) {
+			t.Fatalf("expected *types.MetadataValidationError, got %T: %v", err, err)
+		}
+		if len(mvErr.Missing) != 1 || mvErr.Missing[0] != "name" {
+			t.Errorf("expected missing=[name], got %v", mvErr.Missing)
+		}
+		if resp == nil {
+			t.Fatal("expected partial response alongside error")
 		}
 	})
 }

--- a/internal/clients/container/containerregistry.go
+++ b/internal/clients/container/containerregistry.go
@@ -134,6 +134,9 @@ func (c *containerRegistryClientImpl) Create(ctx context.Context, projectID stri
 			return nil, fmt.Errorf("failed to parse response: %w", err)
 		}
 		response.Data = &data
+		if err := response.Data.Metadata.Validate(); err != nil {
+			return response, fmt.Errorf("invalid create response: %w", err)
+		}
 	} else if response.IsError() && len(respBytes) > 0 {
 		var errorResp types.ErrorResponse
 		if err := json.Unmarshal(respBytes, &errorResp); err == nil {

--- a/internal/clients/container/containerregistry_test.go
+++ b/internal/clients/container/containerregistry_test.go
@@ -3,6 +3,7 @@ package container
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net/http"
 	"testing"
@@ -340,11 +341,13 @@ func TestCreateContainerRegistry(t *testing.T) {
 	t.Run("successful create", func(t *testing.T) {
 		server := testutil.NewMockServer(t, func(w http.ResponseWriter, r *http.Request) {
 			if r.Method == "POST" && r.URL.Path == "/projects/test-project/providers/Aruba.Container/registries" {
+				w.Header().Set("Content-Type", "application/json")
 				w.WriteHeader(http.StatusCreated)
 				resp := types.ContainerRegistryResponse{
 					Metadata: types.ResourceMetadataResponse{
 						Name: types.StringPtr("new-registry"),
 						ID:   types.StringPtr("registry-456"),
+						URI:  types.StringPtr("/projects/test-project/providers/Aruba.Container/registries/registry-456"),
 					},
 					Properties: types.ContainerRegistryPropertiesResult{
 						VPC: types.ReferenceResource{
@@ -434,6 +437,12 @@ func TestCreateContainerRegistry(t *testing.T) {
 		if resp.Data.Properties.ConcurrentUsers == nil || *resp.Data.Properties.ConcurrentUsers != "100" {
 			t.Errorf("expected ConcurrentUsers 100")
 		}
+		if resp.Data.Metadata.ID == nil || *resp.Data.Metadata.ID != "registry-456" {
+			t.Errorf("expected ID 'registry-456', got %v", resp.Data.Metadata.ID)
+		}
+		if resp.Data.Metadata.URI == nil || *resp.Data.Metadata.URI != "/projects/test-project/providers/Aruba.Container/registries/registry-456" {
+			t.Errorf("expected URI, got %v", resp.Data.Metadata.URI)
+		}
 		if resp.Data.Status.State == nil || *resp.Data.Status.State != "creating" {
 			t.Errorf("expected state 'creating'")
 		}
@@ -507,7 +516,7 @@ func TestCreateContainerRegistry(t *testing.T) {
 				t.Errorf("expected api-version=1.0, got %q", got)
 			}
 			w.WriteHeader(http.StatusCreated)
-			fmt.Fprint(w, `{}`)
+			fmt.Fprint(w, `{"metadata":{"id":"x","uri":"/x","name":"x"}}`)
 		})
 		c := testutil.NewClient(t, server.URL)
 		svc := NewContainerRegistryClientImpl(c)
@@ -515,6 +524,78 @@ func TestCreateContainerRegistry(t *testing.T) {
 		body := types.ContainerRegistryRequest{}
 		if _, err := svc.Create(context.Background(), "test-project", body, nil); err != nil {
 			t.Fatalf("unexpected error: %v", err)
+		}
+	})
+
+	t.Run("successful create missing id", func(t *testing.T) {
+		server := testutil.NewMockServer(t, func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusCreated)
+			fmt.Fprint(w, `{"metadata":{"uri":"/projects/test-project/providers/Aruba.Container/registries/res-123","name":"test-name"}}`)
+		})
+		c := testutil.NewClient(t, server.URL)
+		svc := NewContainerRegistryClientImpl(c)
+		resp, err := svc.Create(context.Background(), "test-project", types.ContainerRegistryRequest{}, nil)
+		if err == nil {
+			t.Fatal("expected metadata validation error, got nil")
+		}
+		var mvErr *types.MetadataValidationError
+		if !errors.As(err, &mvErr) {
+			t.Fatalf("expected *types.MetadataValidationError, got %T: %v", err, err)
+		}
+		if len(mvErr.Missing) != 1 || mvErr.Missing[0] != "id" {
+			t.Errorf("expected missing=[id], got %v", mvErr.Missing)
+		}
+		if resp == nil {
+			t.Fatal("expected partial response alongside error")
+		}
+	})
+
+	t.Run("successful create missing uri", func(t *testing.T) {
+		server := testutil.NewMockServer(t, func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusCreated)
+			fmt.Fprint(w, `{"metadata":{"id":"res-123","name":"test-name"}}`)
+		})
+		c := testutil.NewClient(t, server.URL)
+		svc := NewContainerRegistryClientImpl(c)
+		resp, err := svc.Create(context.Background(), "test-project", types.ContainerRegistryRequest{}, nil)
+		if err == nil {
+			t.Fatal("expected metadata validation error, got nil")
+		}
+		var mvErr *types.MetadataValidationError
+		if !errors.As(err, &mvErr) {
+			t.Fatalf("expected *types.MetadataValidationError, got %T: %v", err, err)
+		}
+		if len(mvErr.Missing) != 1 || mvErr.Missing[0] != "uri" {
+			t.Errorf("expected missing=[uri], got %v", mvErr.Missing)
+		}
+		if resp == nil {
+			t.Fatal("expected partial response alongside error")
+		}
+	})
+
+	t.Run("successful create missing name", func(t *testing.T) {
+		server := testutil.NewMockServer(t, func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusCreated)
+			fmt.Fprint(w, `{"metadata":{"id":"res-123","uri":"/projects/test-project/providers/Aruba.Container/registries/res-123"}}`)
+		})
+		c := testutil.NewClient(t, server.URL)
+		svc := NewContainerRegistryClientImpl(c)
+		resp, err := svc.Create(context.Background(), "test-project", types.ContainerRegistryRequest{}, nil)
+		if err == nil {
+			t.Fatal("expected metadata validation error, got nil")
+		}
+		var mvErr *types.MetadataValidationError
+		if !errors.As(err, &mvErr) {
+			t.Fatalf("expected *types.MetadataValidationError, got %T: %v", err, err)
+		}
+		if len(mvErr.Missing) != 1 || mvErr.Missing[0] != "name" {
+			t.Errorf("expected missing=[name], got %v", mvErr.Missing)
+		}
+		if resp == nil {
+			t.Fatal("expected partial response alongside error")
 		}
 	})
 }

--- a/internal/clients/container/kaas.go
+++ b/internal/clients/container/kaas.go
@@ -138,6 +138,9 @@ func (c *kaasClientImpl) Create(ctx context.Context, projectID string, body type
 			return nil, fmt.Errorf("failed to parse response: %w", err)
 		}
 		response.Data = &data
+		if err := response.Data.Metadata.Validate(); err != nil {
+			return response, fmt.Errorf("invalid create response: %w", err)
+		}
 	} else if response.IsError() && len(respBytes) > 0 {
 		var errorResp types.ErrorResponse
 		if err := json.Unmarshal(respBytes, &errorResp); err == nil {

--- a/internal/clients/container/kaas_test.go
+++ b/internal/clients/container/kaas_test.go
@@ -3,6 +3,7 @@ package container
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net/http"
 	"testing"
@@ -280,11 +281,13 @@ func TestCreateKaaS(t *testing.T) {
 	t.Run("successful create", func(t *testing.T) {
 		server := testutil.NewMockServer(t, func(w http.ResponseWriter, r *http.Request) {
 			if r.Method == "POST" && r.URL.Path == "/projects/test-project/providers/Aruba.Container/kaas" {
+				w.Header().Set("Content-Type", "application/json")
 				w.WriteHeader(http.StatusCreated)
 				resp := types.KaaSResponse{
 					Metadata: types.ResourceMetadataResponse{
 						Name: types.StringPtr("new-kaas"),
 						ID:   types.StringPtr("kaas-456"),
+						URI:  types.StringPtr("/projects/test-project/providers/Aruba.Container/kaas/kaas-456"),
 					},
 					Properties: types.KaaSPropertiesResponse{
 						Preset: false,
@@ -329,6 +332,12 @@ func TestCreateKaaS(t *testing.T) {
 		}
 		if resp.Data.Metadata.Name == nil || *resp.Data.Metadata.Name != "new-kaas" {
 			t.Errorf("expected name 'new-kaas'")
+		}
+		if resp.Data.Metadata.ID == nil || *resp.Data.Metadata.ID != "kaas-456" {
+			t.Errorf("expected ID 'kaas-456', got %v", resp.Data.Metadata.ID)
+		}
+		if resp.Data.Metadata.URI == nil || *resp.Data.Metadata.URI != "/projects/test-project/providers/Aruba.Container/kaas/kaas-456" {
+			t.Errorf("expected URI, got %v", resp.Data.Metadata.URI)
 		}
 		if resp.Data.Status.State == nil || *resp.Data.Status.State != "creating" {
 			t.Errorf("expected state 'creating'")
@@ -403,7 +412,7 @@ func TestCreateKaaS(t *testing.T) {
 				t.Errorf("expected api-version=1.0, got %q", got)
 			}
 			w.WriteHeader(http.StatusCreated)
-			fmt.Fprint(w, `{}`)
+			fmt.Fprint(w, `{"metadata":{"id":"x","uri":"/x","name":"x"}}`)
 		})
 		c := testutil.NewClient(t, server.URL)
 		svc := NewKaaSClientImpl(c)
@@ -411,6 +420,78 @@ func TestCreateKaaS(t *testing.T) {
 		body := types.KaaSRequest{}
 		if _, err := svc.Create(context.Background(), "test-project", body, nil); err != nil {
 			t.Fatalf("unexpected error: %v", err)
+		}
+	})
+
+	t.Run("successful create missing id", func(t *testing.T) {
+		server := testutil.NewMockServer(t, func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusCreated)
+			fmt.Fprint(w, `{"metadata":{"uri":"/projects/test-project/providers/Aruba.Container/kaas/res-123","name":"test-name"}}`)
+		})
+		c := testutil.NewClient(t, server.URL)
+		svc := NewKaaSClientImpl(c)
+		resp, err := svc.Create(context.Background(), "test-project", types.KaaSRequest{}, nil)
+		if err == nil {
+			t.Fatal("expected metadata validation error, got nil")
+		}
+		var mvErr *types.MetadataValidationError
+		if !errors.As(err, &mvErr) {
+			t.Fatalf("expected *types.MetadataValidationError, got %T: %v", err, err)
+		}
+		if len(mvErr.Missing) != 1 || mvErr.Missing[0] != "id" {
+			t.Errorf("expected missing=[id], got %v", mvErr.Missing)
+		}
+		if resp == nil {
+			t.Fatal("expected partial response alongside error")
+		}
+	})
+
+	t.Run("successful create missing uri", func(t *testing.T) {
+		server := testutil.NewMockServer(t, func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusCreated)
+			fmt.Fprint(w, `{"metadata":{"id":"res-123","name":"test-name"}}`)
+		})
+		c := testutil.NewClient(t, server.URL)
+		svc := NewKaaSClientImpl(c)
+		resp, err := svc.Create(context.Background(), "test-project", types.KaaSRequest{}, nil)
+		if err == nil {
+			t.Fatal("expected metadata validation error, got nil")
+		}
+		var mvErr *types.MetadataValidationError
+		if !errors.As(err, &mvErr) {
+			t.Fatalf("expected *types.MetadataValidationError, got %T: %v", err, err)
+		}
+		if len(mvErr.Missing) != 1 || mvErr.Missing[0] != "uri" {
+			t.Errorf("expected missing=[uri], got %v", mvErr.Missing)
+		}
+		if resp == nil {
+			t.Fatal("expected partial response alongside error")
+		}
+	})
+
+	t.Run("successful create missing name", func(t *testing.T) {
+		server := testutil.NewMockServer(t, func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusCreated)
+			fmt.Fprint(w, `{"metadata":{"id":"res-123","uri":"/projects/test-project/providers/Aruba.Container/kaas/res-123"}}`)
+		})
+		c := testutil.NewClient(t, server.URL)
+		svc := NewKaaSClientImpl(c)
+		resp, err := svc.Create(context.Background(), "test-project", types.KaaSRequest{}, nil)
+		if err == nil {
+			t.Fatal("expected metadata validation error, got nil")
+		}
+		var mvErr *types.MetadataValidationError
+		if !errors.As(err, &mvErr) {
+			t.Fatalf("expected *types.MetadataValidationError, got %T: %v", err, err)
+		}
+		if len(mvErr.Missing) != 1 || mvErr.Missing[0] != "name" {
+			t.Errorf("expected missing=[name], got %v", mvErr.Missing)
+		}
+		if resp == nil {
+			t.Fatal("expected partial response alongside error")
 		}
 	})
 }

--- a/internal/clients/database/backup.go
+++ b/internal/clients/database/backup.go
@@ -115,7 +115,16 @@ func (c *backupsClientImpl) Create(ctx context.Context, projectID string, body t
 	}
 	defer httpResp.Body.Close()
 
-	return types.ParseResponseBody[types.BackupResponse](httpResp, c.client.Logger())
+	resp, err := types.ParseResponseBody[types.BackupResponse](httpResp, c.client.Logger())
+	if err != nil {
+		return nil, err
+	}
+	if resp.IsSuccess() && resp.Data != nil {
+		if err := resp.Data.Metadata.Validate(); err != nil {
+			return resp, fmt.Errorf("invalid create response: %w", err)
+		}
+	}
+	return resp, nil
 }
 
 // Delete deletes a backup by ID

--- a/internal/clients/database/backup_test.go
+++ b/internal/clients/database/backup_test.go
@@ -3,6 +3,7 @@ package database
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net/http"
 	"testing"
@@ -275,11 +276,13 @@ func TestCreateBackup(t *testing.T) {
 	t.Run("successful create", func(t *testing.T) {
 		server := testutil.NewMockServer(t, func(w http.ResponseWriter, r *http.Request) {
 			if r.Method == "POST" && r.URL.Path == "/projects/test-project/providers/Aruba.Database/backups" {
+				w.Header().Set("Content-Type", "application/json")
 				w.WriteHeader(http.StatusCreated)
 				resp := types.BackupResponse{
 					Metadata: types.ResourceMetadataResponse{
 						Name: types.StringPtr("backup-1"),
 						ID:   types.StringPtr("bk-123"),
+						URI:  types.StringPtr("/projects/test-project/providers/Aruba.Database/backups/bk-123"),
 					},
 					Properties: types.BackupPropertiesResponse{
 						Zone:        "ITBG-1",
@@ -318,6 +321,12 @@ func TestCreateBackup(t *testing.T) {
 		}
 		if resp.Data.Metadata.Name == nil || *resp.Data.Metadata.Name != "backup-1" {
 			t.Errorf("expected name 'backup-1'")
+		}
+		if resp.Data.Metadata.ID == nil || *resp.Data.Metadata.ID != "bk-123" {
+			t.Errorf("expected ID 'bk-123', got %v", resp.Data.Metadata.ID)
+		}
+		if resp.Data.Metadata.URI == nil || *resp.Data.Metadata.URI != "/projects/test-project/providers/Aruba.Database/backups/bk-123" {
+			t.Errorf("expected URI, got %v", resp.Data.Metadata.URI)
 		}
 		if resp.Data.Status.State == nil || *resp.Data.Status.State != "creating" {
 			t.Errorf("expected state 'creating'")
@@ -395,12 +404,84 @@ func TestCreateBackup(t *testing.T) {
 				t.Errorf("expected api-version=1.0, got %q", got)
 			}
 			w.WriteHeader(http.StatusCreated)
-			fmt.Fprint(w, `{}`)
+			fmt.Fprint(w, `{"metadata":{"id":"x","uri":"/x","name":"x"}}`)
 		})
 		c := testutil.NewClient(t, server.URL)
 		svc := NewBackupsClientImpl(c)
 		if _, err := svc.Create(context.Background(), "test-project", types.BackupRequest{}, nil); err != nil {
 			t.Fatalf("unexpected error: %v", err)
+		}
+	})
+
+	t.Run("successful create missing id", func(t *testing.T) {
+		server := testutil.NewMockServer(t, func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusCreated)
+			fmt.Fprint(w, `{"metadata":{"uri":"/projects/test-project/providers/Aruba.Database/backups/res-123","name":"test-name"}}`)
+		})
+		c := testutil.NewClient(t, server.URL)
+		svc := NewBackupsClientImpl(c)
+		resp, err := svc.Create(context.Background(), "test-project", types.BackupRequest{}, nil)
+		if err == nil {
+			t.Fatal("expected metadata validation error, got nil")
+		}
+		var mvErr *types.MetadataValidationError
+		if !errors.As(err, &mvErr) {
+			t.Fatalf("expected *types.MetadataValidationError, got %T: %v", err, err)
+		}
+		if len(mvErr.Missing) != 1 || mvErr.Missing[0] != "id" {
+			t.Errorf("expected missing=[id], got %v", mvErr.Missing)
+		}
+		if resp == nil {
+			t.Fatal("expected partial response alongside error")
+		}
+	})
+
+	t.Run("successful create missing uri", func(t *testing.T) {
+		server := testutil.NewMockServer(t, func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusCreated)
+			fmt.Fprint(w, `{"metadata":{"id":"res-123","name":"test-name"}}`)
+		})
+		c := testutil.NewClient(t, server.URL)
+		svc := NewBackupsClientImpl(c)
+		resp, err := svc.Create(context.Background(), "test-project", types.BackupRequest{}, nil)
+		if err == nil {
+			t.Fatal("expected metadata validation error, got nil")
+		}
+		var mvErr *types.MetadataValidationError
+		if !errors.As(err, &mvErr) {
+			t.Fatalf("expected *types.MetadataValidationError, got %T: %v", err, err)
+		}
+		if len(mvErr.Missing) != 1 || mvErr.Missing[0] != "uri" {
+			t.Errorf("expected missing=[uri], got %v", mvErr.Missing)
+		}
+		if resp == nil {
+			t.Fatal("expected partial response alongside error")
+		}
+	})
+
+	t.Run("successful create missing name", func(t *testing.T) {
+		server := testutil.NewMockServer(t, func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusCreated)
+			fmt.Fprint(w, `{"metadata":{"id":"res-123","uri":"/projects/test-project/providers/Aruba.Database/backups/res-123"}}`)
+		})
+		c := testutil.NewClient(t, server.URL)
+		svc := NewBackupsClientImpl(c)
+		resp, err := svc.Create(context.Background(), "test-project", types.BackupRequest{}, nil)
+		if err == nil {
+			t.Fatal("expected metadata validation error, got nil")
+		}
+		var mvErr *types.MetadataValidationError
+		if !errors.As(err, &mvErr) {
+			t.Fatalf("expected *types.MetadataValidationError, got %T: %v", err, err)
+		}
+		if len(mvErr.Missing) != 1 || mvErr.Missing[0] != "name" {
+			t.Errorf("expected missing=[name], got %v", mvErr.Missing)
+		}
+		if resp == nil {
+			t.Fatal("expected partial response alongside error")
 		}
 	})
 }

--- a/internal/clients/database/dbaas.go
+++ b/internal/clients/database/dbaas.go
@@ -136,6 +136,9 @@ func (c *dbaasClientImpl) Create(ctx context.Context, projectID string, body typ
 			return nil, fmt.Errorf("failed to parse response: %w", err)
 		}
 		response.Data = &data
+		if err := response.Data.Metadata.Validate(); err != nil {
+			return response, fmt.Errorf("invalid create response: %w", err)
+		}
 	} else if response.IsError() && len(respBytes) > 0 {
 		var errorResp types.ErrorResponse
 		if err := json.Unmarshal(respBytes, &errorResp); err == nil {

--- a/internal/clients/database/dbaas_test.go
+++ b/internal/clients/database/dbaas_test.go
@@ -3,6 +3,7 @@ package database
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net/http"
 	"testing"
@@ -273,11 +274,13 @@ func TestCreateDBaaS(t *testing.T) {
 	t.Run("successful create", func(t *testing.T) {
 		server := testutil.NewMockServer(t, func(w http.ResponseWriter, r *http.Request) {
 			if r.Method == "POST" && r.URL.Path == "/projects/test-project/providers/Aruba.Database/dbaas" {
+				w.Header().Set("Content-Type", "application/json")
 				w.WriteHeader(http.StatusCreated)
 				resp := types.DBaaSResponse{
 					Metadata: types.ResourceMetadataResponse{
 						Name: types.StringPtr("dbaas-1"),
 						ID:   types.StringPtr("dbaas-123"),
+						URI:  types.StringPtr("/projects/test-project/providers/Aruba.Database/dbaas/dbaas-123"),
 					},
 					Properties: types.DBaaSPropertiesResponse{
 						Engine: &types.DBaaSEngineResponse{Type: types.StringPtr("MySQL")},
@@ -308,6 +311,12 @@ func TestCreateDBaaS(t *testing.T) {
 		}
 		if resp.Data.Metadata.Name == nil || *resp.Data.Metadata.Name != "dbaas-1" {
 			t.Errorf("expected name 'dbaas-1'")
+		}
+		if resp.Data.Metadata.ID == nil || *resp.Data.Metadata.ID != "dbaas-123" {
+			t.Errorf("expected ID 'dbaas-123', got %v", resp.Data.Metadata.ID)
+		}
+		if resp.Data.Metadata.URI == nil || *resp.Data.Metadata.URI != "/projects/test-project/providers/Aruba.Database/dbaas/dbaas-123" {
+			t.Errorf("expected URI, got %v", resp.Data.Metadata.URI)
 		}
 		if resp.Data.Status.State == nil || *resp.Data.Status.State != "creating" {
 			t.Errorf("expected state 'creating'")
@@ -387,12 +396,84 @@ func TestCreateDBaaS(t *testing.T) {
 				t.Errorf("expected api-version=1.0, got %q", got)
 			}
 			w.WriteHeader(http.StatusCreated)
-			fmt.Fprint(w, `{}`)
+			fmt.Fprint(w, `{"metadata":{"id":"x","uri":"/x","name":"x"}}`)
 		})
 		c := testutil.NewClient(t, server.URL)
 		svc := NewDBaaSClientImpl(c)
 		if _, err := svc.Create(context.Background(), "test-project", types.DBaaSRequest{}, nil); err != nil {
 			t.Fatalf("unexpected error: %v", err)
+		}
+	})
+
+	t.Run("successful create missing id", func(t *testing.T) {
+		server := testutil.NewMockServer(t, func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusCreated)
+			fmt.Fprint(w, `{"metadata":{"uri":"/projects/test-project/providers/Aruba.Database/dbaas/res-123","name":"test-name"}}`)
+		})
+		c := testutil.NewClient(t, server.URL)
+		svc := NewDBaaSClientImpl(c)
+		resp, err := svc.Create(context.Background(), "test-project", types.DBaaSRequest{}, nil)
+		if err == nil {
+			t.Fatal("expected metadata validation error, got nil")
+		}
+		var mvErr *types.MetadataValidationError
+		if !errors.As(err, &mvErr) {
+			t.Fatalf("expected *types.MetadataValidationError, got %T: %v", err, err)
+		}
+		if len(mvErr.Missing) != 1 || mvErr.Missing[0] != "id" {
+			t.Errorf("expected missing=[id], got %v", mvErr.Missing)
+		}
+		if resp == nil {
+			t.Fatal("expected partial response alongside error")
+		}
+	})
+
+	t.Run("successful create missing uri", func(t *testing.T) {
+		server := testutil.NewMockServer(t, func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusCreated)
+			fmt.Fprint(w, `{"metadata":{"id":"res-123","name":"test-name"}}`)
+		})
+		c := testutil.NewClient(t, server.URL)
+		svc := NewDBaaSClientImpl(c)
+		resp, err := svc.Create(context.Background(), "test-project", types.DBaaSRequest{}, nil)
+		if err == nil {
+			t.Fatal("expected metadata validation error, got nil")
+		}
+		var mvErr *types.MetadataValidationError
+		if !errors.As(err, &mvErr) {
+			t.Fatalf("expected *types.MetadataValidationError, got %T: %v", err, err)
+		}
+		if len(mvErr.Missing) != 1 || mvErr.Missing[0] != "uri" {
+			t.Errorf("expected missing=[uri], got %v", mvErr.Missing)
+		}
+		if resp == nil {
+			t.Fatal("expected partial response alongside error")
+		}
+	})
+
+	t.Run("successful create missing name", func(t *testing.T) {
+		server := testutil.NewMockServer(t, func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusCreated)
+			fmt.Fprint(w, `{"metadata":{"id":"res-123","uri":"/projects/test-project/providers/Aruba.Database/dbaas/res-123"}}`)
+		})
+		c := testutil.NewClient(t, server.URL)
+		svc := NewDBaaSClientImpl(c)
+		resp, err := svc.Create(context.Background(), "test-project", types.DBaaSRequest{}, nil)
+		if err == nil {
+			t.Fatal("expected metadata validation error, got nil")
+		}
+		var mvErr *types.MetadataValidationError
+		if !errors.As(err, &mvErr) {
+			t.Fatalf("expected *types.MetadataValidationError, got %T: %v", err, err)
+		}
+		if len(mvErr.Missing) != 1 || mvErr.Missing[0] != "name" {
+			t.Errorf("expected missing=[name], got %v", mvErr.Missing)
+		}
+		if resp == nil {
+			t.Fatal("expected partial response alongside error")
 		}
 	})
 }

--- a/internal/clients/network/elastic-ip.go
+++ b/internal/clients/network/elastic-ip.go
@@ -115,7 +115,16 @@ func (c *elasticIPsClientImpl) Create(ctx context.Context, projectID string, bod
 	}
 	defer httpResp.Body.Close()
 
-	return types.ParseResponseBody[types.ElasticIPResponse](httpResp, c.client.Logger())
+	resp, err := types.ParseResponseBody[types.ElasticIPResponse](httpResp, c.client.Logger())
+	if err != nil {
+		return nil, err
+	}
+	if resp.IsSuccess() && resp.Data != nil {
+		if err := resp.Data.Metadata.Validate(); err != nil {
+			return resp, fmt.Errorf("invalid create response: %w", err)
+		}
+	}
+	return resp, nil
 }
 
 // Update updates an existing elastic IP

--- a/internal/clients/network/elastic-ip_test.go
+++ b/internal/clients/network/elastic-ip_test.go
@@ -2,6 +2,7 @@ package network
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net/http"
 	"testing"
@@ -222,7 +223,7 @@ func TestCreateElasticIP(t *testing.T) {
 		server := testutil.NewMockServer(t, func(w http.ResponseWriter, r *http.Request) {
 			w.Header().Set("Content-Type", "application/json")
 			w.WriteHeader(http.StatusCreated)
-			fmt.Fprint(w, `{"metadata":{"name":"new-eip"}}`)
+			fmt.Fprint(w, `{"metadata":{"id":"res-123","uri":"/projects/test-project/providers/Aruba.Network/elasticIPs/res-123","name":"new-eip"}}`)
 		})
 		c := testutil.NewClient(t, server.URL)
 		svc := NewElasticIPsClientImpl(c)
@@ -241,6 +242,15 @@ func TestCreateElasticIP(t *testing.T) {
 		}
 		if resp.StatusCode != http.StatusCreated {
 			t.Errorf("expected status 201, got %d", resp.StatusCode)
+		}
+		if resp.Data.Metadata.ID == nil || *resp.Data.Metadata.ID != "res-123" {
+			t.Errorf("expected ID 'res-123', got %v", resp.Data.Metadata.ID)
+		}
+		if resp.Data.Metadata.URI == nil || *resp.Data.Metadata.URI != "/projects/test-project/providers/Aruba.Network/elasticIPs/res-123" {
+			t.Errorf("expected URI, got %v", resp.Data.Metadata.URI)
+		}
+		if resp.Data.Metadata.Name == nil || *resp.Data.Metadata.Name != "new-eip" {
+			t.Errorf("expected name 'new-eip', got %v", resp.Data.Metadata.Name)
 		}
 	})
 
@@ -311,7 +321,7 @@ func TestCreateElasticIP(t *testing.T) {
 			}
 			w.Header().Set("Content-Type", "application/json")
 			w.WriteHeader(http.StatusCreated)
-			fmt.Fprint(w, `{"metadata":{"name":"x"}}`)
+			fmt.Fprint(w, `{"metadata":{"id":"x","uri":"/x","name":"x"}}`)
 		})
 		c := testutil.NewClient(t, server.URL)
 		svc := NewElasticIPsClientImpl(c)
@@ -321,6 +331,78 @@ func TestCreateElasticIP(t *testing.T) {
 		}
 		if resp.StatusCode != http.StatusCreated {
 			t.Errorf("expected status 201, got %d", resp.StatusCode)
+		}
+	})
+
+	t.Run("successful create missing id", func(t *testing.T) {
+		server := testutil.NewMockServer(t, func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusCreated)
+			fmt.Fprint(w, `{"metadata":{"uri":"/projects/test-project/providers/Aruba.Network/elasticIPs/res-123","name":"test-name"}}`)
+		})
+		c := testutil.NewClient(t, server.URL)
+		svc := NewElasticIPsClientImpl(c)
+		resp, err := svc.Create(context.Background(), "test-project", types.ElasticIPRequest{}, nil)
+		if err == nil {
+			t.Fatal("expected metadata validation error, got nil")
+		}
+		var mvErr *types.MetadataValidationError
+		if !errors.As(err, &mvErr) {
+			t.Fatalf("expected *types.MetadataValidationError, got %T: %v", err, err)
+		}
+		if len(mvErr.Missing) != 1 || mvErr.Missing[0] != "id" {
+			t.Errorf("expected missing=[id], got %v", mvErr.Missing)
+		}
+		if resp == nil {
+			t.Fatal("expected partial response alongside error")
+		}
+	})
+
+	t.Run("successful create missing uri", func(t *testing.T) {
+		server := testutil.NewMockServer(t, func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusCreated)
+			fmt.Fprint(w, `{"metadata":{"id":"res-123","name":"test-name"}}`)
+		})
+		c := testutil.NewClient(t, server.URL)
+		svc := NewElasticIPsClientImpl(c)
+		resp, err := svc.Create(context.Background(), "test-project", types.ElasticIPRequest{}, nil)
+		if err == nil {
+			t.Fatal("expected metadata validation error, got nil")
+		}
+		var mvErr *types.MetadataValidationError
+		if !errors.As(err, &mvErr) {
+			t.Fatalf("expected *types.MetadataValidationError, got %T: %v", err, err)
+		}
+		if len(mvErr.Missing) != 1 || mvErr.Missing[0] != "uri" {
+			t.Errorf("expected missing=[uri], got %v", mvErr.Missing)
+		}
+		if resp == nil {
+			t.Fatal("expected partial response alongside error")
+		}
+	})
+
+	t.Run("successful create missing name", func(t *testing.T) {
+		server := testutil.NewMockServer(t, func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusCreated)
+			fmt.Fprint(w, `{"metadata":{"id":"res-123","uri":"/projects/test-project/providers/Aruba.Network/elasticIPs/res-123"}}`)
+		})
+		c := testutil.NewClient(t, server.URL)
+		svc := NewElasticIPsClientImpl(c)
+		resp, err := svc.Create(context.Background(), "test-project", types.ElasticIPRequest{}, nil)
+		if err == nil {
+			t.Fatal("expected metadata validation error, got nil")
+		}
+		var mvErr *types.MetadataValidationError
+		if !errors.As(err, &mvErr) {
+			t.Fatalf("expected *types.MetadataValidationError, got %T: %v", err, err)
+		}
+		if len(mvErr.Missing) != 1 || mvErr.Missing[0] != "name" {
+			t.Errorf("expected missing=[name], got %v", mvErr.Missing)
+		}
+		if resp == nil {
+			t.Fatal("expected partial response alongside error")
 		}
 	})
 }

--- a/internal/clients/network/security-group-rule.go
+++ b/internal/clients/network/security-group-rule.go
@@ -145,6 +145,9 @@ func (c *securityGroupRulesClientImpl) Create(ctx context.Context, projectID str
 			return nil, fmt.Errorf("failed to parse response: %w", err)
 		}
 		response.Data = &data
+		if err := response.Data.Metadata.Validate(); err != nil {
+			return response, fmt.Errorf("invalid create response: %w", err)
+		}
 	} else if response.IsError() && len(respBytes) > 0 {
 		var errorResp types.ErrorResponse
 		if err := json.Unmarshal(respBytes, &errorResp); err == nil {

--- a/internal/clients/network/security-group.go
+++ b/internal/clients/network/security-group.go
@@ -145,6 +145,9 @@ func (c *securityGroupsClientImpl) Create(ctx context.Context, projectID string,
 			return nil, fmt.Errorf("failed to parse response: %w", err)
 		}
 		response.Data = &data
+		if err := response.Data.Metadata.Validate(); err != nil {
+			return response, fmt.Errorf("invalid create response: %w", err)
+		}
 	} else if response.IsError() && len(respBytes) > 0 {
 		var errorResp types.ErrorResponse
 		if err := json.Unmarshal(respBytes, &errorResp); err == nil {

--- a/internal/clients/network/subnet.go
+++ b/internal/clients/network/subnet.go
@@ -144,6 +144,9 @@ func (c *subnetsClientImpl) Create(ctx context.Context, projectID string, vpcID 
 			return nil, fmt.Errorf("failed to parse response: %w", err)
 		}
 		response.Data = &data
+		if err := response.Data.Metadata.Validate(); err != nil {
+			return response, fmt.Errorf("invalid create response: %w", err)
+		}
 	} else if response.IsError() && len(respBytes) > 0 {
 		var errorResp types.ErrorResponse
 		if err := json.Unmarshal(respBytes, &errorResp); err == nil {

--- a/internal/clients/network/vpc-peering.go
+++ b/internal/clients/network/vpc-peering.go
@@ -133,6 +133,9 @@ func (c *vpcPeeringsClientImpl) Create(ctx context.Context, projectID string, vp
 			return nil, fmt.Errorf("failed to parse response: %w", err)
 		}
 		response.Data = &data
+		if err := response.Data.Metadata.Validate(); err != nil {
+			return response, fmt.Errorf("invalid create response: %w", err)
+		}
 	} else if response.IsError() && len(respBytes) > 0 {
 		var errorResp types.ErrorResponse
 		if err := json.Unmarshal(respBytes, &errorResp); err == nil {

--- a/internal/clients/network/vpc-peering_test.go
+++ b/internal/clients/network/vpc-peering_test.go
@@ -2,6 +2,7 @@ package network
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net/http"
 	"testing"
@@ -243,7 +244,7 @@ func TestCreateVpcPeering(t *testing.T) {
 			}
 			w.Header().Set("Content-Type", "application/json")
 			w.WriteHeader(http.StatusCreated)
-			fmt.Fprint(w, `{"metadata":{"name":"new-peering"}}`)
+			fmt.Fprint(w, `{"metadata":{"id":"res-123","uri":"/projects/test-project/providers/Aruba.Network/vpcPeerings/res-123","name":"new-peering"}}`)
 		})
 		c := testutil.NewClient(t, server.URL)
 		svc := NewVPCPeeringsClientImpl(c)
@@ -253,6 +254,15 @@ func TestCreateVpcPeering(t *testing.T) {
 		}
 		if resp.StatusCode != http.StatusCreated {
 			t.Errorf("expected status 201, got %d", resp.StatusCode)
+		}
+		if resp.Data.Metadata.ID == nil || *resp.Data.Metadata.ID != "res-123" {
+			t.Errorf("expected ID 'res-123', got %v", resp.Data.Metadata.ID)
+		}
+		if resp.Data.Metadata.URI == nil || *resp.Data.Metadata.URI != "/projects/test-project/providers/Aruba.Network/vpcPeerings/res-123" {
+			t.Errorf("expected URI, got %v", resp.Data.Metadata.URI)
+		}
+		if resp.Data.Metadata.Name == nil || *resp.Data.Metadata.Name != "new-peering" {
+			t.Errorf("expected name 'new-peering', got %v", resp.Data.Metadata.Name)
 		}
 	})
 
@@ -334,7 +344,7 @@ func TestCreateVpcPeering(t *testing.T) {
 			}
 			w.Header().Set("Content-Type", "application/json")
 			w.WriteHeader(http.StatusCreated)
-			fmt.Fprint(w, `{}`)
+			fmt.Fprint(w, `{"metadata":{"id":"x","uri":"/x","name":"x"}}`)
 		})
 		c := testutil.NewClient(t, server.URL)
 		svc := NewVPCPeeringsClientImpl(c)
@@ -344,6 +354,78 @@ func TestCreateVpcPeering(t *testing.T) {
 		}
 		if resp.StatusCode != http.StatusCreated {
 			t.Errorf("expected status 201, got %d", resp.StatusCode)
+		}
+	})
+
+	t.Run("successful create missing id", func(t *testing.T) {
+		server := testutil.NewMockServer(t, func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusCreated)
+			fmt.Fprint(w, `{"metadata":{"uri":"/projects/test-project/providers/Aruba.Network/vpcPeerings/res-123","name":"test-name"}}`)
+		})
+		c := testutil.NewClient(t, server.URL)
+		svc := NewVPCPeeringsClientImpl(c)
+		resp, err := svc.Create(context.Background(), "test-project", "vpc-123", types.VPCPeeringRequest{}, nil)
+		if err == nil {
+			t.Fatal("expected metadata validation error, got nil")
+		}
+		var mvErr *types.MetadataValidationError
+		if !errors.As(err, &mvErr) {
+			t.Fatalf("expected *types.MetadataValidationError, got %T: %v", err, err)
+		}
+		if len(mvErr.Missing) != 1 || mvErr.Missing[0] != "id" {
+			t.Errorf("expected missing=[id], got %v", mvErr.Missing)
+		}
+		if resp == nil {
+			t.Fatal("expected partial response alongside error")
+		}
+	})
+
+	t.Run("successful create missing uri", func(t *testing.T) {
+		server := testutil.NewMockServer(t, func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusCreated)
+			fmt.Fprint(w, `{"metadata":{"id":"res-123","name":"test-name"}}`)
+		})
+		c := testutil.NewClient(t, server.URL)
+		svc := NewVPCPeeringsClientImpl(c)
+		resp, err := svc.Create(context.Background(), "test-project", "vpc-123", types.VPCPeeringRequest{}, nil)
+		if err == nil {
+			t.Fatal("expected metadata validation error, got nil")
+		}
+		var mvErr *types.MetadataValidationError
+		if !errors.As(err, &mvErr) {
+			t.Fatalf("expected *types.MetadataValidationError, got %T: %v", err, err)
+		}
+		if len(mvErr.Missing) != 1 || mvErr.Missing[0] != "uri" {
+			t.Errorf("expected missing=[uri], got %v", mvErr.Missing)
+		}
+		if resp == nil {
+			t.Fatal("expected partial response alongside error")
+		}
+	})
+
+	t.Run("successful create missing name", func(t *testing.T) {
+		server := testutil.NewMockServer(t, func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusCreated)
+			fmt.Fprint(w, `{"metadata":{"id":"res-123","uri":"/projects/test-project/providers/Aruba.Network/vpcPeerings/res-123"}}`)
+		})
+		c := testutil.NewClient(t, server.URL)
+		svc := NewVPCPeeringsClientImpl(c)
+		resp, err := svc.Create(context.Background(), "test-project", "vpc-123", types.VPCPeeringRequest{}, nil)
+		if err == nil {
+			t.Fatal("expected metadata validation error, got nil")
+		}
+		var mvErr *types.MetadataValidationError
+		if !errors.As(err, &mvErr) {
+			t.Fatalf("expected *types.MetadataValidationError, got %T: %v", err, err)
+		}
+		if len(mvErr.Missing) != 1 || mvErr.Missing[0] != "name" {
+			t.Errorf("expected missing=[name], got %v", mvErr.Missing)
+		}
+		if resp == nil {
+			t.Fatal("expected partial response alongside error")
 		}
 	})
 }

--- a/internal/clients/network/vpc.go
+++ b/internal/clients/network/vpc.go
@@ -133,6 +133,9 @@ func (c *vpcsClientImpl) Create(ctx context.Context, projectID string, body type
 			return nil, fmt.Errorf("failed to parse response: %w", err)
 		}
 		response.Data = &data
+		if err := response.Data.Metadata.Validate(); err != nil {
+			return response, fmt.Errorf("invalid create response: %w", err)
+		}
 	} else if response.IsError() && len(respBytes) > 0 {
 		var errorResp types.ErrorResponse
 		if err := json.Unmarshal(respBytes, &errorResp); err == nil {

--- a/internal/clients/network/vpc_test.go
+++ b/internal/clients/network/vpc_test.go
@@ -2,6 +2,7 @@ package network
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net/http"
 	"testing"
@@ -225,7 +226,7 @@ func TestCreateVPC(t *testing.T) {
 			}
 			w.Header().Set("Content-Type", "application/json")
 			w.WriteHeader(http.StatusCreated)
-			fmt.Fprint(w, `{"metadata":{"name":"new-vpc"}}`)
+			fmt.Fprint(w, `{"metadata":{"id":"res-123","uri":"/projects/test-project/providers/Aruba.Network/vpcs/res-123","name":"new-vpc"}}`)
 		})
 		c := testutil.NewClient(t, server.URL)
 		svc := NewVPCsClientImpl(c)
@@ -241,6 +242,15 @@ func TestCreateVPC(t *testing.T) {
 		}
 		if resp.StatusCode != http.StatusCreated {
 			t.Errorf("expected status 201, got %d", resp.StatusCode)
+		}
+		if resp.Data.Metadata.ID == nil || *resp.Data.Metadata.ID != "res-123" {
+			t.Errorf("expected ID 'res-123', got %v", resp.Data.Metadata.ID)
+		}
+		if resp.Data.Metadata.URI == nil || *resp.Data.Metadata.URI != "/projects/test-project/providers/Aruba.Network/vpcs/res-123" {
+			t.Errorf("expected URI, got %v", resp.Data.Metadata.URI)
+		}
+		if resp.Data.Metadata.Name == nil || *resp.Data.Metadata.Name != "new-vpc" {
+			t.Errorf("expected name 'new-vpc', got %v", resp.Data.Metadata.Name)
 		}
 	})
 
@@ -313,7 +323,7 @@ func TestCreateVPC(t *testing.T) {
 			}
 			w.Header().Set("Content-Type", "application/json")
 			w.WriteHeader(http.StatusCreated)
-			fmt.Fprint(w, `{}`)
+			fmt.Fprint(w, `{"metadata":{"id":"x","uri":"/x","name":"x"}}`)
 		})
 		c := testutil.NewClient(t, server.URL)
 		svc := NewVPCsClientImpl(c)
@@ -323,6 +333,78 @@ func TestCreateVPC(t *testing.T) {
 		}
 		if resp.StatusCode != http.StatusCreated {
 			t.Errorf("expected status 201, got %d", resp.StatusCode)
+		}
+	})
+
+	t.Run("successful create missing id", func(t *testing.T) {
+		server := testutil.NewMockServer(t, func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusCreated)
+			fmt.Fprint(w, `{"metadata":{"uri":"/projects/test-project/providers/Aruba.Network/vpcs/res-123","name":"test-name"}}`)
+		})
+		c := testutil.NewClient(t, server.URL)
+		svc := NewVPCsClientImpl(c)
+		resp, err := svc.Create(context.Background(), "test-project", types.VPCRequest{}, nil)
+		if err == nil {
+			t.Fatal("expected metadata validation error, got nil")
+		}
+		var mvErr *types.MetadataValidationError
+		if !errors.As(err, &mvErr) {
+			t.Fatalf("expected *types.MetadataValidationError, got %T: %v", err, err)
+		}
+		if len(mvErr.Missing) != 1 || mvErr.Missing[0] != "id" {
+			t.Errorf("expected missing=[id], got %v", mvErr.Missing)
+		}
+		if resp == nil {
+			t.Fatal("expected partial response alongside error")
+		}
+	})
+
+	t.Run("successful create missing uri", func(t *testing.T) {
+		server := testutil.NewMockServer(t, func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusCreated)
+			fmt.Fprint(w, `{"metadata":{"id":"res-123","name":"test-name"}}`)
+		})
+		c := testutil.NewClient(t, server.URL)
+		svc := NewVPCsClientImpl(c)
+		resp, err := svc.Create(context.Background(), "test-project", types.VPCRequest{}, nil)
+		if err == nil {
+			t.Fatal("expected metadata validation error, got nil")
+		}
+		var mvErr *types.MetadataValidationError
+		if !errors.As(err, &mvErr) {
+			t.Fatalf("expected *types.MetadataValidationError, got %T: %v", err, err)
+		}
+		if len(mvErr.Missing) != 1 || mvErr.Missing[0] != "uri" {
+			t.Errorf("expected missing=[uri], got %v", mvErr.Missing)
+		}
+		if resp == nil {
+			t.Fatal("expected partial response alongside error")
+		}
+	})
+
+	t.Run("successful create missing name", func(t *testing.T) {
+		server := testutil.NewMockServer(t, func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusCreated)
+			fmt.Fprint(w, `{"metadata":{"id":"res-123","uri":"/projects/test-project/providers/Aruba.Network/vpcs/res-123"}}`)
+		})
+		c := testutil.NewClient(t, server.URL)
+		svc := NewVPCsClientImpl(c)
+		resp, err := svc.Create(context.Background(), "test-project", types.VPCRequest{}, nil)
+		if err == nil {
+			t.Fatal("expected metadata validation error, got nil")
+		}
+		var mvErr *types.MetadataValidationError
+		if !errors.As(err, &mvErr) {
+			t.Fatalf("expected *types.MetadataValidationError, got %T: %v", err, err)
+		}
+		if len(mvErr.Missing) != 1 || mvErr.Missing[0] != "name" {
+			t.Errorf("expected missing=[name], got %v", mvErr.Missing)
+		}
+		if resp == nil {
+			t.Fatal("expected partial response alongside error")
 		}
 	})
 }

--- a/internal/clients/network/vpn-route.go
+++ b/internal/clients/network/vpn-route.go
@@ -133,6 +133,9 @@ func (c *vpnRoutesClientImpl) Create(ctx context.Context, projectID string, vpnT
 			return nil, fmt.Errorf("failed to parse response: %w", err)
 		}
 		response.Data = &data
+		if err := response.Data.Metadata.Validate(); err != nil {
+			return response, fmt.Errorf("invalid create response: %w", err)
+		}
 	} else if response.IsError() && len(respBytes) > 0 {
 		var errorResp types.ErrorResponse
 		if err := json.Unmarshal(respBytes, &errorResp); err == nil {

--- a/internal/clients/network/vpn-route_test.go
+++ b/internal/clients/network/vpn-route_test.go
@@ -2,6 +2,7 @@ package network
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net/http"
 	"testing"
@@ -243,7 +244,7 @@ func TestCreateVpnRoute(t *testing.T) {
 			}
 			w.Header().Set("Content-Type", "application/json")
 			w.WriteHeader(http.StatusCreated)
-			fmt.Fprint(w, `{"metadata":{"name":"new-route"}}`)
+			fmt.Fprint(w, `{"metadata":{"id":"res-123","uri":"/projects/test-project/providers/Aruba.Network/vpnRoutes/res-123","name":"new-route"}}`)
 		})
 		c := testutil.NewClient(t, server.URL)
 		svc := NewVPNRoutesClientImpl(c)
@@ -253,6 +254,15 @@ func TestCreateVpnRoute(t *testing.T) {
 		}
 		if resp.StatusCode != http.StatusCreated {
 			t.Errorf("expected status 201, got %d", resp.StatusCode)
+		}
+		if resp.Data.Metadata.ID == nil || *resp.Data.Metadata.ID != "res-123" {
+			t.Errorf("expected ID 'res-123', got %v", resp.Data.Metadata.ID)
+		}
+		if resp.Data.Metadata.URI == nil || *resp.Data.Metadata.URI != "/projects/test-project/providers/Aruba.Network/vpnRoutes/res-123" {
+			t.Errorf("expected URI, got %v", resp.Data.Metadata.URI)
+		}
+		if resp.Data.Metadata.Name == nil || *resp.Data.Metadata.Name != "new-route" {
+			t.Errorf("expected name 'new-route', got %v", resp.Data.Metadata.Name)
 		}
 	})
 
@@ -334,7 +344,7 @@ func TestCreateVpnRoute(t *testing.T) {
 			}
 			w.Header().Set("Content-Type", "application/json")
 			w.WriteHeader(http.StatusCreated)
-			fmt.Fprint(w, `{}`)
+			fmt.Fprint(w, `{"metadata":{"id":"x","uri":"/x","name":"x"}}`)
 		})
 		c := testutil.NewClient(t, server.URL)
 		svc := NewVPNRoutesClientImpl(c)
@@ -344,6 +354,78 @@ func TestCreateVpnRoute(t *testing.T) {
 		}
 		if resp.StatusCode != http.StatusCreated {
 			t.Errorf("expected status 201, got %d", resp.StatusCode)
+		}
+	})
+
+	t.Run("successful create missing id", func(t *testing.T) {
+		server := testutil.NewMockServer(t, func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusCreated)
+			fmt.Fprint(w, `{"metadata":{"uri":"/projects/test-project/providers/Aruba.Network/vpnRoutes/res-123","name":"test-name"}}`)
+		})
+		c := testutil.NewClient(t, server.URL)
+		svc := NewVPNRoutesClientImpl(c)
+		resp, err := svc.Create(context.Background(), "test-project", "tunnel-123", types.VPNRouteRequest{}, nil)
+		if err == nil {
+			t.Fatal("expected metadata validation error, got nil")
+		}
+		var mvErr *types.MetadataValidationError
+		if !errors.As(err, &mvErr) {
+			t.Fatalf("expected *types.MetadataValidationError, got %T: %v", err, err)
+		}
+		if len(mvErr.Missing) != 1 || mvErr.Missing[0] != "id" {
+			t.Errorf("expected missing=[id], got %v", mvErr.Missing)
+		}
+		if resp == nil {
+			t.Fatal("expected partial response alongside error")
+		}
+	})
+
+	t.Run("successful create missing uri", func(t *testing.T) {
+		server := testutil.NewMockServer(t, func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusCreated)
+			fmt.Fprint(w, `{"metadata":{"id":"res-123","name":"test-name"}}`)
+		})
+		c := testutil.NewClient(t, server.URL)
+		svc := NewVPNRoutesClientImpl(c)
+		resp, err := svc.Create(context.Background(), "test-project", "tunnel-123", types.VPNRouteRequest{}, nil)
+		if err == nil {
+			t.Fatal("expected metadata validation error, got nil")
+		}
+		var mvErr *types.MetadataValidationError
+		if !errors.As(err, &mvErr) {
+			t.Fatalf("expected *types.MetadataValidationError, got %T: %v", err, err)
+		}
+		if len(mvErr.Missing) != 1 || mvErr.Missing[0] != "uri" {
+			t.Errorf("expected missing=[uri], got %v", mvErr.Missing)
+		}
+		if resp == nil {
+			t.Fatal("expected partial response alongside error")
+		}
+	})
+
+	t.Run("successful create missing name", func(t *testing.T) {
+		server := testutil.NewMockServer(t, func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusCreated)
+			fmt.Fprint(w, `{"metadata":{"id":"res-123","uri":"/projects/test-project/providers/Aruba.Network/vpnRoutes/res-123"}}`)
+		})
+		c := testutil.NewClient(t, server.URL)
+		svc := NewVPNRoutesClientImpl(c)
+		resp, err := svc.Create(context.Background(), "test-project", "tunnel-123", types.VPNRouteRequest{}, nil)
+		if err == nil {
+			t.Fatal("expected metadata validation error, got nil")
+		}
+		var mvErr *types.MetadataValidationError
+		if !errors.As(err, &mvErr) {
+			t.Fatalf("expected *types.MetadataValidationError, got %T: %v", err, err)
+		}
+		if len(mvErr.Missing) != 1 || mvErr.Missing[0] != "name" {
+			t.Errorf("expected missing=[name], got %v", mvErr.Missing)
+		}
+		if resp == nil {
+			t.Fatal("expected partial response alongside error")
 		}
 	})
 }

--- a/internal/clients/network/vpn-tunnel.go
+++ b/internal/clients/network/vpn-tunnel.go
@@ -133,6 +133,9 @@ func (c *vpnTunnelsClientImpl) Create(ctx context.Context, projectID string, bod
 			return nil, fmt.Errorf("failed to parse response: %w", err)
 		}
 		response.Data = &data
+		if err := response.Data.Metadata.Validate(); err != nil {
+			return response, fmt.Errorf("invalid create response: %w", err)
+		}
 	} else if response.IsError() && len(respBytes) > 0 {
 		var errorResp types.ErrorResponse
 		if err := json.Unmarshal(respBytes, &errorResp); err == nil {

--- a/internal/clients/network/vpn-tunnel_test.go
+++ b/internal/clients/network/vpn-tunnel_test.go
@@ -2,6 +2,7 @@ package network
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net/http"
 	"testing"
@@ -225,7 +226,7 @@ func TestCreateVpnTunnel(t *testing.T) {
 			}
 			w.Header().Set("Content-Type", "application/json")
 			w.WriteHeader(http.StatusCreated)
-			fmt.Fprint(w, `{"metadata":{"name":"new-vpn"}}`)
+			fmt.Fprint(w, `{"metadata":{"id":"res-123","uri":"/projects/test-project/providers/Aruba.Network/vpnTunnels/res-123","name":"new-vpn"}}`)
 		})
 		c := testutil.NewClient(t, server.URL)
 		svc := NewVPNTunnelsClientImpl(c)
@@ -235,6 +236,15 @@ func TestCreateVpnTunnel(t *testing.T) {
 		}
 		if resp.StatusCode != http.StatusCreated {
 			t.Errorf("expected status 201, got %d", resp.StatusCode)
+		}
+		if resp.Data.Metadata.ID == nil || *resp.Data.Metadata.ID != "res-123" {
+			t.Errorf("expected ID 'res-123', got %v", resp.Data.Metadata.ID)
+		}
+		if resp.Data.Metadata.URI == nil || *resp.Data.Metadata.URI != "/projects/test-project/providers/Aruba.Network/vpnTunnels/res-123" {
+			t.Errorf("expected URI, got %v", resp.Data.Metadata.URI)
+		}
+		if resp.Data.Metadata.Name == nil || *resp.Data.Metadata.Name != "new-vpn" {
+			t.Errorf("expected name 'new-vpn', got %v", resp.Data.Metadata.Name)
 		}
 	})
 
@@ -307,7 +317,7 @@ func TestCreateVpnTunnel(t *testing.T) {
 			}
 			w.Header().Set("Content-Type", "application/json")
 			w.WriteHeader(http.StatusCreated)
-			fmt.Fprint(w, `{}`)
+			fmt.Fprint(w, `{"metadata":{"id":"x","uri":"/x","name":"x"}}`)
 		})
 		c := testutil.NewClient(t, server.URL)
 		svc := NewVPNTunnelsClientImpl(c)
@@ -317,6 +327,78 @@ func TestCreateVpnTunnel(t *testing.T) {
 		}
 		if resp.StatusCode != http.StatusCreated {
 			t.Errorf("expected status 201, got %d", resp.StatusCode)
+		}
+	})
+
+	t.Run("successful create missing id", func(t *testing.T) {
+		server := testutil.NewMockServer(t, func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusCreated)
+			fmt.Fprint(w, `{"metadata":{"uri":"/projects/test-project/providers/Aruba.Network/vpnTunnels/res-123","name":"test-name"}}`)
+		})
+		c := testutil.NewClient(t, server.URL)
+		svc := NewVPNTunnelsClientImpl(c)
+		resp, err := svc.Create(context.Background(), "test-project", types.VPNTunnelRequest{}, nil)
+		if err == nil {
+			t.Fatal("expected metadata validation error, got nil")
+		}
+		var mvErr *types.MetadataValidationError
+		if !errors.As(err, &mvErr) {
+			t.Fatalf("expected *types.MetadataValidationError, got %T: %v", err, err)
+		}
+		if len(mvErr.Missing) != 1 || mvErr.Missing[0] != "id" {
+			t.Errorf("expected missing=[id], got %v", mvErr.Missing)
+		}
+		if resp == nil {
+			t.Fatal("expected partial response alongside error")
+		}
+	})
+
+	t.Run("successful create missing uri", func(t *testing.T) {
+		server := testutil.NewMockServer(t, func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusCreated)
+			fmt.Fprint(w, `{"metadata":{"id":"res-123","name":"test-name"}}`)
+		})
+		c := testutil.NewClient(t, server.URL)
+		svc := NewVPNTunnelsClientImpl(c)
+		resp, err := svc.Create(context.Background(), "test-project", types.VPNTunnelRequest{}, nil)
+		if err == nil {
+			t.Fatal("expected metadata validation error, got nil")
+		}
+		var mvErr *types.MetadataValidationError
+		if !errors.As(err, &mvErr) {
+			t.Fatalf("expected *types.MetadataValidationError, got %T: %v", err, err)
+		}
+		if len(mvErr.Missing) != 1 || mvErr.Missing[0] != "uri" {
+			t.Errorf("expected missing=[uri], got %v", mvErr.Missing)
+		}
+		if resp == nil {
+			t.Fatal("expected partial response alongside error")
+		}
+	})
+
+	t.Run("successful create missing name", func(t *testing.T) {
+		server := testutil.NewMockServer(t, func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusCreated)
+			fmt.Fprint(w, `{"metadata":{"id":"res-123","uri":"/projects/test-project/providers/Aruba.Network/vpnTunnels/res-123"}}`)
+		})
+		c := testutil.NewClient(t, server.URL)
+		svc := NewVPNTunnelsClientImpl(c)
+		resp, err := svc.Create(context.Background(), "test-project", types.VPNTunnelRequest{}, nil)
+		if err == nil {
+			t.Fatal("expected metadata validation error, got nil")
+		}
+		var mvErr *types.MetadataValidationError
+		if !errors.As(err, &mvErr) {
+			t.Fatalf("expected *types.MetadataValidationError, got %T: %v", err, err)
+		}
+		if len(mvErr.Missing) != 1 || mvErr.Missing[0] != "name" {
+			t.Errorf("expected missing=[name], got %v", mvErr.Missing)
+		}
+		if resp == nil {
+			t.Fatal("expected partial response alongside error")
 		}
 	})
 }

--- a/internal/clients/project/project.go
+++ b/internal/clients/project/project.go
@@ -126,6 +126,9 @@ func (c *projectsClientImpl) Create(ctx context.Context, body types.ProjectReque
 			return nil, fmt.Errorf("failed to parse response: %w", err)
 		}
 		response.Data = &data
+		if err := response.Data.Metadata.Validate(); err != nil {
+			return response, fmt.Errorf("invalid create response: %w", err)
+		}
 	} else if response.IsError() && len(respBytes) > 0 {
 		var errorResp types.ErrorResponse
 		if err := json.Unmarshal(respBytes, &errorResp); err == nil {

--- a/internal/clients/project/project_test.go
+++ b/internal/clients/project/project_test.go
@@ -2,6 +2,7 @@ package project
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net/http"
 	"testing"
@@ -213,7 +214,7 @@ func TestCreateProject(t *testing.T) {
 		server := testutil.NewMockServer(t, func(w http.ResponseWriter, r *http.Request) {
 			w.Header().Set("Content-Type", "application/json")
 			w.WriteHeader(http.StatusCreated)
-			fmt.Fprint(w, `{"metadata":{"name":"new-project","id":"project-789"},"properties":{"description":"A new project","default":false,"resourcesNumber":0}}`)
+			fmt.Fprint(w, `{"metadata":{"name":"new-project","id":"project-789","uri":"/projects/project-789"},"properties":{"description":"A new project","default":false,"resourcesNumber":0}}`)
 		})
 		c := testutil.NewClient(t, server.URL)
 		svc := NewProjectsClientImpl(c)
@@ -230,6 +231,12 @@ func TestCreateProject(t *testing.T) {
 		}
 		if resp.Data.Metadata.Name == nil || *resp.Data.Metadata.Name != "new-project" {
 			t.Errorf("expected name 'new-project', got %v", resp.Data.Metadata.Name)
+		}
+		if resp.Data.Metadata.ID == nil || *resp.Data.Metadata.ID != "project-789" {
+			t.Errorf("expected ID 'project-789', got %v", resp.Data.Metadata.ID)
+		}
+		if resp.Data.Metadata.URI == nil || *resp.Data.Metadata.URI != "/projects/project-789" {
+			t.Errorf("expected URI, got %v", resp.Data.Metadata.URI)
 		}
 	})
 
@@ -293,7 +300,7 @@ func TestCreateProject(t *testing.T) {
 			}
 			w.Header().Set("Content-Type", "application/json")
 			w.WriteHeader(http.StatusCreated)
-			fmt.Fprint(w, `{"metadata":{"name":"x"}}`)
+			fmt.Fprint(w, `{"metadata":{"id":"x","uri":"/x","name":"x"}}`)
 		})
 		c := testutil.NewClient(t, server.URL)
 		svc := NewProjectsClientImpl(c)
@@ -303,6 +310,78 @@ func TestCreateProject(t *testing.T) {
 		}
 		if resp.StatusCode != http.StatusCreated {
 			t.Errorf("expected status 201, got %d", resp.StatusCode)
+		}
+	})
+
+	t.Run("successful create missing id", func(t *testing.T) {
+		server := testutil.NewMockServer(t, func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusCreated)
+			fmt.Fprint(w, `{"metadata":{"uri":"/projects/res-123","name":"test-name"}}`)
+		})
+		c := testutil.NewClient(t, server.URL)
+		svc := NewProjectsClientImpl(c)
+		resp, err := svc.Create(context.Background(), types.ProjectRequest{}, nil)
+		if err == nil {
+			t.Fatal("expected metadata validation error, got nil")
+		}
+		var mvErr *types.MetadataValidationError
+		if !errors.As(err, &mvErr) {
+			t.Fatalf("expected *types.MetadataValidationError, got %T: %v", err, err)
+		}
+		if len(mvErr.Missing) != 1 || mvErr.Missing[0] != "id" {
+			t.Errorf("expected missing=[id], got %v", mvErr.Missing)
+		}
+		if resp == nil {
+			t.Fatal("expected partial response alongside error")
+		}
+	})
+
+	t.Run("successful create missing uri", func(t *testing.T) {
+		server := testutil.NewMockServer(t, func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusCreated)
+			fmt.Fprint(w, `{"metadata":{"id":"res-123","name":"test-name"}}`)
+		})
+		c := testutil.NewClient(t, server.URL)
+		svc := NewProjectsClientImpl(c)
+		resp, err := svc.Create(context.Background(), types.ProjectRequest{}, nil)
+		if err == nil {
+			t.Fatal("expected metadata validation error, got nil")
+		}
+		var mvErr *types.MetadataValidationError
+		if !errors.As(err, &mvErr) {
+			t.Fatalf("expected *types.MetadataValidationError, got %T: %v", err, err)
+		}
+		if len(mvErr.Missing) != 1 || mvErr.Missing[0] != "uri" {
+			t.Errorf("expected missing=[uri], got %v", mvErr.Missing)
+		}
+		if resp == nil {
+			t.Fatal("expected partial response alongside error")
+		}
+	})
+
+	t.Run("successful create missing name", func(t *testing.T) {
+		server := testutil.NewMockServer(t, func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusCreated)
+			fmt.Fprint(w, `{"metadata":{"id":"res-123","uri":"/projects/res-123"}}`)
+		})
+		c := testutil.NewClient(t, server.URL)
+		svc := NewProjectsClientImpl(c)
+		resp, err := svc.Create(context.Background(), types.ProjectRequest{}, nil)
+		if err == nil {
+			t.Fatal("expected metadata validation error, got nil")
+		}
+		var mvErr *types.MetadataValidationError
+		if !errors.As(err, &mvErr) {
+			t.Fatalf("expected *types.MetadataValidationError, got %T: %v", err, err)
+		}
+		if len(mvErr.Missing) != 1 || mvErr.Missing[0] != "name" {
+			t.Errorf("expected missing=[name], got %v", mvErr.Missing)
+		}
+		if resp == nil {
+			t.Fatal("expected partial response alongside error")
 		}
 	})
 }

--- a/internal/clients/schedule/job.go
+++ b/internal/clients/schedule/job.go
@@ -133,6 +133,9 @@ func (c *jobsClientImpl) Create(ctx context.Context, projectID string, body type
 			return nil, fmt.Errorf("failed to parse response: %w", err)
 		}
 		response.Data = &data
+		if err := response.Data.Metadata.Validate(); err != nil {
+			return response, fmt.Errorf("invalid create response: %w", err)
+		}
 	} else if response.IsError() && len(respBytes) > 0 {
 		var errorResp types.ErrorResponse
 		if err := json.Unmarshal(respBytes, &errorResp); err == nil {

--- a/internal/clients/schedule/job_test.go
+++ b/internal/clients/schedule/job_test.go
@@ -2,6 +2,7 @@ package schedule
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net/http"
 	"testing"
@@ -251,7 +252,7 @@ func TestCreateScheduleJob(t *testing.T) {
 		server := testutil.NewMockServer(t, func(w http.ResponseWriter, r *http.Request) {
 			w.Header().Set("Content-Type", "application/json")
 			w.WriteHeader(http.StatusCreated)
-			fmt.Fprint(w, `{"metadata":{"name":"weekly-cleanup","id":"job-789"},"properties":{"enabled":true,"scheduleJobType":"Recurring","cron":"0 3 * * 0"},"status":{"state":"active"}}`)
+			fmt.Fprint(w, `{"metadata":{"name":"weekly-cleanup","id":"job-789","uri":"/projects/test-project/providers/Aruba.Schedule/jobs/job-789"},"properties":{"enabled":true,"scheduleJobType":"Recurring","cron":"0 3 * * 0"},"status":{"state":"active"}}`)
 		})
 		c := testutil.NewClient(t, server.URL)
 		svc := NewJobsClientImpl(c)
@@ -282,6 +283,12 @@ func TestCreateScheduleJob(t *testing.T) {
 		if resp.Data.Metadata.Name == nil || *resp.Data.Metadata.Name != "weekly-cleanup" {
 			t.Errorf("expected name 'weekly-cleanup', got %v", resp.Data.Metadata.Name)
 		}
+		if resp.Data.Metadata.ID == nil || *resp.Data.Metadata.ID != "job-789" {
+			t.Errorf("expected ID 'job-789', got %v", resp.Data.Metadata.ID)
+		}
+		if resp.Data.Metadata.URI == nil || *resp.Data.Metadata.URI != "/projects/test-project/providers/Aruba.Schedule/jobs/job-789" {
+			t.Errorf("expected URI, got %v", resp.Data.Metadata.URI)
+		}
 		if resp.Data.Properties.JobType != types.TypeJobRecurring {
 			t.Errorf("expected recurring job type")
 		}
@@ -291,7 +298,7 @@ func TestCreateScheduleJob(t *testing.T) {
 		server := testutil.NewMockServer(t, func(w http.ResponseWriter, r *http.Request) {
 			w.Header().Set("Content-Type", "application/json")
 			w.WriteHeader(http.StatusCreated)
-			fmt.Fprint(w, `{"metadata":{"name":"maintenance-window","id":"job-999"},"properties":{"enabled":true,"scheduleJobType":"OneShot","scheduleAt":"2025-11-20T22:00:00Z"},"status":{"state":"scheduled"}}`)
+			fmt.Fprint(w, `{"metadata":{"name":"maintenance-window","id":"job-999","uri":"/projects/test-project/providers/Aruba.Schedule/jobs/job-999"},"properties":{"enabled":true,"scheduleJobType":"OneShot","scheduleAt":"2025-11-20T22:00:00Z"},"status":{"state":"scheduled"}}`)
 		})
 		c := testutil.NewClient(t, server.URL)
 		svc := NewJobsClientImpl(c)
@@ -320,6 +327,12 @@ func TestCreateScheduleJob(t *testing.T) {
 		}
 		if resp.Data.Metadata.Name == nil || *resp.Data.Metadata.Name != "maintenance-window" {
 			t.Errorf("expected name 'maintenance-window', got %v", resp.Data.Metadata.Name)
+		}
+		if resp.Data.Metadata.ID == nil || *resp.Data.Metadata.ID != "job-999" {
+			t.Errorf("expected ID 'job-999', got %v", resp.Data.Metadata.ID)
+		}
+		if resp.Data.Metadata.URI == nil || *resp.Data.Metadata.URI != "/projects/test-project/providers/Aruba.Schedule/jobs/job-999" {
+			t.Errorf("expected URI, got %v", resp.Data.Metadata.URI)
 		}
 		if resp.Data.Properties.JobType != types.TypeJobOneShot {
 			t.Errorf("expected one-shot job type")
@@ -398,7 +411,7 @@ func TestCreateScheduleJob(t *testing.T) {
 			}
 			w.Header().Set("Content-Type", "application/json")
 			w.WriteHeader(http.StatusCreated)
-			fmt.Fprint(w, `{"metadata":{"name":"x"}}`)
+			fmt.Fprint(w, `{"metadata":{"id":"x","uri":"/x","name":"x"}}`)
 		})
 		c := testutil.NewClient(t, server.URL)
 		svc := NewJobsClientImpl(c)
@@ -408,6 +421,78 @@ func TestCreateScheduleJob(t *testing.T) {
 		}
 		if resp.StatusCode != http.StatusCreated {
 			t.Errorf("expected status 201, got %d", resp.StatusCode)
+		}
+	})
+
+	t.Run("successful create missing id", func(t *testing.T) {
+		server := testutil.NewMockServer(t, func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusCreated)
+			fmt.Fprint(w, `{"metadata":{"uri":"/projects/test-project/providers/Aruba.Schedule/jobs/res-123","name":"test-name"}}`)
+		})
+		c := testutil.NewClient(t, server.URL)
+		svc := NewJobsClientImpl(c)
+		resp, err := svc.Create(context.Background(), "test-project", types.JobRequest{}, nil)
+		if err == nil {
+			t.Fatal("expected metadata validation error, got nil")
+		}
+		var mvErr *types.MetadataValidationError
+		if !errors.As(err, &mvErr) {
+			t.Fatalf("expected *types.MetadataValidationError, got %T: %v", err, err)
+		}
+		if len(mvErr.Missing) != 1 || mvErr.Missing[0] != "id" {
+			t.Errorf("expected missing=[id], got %v", mvErr.Missing)
+		}
+		if resp == nil {
+			t.Fatal("expected partial response alongside error")
+		}
+	})
+
+	t.Run("successful create missing uri", func(t *testing.T) {
+		server := testutil.NewMockServer(t, func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusCreated)
+			fmt.Fprint(w, `{"metadata":{"id":"res-123","name":"test-name"}}`)
+		})
+		c := testutil.NewClient(t, server.URL)
+		svc := NewJobsClientImpl(c)
+		resp, err := svc.Create(context.Background(), "test-project", types.JobRequest{}, nil)
+		if err == nil {
+			t.Fatal("expected metadata validation error, got nil")
+		}
+		var mvErr *types.MetadataValidationError
+		if !errors.As(err, &mvErr) {
+			t.Fatalf("expected *types.MetadataValidationError, got %T: %v", err, err)
+		}
+		if len(mvErr.Missing) != 1 || mvErr.Missing[0] != "uri" {
+			t.Errorf("expected missing=[uri], got %v", mvErr.Missing)
+		}
+		if resp == nil {
+			t.Fatal("expected partial response alongside error")
+		}
+	})
+
+	t.Run("successful create missing name", func(t *testing.T) {
+		server := testutil.NewMockServer(t, func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusCreated)
+			fmt.Fprint(w, `{"metadata":{"id":"res-123","uri":"/projects/test-project/providers/Aruba.Schedule/jobs/res-123"}}`)
+		})
+		c := testutil.NewClient(t, server.URL)
+		svc := NewJobsClientImpl(c)
+		resp, err := svc.Create(context.Background(), "test-project", types.JobRequest{}, nil)
+		if err == nil {
+			t.Fatal("expected metadata validation error, got nil")
+		}
+		var mvErr *types.MetadataValidationError
+		if !errors.As(err, &mvErr) {
+			t.Fatalf("expected *types.MetadataValidationError, got %T: %v", err, err)
+		}
+		if len(mvErr.Missing) != 1 || mvErr.Missing[0] != "name" {
+			t.Errorf("expected missing=[name], got %v", mvErr.Missing)
+		}
+		if resp == nil {
+			t.Fatal("expected partial response alongside error")
 		}
 	})
 }

--- a/internal/clients/security/kms.go
+++ b/internal/clients/security/kms.go
@@ -134,6 +134,9 @@ func (c *kmsClientImpl) Create(ctx context.Context, projectID string, body types
 			return nil, fmt.Errorf("failed to parse response: %w", err)
 		}
 		response.Data = &data
+		if err := response.Data.Metadata.Validate(); err != nil {
+			return response, fmt.Errorf("invalid create response: %w", err)
+		}
 	} else if response.IsError() && len(respBytes) > 0 {
 		var errorResp types.ErrorResponse
 		if err := json.Unmarshal(respBytes, &errorResp); err == nil {

--- a/internal/clients/security/kms_test.go
+++ b/internal/clients/security/kms_test.go
@@ -2,6 +2,7 @@ package security
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net/http"
 	"testing"
@@ -228,7 +229,7 @@ func TestCreateKMSKey(t *testing.T) {
 		server := testutil.NewMockServer(t, func(w http.ResponseWriter, r *http.Request) {
 			w.Header().Set("Content-Type", "application/json")
 			w.WriteHeader(http.StatusCreated)
-			fmt.Fprint(w, `{"metadata":{"name":"new-encryption-key","id":"kms-789"},"properties":{"billingPeriod":"Month"},"status":{"state":"creating"}}`)
+			fmt.Fprint(w, `{"metadata":{"name":"new-encryption-key","id":"kms-789","uri":"/projects/test-project/providers/Aruba.Security/kmsKeys/kms-789"},"properties":{"billingPeriod":"Month"},"status":{"state":"creating"}}`)
 		})
 		c := testutil.NewClient(t, server.URL)
 		svc := NewKMSClientImpl(c)
@@ -245,6 +246,12 @@ func TestCreateKMSKey(t *testing.T) {
 		}
 		if resp.Data.Metadata.Name == nil || *resp.Data.Metadata.Name != "new-encryption-key" {
 			t.Errorf("expected name 'new-encryption-key', got %v", resp.Data.Metadata.Name)
+		}
+		if resp.Data.Metadata.ID == nil || *resp.Data.Metadata.ID != "kms-789" {
+			t.Errorf("expected ID 'kms-789', got %v", resp.Data.Metadata.ID)
+		}
+		if resp.Data.Metadata.URI == nil || *resp.Data.Metadata.URI != "/projects/test-project/providers/Aruba.Security/kmsKeys/kms-789" {
+			t.Errorf("expected URI, got %v", resp.Data.Metadata.URI)
 		}
 		if resp.Data.Status.State == nil || *resp.Data.Status.State != "creating" {
 			t.Errorf("expected state 'creating', got %v", resp.Data.Status.State)
@@ -317,7 +324,7 @@ func TestCreateKMSKey(t *testing.T) {
 			}
 			w.Header().Set("Content-Type", "application/json")
 			w.WriteHeader(http.StatusCreated)
-			fmt.Fprint(w, `{"metadata":{"name":"x"}}`)
+			fmt.Fprint(w, `{"metadata":{"id":"x","uri":"/x","name":"x"}}`)
 		})
 		c := testutil.NewClient(t, server.URL)
 		svc := NewKMSClientImpl(c)
@@ -327,6 +334,78 @@ func TestCreateKMSKey(t *testing.T) {
 		}
 		if resp.StatusCode != http.StatusCreated {
 			t.Errorf("expected status 201, got %d", resp.StatusCode)
+		}
+	})
+
+	t.Run("successful create missing id", func(t *testing.T) {
+		server := testutil.NewMockServer(t, func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusCreated)
+			fmt.Fprint(w, `{"metadata":{"uri":"/projects/test-project/providers/Aruba.Security/kmsKeys/res-123","name":"test-name"}}`)
+		})
+		c := testutil.NewClient(t, server.URL)
+		svc := NewKMSClientImpl(c)
+		resp, err := svc.Create(context.Background(), "test-project", types.KmsRequest{}, nil)
+		if err == nil {
+			t.Fatal("expected metadata validation error, got nil")
+		}
+		var mvErr *types.MetadataValidationError
+		if !errors.As(err, &mvErr) {
+			t.Fatalf("expected *types.MetadataValidationError, got %T: %v", err, err)
+		}
+		if len(mvErr.Missing) != 1 || mvErr.Missing[0] != "id" {
+			t.Errorf("expected missing=[id], got %v", mvErr.Missing)
+		}
+		if resp == nil {
+			t.Fatal("expected partial response alongside error")
+		}
+	})
+
+	t.Run("successful create missing uri", func(t *testing.T) {
+		server := testutil.NewMockServer(t, func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusCreated)
+			fmt.Fprint(w, `{"metadata":{"id":"res-123","name":"test-name"}}`)
+		})
+		c := testutil.NewClient(t, server.URL)
+		svc := NewKMSClientImpl(c)
+		resp, err := svc.Create(context.Background(), "test-project", types.KmsRequest{}, nil)
+		if err == nil {
+			t.Fatal("expected metadata validation error, got nil")
+		}
+		var mvErr *types.MetadataValidationError
+		if !errors.As(err, &mvErr) {
+			t.Fatalf("expected *types.MetadataValidationError, got %T: %v", err, err)
+		}
+		if len(mvErr.Missing) != 1 || mvErr.Missing[0] != "uri" {
+			t.Errorf("expected missing=[uri], got %v", mvErr.Missing)
+		}
+		if resp == nil {
+			t.Fatal("expected partial response alongside error")
+		}
+	})
+
+	t.Run("successful create missing name", func(t *testing.T) {
+		server := testutil.NewMockServer(t, func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusCreated)
+			fmt.Fprint(w, `{"metadata":{"id":"res-123","uri":"/projects/test-project/providers/Aruba.Security/kmsKeys/res-123"}}`)
+		})
+		c := testutil.NewClient(t, server.URL)
+		svc := NewKMSClientImpl(c)
+		resp, err := svc.Create(context.Background(), "test-project", types.KmsRequest{}, nil)
+		if err == nil {
+			t.Fatal("expected metadata validation error, got nil")
+		}
+		var mvErr *types.MetadataValidationError
+		if !errors.As(err, &mvErr) {
+			t.Fatalf("expected *types.MetadataValidationError, got %T: %v", err, err)
+		}
+		if len(mvErr.Missing) != 1 || mvErr.Missing[0] != "name" {
+			t.Errorf("expected missing=[name], got %v", mvErr.Missing)
+		}
+		if resp == nil {
+			t.Fatal("expected partial response alongside error")
 		}
 	})
 }

--- a/internal/clients/storage/backup.go
+++ b/internal/clients/storage/backup.go
@@ -134,6 +134,9 @@ func (c *backupClientImpl) Create(ctx context.Context, projectID string, body ty
 			return nil, fmt.Errorf("failed to parse response: %w", err)
 		}
 		response.Data = &data
+		if err := response.Data.Metadata.Validate(); err != nil {
+			return response, fmt.Errorf("invalid create response: %w", err)
+		}
 	} else if response.IsError() && len(respBytes) > 0 {
 		var errorResp types.ErrorResponse
 		if err := json.Unmarshal(respBytes, &errorResp); err == nil {

--- a/internal/clients/storage/backup_test.go
+++ b/internal/clients/storage/backup_test.go
@@ -2,6 +2,7 @@ package storage
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net/http"
 	"testing"
@@ -234,7 +235,7 @@ func TestCreateBackup(t *testing.T) {
 		server := testutil.NewMockServer(t, func(w http.ResponseWriter, r *http.Request) {
 			w.Header().Set("Content-Type", "application/json")
 			w.WriteHeader(http.StatusCreated)
-			fmt.Fprint(w, `{"metadata":{"name":"new-backup","id":"backup-456"},"properties":{"type":"Full","sourceVolume":{"uri":"/projects/test-project/providers/Aruba.Storage/blockstorages/volume-456"},"retentionDays":20,"billingPeriod":"Yearly"},"status":{"state":"creating"}}`)
+			fmt.Fprint(w, `{"metadata":{"name":"new-backup","id":"backup-456","uri":"/projects/test-project/providers/Aruba.Storage/backups/backup-456"},"properties":{"type":"Full","sourceVolume":{"uri":"/projects/test-project/providers/Aruba.Storage/blockstorages/volume-456"},"retentionDays":20,"billingPeriod":"Yearly"},"status":{"state":"creating"}}`)
 		})
 		c := testutil.NewClient(t, server.URL)
 		svc := NewBackupClientImpl(c)
@@ -255,6 +256,12 @@ func TestCreateBackup(t *testing.T) {
 		}
 		if resp.Data.Metadata.Name == nil || *resp.Data.Metadata.Name != "new-backup" {
 			t.Errorf("expected name 'new-backup', got %v", resp.Data.Metadata.Name)
+		}
+		if resp.Data.Metadata.ID == nil || *resp.Data.Metadata.ID != "backup-456" {
+			t.Errorf("expected ID 'backup-456', got %v", resp.Data.Metadata.ID)
+		}
+		if resp.Data.Metadata.URI == nil || *resp.Data.Metadata.URI != "/projects/test-project/providers/Aruba.Storage/backups/backup-456" {
+			t.Errorf("expected URI, got %v", resp.Data.Metadata.URI)
 		}
 		if resp.Data.Status.State == nil || *resp.Data.Status.State != "creating" {
 			t.Errorf("expected state 'creating', got %v", resp.Data.Status.State)
@@ -327,7 +334,7 @@ func TestCreateBackup(t *testing.T) {
 			}
 			w.Header().Set("Content-Type", "application/json")
 			w.WriteHeader(http.StatusCreated)
-			fmt.Fprint(w, `{"metadata":{"name":"x"}}`)
+			fmt.Fprint(w, `{"metadata":{"id":"x","uri":"/x","name":"x"}}`)
 		})
 		c := testutil.NewClient(t, server.URL)
 		svc := NewBackupClientImpl(c)
@@ -337,6 +344,78 @@ func TestCreateBackup(t *testing.T) {
 		}
 		if resp.StatusCode != http.StatusCreated {
 			t.Errorf("expected status 201, got %d", resp.StatusCode)
+		}
+	})
+
+	t.Run("successful create missing id", func(t *testing.T) {
+		server := testutil.NewMockServer(t, func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusCreated)
+			fmt.Fprint(w, `{"metadata":{"uri":"/projects/test-project/providers/Aruba.Storage/backups/res-123","name":"test-name"}}`)
+		})
+		c := testutil.NewClient(t, server.URL)
+		svc := NewBackupClientImpl(c)
+		resp, err := svc.Create(context.Background(), "test-project", types.StorageBackupRequest{}, nil)
+		if err == nil {
+			t.Fatal("expected metadata validation error, got nil")
+		}
+		var mvErr *types.MetadataValidationError
+		if !errors.As(err, &mvErr) {
+			t.Fatalf("expected *types.MetadataValidationError, got %T: %v", err, err)
+		}
+		if len(mvErr.Missing) != 1 || mvErr.Missing[0] != "id" {
+			t.Errorf("expected missing=[id], got %v", mvErr.Missing)
+		}
+		if resp == nil {
+			t.Fatal("expected partial response alongside error")
+		}
+	})
+
+	t.Run("successful create missing uri", func(t *testing.T) {
+		server := testutil.NewMockServer(t, func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusCreated)
+			fmt.Fprint(w, `{"metadata":{"id":"res-123","name":"test-name"}}`)
+		})
+		c := testutil.NewClient(t, server.URL)
+		svc := NewBackupClientImpl(c)
+		resp, err := svc.Create(context.Background(), "test-project", types.StorageBackupRequest{}, nil)
+		if err == nil {
+			t.Fatal("expected metadata validation error, got nil")
+		}
+		var mvErr *types.MetadataValidationError
+		if !errors.As(err, &mvErr) {
+			t.Fatalf("expected *types.MetadataValidationError, got %T: %v", err, err)
+		}
+		if len(mvErr.Missing) != 1 || mvErr.Missing[0] != "uri" {
+			t.Errorf("expected missing=[uri], got %v", mvErr.Missing)
+		}
+		if resp == nil {
+			t.Fatal("expected partial response alongside error")
+		}
+	})
+
+	t.Run("successful create missing name", func(t *testing.T) {
+		server := testutil.NewMockServer(t, func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusCreated)
+			fmt.Fprint(w, `{"metadata":{"id":"res-123","uri":"/projects/test-project/providers/Aruba.Storage/backups/res-123"}}`)
+		})
+		c := testutil.NewClient(t, server.URL)
+		svc := NewBackupClientImpl(c)
+		resp, err := svc.Create(context.Background(), "test-project", types.StorageBackupRequest{}, nil)
+		if err == nil {
+			t.Fatal("expected metadata validation error, got nil")
+		}
+		var mvErr *types.MetadataValidationError
+		if !errors.As(err, &mvErr) {
+			t.Fatalf("expected *types.MetadataValidationError, got %T: %v", err, err)
+		}
+		if len(mvErr.Missing) != 1 || mvErr.Missing[0] != "name" {
+			t.Errorf("expected missing=[name], got %v", mvErr.Missing)
+		}
+		if resp == nil {
+			t.Fatal("expected partial response alongside error")
 		}
 	})
 }

--- a/internal/clients/storage/block-storage.go
+++ b/internal/clients/storage/block-storage.go
@@ -151,7 +151,16 @@ func (c *volumesClientImpl) Create(ctx context.Context, projectID string, body t
 	}
 	defer httpResp.Body.Close()
 
-	return types.ParseResponseBody[types.BlockStorageResponse](httpResp, c.client.Logger())
+	resp, err := types.ParseResponseBody[types.BlockStorageResponse](httpResp, c.client.Logger())
+	if err != nil {
+		return nil, err
+	}
+	if resp.IsSuccess() && resp.Data != nil {
+		if err := resp.Data.Metadata.Validate(); err != nil {
+			return resp, fmt.Errorf("invalid create response: %w", err)
+		}
+	}
+	return resp, nil
 }
 
 // Delete deletes a block storage volume by ID

--- a/internal/clients/storage/restore.go
+++ b/internal/clients/storage/restore.go
@@ -145,6 +145,9 @@ func (c *restoreClientImpl) Create(ctx context.Context, projectID string, backup
 			return nil, fmt.Errorf("failed to parse response: %w", err)
 		}
 		response.Data = &data
+		if err := response.Data.Metadata.Validate(); err != nil {
+			return response, fmt.Errorf("invalid create response: %w", err)
+		}
 	} else if response.IsError() && len(respBytes) > 0 {
 		var errorResp types.ErrorResponse
 		if err := json.Unmarshal(respBytes, &errorResp); err == nil {

--- a/internal/clients/storage/restore_test.go
+++ b/internal/clients/storage/restore_test.go
@@ -2,6 +2,7 @@ package storage
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net/http"
 	"strings"
@@ -243,7 +244,7 @@ func TestCreateRestore(t *testing.T) {
 		server := testutil.NewMockServer(t, func(w http.ResponseWriter, r *http.Request) {
 			w.Header().Set("Content-Type", "application/json")
 			w.WriteHeader(http.StatusCreated)
-			fmt.Fprint(w, `{"metadata":{"name":"new-restore","id":"restore-456"},"properties":{"destinationVolume":{"uri":"/projects/test-project/providers/Aruba.Storage/blockstorages/vol-789"}},"status":{"state":"creating"}}`)
+			fmt.Fprint(w, `{"metadata":{"name":"new-restore","id":"restore-456","uri":"/projects/test-project/providers/Aruba.Storage/restores/restore-456"},"properties":{"destinationVolume":{"uri":"/projects/test-project/providers/Aruba.Storage/blockstorages/vol-789"}},"status":{"state":"creating"}}`)
 		})
 		svc := newRestoreSvc(t, server.URL)
 		body := types.RestoreRequest{
@@ -260,6 +261,12 @@ func TestCreateRestore(t *testing.T) {
 		}
 		if resp.Data.Metadata.Name == nil || *resp.Data.Metadata.Name != "new-restore" {
 			t.Errorf("expected name 'new-restore', got %v", resp.Data.Metadata.Name)
+		}
+		if resp.Data.Metadata.ID == nil || *resp.Data.Metadata.ID != "restore-456" {
+			t.Errorf("expected ID 'restore-456', got %v", resp.Data.Metadata.ID)
+		}
+		if resp.Data.Metadata.URI == nil || *resp.Data.Metadata.URI != "/projects/test-project/providers/Aruba.Storage/restores/restore-456" {
+			t.Errorf("expected URI, got %v", resp.Data.Metadata.URI)
 		}
 		if resp.Data.Status.State == nil || *resp.Data.Status.State != "creating" {
 			t.Errorf("expected state 'creating', got %v", resp.Data.Status.State)
@@ -340,7 +347,7 @@ func TestCreateRestore(t *testing.T) {
 			}
 			w.Header().Set("Content-Type", "application/json")
 			w.WriteHeader(http.StatusCreated)
-			fmt.Fprint(w, `{"metadata":{"name":"x"}}`)
+			fmt.Fprint(w, `{"metadata":{"id":"x","uri":"/x","name":"x"}}`)
 		})
 		svc := newRestoreSvc(t, server.URL)
 		body := types.RestoreRequest{Properties: types.RestorePropertiesRequest{Target: types.ReferenceResource{URI: "dummy"}}}
@@ -350,6 +357,78 @@ func TestCreateRestore(t *testing.T) {
 		}
 		if resp.StatusCode != http.StatusCreated {
 			t.Errorf("expected status 201, got %d", resp.StatusCode)
+		}
+	})
+
+	t.Run("successful create missing id", func(t *testing.T) {
+		server := testutil.NewMockServer(t, func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusCreated)
+			fmt.Fprint(w, `{"metadata":{"uri":"/projects/test-project/providers/Aruba.Storage/restores/res-123","name":"test-name"}}`)
+		})
+		svc := newRestoreSvc(t, server.URL)
+		body := types.RestoreRequest{Properties: types.RestorePropertiesRequest{Target: types.ReferenceResource{URI: "dummy"}}}
+		resp, err := svc.Create(context.Background(), "test-project", "backup-123", body, nil)
+		if err == nil {
+			t.Fatal("expected metadata validation error, got nil")
+		}
+		var mvErr *types.MetadataValidationError
+		if !errors.As(err, &mvErr) {
+			t.Fatalf("expected *types.MetadataValidationError, got %T: %v", err, err)
+		}
+		if len(mvErr.Missing) != 1 || mvErr.Missing[0] != "id" {
+			t.Errorf("expected missing=[id], got %v", mvErr.Missing)
+		}
+		if resp == nil {
+			t.Fatal("expected partial response alongside error")
+		}
+	})
+
+	t.Run("successful create missing uri", func(t *testing.T) {
+		server := testutil.NewMockServer(t, func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusCreated)
+			fmt.Fprint(w, `{"metadata":{"id":"res-123","name":"test-name"}}`)
+		})
+		svc := newRestoreSvc(t, server.URL)
+		body := types.RestoreRequest{Properties: types.RestorePropertiesRequest{Target: types.ReferenceResource{URI: "dummy"}}}
+		resp, err := svc.Create(context.Background(), "test-project", "backup-123", body, nil)
+		if err == nil {
+			t.Fatal("expected metadata validation error, got nil")
+		}
+		var mvErr *types.MetadataValidationError
+		if !errors.As(err, &mvErr) {
+			t.Fatalf("expected *types.MetadataValidationError, got %T: %v", err, err)
+		}
+		if len(mvErr.Missing) != 1 || mvErr.Missing[0] != "uri" {
+			t.Errorf("expected missing=[uri], got %v", mvErr.Missing)
+		}
+		if resp == nil {
+			t.Fatal("expected partial response alongside error")
+		}
+	})
+
+	t.Run("successful create missing name", func(t *testing.T) {
+		server := testutil.NewMockServer(t, func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusCreated)
+			fmt.Fprint(w, `{"metadata":{"id":"res-123","uri":"/projects/test-project/providers/Aruba.Storage/restores/res-123"}}`)
+		})
+		svc := newRestoreSvc(t, server.URL)
+		body := types.RestoreRequest{Properties: types.RestorePropertiesRequest{Target: types.ReferenceResource{URI: "dummy"}}}
+		resp, err := svc.Create(context.Background(), "test-project", "backup-123", body, nil)
+		if err == nil {
+			t.Fatal("expected metadata validation error, got nil")
+		}
+		var mvErr *types.MetadataValidationError
+		if !errors.As(err, &mvErr) {
+			t.Fatalf("expected *types.MetadataValidationError, got %T: %v", err, err)
+		}
+		if len(mvErr.Missing) != 1 || mvErr.Missing[0] != "name" {
+			t.Errorf("expected missing=[name], got %v", mvErr.Missing)
+		}
+		if resp == nil {
+			t.Fatal("expected partial response alongside error")
 		}
 	})
 }

--- a/internal/clients/storage/snapshot.go
+++ b/internal/clients/storage/snapshot.go
@@ -171,7 +171,16 @@ func (c *snapshotsClientImpl) Create(ctx context.Context, projectID string, body
 	}
 	defer httpResp.Body.Close()
 
-	return types.ParseResponseBody[types.SnapshotResponse](httpResp, c.client.Logger())
+	resp, err := types.ParseResponseBody[types.SnapshotResponse](httpResp, c.client.Logger())
+	if err != nil {
+		return nil, err
+	}
+	if resp.IsSuccess() && resp.Data != nil {
+		if err := resp.Data.Metadata.Validate(); err != nil {
+			return resp, fmt.Errorf("invalid create response: %w", err)
+		}
+	}
+	return resp, nil
 }
 
 // Delete deletes a snapshot by ID

--- a/internal/clients/storage/storage_test.go
+++ b/internal/clients/storage/storage_test.go
@@ -2,6 +2,7 @@ package storage
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net/http"
 	"strings"
@@ -240,7 +241,7 @@ func TestCreateBlockStorageVolume(t *testing.T) {
 		server := testutil.NewMockServer(t, func(w http.ResponseWriter, r *http.Request) {
 			w.Header().Set("Content-Type", "application/json")
 			w.WriteHeader(http.StatusCreated)
-			fmt.Fprint(w, `{"metadata":{"name":"new-volume","id":"vol-789"},"properties":{"sizeGb":50,"billingPeriod":"Hour","dataCenter":"it-eur-1","type":"Standard"},"status":{"state":"creating"}}`)
+			fmt.Fprint(w, `{"metadata":{"name":"new-volume","id":"vol-789","uri":"/projects/test-project/providers/Aruba.Storage/blockStorages/vol-789"},"properties":{"sizeGb":50,"billingPeriod":"Hour","dataCenter":"it-eur-1","type":"Standard"},"status":{"state":"creating"}}`)
 		})
 		c := testutil.NewClient(t, server.URL)
 		svc := NewVolumesClientImpl(c)
@@ -262,6 +263,12 @@ func TestCreateBlockStorageVolume(t *testing.T) {
 		}
 		if resp.Data.Metadata.Name == nil || *resp.Data.Metadata.Name != "new-volume" {
 			t.Errorf("expected name 'new-volume', got %v", resp.Data.Metadata.Name)
+		}
+		if resp.Data.Metadata.ID == nil || *resp.Data.Metadata.ID != "vol-789" {
+			t.Errorf("expected ID 'vol-789', got %v", resp.Data.Metadata.ID)
+		}
+		if resp.Data.Metadata.URI == nil || *resp.Data.Metadata.URI != "/projects/test-project/providers/Aruba.Storage/blockStorages/vol-789" {
+			t.Errorf("expected URI, got %v", resp.Data.Metadata.URI)
 		}
 		if resp.Data.Status.State == nil || *resp.Data.Status.State != "creating" {
 			t.Errorf("expected state 'creating', got %v", resp.Data.Status.State)
@@ -335,7 +342,7 @@ func TestCreateBlockStorageVolume(t *testing.T) {
 			}
 			w.Header().Set("Content-Type", "application/json")
 			w.WriteHeader(http.StatusCreated)
-			fmt.Fprint(w, `{"metadata":{"name":"x"}}`)
+			fmt.Fprint(w, `{"metadata":{"id":"x","uri":"/x","name":"x"}}`)
 		})
 		c := testutil.NewClient(t, server.URL)
 		svc := NewVolumesClientImpl(c)
@@ -345,6 +352,78 @@ func TestCreateBlockStorageVolume(t *testing.T) {
 		}
 		if resp.StatusCode != http.StatusCreated {
 			t.Errorf("expected status 201, got %d", resp.StatusCode)
+		}
+	})
+
+	t.Run("successful create missing id", func(t *testing.T) {
+		server := testutil.NewMockServer(t, func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusCreated)
+			fmt.Fprint(w, `{"metadata":{"uri":"/projects/test-project/providers/Aruba.Storage/blockStorages/res-123","name":"test-name"}}`)
+		})
+		c := testutil.NewClient(t, server.URL)
+		svc := NewVolumesClientImpl(c)
+		resp, err := svc.Create(context.Background(), "test-project", types.BlockStorageRequest{}, nil)
+		if err == nil {
+			t.Fatal("expected metadata validation error, got nil")
+		}
+		var mvErr *types.MetadataValidationError
+		if !errors.As(err, &mvErr) {
+			t.Fatalf("expected *types.MetadataValidationError, got %T: %v", err, err)
+		}
+		if len(mvErr.Missing) != 1 || mvErr.Missing[0] != "id" {
+			t.Errorf("expected missing=[id], got %v", mvErr.Missing)
+		}
+		if resp == nil {
+			t.Fatal("expected partial response alongside error")
+		}
+	})
+
+	t.Run("successful create missing uri", func(t *testing.T) {
+		server := testutil.NewMockServer(t, func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusCreated)
+			fmt.Fprint(w, `{"metadata":{"id":"res-123","name":"test-name"}}`)
+		})
+		c := testutil.NewClient(t, server.URL)
+		svc := NewVolumesClientImpl(c)
+		resp, err := svc.Create(context.Background(), "test-project", types.BlockStorageRequest{}, nil)
+		if err == nil {
+			t.Fatal("expected metadata validation error, got nil")
+		}
+		var mvErr *types.MetadataValidationError
+		if !errors.As(err, &mvErr) {
+			t.Fatalf("expected *types.MetadataValidationError, got %T: %v", err, err)
+		}
+		if len(mvErr.Missing) != 1 || mvErr.Missing[0] != "uri" {
+			t.Errorf("expected missing=[uri], got %v", mvErr.Missing)
+		}
+		if resp == nil {
+			t.Fatal("expected partial response alongside error")
+		}
+	})
+
+	t.Run("successful create missing name", func(t *testing.T) {
+		server := testutil.NewMockServer(t, func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusCreated)
+			fmt.Fprint(w, `{"metadata":{"id":"res-123","uri":"/projects/test-project/providers/Aruba.Storage/blockStorages/res-123"}}`)
+		})
+		c := testutil.NewClient(t, server.URL)
+		svc := NewVolumesClientImpl(c)
+		resp, err := svc.Create(context.Background(), "test-project", types.BlockStorageRequest{}, nil)
+		if err == nil {
+			t.Fatal("expected metadata validation error, got nil")
+		}
+		var mvErr *types.MetadataValidationError
+		if !errors.As(err, &mvErr) {
+			t.Fatalf("expected *types.MetadataValidationError, got %T: %v", err, err)
+		}
+		if len(mvErr.Missing) != 1 || mvErr.Missing[0] != "name" {
+			t.Errorf("expected missing=[name], got %v", mvErr.Missing)
+		}
+		if resp == nil {
+			t.Fatal("expected partial response alongside error")
 		}
 	})
 }
@@ -845,7 +924,7 @@ func TestCreateSnapshot(t *testing.T) {
 			}
 			w.Header().Set("Content-Type", "application/json")
 			w.WriteHeader(http.StatusCreated)
-			fmt.Fprint(w, `{"metadata":{"name":"x"}}`)
+			fmt.Fprint(w, `{"metadata":{"id":"x","uri":"/x","name":"x"}}`)
 		})
 		svc := newSnapshotSvc(t, server.URL)
 		resp, err := svc.Create(context.Background(), "test-project", types.SnapshotRequest{}, nil)
@@ -854,6 +933,75 @@ func TestCreateSnapshot(t *testing.T) {
 		}
 		if resp.StatusCode != http.StatusCreated {
 			t.Errorf("expected status 201, got %d", resp.StatusCode)
+		}
+	})
+
+	t.Run("successful create missing id", func(t *testing.T) {
+		server := testutil.NewMockServer(t, func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusCreated)
+			fmt.Fprint(w, `{"metadata":{"uri":"/projects/test-project/providers/Aruba.Storage/snapshots/res-123","name":"test-name"}}`)
+		})
+		svc := newSnapshotSvc(t, server.URL)
+		resp, err := svc.Create(context.Background(), "test-project", types.SnapshotRequest{}, nil)
+		if err == nil {
+			t.Fatal("expected metadata validation error, got nil")
+		}
+		var mvErr *types.MetadataValidationError
+		if !errors.As(err, &mvErr) {
+			t.Fatalf("expected *types.MetadataValidationError, got %T: %v", err, err)
+		}
+		if len(mvErr.Missing) != 1 || mvErr.Missing[0] != "id" {
+			t.Errorf("expected missing=[id], got %v", mvErr.Missing)
+		}
+		if resp == nil {
+			t.Fatal("expected partial response alongside error")
+		}
+	})
+
+	t.Run("successful create missing uri", func(t *testing.T) {
+		server := testutil.NewMockServer(t, func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusCreated)
+			fmt.Fprint(w, `{"metadata":{"id":"res-123","name":"test-name"}}`)
+		})
+		svc := newSnapshotSvc(t, server.URL)
+		resp, err := svc.Create(context.Background(), "test-project", types.SnapshotRequest{}, nil)
+		if err == nil {
+			t.Fatal("expected metadata validation error, got nil")
+		}
+		var mvErr *types.MetadataValidationError
+		if !errors.As(err, &mvErr) {
+			t.Fatalf("expected *types.MetadataValidationError, got %T: %v", err, err)
+		}
+		if len(mvErr.Missing) != 1 || mvErr.Missing[0] != "uri" {
+			t.Errorf("expected missing=[uri], got %v", mvErr.Missing)
+		}
+		if resp == nil {
+			t.Fatal("expected partial response alongside error")
+		}
+	})
+
+	t.Run("successful create missing name", func(t *testing.T) {
+		server := testutil.NewMockServer(t, func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusCreated)
+			fmt.Fprint(w, `{"metadata":{"id":"res-123","uri":"/projects/test-project/providers/Aruba.Storage/snapshots/res-123"}}`)
+		})
+		svc := newSnapshotSvc(t, server.URL)
+		resp, err := svc.Create(context.Background(), "test-project", types.SnapshotRequest{}, nil)
+		if err == nil {
+			t.Fatal("expected metadata validation error, got nil")
+		}
+		var mvErr *types.MetadataValidationError
+		if !errors.As(err, &mvErr) {
+			t.Fatalf("expected *types.MetadataValidationError, got %T: %v", err, err)
+		}
+		if len(mvErr.Missing) != 1 || mvErr.Missing[0] != "name" {
+			t.Errorf("expected missing=[name], got %v", mvErr.Missing)
+		}
+		if resp == nil {
+			t.Fatal("expected partial response alongside error")
 		}
 	})
 }

--- a/pkg/types/resource.go
+++ b/pkg/types/resource.go
@@ -1,7 +1,9 @@
 package types
 
 import (
+	"fmt"
 	"net/http"
+	"strings"
 	"time"
 )
 
@@ -141,6 +143,40 @@ type Response[T any] struct {
 
 	// RawBody contains the raw response body (if requested)
 	RawBody []byte
+}
+
+// MetadataValidationError reports which required identity fields were absent
+// in a successful API response. Callers can use errors.As to branch on this
+// specifically and distinguish API-contract violations from network errors.
+type MetadataValidationError struct {
+	Missing []string
+}
+
+func (e *MetadataValidationError) Error() string {
+	return fmt.Sprintf("response metadata missing required field(s): %s", strings.Join(e.Missing, ", "))
+}
+
+// Validate returns a *MetadataValidationError if any of ID, URI, or Name are
+// absent or empty. The Aruba Cloud API must populate all three on a successful
+// Create response; callers rely on them to identify and reference the resource.
+func (m *ResourceMetadataResponse) Validate() error {
+	if m == nil {
+		return &MetadataValidationError{Missing: []string{"metadata"}}
+	}
+	var missing []string
+	if m.ID == nil || *m.ID == "" {
+		missing = append(missing, "id")
+	}
+	if m.URI == nil || *m.URI == "" {
+		missing = append(missing, "uri")
+	}
+	if m.Name == nil || *m.Name == "" {
+		missing = append(missing, "name")
+	}
+	if len(missing) > 0 {
+		return &MetadataValidationError{Missing: missing}
+	}
+	return nil
 }
 
 // IsSuccess returns true if the status code is 2xx

--- a/pkg/types/resource_test.go
+++ b/pkg/types/resource_test.go
@@ -1,0 +1,157 @@
+package types_test
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/Arubacloud/sdk-go/pkg/types"
+)
+
+func TestResourceMetadataResponse_Validate(t *testing.T) {
+	id := "res-123"
+	uri := "/projects/p/providers/Aruba.Compute/cloudServers/res-123"
+	name := "my-server"
+
+	t.Run("all fields present", func(t *testing.T) {
+		m := &types.ResourceMetadataResponse{
+			ID:   &id,
+			URI:  &uri,
+			Name: &name,
+		}
+		if err := m.Validate(); err != nil {
+			t.Errorf("expected nil, got %v", err)
+		}
+	})
+
+	t.Run("nil receiver", func(t *testing.T) {
+		var m *types.ResourceMetadataResponse
+		err := m.Validate()
+		if err == nil {
+			t.Fatal("expected error, got nil")
+		}
+		var mvErr *types.MetadataValidationError
+		if !errors.As(err, &mvErr) {
+			t.Fatalf("expected MetadataValidationError, got %T", err)
+		}
+	})
+
+	t.Run("missing id nil", func(t *testing.T) {
+		m := &types.ResourceMetadataResponse{URI: &uri, Name: &name}
+		err := m.Validate()
+		if err == nil {
+			t.Fatal("expected error, got nil")
+		}
+		var mvErr *types.MetadataValidationError
+		if !errors.As(err, &mvErr) {
+			t.Fatalf("expected MetadataValidationError, got %T", err)
+		}
+		if len(mvErr.Missing) != 1 || mvErr.Missing[0] != "id" {
+			t.Errorf("expected missing=[id], got %v", mvErr.Missing)
+		}
+	})
+
+	t.Run("missing id empty string", func(t *testing.T) {
+		empty := ""
+		m := &types.ResourceMetadataResponse{ID: &empty, URI: &uri, Name: &name}
+		err := m.Validate()
+		if err == nil {
+			t.Fatal("expected error, got nil")
+		}
+		var mvErr *types.MetadataValidationError
+		if !errors.As(err, &mvErr) {
+			t.Fatalf("expected MetadataValidationError, got %T", err)
+		}
+		if len(mvErr.Missing) != 1 || mvErr.Missing[0] != "id" {
+			t.Errorf("expected missing=[id], got %v", mvErr.Missing)
+		}
+	})
+
+	t.Run("missing uri nil", func(t *testing.T) {
+		m := &types.ResourceMetadataResponse{ID: &id, Name: &name}
+		err := m.Validate()
+		if err == nil {
+			t.Fatal("expected error, got nil")
+		}
+		var mvErr *types.MetadataValidationError
+		if !errors.As(err, &mvErr) {
+			t.Fatalf("expected MetadataValidationError, got %T", err)
+		}
+		if len(mvErr.Missing) != 1 || mvErr.Missing[0] != "uri" {
+			t.Errorf("expected missing=[uri], got %v", mvErr.Missing)
+		}
+	})
+
+	t.Run("missing uri empty string", func(t *testing.T) {
+		empty := ""
+		m := &types.ResourceMetadataResponse{ID: &id, URI: &empty, Name: &name}
+		err := m.Validate()
+		if err == nil {
+			t.Fatal("expected error, got nil")
+		}
+		var mvErr *types.MetadataValidationError
+		if !errors.As(err, &mvErr) {
+			t.Fatalf("expected MetadataValidationError, got %T", err)
+		}
+		if len(mvErr.Missing) != 1 || mvErr.Missing[0] != "uri" {
+			t.Errorf("expected missing=[uri], got %v", mvErr.Missing)
+		}
+	})
+
+	t.Run("missing name nil", func(t *testing.T) {
+		m := &types.ResourceMetadataResponse{ID: &id, URI: &uri}
+		err := m.Validate()
+		if err == nil {
+			t.Fatal("expected error, got nil")
+		}
+		var mvErr *types.MetadataValidationError
+		if !errors.As(err, &mvErr) {
+			t.Fatalf("expected MetadataValidationError, got %T", err)
+		}
+		if len(mvErr.Missing) != 1 || mvErr.Missing[0] != "name" {
+			t.Errorf("expected missing=[name], got %v", mvErr.Missing)
+		}
+	})
+
+	t.Run("missing name empty string", func(t *testing.T) {
+		empty := ""
+		m := &types.ResourceMetadataResponse{ID: &id, URI: &uri, Name: &empty}
+		err := m.Validate()
+		if err == nil {
+			t.Fatal("expected error, got nil")
+		}
+		var mvErr *types.MetadataValidationError
+		if !errors.As(err, &mvErr) {
+			t.Fatalf("expected MetadataValidationError, got %T", err)
+		}
+		if len(mvErr.Missing) != 1 || mvErr.Missing[0] != "name" {
+			t.Errorf("expected missing=[name], got %v", mvErr.Missing)
+		}
+	})
+
+	t.Run("all fields missing", func(t *testing.T) {
+		m := &types.ResourceMetadataResponse{}
+		err := m.Validate()
+		if err == nil {
+			t.Fatal("expected error, got nil")
+		}
+		var mvErr *types.MetadataValidationError
+		if !errors.As(err, &mvErr) {
+			t.Fatalf("expected MetadataValidationError, got %T", err)
+		}
+		if len(mvErr.Missing) != 3 {
+			t.Errorf("expected 3 missing fields, got %v", mvErr.Missing)
+		}
+	})
+
+	t.Run("error message lists missing fields", func(t *testing.T) {
+		m := &types.ResourceMetadataResponse{Name: &name}
+		err := m.Validate()
+		if err == nil {
+			t.Fatal("expected error, got nil")
+		}
+		msg := err.Error()
+		if msg == "" {
+			t.Error("expected non-empty error message")
+		}
+	})
+}


### PR DESCRIPTION
## Summary

- Add `ResourceMetadataResponse.Validate()` returning a typed `*MetadataValidationError` when `id`, `uri`, or `name` are absent or empty in a 2xx Create response.
- Call `Validate()` in all 21 `Create` methods that return a `ResourceMetadataResponse`-bearing type; return `(response, err)` so callers retain access to the partial response for diagnostics.
- Add `pkg/types/resource_test.go` with 11 unit tests covering every `Validate()` branch.
- Update all matching `TestCreateXxx/successful create` subtests to populate and assert the three fields.
- Add `TestCreateXxx/successful create missing id|uri|name` subtests (3 × 16 resources = 48 new subtests) that assert `errors.As(err, &MetadataValidationError)` and `resp != nil`.

## Breaking change

`Create` methods previously succeeded silently when the API response omitted identity fields; they now return an error. This is intentional: the API contract requires all three fields, and callers rely on them to reference the new resource.

## Exclusions (with rationale)

- `network/subnet`, `network/security-group`, `network/security-group-rule` — entire `TestCreateXxx` is already skipped (pre-existing VPC/SG polling mock complexity, tracked in TD-020 TODO comments). Validation is still enforced in the impl; tests need a future mock refactor.
- `network/vpc-peering-route` — response type uses `RegionalResourceMetadataRequest` instead of `ResourceMetadataResponse` (separate struct bug; follow-up needed).
- `security/kmip`, `security/key` — response types own non-standard fields without `ResourceMetadataResponse`; out of scope.
- `database/{database,user,grant}` — sub-resources with no independent ID.

## Test plan

- [x] `go test ./...` — all packages pass.
- [x] `make verify` — lint + coverage pass.
- [x] `go test -run TestCreateCloudServer/successful_create_missing_id ./internal/clients/compute/` — passes.

## Related

- Closes #175
- Downstream unblock: Arubacloud/acloud-cli#45

🤖 Generated with [Claude Code](https://claude.com/claude-code)