### PR TITLE
fix(ci): make deploy-docs workflow idempotent on existing versions

### DIFF
--- a/.github/workflows/docs-version.yml
+++ b/.github/workflows/docs-version.yml
@@ -106,14 +106,19 @@ jobs:
         run: |
           VERSION="${{ steps.extract_version.outputs.version }}"
           echo "Creating versioned docs for version: $VERSION"
-          npm run version "$VERSION"
-          
-          # Verify the version was created
-          if [ ! -d "versioned_docs/version-${VERSION}" ]; then
-            echo "⚠️  ERROR: Version directory was not created: versioned_docs/version-${VERSION}"
-            exit 1
+
+          if [ -d "versioned_docs/version-${VERSION}" ]; then
+            echo "ℹ️  Version ${VERSION} already exists, skipping creation"
+          else
+            npm run version "$VERSION"
+
+            # Verify the version was created
+            if [ ! -d "versioned_docs/version-${VERSION}" ]; then
+              echo "⚠️  ERROR: Version directory was not created: versioned_docs/version-${VERSION}"
+              exit 1
+            fi
+            echo "✓ Versioned docs created successfully: versioned_docs/version-${VERSION}"
           fi
-          echo "✓ Versioned docs created successfully: versioned_docs/version-${VERSION}"
 
       - name: Sync translations for all versions
         working-directory: docs/website
@@ -210,9 +215,13 @@ jobs:
           git config --local user.name "GitHub Action"
           # Pull latest changes to ensure we're up to date
           git pull origin main || true
-          # Create a branch for the versioned docs
+          # Create a branch for the versioned docs (reuse if it already exists remotely)
           BRANCH_NAME="docs/version-${{ steps.extract_version.outputs.version }}"
-          git checkout -b "$BRANCH_NAME"
+          if git ls-remote --exit-code --heads origin "$BRANCH_NAME" > /dev/null 2>&1; then
+            git checkout -B "$BRANCH_NAME" "origin/$BRANCH_NAME"
+          else
+            git checkout -b "$BRANCH_NAME"
+          fi
           # Add versioned docs
           git add docs/website/versioned_docs docs/website/versioned_sidebars docs/website/versions.json
           if ! git diff --staged --quiet; then


### PR DESCRIPTION
## Summary

- **Root cause**: the `0.1.28` release was initially created without the `v` prefix, which triggered the workflow and committed `versioned_docs/version-0.1.28` to main. When the release was deleted and re-created as `v0.1.28`, the workflow fired again for the same stripped version `0.1.28` — Docusaurus refuses to create a version that already exists on disk, causing the `Create versioned docs` step to exit 1.
- **Fix 1 (`Create versioned docs`)**: skip `npm run version` if `versioned_docs/version-${VERSION}` already exists; the rest of the pipeline (translations, cleanup, build, deploy) proceeds normally.
- **Fix 2 (`Commit versioned docs`)**: check if the remote branch `docs/version-X` already exists before creating it; if it does, check it out with `-B` (reset) instead of `-b` (create), so the push is not rejected.

## Test plan

- [ ] Merge this PR into `main`
- [ ] Re-trigger the failed pipeline via **Actions → Deploy Documentation Version → Run workflow**, entering `0.1.28` as the version
- [ ] Verify the `Create versioned docs` step logs `ℹ️  Version 0.1.28 already exists, skipping creation` and the rest of the job succeeds

🤖 Generated with [Claude Code](https://claude.ai/claude-code)