### PR TITLE
feat(kaas): drop KubernetesVersion1313, add KubernetesVersion1341

### DIFF
--- a/docs/website/docs/resources.md
+++ b/docs/website/docs/resources.md
@@ -1583,6 +1583,7 @@ All enum types are re-exported from `pkg/aruba` — no extra import needed. The 
 |----------|-------------|
 | `aruba.KubernetesVersion1323` | Kubernetes 1.32.3 |
 | `aruba.KubernetesVersion1332` | Kubernetes 1.33.2 |
+| `aruba.KubernetesVersion1341` | Kubernetes 1.34.1 |
 | `aruba.NodePoolInstanceK2A4` | 2 vCPU, 4 GB RAM |
 | `aruba.NodePoolInstanceK4A8` | 4 vCPU, 8 GB RAM |
 | `aruba.NodePoolInstanceK8A16` | 8 vCPU, 16 GB RAM |

--- a/examples/all-resources/resource_kaas.go
+++ b/examples/all-resources/resource_kaas.go
@@ -29,7 +29,7 @@ func createKaaS(ctx context.Context, arubaClient aruba.Client, proj aruba.Ref, v
 		AddTag("kubernetes").
 		AddTag("container").
 		InRegion(aruba.RegionITBGBergamo).
-		WithKubernetesVersion(aruba.KubernetesVersion1332).
+		WithKubernetesVersion(aruba.KubernetesVersion1341).
 		WithPodCIDR("10.0.3.0/24").
 		WithNodeCIDR("172.16.0.0/16", resourceName(NameKaaSNodeCIDR)).
 		WithHA(true).

--- a/pkg/aruba/aliases.go
+++ b/pkg/aruba/aliases.go
@@ -335,9 +335,9 @@ const (
 type KubernetesVersion = types.KubernetesVersion
 
 const (
-	KubernetesVersion1313 = types.KubernetesVersion1313 // Kubernetes 1.31.3
 	KubernetesVersion1323 = types.KubernetesVersion1323 // Kubernetes 1.32.3
 	KubernetesVersion1332 = types.KubernetesVersion1332 // Kubernetes 1.33.2
+	KubernetesVersion1341 = types.KubernetesVersion1341 // Kubernetes 1.34.1
 )
 
 // NodePoolInstance identifies a KaaS node pool instance type.

--- a/pkg/types/container.kaas.go
+++ b/pkg/types/container.kaas.go
@@ -10,9 +10,9 @@ package types
 type KubernetesVersion string
 
 const (
-	KubernetesVersion1313 KubernetesVersion = "1.31.3"
 	KubernetesVersion1323 KubernetesVersion = "1.32.3"
 	KubernetesVersion1332 KubernetesVersion = "1.33.2"
+	KubernetesVersion1341 KubernetesVersion = "1.34.1"
 )
 
 // NodePoolInstance identifies a KaaS node pool instance type.


### PR DESCRIPTION
## Summary
- Remove `KubernetesVersion1313` (Kubernetes 1.31.3) — no longer in the live catalog.
- Add `KubernetesVersion1341` (Kubernetes 1.34.1) — newest catalog entry.
- Update the English constants table in `docs/website/docs/resources.md`.
- Bump the `examples/all-resources` KaaS sample to point at the newest constant.

## Test plan
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test -race ./...`
- [x] `golangci-lint run --timeout=5m ./...`
- [x] CI matrix green (Test ×3 Go versions, Lint, Build ×5, Security)