### PR TITLE
fix(network): correct VPN tunnel / VPN route / VPC peering route URL paths (#229)

### DIFF
--- a/internal/clients/network/path.go
+++ b/internal/clients/network/path.go
@@ -31,14 +31,14 @@ const (
 	VPCPeeringPath  = "/projects/%s/providers/Aruba.Network/vpcs/%s/vpcPeerings/%s"
 
 	// VPC Peering Route paths
-	VPCPeeringRoutesPath = "/projects/%s/providers/Aruba.Network/vpcs/%s/vpcPeerings/%s/routes"
-	VPCPeeringRoutePath  = "/projects/%s/providers/Aruba.Network/vpcs/%s/vpcPeerings/%s/routes/%s"
+	VPCPeeringRoutesPath = "/projects/%s/providers/Aruba.Network/vpcs/%s/vpcPeerings/%s/vpcPeeringRoutes"
+	VPCPeeringRoutePath  = "/projects/%s/providers/Aruba.Network/vpcs/%s/vpcPeerings/%s/vpcPeeringRoutes/%s"
 
 	// VPN Tunnel paths
-	VPNTunnelsPath = "/projects/%s/providers/Aruba.Network/vpntunnels"
-	VPNTunnelPath  = "/projects/%s/providers/Aruba.Network/vpntunnels/%s"
+	VPNTunnelsPath = "/projects/%s/providers/Aruba.Network/vpnTunnels"
+	VPNTunnelPath  = "/projects/%s/providers/Aruba.Network/vpnTunnels/%s"
 
 	// VPN Route paths
-	VPNRoutesPath = "/projects/%s/providers/Aruba.Network/vpntunnels/%s/routes"
-	VPNRoutePath  = "/projects/%s/providers/Aruba.Network/vpntunnels/%s/routes/%s"
+	VPNRoutesPath = "/projects/%s/providers/Aruba.Network/vpnTunnels/%s/vpnRoutes"
+	VPNRoutePath  = "/projects/%s/providers/Aruba.Network/vpnTunnels/%s/vpnRoutes/%s"
 )


### PR DESCRIPTION
## Summary

Three URL path constants in \`internal/clients/network/path.go\` used incorrect casing / sub-resource names, so every CRUD call against VPN tunnels, VPN routes, and VPC peering routes hit non-existent endpoints — the API returned \`403 Forbidden\` (its behaviour for unknown paths) making the root cause non-obvious.

| Constant | Before | After |
|---|---|---|
| \`VPNTunnelsPath\`        | \`.../vpntunnels\`                       | \`.../vpnTunnels\`                           |
| \`VPNTunnelPath\`         | \`.../vpntunnels/{id}\`                  | \`.../vpnTunnels/{id}\`                      |
| \`VPNRoutesPath\`         | \`.../vpntunnels/{id}/routes\`           | \`.../vpnTunnels/{id}/vpnRoutes\`            |
| \`VPNRoutePath\`          | \`.../vpntunnels/{id}/routes/{id}\`      | \`.../vpnTunnels/{id}/vpnRoutes/{id}\`       |
| \`VPCPeeringRoutesPath\`  | \`.../vpcPeerings/{id}/routes\`          | \`.../vpcPeerings/{id}/vpcPeeringRoutes\`    |
| \`VPCPeeringRoutePath\`   | \`.../vpcPeerings/{id}/routes/{id}\`     | \`.../vpcPeerings/{id}/vpcPeeringRoutes/{id}\` |

The new casing matches the convention already used by \`vpcPeerings\` / \`elasticIps\` / etc. in the same file and the live API paths listed in the issue.

Fixes #229

## Test plan

- [x] \`go build ./...\`
- [x] \`go vet ./...\`
- [x] \`go test ./internal/clients/network/... -count=1 -timeout 60s\` — green