### PR TITLE
docs(readme): add badges and streamline structure; fix CI coverage upload (#232)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,9 +47,9 @@ jobs:
       if: matrix.go-version == '1.24'
       uses: codecov/codecov-action@v4
       with:
-        file: ./coverage.out
+        token: ${{ secrets.CODECOV_TOKEN }}
+        files: ./coverage.out
         flags: unittests
-        name: codecov-umbrella
         fail_ci_if_error: false
 
   lint:

--- a/README.md
+++ b/README.md
@@ -104,16 +104,14 @@ _, err       = arubaClient.FromStorage().Volumes().Delete(ctx, projectID, volume
 #### Filters
 
 ```go
-filter := types.NewFilterBuilder().
-    Equal("status", "running").
-    GreaterThan("cpu", 2).
-    Build() // "status:eq:running,cpu:gt:2"
+// Filters follow the format "field:operator:value"; combine with "," (AND) or ";" (OR).
+filter := "status:eq:running,cpu:gt:2"
 
 resp, err := arubaClient.FromCompute().CloudServers().List(ctx, projectID,
     &types.RequestParameters{Filter: &filter})
 ```
 
-Supported operators: `Equal`, `NotEqual`, `GreaterThan`, `LessThan`, `In`, `Contains`, `StartsWith`, `EndsWith`.
+Supported operators: `eq`, `ne`, `gt`, `lt`, `in`, `contains`, `startswith`, `endswith`.
 
 For the full filtering guide see [`docs/website/docs/filters.md`](docs/website/docs/filters.md).
 
@@ -172,6 +170,10 @@ future := async.DefaultWaitFor(
 )
 
 result, err := future.Await(ctx)
+if err != nil {
+    log.Fatalf("wait failed: %v", err)
+}
+fmt.Printf("server status: %s\n", result.Data.Properties.Status)
 ```
 
 `async.DefaultWaitFor` retries 10 times with a 10 s delay and a 60 s total timeout. Use `async.WaitFor` for custom retry counts, delay, and timeout.

--- a/README.md
+++ b/README.md
@@ -1,8 +1,24 @@
 # Aruba Cloud SDK for Go
 
-> **Note**: This SDK is currently in its **Alpha** stage. The API is not yet stable, and breaking changes may be introduced in future releases without prior notice. Please use with caution and be prepared for updates.
+[![Build](https://github.com/Arubacloud/sdk-go/actions/workflows/ci.yml/badge.svg)](https://github.com/Arubacloud/sdk-go/actions/workflows/ci.yml)
+[![Go Version](https://img.shields.io/github/go-mod/go-version/Arubacloud/sdk-go)](https://github.com/Arubacloud/sdk-go/blob/main/go.mod)
+[![Release](https://img.shields.io/github/v/release/Arubacloud/sdk-go)](https://github.com/Arubacloud/sdk-go/releases)
+[![Codecov](https://codecov.io/gh/Arubacloud/sdk-go/branch/main/graph/badge.svg)](https://codecov.io/gh/Arubacloud/sdk-go)
+[![License](https://img.shields.io/github/license/Arubacloud/sdk-go)](LICENSE)
 
-### Table of Contents
+> **Note**: This SDK is currently in its **Alpha** stage. The API is not yet stable, and breaking changes may be introduced in future releases without prior notice.
+
+Official Go SDK for the Aruba Cloud API. Manage cloud resources — compute instances, VPCs, storage, databases, and more — from Go code.
+
+## Highlights
+
+- Strongly-typed request/response structs for all resources
+- Automatic OAuth2 token management with configurable refresh strategies
+- Generic `Response[T]` wrapper with consistent error handling across all calls
+- Built-in async polling helpers for long-running operations
+- Multi-tenant client management out of the box
+
+## Table of Contents
 
 - [1. Quick Start](#1-quick-start)
 - [2. Usage Details](#2-usage-details)
@@ -12,15 +28,9 @@
   - [2.4. Handling Asynchronous Operations](#24-handling-asynchronous-operations)
   - [2.5. Data Types](#25-data-types)
 
-Welcome to the official Go SDK for the Aruba Cloud API. This SDK provides a convenient and powerful way for Go developers to interact with the Aruba Cloud API. The primary goal is to simplify the management of cloud resources, allowing you to programmatically create, read, update, and delete resources such as compute instances, virtual private clouds (VPCs), block storage, and more.
-
 ## 1. Quick Start
 
-Getting started with the SDK is straightforward. You need to import the `aruba` package, create a client with your credentials, and then you can start making API calls.
-
-The first and most fundamental resource in the Aruba Cloud is the **Project**. All other resources belong to a project.
-
-Here’s how to initialize the SDK client and create your first project:
+Import the `aruba` package, create a client with your credentials, and start making API calls.
 
 ```go
 package main
@@ -36,57 +46,28 @@ import (
 )
 
 func main() {
-	// Your API credentials
-	clientID := "your-client-id"
-	clientSecret := "your-client-secret"
-
-	// 1. Initialize the SDK Client using default options
-	arubaClient, err := aruba.NewClient(aruba.DefaultOptions(clientID, clientSecret))
+	arubaClient, err := aruba.NewClient(aruba.DefaultOptions("your-client-id", "your-client-secret"))
 	if err != nil {
 		log.Fatalf("Failed to create SDK client: %v", err)
 	}
 
-	// Create a context with a timeout
 	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
 	defer cancel()
 
-	// 2. Define the request to create a new Project
-	projectReq := aruba_types.ProjectRequest{
+	createResp, err := arubaClient.FromProject().Create(ctx, aruba_types.ProjectRequest{
 		Metadata: aruba_types.ResourceMetadataRequest{
 			Name: "my-first-project",
 			Tags: []string{"go-sdk", "quick-start"},
 		},
-		Properties: aruba_types.ProjectPropertiesRequest{
-			Description: stringPtr("A project created with the Go SDK"),
-		},
-	}
-
-	// 3. Create the Project
-	fmt.Println("Creating a new project...")
-	createResp, err := arubaClient.FromProject().Create(ctx, projectReq, nil)
+	}, nil)
 	if err != nil {
-		// Handle network errors or client-side validation errors
 		log.Fatalf("Error creating project: %v", err)
 	}
-
-	// 4. Check the API response
 	if !createResp.IsSuccess() {
-		// Handle API errors (e.g., 4xx or 5xx statuses)
-		log.Fatalf("API Error: Failed to create project - Status: %d, Title: %s, Detail: %s",
-			createResp.StatusCode,
-			stringValue(createResp.Error.Title),
-			stringValue(createResp.Error.Detail))
+		log.Fatalf("API error %d: %s", createResp.StatusCode, *createResp.Error.Title)
 	}
 
-	projectID := *createResp.Data.Metadata.ID
-	fmt.Printf("✓ Successfully created project with ID: %s\n", projectID)
-}
-
-// Helper functions for pointers
-func stringPtr(s string) *string { return &s }
-func stringValue(s *string) string {
-	if s == nil { return "" }
-	return *s
+	fmt.Printf("Created project: %s\n", *createResp.Data.Metadata.ID)
 }
 ```
 
@@ -94,262 +75,114 @@ func stringValue(s *string) string {
 
 ### 2.1. Config Options
 
-The SDK client is configured using an `Options` object. The easiest way to get started is with `aruba.DefaultOptions`, which sets up a production-ready client.
+Configure the client via the `Options` fluent builder. `aruba.DefaultOptions` covers the most common case.
 
 ```go
-// Creates a client with default settings for production
 options := aruba.DefaultOptions("your-client-id", "your-client-secret")
-
-// You can further customize the options using a fluent API
-options.WithNativeLogger() // Enable built-in logging
-
-// Create the client from the options
-arubaClient, err := aruba.NewClient(options)
+options.WithNativeLogger()          // enable built-in logging
+options.WithCustomHTTPClient(hc)    // supply a custom *http.Client
 ```
 
-Key configuration areas include:
+Key areas:
 
--   **Authentication**: By default, the SDK uses the provided `clientID` and `clientSecret` to automatically manage OAuth2 tokens. For advanced scenarios, you can use `WithToken()` for static tokens or configure a Vault repository.
--   **Logging**: Logging is disabled by default. You can enable the built-in logger with `WithNativeLogger()` or provide your own `logger.Logger` implementation with `WithCustomLogger()`.
--   **HTTP Client**: The SDK uses `http.DefaultClient`. You can supply your own `*http.Client` with custom settings (like timeouts) using `WithCustomHTTPClient()`.
+- **Authentication** — OAuth2 client credentials by default. Use `WithToken()` for a static token, or configure Vault-backed credentials for secrets management.
+- **Logging** — disabled by default. Enable with `WithNativeLogger()` or inject your own `logger.Logger`.
+- **HTTP client** — defaults to `http.DefaultClient`. Override with `WithCustomHTTPClient()` to set timeouts or a custom transport.
 
-For a comprehensive guide on all available SDK configuration options, including detailed explanations of mutual exclusions and side effects, please refer to the [Options Documentation](./doc/OPTIONS.md).
+For the full options reference see [`docs/website/docs/options.md`](docs/website/docs/options.md).
 
 ### 2.2. Performing Calls, Setting Filters, and Handling Responses
 
-#### Performing API Calls
-
-API calls are organized into logical groups (e.g., `Compute`, `Network`, `Storage`). You can access these groups from the main `arubaClient` object.
-
-The general pattern is: `arubaClient.From<Group>().<Resource>().<Action>()`
+#### API calls
 
 ```go
-// Example: List all Cloud Servers in a project
 servers, err := arubaClient.FromCompute().CloudServers().List(ctx, projectID, nil)
-
-// Example: Get a specific VPC
-vpc, err := arubaClient.FromNetwork().VPCs().Get(ctx, projectID, vpcID, nil)
-
-// Example: Delete a Block Storage volume
-deleteResp, err := arubaClient.FromStorage().Volumes().Delete(ctx, projectID, volumeID, nil)
+vpc, err    := arubaClient.FromNetwork().VPCs().Get(ctx, projectID, vpcID, nil)
+_, err       = arubaClient.FromStorage().Volumes().Delete(ctx, projectID, volumeID, nil)
 ```
 
-#### Setting Filters
-
-When listing resources, you can use filters to narrow down the results. The SDK provides a `FilterBuilder` to construct complex filter expressions programmatically.
-
-Filters follow the format `field:operator:value`. Multiple filters are combined with `,` (for AND) or `;` (for OR).
-
-**Example: Find all 'running' cloud servers with more than 2 CPU cores.**
+#### Filters
 
 ```go
-import "github.com/Arubacloud/sdk-go/pkg/types"
-
-// Construct the filter string
-filterStr := types.NewFilterBuilder().
+filter := types.NewFilterBuilder().
     Equal("status", "running").
     GreaterThan("cpu", 2).
-    Build() // Builds the string: "status:eq:running,cpu:gt:2"
+    Build() // "status:eq:running,cpu:gt:2"
 
-// Create request parameters and assign the filter
-params := &types.RequestParameters{
-    Filter: &filterStr,
-}
-
-// Perform the call
-resp, err := arubaClient.FromCompute().CloudServers().List(ctx, projectID, params)
+resp, err := arubaClient.FromCompute().CloudServers().List(ctx, projectID,
+    &types.RequestParameters{Filter: &filter})
 ```
 
-Supported operators include `Equal`, `NotEqual`, `GreaterThan`, `LessThan`, `In`, `Contains`, `StartsWith`, and `EndsWith`.
+Supported operators: `Equal`, `NotEqual`, `GreaterThan`, `LessThan`, `In`, `Contains`, `StartsWith`, `EndsWith`.
 
-For a comprehensive guide on advanced filtering capabilities, including programmatic filter building and practical examples, please refer to the [Filtering Guide](./doc/FILTERS.md).
+For the full filtering guide see [`docs/website/docs/filters.md`](docs/website/docs/filters.md).
 
-#### Handling Responses
+#### Responses
 
-All API calls return a `*types.Response[T]` and an `error`.
-
-1.  **Always check the `error` first.** This indicates a network problem, a context timeout, or a client-side issue.
-2.  **If `error` is `nil`, check the response status.** The `Response` object contains helper methods like `IsSuccess()` (for 2xx statuses) and `IsError()` (for 4xx/5xx statuses).
-
-The generic `Response` struct looks like this:
+Every call returns `*types.Response[T]` and `error`. Check `error` first (network/client issues), then `IsSuccess()` / `IsError()` for the API result.
 
 ```go
-type Response[T any] struct {
-    Data         *T              // Populated on success (2xx)
-    Error        *ErrorResponse  // Populated on failure (4xx/5xx)
-    HTTPResponse *http.Response  // The raw HTTP response
-    StatusCode   int             // The HTTP status code
-    RawBody      []byte          // The raw response body
-}
-```
-
-**Standard response handling pattern:**
-
-```go
-resp, err := arubaClient.FromNetwork().VPCs().Get(ctx, projectID, "non-existent-vpc", nil)
-
-// 1. Check for network/client errors
+resp, err := arubaClient.FromNetwork().VPCs().Get(ctx, projectID, vpcID, nil)
 if err != nil {
-    log.Fatalf("Request failed: %v", err)
+    log.Fatalf("request failed: %v", err)
 }
-
-// 2. Check for success (2xx)
 if resp.IsSuccess() {
-    // Safely access the response data
-    fmt.Printf("VPC Name: %s\n", *resp.Data.Metadata.Name)
-    return
-}
-
-// 3. Handle API errors (4xx/5xx)
-if resp.IsError() && resp.Error != nil {
-    // Log structured error details
-    log.Printf("API Error Occurred (Status %d):", resp.StatusCode)
-    log.Printf("  Title: %s", stringValue(resp.Error.Title))
-    log.Printf("  Detail: %s", stringValue(resp.Error.Detail))
-
-    // You can also inspect specific status codes
-    if resp.StatusCode == 404 {
-        log.Println("  Diagnosis: The resource was not found.")
-    }
+    fmt.Println(*resp.Data.Metadata.Name)
+} else {
+    log.Printf("API error %d: %s", resp.StatusCode, *resp.Error.Title)
 }
 ```
 
-For a comprehensive guide on response handling, including detailed error scenarios and best practices, please refer to the [Response Handling Guide](./doc/RESPONSE_HANDLING.md).
+For detailed error handling patterns see [`docs/website/docs/response-handling.md`](docs/website/docs/response-handling.md).
 
 ### 2.3. SDK Client API Reference
 
-#### Groups
+#### Service groups
 
-The SDK is divided into the following service groups, accessible from the `arubaClient`:
+| Accessor | Resources |
+|---|---|
+| `FromAudit()` | Audit events |
+| `FromCompute()` | Cloud servers, key pairs |
+| `FromContainer()` | Kubernetes (KaaS), container registries |
+| `FromDatabase()` | Database-as-a-Service instances |
+| `FromMetric()` | Metrics and alerts |
+| `FromNetwork()` | VPCs, subnets, security groups, elastic IPs, load balancers, VPN tunnels, VPC peerings |
+| `FromProject()` | Projects |
+| `FromSchedule()` | Scheduled jobs |
+| `FromSecurity()` | KMS keys |
+| `FromStorage()` | Volumes, snapshots, backups, restores |
 
--   `FromAudit()`: Access audit events.
--   `FromCompute()`: Manage virtual machines and SSH keys.
--   `FromContainer()`: Manage Kubernetes (KaaS) and Container Registry services.
--   `FromDatabase()`: Manage Database-as-a-Service (DBaaS) instances.
--   `FromMetric()`: Access metrics and alerts.
--   `FromNetwork()`: Manage VPCs, subnets, security groups, elastic IPs, etc.
--   `FromProject()`: Manage projects.
--   `FromSchedule()`: Manage scheduled jobs.
--   `FromSecurity()`: Manage KMS keys.
--   `FromStorage()`: Manage block storage volumes, snapshots, backups, and restores.
+Each resource client provides `Create`, `List`, `Get`, `Update`, `Delete` where applicable.
 
-#### Resources
-
-Each group provides clients for specific resources. For example:
-
--   `arubaClient.FromCompute().CloudServers()`
--   `arubaClient.FromCompute().KeyPairs()`
--   `arubaClient.FromNetwork().VPCs()`
--   `arubaClient.FromNetwork().Subnets()`
--   `arubaClient.FromStorage().Volumes()`
-
-Each resource client provides methods for CRUD operations (`Create`, `List`, `Get`, `Update`, `Delete`), where applicable.
-
-For a comprehensive guide on all API groups, resource clients, and their available operations, please refer to the [API Groups and Resources Documentation](./doc/RESOURCES.md).
+For the full resource listing see [`docs/website/docs/resources.md`](docs/website/docs/resources.md).
 
 ### 2.4. Handling Asynchronous Operations
 
-Many operations in a cloud environment are asynchronous. For instance, when you create a new Cloud Server, the API call might return successfully, but the server itself takes a few minutes to be provisioned and ready. The SDK provides helpers in the `pkg/async` package to manage these scenarios by polling for a desired state.
-
-The primary tool for this is the `async.WaitFor` function. It repeatedly executes an API call until a specific condition is met or a timeout is reached. A simpler `async.DefaultWaitFor` is also available for common use cases.
-
-**Example: Waiting for a Cloud Server to be 'running'**
-
-Let's say you've just created a Cloud Server and want to wait until it is fully provisioned and has a status of `"running"`.
+Many cloud operations are asynchronous. Use `async.DefaultWaitFor` to poll until the resource reaches the desired state.
 
 ```go
-package main
-
-import (
-	"context"
-	"fmt"
-	"log"
-	"time"
-
-	"github.com/Arubacloud/sdk-go/pkg/aruba"
-	"github.com/Arubacloud/sdk-go/pkg/async"
-	aruba_types "github.com/Arubacloud/sdk-go/pkg/types"
-)
-
-// Assume arubaClient is initialized and projectID and serverID are available.
-var arubaClient *aruba.Client
-var projectID = "your-project-id"
-var serverID = "your-server-id"
-
-func main() {
-	// Initialize client, create server, etc.
-	// ...
-
-	fmt.Printf("Waiting for server %s to become ready...\n", serverID)
-
-	// Use DefaultWaitFor for simple polling with default settings.
-	// It will retry every 10s for up to 10 times with a total timeout of 60s.
-	waitFuture := async.DefaultWaitFor(
-		context.Background(),
-		// This is the function that will be called repeatedly.
-		// It should fetch the resource's current state.
-		func(ctx context.Context) (*aruba_types.Response[aruba_types.CloudServerResponse], error) {
-			return arubaClient.FromCompute().CloudServers().Get(ctx, projectID, serverID, nil)
-		},
-		// This function checks if the desired state has been reached.
-		// It returns 'true' to stop waiting, or 'false' to continue.
-		func(resp *aruba_types.Response[aruba_types.CloudServerResponse]) (bool, error) {
-			if resp.IsSuccess() {
-				// Replace "running" with the actual desired status of the resource.
-				isReady := resp.Data.Properties.Status == "running"
-				if isReady {
-					fmt.Println("✓ Server is now running.")
-				}
-				return isReady, nil
-			}
-			// Continue waiting if the resource isn't ready or if there's a temporary API issue.
-			return false, nil
-		},
-	)
-
-	// Await blocks until the wait operation is complete (or fails).
-	finalResp, err := waitFuture.Await(context.Background())
-	if err != nil {
-		log.Fatalf("Error waiting for server: %v", err)
-	}
-
-	// Now you can safely work with the resource, knowing it is in the desired state.
-	fmt.Printf("Server %s is ready. Status: %s\n", *finalResp.Data.Metadata.ID, finalResp.Data.Properties.Status)
-}
-```
-
-For more control over the polling behavior, you can use the `async.WaitFor` function directly. This allows you to specify custom retry counts, delays, and a total timeout.
-
-```go
-// Example with custom parameters
-waitFutureCustom := async.WaitFor(
-    context.Background(),
-    15,                 // retries
-    5*time.Second,      // delay between retries
-    2*time.Minute,      // total timeout
-    func(ctx context.Context) (*aruba_types.Response[aruba_types.CloudServerResponse], error) {
-		return arubaClient.FromCompute().CloudServers().Get(ctx, projectID, serverID, nil)
+future := async.DefaultWaitFor(
+    ctx,
+    func(ctx context.Context) (*types.Response[types.CloudServerResponse], error) {
+        return arubaClient.FromCompute().CloudServers().Get(ctx, projectID, serverID, nil)
     },
-    func(resp *aruba_types.Response[aruba_types.CloudServerResponse]) (bool, error) {
-        // The check function returns true when the desired state is reached.
-		return resp.IsSuccess() && resp.Data.Properties.Status == "running", nil
+    func(resp *types.Response[types.CloudServerResponse]) (bool, error) {
+        return resp.IsSuccess() && resp.Data.Properties.Status == "running", nil
     },
 )
 
-// Await the result
-finalRespCustom, err := waitFutureCustom.Await(context.Background())
-if err != nil {
-    log.Fatalf("Error waiting for server with custom settings: %v", err)
-}
-fmt.Printf("Server %s is ready after custom wait. Status: %s\n", *finalRespCustom.Data.Metadata.ID, finalRespCustom.Data.Properties.Status)
+result, err := future.Await(ctx)
 ```
+
+`async.DefaultWaitFor` retries 10 times with a 10 s delay and a 60 s total timeout. Use `async.WaitFor` for custom retry counts, delay, and timeout.
 
 ### 2.5. Data Types
 
-All request bodies, response objects, and data models are defined in the `pkg/types` package. They are named to correspond with the resources they represent.
+All models live in `pkg/types`:
 
--   **Requests**: Typically end in `Request` (e.g., `types.VPCRequest`, `types.CloudServerRequest`).
--   **Responses**: Typically end in `Response` or `List` (e.g., `types.VPCResponse`, `types.VPCList`).
--   **Shared Structures**: Common structures like `ResourceMetadataRequest`, `ResourceMetadataResponse`, and `ResourceStatus` are used across many types.
+- **Requests** end in `Request` — e.g. `types.VPCRequest`, `types.CloudServerRequest`
+- **Single responses** end in `Response` — e.g. `types.VPCResponse`
+- **Collection responses** end in `List` — e.g. `types.VPCList`
+- **Shared structures** — `ResourceMetadataRequest`, `ResourceMetadataResponse`, `ResourceStatus`
 
-For a comprehensive guide on all SDK data types, including their structure and usage in requests and responses, please refer to the [SDK Data Types Documentation](./doc/TYPES.md).
+For the full type reference see [`docs/website/docs/types.md`](docs/website/docs/types.md).


### PR DESCRIPTION
## Summary

- **Badges** — Build status, Go version (from `go.mod`), latest release, Codecov coverage, license
- **README restructure** — intro paragraph before ToC, new Highlights section, condensed Quick Start, shorter sections 2.2–2.5 pointing to the existing `docs/website/` pages; fixes broken `./doc/*.md` links that pointed to non-existent files
- **CI** — adds `token: ${{ secrets.CODECOV_TOKEN }}` and renames `file:` → `files:` on the Codecov upload step, aligning with the pattern used in `acloud-cli/.github/workflows/build.yml`

Fixes #232

## Commits

| Commit | Scope |
|---|---|
| `ci: add CODECOV_TOKEN and fix coverage upload parameters` | `.github/workflows/ci.yml` |
| `docs(readme): add badges and streamline structure` | `README.md` |

## Notes

- The `CODECOV_TOKEN` secret must be set in the repo settings for the upload to authenticate correctly.
- Go Version badge reads directly from `go.mod`, so it tracks the minimum Go requirement automatically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)