### PR TITLE
fix(network): correct VPN / VPC peering route URL paths and response metadata type (#229)

### DIFF
--- a/internal/clients/network/path.go
+++ b/internal/clients/network/path.go
@@ -31,14 +31,14 @@ const (
 	VPCPeeringPath  = "/projects/%s/providers/Aruba.Network/vpcs/%s/vpcPeerings/%s"
 
 	// VPC Peering Route paths
-	VPCPeeringRoutesPath = "/projects/%s/providers/Aruba.Network/vpcs/%s/vpcPeerings/%s/routes"
-	VPCPeeringRoutePath  = "/projects/%s/providers/Aruba.Network/vpcs/%s/vpcPeerings/%s/routes/%s"
+	VPCPeeringRoutesPath = "/projects/%s/providers/Aruba.Network/vpcs/%s/vpcPeerings/%s/vpcPeeringRoutes"
+	VPCPeeringRoutePath  = "/projects/%s/providers/Aruba.Network/vpcs/%s/vpcPeerings/%s/vpcPeeringRoutes/%s"
 
 	// VPN Tunnel paths
-	VPNTunnelsPath = "/projects/%s/providers/Aruba.Network/vpntunnels"
-	VPNTunnelPath  = "/projects/%s/providers/Aruba.Network/vpntunnels/%s"
+	VPNTunnelsPath = "/projects/%s/providers/Aruba.Network/vpnTunnels"
+	VPNTunnelPath  = "/projects/%s/providers/Aruba.Network/vpnTunnels/%s"
 
 	// VPN Route paths
-	VPNRoutesPath = "/projects/%s/providers/Aruba.Network/vpntunnels/%s/routes"
-	VPNRoutePath  = "/projects/%s/providers/Aruba.Network/vpntunnels/%s/routes/%s"
+	VPNRoutesPath = "/projects/%s/providers/Aruba.Network/vpnTunnels/%s/vpnRoutes"
+	VPNRoutePath  = "/projects/%s/providers/Aruba.Network/vpnTunnels/%s/vpnRoutes/%s"
 )

--- a/internal/clients/network/vpc-peering-route.go
+++ b/internal/clients/network/vpc-peering-route.go
@@ -133,6 +133,9 @@ func (c *vpcPeeringRoutesClientImpl) Create(ctx context.Context, projectID strin
 			return nil, fmt.Errorf("failed to parse response: %w", err)
 		}
 		response.Data = &data
+		if err := response.Data.Metadata.Validate(); err != nil {
+			return response, fmt.Errorf("invalid create response: %w", err)
+		}
 	} else if response.IsError() && len(respBytes) > 0 {
 		var errorResp types.ErrorResponse
 		if err := json.Unmarshal(respBytes, &errorResp); err == nil {

--- a/internal/clients/network/vpc-peering-route_test.go
+++ b/internal/clients/network/vpc-peering-route_test.go
@@ -2,6 +2,7 @@ package network
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net/http"
 	"testing"
@@ -140,8 +141,8 @@ func TestGetVpcPeeringRoute(t *testing.T) {
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
-		if resp.Data.Metadata.Name != "route-1" {
-			t.Errorf("expected route name 'route-1', got %q", resp.Data.Metadata.Name)
+		if resp.Data.Metadata.Name == nil || *resp.Data.Metadata.Name != "route-1" {
+			t.Errorf("expected route name 'route-1', got %v", resp.Data.Metadata.Name)
 		}
 	})
 
@@ -251,6 +252,24 @@ func TestGetVpcPeeringRoute(t *testing.T) {
 			t.Errorf("expected status 200, got %d", resp.StatusCode)
 		}
 	})
+
+	t.Run("hits expected URL path", func(t *testing.T) {
+		const want = "/projects/test-project/providers/Aruba.Network/vpcs/vpc-123/vpcPeerings/peering-1/vpcPeeringRoutes/route-1"
+		server := testutil.NewMockServer(t, func(w http.ResponseWriter, r *http.Request) {
+			if r.URL.Path != want {
+				t.Errorf("expected path %q, got %q", want, r.URL.Path)
+			}
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusOK)
+			fmt.Fprint(w, `{}`)
+		})
+		c := testutil.NewClient(t, server.URL)
+		svc := NewVPCPeeringRoutesClientImpl(c)
+		_, err := svc.Get(context.Background(), "test-project", "vpc-123", "peering-1", "route-1", nil)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
 }
 
 func TestCreateVpcPeeringRoute(t *testing.T) {
@@ -261,7 +280,7 @@ func TestCreateVpcPeeringRoute(t *testing.T) {
 			}
 			w.Header().Set("Content-Type", "application/json")
 			w.WriteHeader(http.StatusCreated)
-			fmt.Fprint(w, `{"metadata":{"name":"new-route"}}`)
+			fmt.Fprint(w, `{"metadata":{"id":"res-123","uri":"/projects/test-project/providers/Aruba.Network/vpcs/vpc-123/vpcPeerings/peering-1/vpcPeeringRoutes/res-123","name":"new-route"}}`)
 		})
 		c := testutil.NewClient(t, server.URL)
 		svc := NewVPCPeeringRoutesClientImpl(c)
@@ -271,6 +290,12 @@ func TestCreateVpcPeeringRoute(t *testing.T) {
 		}
 		if resp.StatusCode != http.StatusCreated {
 			t.Errorf("expected status 201, got %d", resp.StatusCode)
+		}
+		if resp.Data.Metadata.ID == nil || *resp.Data.Metadata.ID != "res-123" {
+			t.Errorf("expected ID 'res-123', got %v", resp.Data.Metadata.ID)
+		}
+		if resp.Data.Metadata.Name == nil || *resp.Data.Metadata.Name != "new-route" {
+			t.Errorf("expected name 'new-route', got %v", resp.Data.Metadata.Name)
 		}
 	})
 
@@ -361,7 +386,7 @@ func TestCreateVpcPeeringRoute(t *testing.T) {
 			}
 			w.Header().Set("Content-Type", "application/json")
 			w.WriteHeader(http.StatusCreated)
-			fmt.Fprint(w, `{}`)
+			fmt.Fprint(w, `{"metadata":{"id":"x","uri":"/x","name":"x"}}`)
 		})
 		c := testutil.NewClient(t, server.URL)
 		svc := NewVPCPeeringRoutesClientImpl(c)
@@ -371,6 +396,54 @@ func TestCreateVpcPeeringRoute(t *testing.T) {
 		}
 		if resp.StatusCode != http.StatusCreated {
 			t.Errorf("expected status 201, got %d", resp.StatusCode)
+		}
+	})
+
+	t.Run("successful create missing id", func(t *testing.T) {
+		server := testutil.NewMockServer(t, func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusCreated)
+			fmt.Fprint(w, `{"metadata":{"uri":"/projects/test-project/providers/Aruba.Network/vpcs/vpc-123/vpcPeerings/peering-1/vpcPeeringRoutes/res-123","name":"test-name"}}`)
+		})
+		c := testutil.NewClient(t, server.URL)
+		svc := NewVPCPeeringRoutesClientImpl(c)
+		resp, err := svc.Create(context.Background(), "test-project", "vpc-123", "peering-1", types.VPCPeeringRouteRequest{}, nil)
+		if err == nil {
+			t.Fatal("expected metadata validation error, got nil")
+		}
+		var mvErr *types.MetadataValidationError
+		if !errors.As(err, &mvErr) {
+			t.Fatalf("expected *types.MetadataValidationError, got %T: %v", err, err)
+		}
+		if len(mvErr.Missing) != 1 || mvErr.Missing[0] != "id" {
+			t.Errorf("expected missing=[id], got %v", mvErr.Missing)
+		}
+		if resp == nil {
+			t.Fatal("expected partial response alongside error")
+		}
+	})
+
+	t.Run("successful create missing name", func(t *testing.T) {
+		server := testutil.NewMockServer(t, func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusCreated)
+			fmt.Fprint(w, `{"metadata":{"id":"res-123","uri":"/projects/test-project/providers/Aruba.Network/vpcs/vpc-123/vpcPeerings/peering-1/vpcPeeringRoutes/res-123"}}`)
+		})
+		c := testutil.NewClient(t, server.URL)
+		svc := NewVPCPeeringRoutesClientImpl(c)
+		resp, err := svc.Create(context.Background(), "test-project", "vpc-123", "peering-1", types.VPCPeeringRouteRequest{}, nil)
+		if err == nil {
+			t.Fatal("expected metadata validation error, got nil")
+		}
+		var mvErr *types.MetadataValidationError
+		if !errors.As(err, &mvErr) {
+			t.Fatalf("expected *types.MetadataValidationError, got %T: %v", err, err)
+		}
+		if len(mvErr.Missing) != 1 || mvErr.Missing[0] != "name" {
+			t.Errorf("expected missing=[name], got %v", mvErr.Missing)
+		}
+		if resp == nil {
+			t.Fatal("expected partial response alongside error")
 		}
 	})
 }

--- a/internal/clients/network/vpc-peering-route_test.go
+++ b/internal/clients/network/vpc-peering-route_test.go
@@ -126,6 +126,24 @@ func TestListVpcPeeringRoutes(t *testing.T) {
 			t.Errorf("expected status 200, got %d", resp.StatusCode)
 		}
 	})
+
+	t.Run("hits expected URL path", func(t *testing.T) {
+		const want = "/projects/test-project/providers/Aruba.Network/vpcs/vpc-123/vpcPeerings/peering-1/vpcPeeringRoutes"
+		server := testutil.NewMockServer(t, func(w http.ResponseWriter, r *http.Request) {
+			if r.URL.Path != want {
+				t.Errorf("expected path %q, got %q", want, r.URL.Path)
+			}
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusOK)
+			fmt.Fprint(w, `{"total":0,"values":[]}`)
+		})
+		c := testutil.NewClient(t, server.URL)
+		svc := NewVPCPeeringRoutesClientImpl(c)
+		_, err := svc.List(context.Background(), "test-project", "vpc-123", "peering-1", nil)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
 }
 
 func TestGetVpcPeeringRoute(t *testing.T) {

--- a/internal/clients/network/vpn-route_test.go
+++ b/internal/clients/network/vpn-route_test.go
@@ -234,6 +234,24 @@ func TestGetVpnRoute(t *testing.T) {
 			t.Errorf("expected status 200, got %d", resp.StatusCode)
 		}
 	})
+
+	t.Run("hits expected URL path", func(t *testing.T) {
+		const want = "/projects/test-project/providers/Aruba.Network/vpnTunnels/tunnel-123/vpnRoutes/route-1"
+		server := testutil.NewMockServer(t, func(w http.ResponseWriter, r *http.Request) {
+			if r.URL.Path != want {
+				t.Errorf("expected path %q, got %q", want, r.URL.Path)
+			}
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusOK)
+			fmt.Fprint(w, `{}`)
+		})
+		c := testutil.NewClient(t, server.URL)
+		svc := NewVPNRoutesClientImpl(c)
+		_, err := svc.Get(context.Background(), "test-project", "tunnel-123", "route-1", nil)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
 }
 
 func TestCreateVpnRoute(t *testing.T) {

--- a/internal/clients/network/vpn-route_test.go
+++ b/internal/clients/network/vpn-route_test.go
@@ -117,6 +117,24 @@ func TestListVpnRoutes(t *testing.T) {
 			t.Errorf("expected status 200, got %d", resp.StatusCode)
 		}
 	})
+
+	t.Run("hits expected URL path", func(t *testing.T) {
+		const want = "/projects/test-project/providers/Aruba.Network/vpnTunnels/tunnel-123/vpnRoutes"
+		server := testutil.NewMockServer(t, func(w http.ResponseWriter, r *http.Request) {
+			if r.URL.Path != want {
+				t.Errorf("expected path %q, got %q", want, r.URL.Path)
+			}
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusOK)
+			fmt.Fprint(w, `{"total":0,"values":[]}`)
+		})
+		c := testutil.NewClient(t, server.URL)
+		svc := NewVPNRoutesClientImpl(c)
+		_, err := svc.List(context.Background(), "test-project", "tunnel-123", nil)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
 }
 
 func TestGetVpnRoute(t *testing.T) {

--- a/internal/clients/network/vpn-tunnel_test.go
+++ b/internal/clients/network/vpn-tunnel_test.go
@@ -108,6 +108,24 @@ func TestListVpnTunnels(t *testing.T) {
 			t.Errorf("expected status 200, got %d", resp.StatusCode)
 		}
 	})
+
+	t.Run("hits expected URL path", func(t *testing.T) {
+		const want = "/projects/test-project/providers/Aruba.Network/vpnTunnels"
+		server := testutil.NewMockServer(t, func(w http.ResponseWriter, r *http.Request) {
+			if r.URL.Path != want {
+				t.Errorf("expected path %q, got %q", want, r.URL.Path)
+			}
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusOK)
+			fmt.Fprint(w, `{"total":0,"values":[]}`)
+		})
+		c := testutil.NewClient(t, server.URL)
+		svc := NewVPNTunnelsClientImpl(c)
+		_, err := svc.List(context.Background(), "test-project", nil)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
 }
 
 func TestGetVpnTunnel(t *testing.T) {

--- a/internal/clients/network/vpn-tunnel_test.go
+++ b/internal/clients/network/vpn-tunnel_test.go
@@ -216,6 +216,24 @@ func TestGetVpnTunnel(t *testing.T) {
 			t.Errorf("expected status 200, got %d", resp.StatusCode)
 		}
 	})
+
+	t.Run("hits expected URL path", func(t *testing.T) {
+		const want = "/projects/test-project/providers/Aruba.Network/vpnTunnels/vpn-123"
+		server := testutil.NewMockServer(t, func(w http.ResponseWriter, r *http.Request) {
+			if r.URL.Path != want {
+				t.Errorf("expected path %q, got %q", want, r.URL.Path)
+			}
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusOK)
+			fmt.Fprint(w, `{}`)
+		})
+		c := testutil.NewClient(t, server.URL)
+		svc := NewVPNTunnelsClientImpl(c)
+		_, err := svc.Get(context.Background(), "test-project", "vpn-123", nil)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
 }
 
 func TestCreateVpnTunnel(t *testing.T) {

--- a/pkg/types/network.vpc-peering-route.go
+++ b/pkg/types/network.vpc-peering-route.go
@@ -31,7 +31,7 @@ type VPCPeeringRouteRequest struct {
 
 type VPCPeeringRouteResponse struct {
 	// Metadata of the VPC Peering Route
-	Metadata RegionalResourceMetadataRequest `json:"metadata"`
+	Metadata ResourceMetadataResponse `json:"metadata"`
 	// Spec contains the VPC Peering Route specification
 	Properties VPCPeeringRoutePropertiesResponse `json:"properties"`
 


### PR DESCRIPTION
## Summary

- **Path bug** — six URL path constants in `internal/clients/network/path.go` used `vpntunnels` (lowercase) and a generic `/routes` sub-resource that the Aruba Cloud API does not recognise; every CRUD call against VPN tunnels, VPN routes, and VPC peering routes returned `403 Forbidden`.
- **Type bug** — `VPCPeeringRouteResponse.Metadata` was typed as `RegionalResourceMetadataRequest` (a request type) instead of `ResourceMetadataResponse`, silently dropping `ID`, `URI`, `CreationDate`, and all other response-only fields when parsing a successful create/get.
- **Consistency** — `VPCPeeringRouteResponse` is now typed correctly, so `Create` can call `Metadata.Validate()` inline with every other `Create` in the network package (landed in #176).
- **Regression tests** — existing tests used a path-blind mock server; all three resources now have a `"hits expected URL path"` subtest that will catch this class of bug going forward. `TestCreateVpcPeeringRoute` gains `"successful create missing id/name"` coverage for the new `Validate()` call.

Fixes #229

## Commits

| Commit | Scope |
|---|---|
| `fix(network): correct VPN tunnel / VPN route / VPC peering route URL paths` | `internal/clients/network/path.go` — 6 constants |
| `fix(types): use ResourceMetadataResponse for VPCPeeringRouteResponse` | `pkg/types/network.vpc-peering-route.go` + `internal/clients/network/vpc-peering-route.go` |
| `test(network): add path and metadata validation tests for VPN / VPC peering resources` | `*_test.go` for vpn-tunnel, vpn-route, vpc-peering-route |

## Test plan

- [x] `go build ./...` — clean
- [x] `go vet ./...` — clean
- [x] `go test ./... -count=1` — all 28 packages green
- [x] New `"hits expected URL path"` subtests fail against the old constants and pass with the fix
- [x] New `"successful create missing id/name"` subtests verify `Metadata.Validate()` behaviour on VPC peering route Create

🤖 Generated with [Claude Code](https://claude.com/claude-code)