### PR TITLE
fix(types): drop URI from Create response metadata validation

### DIFF
--- a/ai/TECH_DEBT.md
+++ b/ai/TECH_DEBT.md
@@ -248,7 +248,7 @@ Replace all manual implementations with calls to this helper.
 
 All `*.Create` methods returned success even when the API response omitted required identity fields (`metadata.id`, `metadata.uri`, `metadata.name`). Downstream consumers (e.g., acloud-cli) silently received `nil` pointers and fell back to broken workarounds.
 
-**Fix:** Added `ResourceMetadataResponse.Validate()` (returns `*MetadataValidationError` if any of the three fields is absent) and called it in every Create method that returns a `ResourceMetadataResponse`-bearing type. Added `pkg/types/resource_test.go` unit tests for the validator and "missing id/uri/name" subtests in each Create test file.
+**Fix:** Added `ResourceMetadataResponse.Validate()` and called it in every Create method. URI was initially included but later removed: the Aruba Cloud API does not consistently populate `metadata.uri` on Create responses, causing false-positive failures in production (acloud-cli `project create` error). The validator now only requires `id` and `name`. Added `pkg/types/resource_test.go` unit tests and "missing id/name" subtests in each Create test file.
 
 **Effort:** M — 21 impl files + 21 test files; mechanical but thorough.
 

--- a/internal/clients/compute/cloudserver_test.go
+++ b/internal/clients/compute/cloudserver_test.go
@@ -361,30 +361,6 @@ func TestCreateCloudServer(t *testing.T) {
 		}
 	})
 
-	t.Run("successful create missing uri", func(t *testing.T) {
-		server := testutil.NewMockServer(t, func(w http.ResponseWriter, r *http.Request) {
-			w.Header().Set("Content-Type", "application/json")
-			w.WriteHeader(http.StatusCreated)
-			fmt.Fprint(w, `{"metadata":{"id":"res-123","name":"new-server"}}`)
-		})
-		c := testutil.NewClient(t, server.URL)
-		svc := NewCloudServersClientImpl(c)
-		resp, err := svc.Create(context.Background(), "test-project", types.CloudServerRequest{}, nil)
-		if err == nil {
-			t.Fatal("expected metadata validation error, got nil")
-		}
-		var mvErr *types.MetadataValidationError
-		if !errors.As(err, &mvErr) {
-			t.Fatalf("expected *types.MetadataValidationError, got %T: %v", err, err)
-		}
-		if len(mvErr.Missing) != 1 || mvErr.Missing[0] != "uri" {
-			t.Errorf("expected missing=[uri], got %v", mvErr.Missing)
-		}
-		if resp == nil {
-			t.Fatal("expected partial response alongside error")
-		}
-	})
-
 	t.Run("successful create missing name", func(t *testing.T) {
 		server := testutil.NewMockServer(t, func(w http.ResponseWriter, r *http.Request) {
 			w.Header().Set("Content-Type", "application/json")

--- a/internal/clients/compute/keypair_test.go
+++ b/internal/clients/compute/keypair_test.go
@@ -352,30 +352,6 @@ func TestCreateKeyPair(t *testing.T) {
 		}
 	})
 
-	t.Run("successful create missing uri", func(t *testing.T) {
-		server := testutil.NewMockServer(t, func(w http.ResponseWriter, r *http.Request) {
-			w.Header().Set("Content-Type", "application/json")
-			w.WriteHeader(http.StatusCreated)
-			fmt.Fprint(w, `{"metadata":{"id":"res-123","name":"new-keypair"}}`)
-		})
-		c := testutil.NewClient(t, server.URL)
-		svc := NewKeyPairsClientImpl(c)
-		resp, err := svc.Create(context.Background(), "test-project", types.KeyPairRequest{}, nil)
-		if err == nil {
-			t.Fatal("expected metadata validation error, got nil")
-		}
-		var mvErr *types.MetadataValidationError
-		if !errors.As(err, &mvErr) {
-			t.Fatalf("expected *types.MetadataValidationError, got %T: %v", err, err)
-		}
-		if len(mvErr.Missing) != 1 || mvErr.Missing[0] != "uri" {
-			t.Errorf("expected missing=[uri], got %v", mvErr.Missing)
-		}
-		if resp == nil {
-			t.Fatal("expected partial response alongside error")
-		}
-	})
-
 	t.Run("successful create missing name", func(t *testing.T) {
 		server := testutil.NewMockServer(t, func(w http.ResponseWriter, r *http.Request) {
 			w.Header().Set("Content-Type", "application/json")

--- a/internal/clients/container/containerregistry_test.go
+++ b/internal/clients/container/containerregistry_test.go
@@ -551,30 +551,6 @@ func TestCreateContainerRegistry(t *testing.T) {
 		}
 	})
 
-	t.Run("successful create missing uri", func(t *testing.T) {
-		server := testutil.NewMockServer(t, func(w http.ResponseWriter, r *http.Request) {
-			w.Header().Set("Content-Type", "application/json")
-			w.WriteHeader(http.StatusCreated)
-			fmt.Fprint(w, `{"metadata":{"id":"res-123","name":"test-name"}}`)
-		})
-		c := testutil.NewClient(t, server.URL)
-		svc := NewContainerRegistryClientImpl(c)
-		resp, err := svc.Create(context.Background(), "test-project", types.ContainerRegistryRequest{}, nil)
-		if err == nil {
-			t.Fatal("expected metadata validation error, got nil")
-		}
-		var mvErr *types.MetadataValidationError
-		if !errors.As(err, &mvErr) {
-			t.Fatalf("expected *types.MetadataValidationError, got %T: %v", err, err)
-		}
-		if len(mvErr.Missing) != 1 || mvErr.Missing[0] != "uri" {
-			t.Errorf("expected missing=[uri], got %v", mvErr.Missing)
-		}
-		if resp == nil {
-			t.Fatal("expected partial response alongside error")
-		}
-	})
-
 	t.Run("successful create missing name", func(t *testing.T) {
 		server := testutil.NewMockServer(t, func(w http.ResponseWriter, r *http.Request) {
 			w.Header().Set("Content-Type", "application/json")

--- a/internal/clients/container/kaas_test.go
+++ b/internal/clients/container/kaas_test.go
@@ -447,30 +447,6 @@ func TestCreateKaaS(t *testing.T) {
 		}
 	})
 
-	t.Run("successful create missing uri", func(t *testing.T) {
-		server := testutil.NewMockServer(t, func(w http.ResponseWriter, r *http.Request) {
-			w.Header().Set("Content-Type", "application/json")
-			w.WriteHeader(http.StatusCreated)
-			fmt.Fprint(w, `{"metadata":{"id":"res-123","name":"test-name"}}`)
-		})
-		c := testutil.NewClient(t, server.URL)
-		svc := NewKaaSClientImpl(c)
-		resp, err := svc.Create(context.Background(), "test-project", types.KaaSRequest{}, nil)
-		if err == nil {
-			t.Fatal("expected metadata validation error, got nil")
-		}
-		var mvErr *types.MetadataValidationError
-		if !errors.As(err, &mvErr) {
-			t.Fatalf("expected *types.MetadataValidationError, got %T: %v", err, err)
-		}
-		if len(mvErr.Missing) != 1 || mvErr.Missing[0] != "uri" {
-			t.Errorf("expected missing=[uri], got %v", mvErr.Missing)
-		}
-		if resp == nil {
-			t.Fatal("expected partial response alongside error")
-		}
-	})
-
 	t.Run("successful create missing name", func(t *testing.T) {
 		server := testutil.NewMockServer(t, func(w http.ResponseWriter, r *http.Request) {
 			w.Header().Set("Content-Type", "application/json")

--- a/internal/clients/database/backup_test.go
+++ b/internal/clients/database/backup_test.go
@@ -437,30 +437,6 @@ func TestCreateBackup(t *testing.T) {
 		}
 	})
 
-	t.Run("successful create missing uri", func(t *testing.T) {
-		server := testutil.NewMockServer(t, func(w http.ResponseWriter, r *http.Request) {
-			w.Header().Set("Content-Type", "application/json")
-			w.WriteHeader(http.StatusCreated)
-			fmt.Fprint(w, `{"metadata":{"id":"res-123","name":"test-name"}}`)
-		})
-		c := testutil.NewClient(t, server.URL)
-		svc := NewBackupsClientImpl(c)
-		resp, err := svc.Create(context.Background(), "test-project", types.BackupRequest{}, nil)
-		if err == nil {
-			t.Fatal("expected metadata validation error, got nil")
-		}
-		var mvErr *types.MetadataValidationError
-		if !errors.As(err, &mvErr) {
-			t.Fatalf("expected *types.MetadataValidationError, got %T: %v", err, err)
-		}
-		if len(mvErr.Missing) != 1 || mvErr.Missing[0] != "uri" {
-			t.Errorf("expected missing=[uri], got %v", mvErr.Missing)
-		}
-		if resp == nil {
-			t.Fatal("expected partial response alongside error")
-		}
-	})
-
 	t.Run("successful create missing name", func(t *testing.T) {
 		server := testutil.NewMockServer(t, func(w http.ResponseWriter, r *http.Request) {
 			w.Header().Set("Content-Type", "application/json")

--- a/internal/clients/database/dbaas_test.go
+++ b/internal/clients/database/dbaas_test.go
@@ -429,30 +429,6 @@ func TestCreateDBaaS(t *testing.T) {
 		}
 	})
 
-	t.Run("successful create missing uri", func(t *testing.T) {
-		server := testutil.NewMockServer(t, func(w http.ResponseWriter, r *http.Request) {
-			w.Header().Set("Content-Type", "application/json")
-			w.WriteHeader(http.StatusCreated)
-			fmt.Fprint(w, `{"metadata":{"id":"res-123","name":"test-name"}}`)
-		})
-		c := testutil.NewClient(t, server.URL)
-		svc := NewDBaaSClientImpl(c)
-		resp, err := svc.Create(context.Background(), "test-project", types.DBaaSRequest{}, nil)
-		if err == nil {
-			t.Fatal("expected metadata validation error, got nil")
-		}
-		var mvErr *types.MetadataValidationError
-		if !errors.As(err, &mvErr) {
-			t.Fatalf("expected *types.MetadataValidationError, got %T: %v", err, err)
-		}
-		if len(mvErr.Missing) != 1 || mvErr.Missing[0] != "uri" {
-			t.Errorf("expected missing=[uri], got %v", mvErr.Missing)
-		}
-		if resp == nil {
-			t.Fatal("expected partial response alongside error")
-		}
-	})
-
 	t.Run("successful create missing name", func(t *testing.T) {
 		server := testutil.NewMockServer(t, func(w http.ResponseWriter, r *http.Request) {
 			w.Header().Set("Content-Type", "application/json")

--- a/internal/clients/network/elastic-ip_test.go
+++ b/internal/clients/network/elastic-ip_test.go
@@ -358,30 +358,6 @@ func TestCreateElasticIP(t *testing.T) {
 		}
 	})
 
-	t.Run("successful create missing uri", func(t *testing.T) {
-		server := testutil.NewMockServer(t, func(w http.ResponseWriter, r *http.Request) {
-			w.Header().Set("Content-Type", "application/json")
-			w.WriteHeader(http.StatusCreated)
-			fmt.Fprint(w, `{"metadata":{"id":"res-123","name":"test-name"}}`)
-		})
-		c := testutil.NewClient(t, server.URL)
-		svc := NewElasticIPsClientImpl(c)
-		resp, err := svc.Create(context.Background(), "test-project", types.ElasticIPRequest{}, nil)
-		if err == nil {
-			t.Fatal("expected metadata validation error, got nil")
-		}
-		var mvErr *types.MetadataValidationError
-		if !errors.As(err, &mvErr) {
-			t.Fatalf("expected *types.MetadataValidationError, got %T: %v", err, err)
-		}
-		if len(mvErr.Missing) != 1 || mvErr.Missing[0] != "uri" {
-			t.Errorf("expected missing=[uri], got %v", mvErr.Missing)
-		}
-		if resp == nil {
-			t.Fatal("expected partial response alongside error")
-		}
-	})
-
 	t.Run("successful create missing name", func(t *testing.T) {
 		server := testutil.NewMockServer(t, func(w http.ResponseWriter, r *http.Request) {
 			w.Header().Set("Content-Type", "application/json")

--- a/internal/clients/network/vpc-peering_test.go
+++ b/internal/clients/network/vpc-peering_test.go
@@ -381,30 +381,6 @@ func TestCreateVpcPeering(t *testing.T) {
 		}
 	})
 
-	t.Run("successful create missing uri", func(t *testing.T) {
-		server := testutil.NewMockServer(t, func(w http.ResponseWriter, r *http.Request) {
-			w.Header().Set("Content-Type", "application/json")
-			w.WriteHeader(http.StatusCreated)
-			fmt.Fprint(w, `{"metadata":{"id":"res-123","name":"test-name"}}`)
-		})
-		c := testutil.NewClient(t, server.URL)
-		svc := NewVPCPeeringsClientImpl(c)
-		resp, err := svc.Create(context.Background(), "test-project", "vpc-123", types.VPCPeeringRequest{}, nil)
-		if err == nil {
-			t.Fatal("expected metadata validation error, got nil")
-		}
-		var mvErr *types.MetadataValidationError
-		if !errors.As(err, &mvErr) {
-			t.Fatalf("expected *types.MetadataValidationError, got %T: %v", err, err)
-		}
-		if len(mvErr.Missing) != 1 || mvErr.Missing[0] != "uri" {
-			t.Errorf("expected missing=[uri], got %v", mvErr.Missing)
-		}
-		if resp == nil {
-			t.Fatal("expected partial response alongside error")
-		}
-	})
-
 	t.Run("successful create missing name", func(t *testing.T) {
 		server := testutil.NewMockServer(t, func(w http.ResponseWriter, r *http.Request) {
 			w.Header().Set("Content-Type", "application/json")

--- a/internal/clients/network/vpc_test.go
+++ b/internal/clients/network/vpc_test.go
@@ -360,30 +360,6 @@ func TestCreateVPC(t *testing.T) {
 		}
 	})
 
-	t.Run("successful create missing uri", func(t *testing.T) {
-		server := testutil.NewMockServer(t, func(w http.ResponseWriter, r *http.Request) {
-			w.Header().Set("Content-Type", "application/json")
-			w.WriteHeader(http.StatusCreated)
-			fmt.Fprint(w, `{"metadata":{"id":"res-123","name":"test-name"}}`)
-		})
-		c := testutil.NewClient(t, server.URL)
-		svc := NewVPCsClientImpl(c)
-		resp, err := svc.Create(context.Background(), "test-project", types.VPCRequest{}, nil)
-		if err == nil {
-			t.Fatal("expected metadata validation error, got nil")
-		}
-		var mvErr *types.MetadataValidationError
-		if !errors.As(err, &mvErr) {
-			t.Fatalf("expected *types.MetadataValidationError, got %T: %v", err, err)
-		}
-		if len(mvErr.Missing) != 1 || mvErr.Missing[0] != "uri" {
-			t.Errorf("expected missing=[uri], got %v", mvErr.Missing)
-		}
-		if resp == nil {
-			t.Fatal("expected partial response alongside error")
-		}
-	})
-
 	t.Run("successful create missing name", func(t *testing.T) {
 		server := testutil.NewMockServer(t, func(w http.ResponseWriter, r *http.Request) {
 			w.Header().Set("Content-Type", "application/json")

--- a/internal/clients/network/vpn-route_test.go
+++ b/internal/clients/network/vpn-route_test.go
@@ -381,30 +381,6 @@ func TestCreateVpnRoute(t *testing.T) {
 		}
 	})
 
-	t.Run("successful create missing uri", func(t *testing.T) {
-		server := testutil.NewMockServer(t, func(w http.ResponseWriter, r *http.Request) {
-			w.Header().Set("Content-Type", "application/json")
-			w.WriteHeader(http.StatusCreated)
-			fmt.Fprint(w, `{"metadata":{"id":"res-123","name":"test-name"}}`)
-		})
-		c := testutil.NewClient(t, server.URL)
-		svc := NewVPNRoutesClientImpl(c)
-		resp, err := svc.Create(context.Background(), "test-project", "tunnel-123", types.VPNRouteRequest{}, nil)
-		if err == nil {
-			t.Fatal("expected metadata validation error, got nil")
-		}
-		var mvErr *types.MetadataValidationError
-		if !errors.As(err, &mvErr) {
-			t.Fatalf("expected *types.MetadataValidationError, got %T: %v", err, err)
-		}
-		if len(mvErr.Missing) != 1 || mvErr.Missing[0] != "uri" {
-			t.Errorf("expected missing=[uri], got %v", mvErr.Missing)
-		}
-		if resp == nil {
-			t.Fatal("expected partial response alongside error")
-		}
-	})
-
 	t.Run("successful create missing name", func(t *testing.T) {
 		server := testutil.NewMockServer(t, func(w http.ResponseWriter, r *http.Request) {
 			w.Header().Set("Content-Type", "application/json")

--- a/internal/clients/network/vpn-tunnel_test.go
+++ b/internal/clients/network/vpn-tunnel_test.go
@@ -354,30 +354,6 @@ func TestCreateVpnTunnel(t *testing.T) {
 		}
 	})
 
-	t.Run("successful create missing uri", func(t *testing.T) {
-		server := testutil.NewMockServer(t, func(w http.ResponseWriter, r *http.Request) {
-			w.Header().Set("Content-Type", "application/json")
-			w.WriteHeader(http.StatusCreated)
-			fmt.Fprint(w, `{"metadata":{"id":"res-123","name":"test-name"}}`)
-		})
-		c := testutil.NewClient(t, server.URL)
-		svc := NewVPNTunnelsClientImpl(c)
-		resp, err := svc.Create(context.Background(), "test-project", types.VPNTunnelRequest{}, nil)
-		if err == nil {
-			t.Fatal("expected metadata validation error, got nil")
-		}
-		var mvErr *types.MetadataValidationError
-		if !errors.As(err, &mvErr) {
-			t.Fatalf("expected *types.MetadataValidationError, got %T: %v", err, err)
-		}
-		if len(mvErr.Missing) != 1 || mvErr.Missing[0] != "uri" {
-			t.Errorf("expected missing=[uri], got %v", mvErr.Missing)
-		}
-		if resp == nil {
-			t.Fatal("expected partial response alongside error")
-		}
-	})
-
 	t.Run("successful create missing name", func(t *testing.T) {
 		server := testutil.NewMockServer(t, func(w http.ResponseWriter, r *http.Request) {
 			w.Header().Set("Content-Type", "application/json")

--- a/internal/clients/project/project_test.go
+++ b/internal/clients/project/project_test.go
@@ -337,30 +337,6 @@ func TestCreateProject(t *testing.T) {
 		}
 	})
 
-	t.Run("successful create missing uri", func(t *testing.T) {
-		server := testutil.NewMockServer(t, func(w http.ResponseWriter, r *http.Request) {
-			w.Header().Set("Content-Type", "application/json")
-			w.WriteHeader(http.StatusCreated)
-			fmt.Fprint(w, `{"metadata":{"id":"res-123","name":"test-name"}}`)
-		})
-		c := testutil.NewClient(t, server.URL)
-		svc := NewProjectsClientImpl(c)
-		resp, err := svc.Create(context.Background(), types.ProjectRequest{}, nil)
-		if err == nil {
-			t.Fatal("expected metadata validation error, got nil")
-		}
-		var mvErr *types.MetadataValidationError
-		if !errors.As(err, &mvErr) {
-			t.Fatalf("expected *types.MetadataValidationError, got %T: %v", err, err)
-		}
-		if len(mvErr.Missing) != 1 || mvErr.Missing[0] != "uri" {
-			t.Errorf("expected missing=[uri], got %v", mvErr.Missing)
-		}
-		if resp == nil {
-			t.Fatal("expected partial response alongside error")
-		}
-	})
-
 	t.Run("successful create missing name", func(t *testing.T) {
 		server := testutil.NewMockServer(t, func(w http.ResponseWriter, r *http.Request) {
 			w.Header().Set("Content-Type", "application/json")

--- a/internal/clients/schedule/job_test.go
+++ b/internal/clients/schedule/job_test.go
@@ -448,30 +448,6 @@ func TestCreateScheduleJob(t *testing.T) {
 		}
 	})
 
-	t.Run("successful create missing uri", func(t *testing.T) {
-		server := testutil.NewMockServer(t, func(w http.ResponseWriter, r *http.Request) {
-			w.Header().Set("Content-Type", "application/json")
-			w.WriteHeader(http.StatusCreated)
-			fmt.Fprint(w, `{"metadata":{"id":"res-123","name":"test-name"}}`)
-		})
-		c := testutil.NewClient(t, server.URL)
-		svc := NewJobsClientImpl(c)
-		resp, err := svc.Create(context.Background(), "test-project", types.JobRequest{}, nil)
-		if err == nil {
-			t.Fatal("expected metadata validation error, got nil")
-		}
-		var mvErr *types.MetadataValidationError
-		if !errors.As(err, &mvErr) {
-			t.Fatalf("expected *types.MetadataValidationError, got %T: %v", err, err)
-		}
-		if len(mvErr.Missing) != 1 || mvErr.Missing[0] != "uri" {
-			t.Errorf("expected missing=[uri], got %v", mvErr.Missing)
-		}
-		if resp == nil {
-			t.Fatal("expected partial response alongside error")
-		}
-	})
-
 	t.Run("successful create missing name", func(t *testing.T) {
 		server := testutil.NewMockServer(t, func(w http.ResponseWriter, r *http.Request) {
 			w.Header().Set("Content-Type", "application/json")

--- a/internal/clients/security/kms_test.go
+++ b/internal/clients/security/kms_test.go
@@ -361,30 +361,6 @@ func TestCreateKMSKey(t *testing.T) {
 		}
 	})
 
-	t.Run("successful create missing uri", func(t *testing.T) {
-		server := testutil.NewMockServer(t, func(w http.ResponseWriter, r *http.Request) {
-			w.Header().Set("Content-Type", "application/json")
-			w.WriteHeader(http.StatusCreated)
-			fmt.Fprint(w, `{"metadata":{"id":"res-123","name":"test-name"}}`)
-		})
-		c := testutil.NewClient(t, server.URL)
-		svc := NewKMSClientImpl(c)
-		resp, err := svc.Create(context.Background(), "test-project", types.KmsRequest{}, nil)
-		if err == nil {
-			t.Fatal("expected metadata validation error, got nil")
-		}
-		var mvErr *types.MetadataValidationError
-		if !errors.As(err, &mvErr) {
-			t.Fatalf("expected *types.MetadataValidationError, got %T: %v", err, err)
-		}
-		if len(mvErr.Missing) != 1 || mvErr.Missing[0] != "uri" {
-			t.Errorf("expected missing=[uri], got %v", mvErr.Missing)
-		}
-		if resp == nil {
-			t.Fatal("expected partial response alongside error")
-		}
-	})
-
 	t.Run("successful create missing name", func(t *testing.T) {
 		server := testutil.NewMockServer(t, func(w http.ResponseWriter, r *http.Request) {
 			w.Header().Set("Content-Type", "application/json")

--- a/internal/clients/storage/backup_test.go
+++ b/internal/clients/storage/backup_test.go
@@ -371,30 +371,6 @@ func TestCreateBackup(t *testing.T) {
 		}
 	})
 
-	t.Run("successful create missing uri", func(t *testing.T) {
-		server := testutil.NewMockServer(t, func(w http.ResponseWriter, r *http.Request) {
-			w.Header().Set("Content-Type", "application/json")
-			w.WriteHeader(http.StatusCreated)
-			fmt.Fprint(w, `{"metadata":{"id":"res-123","name":"test-name"}}`)
-		})
-		c := testutil.NewClient(t, server.URL)
-		svc := NewBackupClientImpl(c)
-		resp, err := svc.Create(context.Background(), "test-project", types.StorageBackupRequest{}, nil)
-		if err == nil {
-			t.Fatal("expected metadata validation error, got nil")
-		}
-		var mvErr *types.MetadataValidationError
-		if !errors.As(err, &mvErr) {
-			t.Fatalf("expected *types.MetadataValidationError, got %T: %v", err, err)
-		}
-		if len(mvErr.Missing) != 1 || mvErr.Missing[0] != "uri" {
-			t.Errorf("expected missing=[uri], got %v", mvErr.Missing)
-		}
-		if resp == nil {
-			t.Fatal("expected partial response alongside error")
-		}
-	})
-
 	t.Run("successful create missing name", func(t *testing.T) {
 		server := testutil.NewMockServer(t, func(w http.ResponseWriter, r *http.Request) {
 			w.Header().Set("Content-Type", "application/json")

--- a/internal/clients/storage/restore_test.go
+++ b/internal/clients/storage/restore_test.go
@@ -384,30 +384,6 @@ func TestCreateRestore(t *testing.T) {
 		}
 	})
 
-	t.Run("successful create missing uri", func(t *testing.T) {
-		server := testutil.NewMockServer(t, func(w http.ResponseWriter, r *http.Request) {
-			w.Header().Set("Content-Type", "application/json")
-			w.WriteHeader(http.StatusCreated)
-			fmt.Fprint(w, `{"metadata":{"id":"res-123","name":"test-name"}}`)
-		})
-		svc := newRestoreSvc(t, server.URL)
-		body := types.RestoreRequest{Properties: types.RestorePropertiesRequest{Target: types.ReferenceResource{URI: "dummy"}}}
-		resp, err := svc.Create(context.Background(), "test-project", "backup-123", body, nil)
-		if err == nil {
-			t.Fatal("expected metadata validation error, got nil")
-		}
-		var mvErr *types.MetadataValidationError
-		if !errors.As(err, &mvErr) {
-			t.Fatalf("expected *types.MetadataValidationError, got %T: %v", err, err)
-		}
-		if len(mvErr.Missing) != 1 || mvErr.Missing[0] != "uri" {
-			t.Errorf("expected missing=[uri], got %v", mvErr.Missing)
-		}
-		if resp == nil {
-			t.Fatal("expected partial response alongside error")
-		}
-	})
-
 	t.Run("successful create missing name", func(t *testing.T) {
 		server := testutil.NewMockServer(t, func(w http.ResponseWriter, r *http.Request) {
 			w.Header().Set("Content-Type", "application/json")

--- a/internal/clients/storage/storage_test.go
+++ b/internal/clients/storage/storage_test.go
@@ -379,30 +379,6 @@ func TestCreateBlockStorageVolume(t *testing.T) {
 		}
 	})
 
-	t.Run("successful create missing uri", func(t *testing.T) {
-		server := testutil.NewMockServer(t, func(w http.ResponseWriter, r *http.Request) {
-			w.Header().Set("Content-Type", "application/json")
-			w.WriteHeader(http.StatusCreated)
-			fmt.Fprint(w, `{"metadata":{"id":"res-123","name":"test-name"}}`)
-		})
-		c := testutil.NewClient(t, server.URL)
-		svc := NewVolumesClientImpl(c)
-		resp, err := svc.Create(context.Background(), "test-project", types.BlockStorageRequest{}, nil)
-		if err == nil {
-			t.Fatal("expected metadata validation error, got nil")
-		}
-		var mvErr *types.MetadataValidationError
-		if !errors.As(err, &mvErr) {
-			t.Fatalf("expected *types.MetadataValidationError, got %T: %v", err, err)
-		}
-		if len(mvErr.Missing) != 1 || mvErr.Missing[0] != "uri" {
-			t.Errorf("expected missing=[uri], got %v", mvErr.Missing)
-		}
-		if resp == nil {
-			t.Fatal("expected partial response alongside error")
-		}
-	})
-
 	t.Run("successful create missing name", func(t *testing.T) {
 		server := testutil.NewMockServer(t, func(w http.ResponseWriter, r *http.Request) {
 			w.Header().Set("Content-Type", "application/json")
@@ -953,29 +929,6 @@ func TestCreateSnapshot(t *testing.T) {
 		}
 		if len(mvErr.Missing) != 1 || mvErr.Missing[0] != "id" {
 			t.Errorf("expected missing=[id], got %v", mvErr.Missing)
-		}
-		if resp == nil {
-			t.Fatal("expected partial response alongside error")
-		}
-	})
-
-	t.Run("successful create missing uri", func(t *testing.T) {
-		server := testutil.NewMockServer(t, func(w http.ResponseWriter, r *http.Request) {
-			w.Header().Set("Content-Type", "application/json")
-			w.WriteHeader(http.StatusCreated)
-			fmt.Fprint(w, `{"metadata":{"id":"res-123","name":"test-name"}}`)
-		})
-		svc := newSnapshotSvc(t, server.URL)
-		resp, err := svc.Create(context.Background(), "test-project", types.SnapshotRequest{}, nil)
-		if err == nil {
-			t.Fatal("expected metadata validation error, got nil")
-		}
-		var mvErr *types.MetadataValidationError
-		if !errors.As(err, &mvErr) {
-			t.Fatalf("expected *types.MetadataValidationError, got %T: %v", err, err)
-		}
-		if len(mvErr.Missing) != 1 || mvErr.Missing[0] != "uri" {
-			t.Errorf("expected missing=[uri], got %v", mvErr.Missing)
 		}
 		if resp == nil {
 			t.Fatal("expected partial response alongside error")

--- a/pkg/types/resource.go
+++ b/pkg/types/resource.go
@@ -156,9 +156,9 @@ func (e *MetadataValidationError) Error() string {
 	return fmt.Sprintf("response metadata missing required field(s): %s", strings.Join(e.Missing, ", "))
 }
 
-// Validate returns a *MetadataValidationError if any of ID, URI, or Name are
-// absent or empty. The Aruba Cloud API must populate all three on a successful
-// Create response; callers rely on them to identify and reference the resource.
+// Validate returns a *MetadataValidationError if ID or Name are absent or
+// empty. The Aruba Cloud API must populate both on a successful Create
+// response; callers rely on them to identify the resource.
 func (m *ResourceMetadataResponse) Validate() error {
 	if m == nil {
 		return &MetadataValidationError{Missing: []string{"metadata"}}
@@ -166,9 +166,6 @@ func (m *ResourceMetadataResponse) Validate() error {
 	var missing []string
 	if m.ID == nil || *m.ID == "" {
 		missing = append(missing, "id")
-	}
-	if m.URI == nil || *m.URI == "" {
-		missing = append(missing, "uri")
 	}
 	if m.Name == nil || *m.Name == "" {
 		missing = append(missing, "name")

--- a/pkg/types/resource_test.go
+++ b/pkg/types/resource_test.go
@@ -66,37 +66,6 @@ func TestResourceMetadataResponse_Validate(t *testing.T) {
 		}
 	})
 
-	t.Run("missing uri nil", func(t *testing.T) {
-		m := &types.ResourceMetadataResponse{ID: &id, Name: &name}
-		err := m.Validate()
-		if err == nil {
-			t.Fatal("expected error, got nil")
-		}
-		var mvErr *types.MetadataValidationError
-		if !errors.As(err, &mvErr) {
-			t.Fatalf("expected MetadataValidationError, got %T", err)
-		}
-		if len(mvErr.Missing) != 1 || mvErr.Missing[0] != "uri" {
-			t.Errorf("expected missing=[uri], got %v", mvErr.Missing)
-		}
-	})
-
-	t.Run("missing uri empty string", func(t *testing.T) {
-		empty := ""
-		m := &types.ResourceMetadataResponse{ID: &id, URI: &empty, Name: &name}
-		err := m.Validate()
-		if err == nil {
-			t.Fatal("expected error, got nil")
-		}
-		var mvErr *types.MetadataValidationError
-		if !errors.As(err, &mvErr) {
-			t.Fatalf("expected MetadataValidationError, got %T", err)
-		}
-		if len(mvErr.Missing) != 1 || mvErr.Missing[0] != "uri" {
-			t.Errorf("expected missing=[uri], got %v", mvErr.Missing)
-		}
-	})
-
 	t.Run("missing name nil", func(t *testing.T) {
 		m := &types.ResourceMetadataResponse{ID: &id, URI: &uri}
 		err := m.Validate()
@@ -138,8 +107,8 @@ func TestResourceMetadataResponse_Validate(t *testing.T) {
 		if !errors.As(err, &mvErr) {
 			t.Fatalf("expected MetadataValidationError, got %T", err)
 		}
-		if len(mvErr.Missing) != 3 {
-			t.Errorf("expected 3 missing fields, got %v", mvErr.Missing)
+		if len(mvErr.Missing) != 2 {
+			t.Errorf("expected 2 missing fields, got %v", mvErr.Missing)
 		}
 	})
 


### PR DESCRIPTION
## Summary

- Removes `uri` from `ResourceMetadataResponse.Validate()` — only `id` and `name` are now required.
- Removes the 19 `"successful create missing uri"` subtests across all 18 client test files.
- Updates `pkg/types/resource_test.go` (`"all fields missing"` now expects 2 missing fields, not 3).
- Updates the TD-021 entry in `ai/TECH_DEBT.md` to document why URI validation was dropped.

## Background

The previous PR (#175, TD-021) added metadata contract validation to all 21 Create methods. It required `id`, `uri`, and `name` to be present. In practice the Aruba Cloud API does not consistently return `metadata.uri` on successful Create responses, causing this regression in acloud-cli:

```
acloud management project create --name atn-pro -o yaml
Error: creating project: invalid create response: response metadata missing required field(s): uri
```

`id` and `name` remain required — those are the fields consumers need to identify and work with a newly created resource.

## Test plan

- [x] `go build ./...` — clean
- [x] `go test ./pkg/types/... ./internal/clients/...` — all 11 packages pass
- [ ] Manual: run `acloud management project create` against a real endpoint and confirm no false-positive validation error

🤖 Generated with [Claude Code](https://claude.com/claude-code)