### PR TITLE
docs(changelog): add CHANGELOG.md with full release history and v0.1.x/v0.2.x branch policy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,508 @@
+# Changelog
+
+All notable changes to this project are documented in this file.
+
+The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/).
+
+## Versioning & Branch Policy
+
+| Branch | Version series | Status |
+|--------|----------------|--------|
+| `main` | **v0.2.x** | Active development — new features, ongoing releases |
+| `legacy` | **v0.1.x** | Maintenance — bug fixes and security patches only |
+
+- **`main` — v0.2.x (current)**: Introduces the `pkg/aruba/` wrapper
+  layer — a major, breaking redesign of the public API surface. Adopters
+  upgrading from v0.1.x should expect compile-time breakage; see the
+  [v0.2.0 Unreleased](#unreleased--v020) section below for a full
+  migration summary.
+- **`legacy` — v0.1.x (maintenance)**: Supported for **6 months** after
+  the v0.2.0 release date with bug-fix and security-patch releases only
+  (tagged `v0.1.29`, `v0.1.30`, …). No new features will be backported.
+  Once the support window closes the `legacy` branch will be archived.
+
+---
+
+## [Unreleased] — v0.2.0
+
+> **Breaking change release.** All service-client CRUD interfaces have
+> been replaced with wrapper-based signatures. See the Changed and
+> Removed sections below before upgrading.
+
+### Added
+
+- `pkg/aruba/` wrapper layer with **31 fluent resource types**:
+  `CloudServer`, `BlockStorage`, `Snapshot`, `StorageBackup`,
+  `StorageRestore`, `KaaS`, `ContainerRegistry`, `KMS`, `Key`, `Kmip`,
+  `DBaaS`, `Database`, `User`, `Grant`, `DBaaSBackup`, `KeyPair`,
+  `LoadBalancer`, `SecurityGroup`, `SecurityRule`, `Subnet`, `VPC`,
+  `VPCPeering`, `VPCPeeringRoute`, `VPNTunnel`, `VPNRoute`, `ElasticIP`,
+  `Job`, `AuditEvent`, `Alert`, `Metric`, `Project`.
+- Fluent factory functions for every resource (`aruba.NewKaaS()`,
+  `aruba.NewVPC()`, `aruba.NewDBaaS()`, …).
+- `Ref` interface and `aruba.URI(s)` escape hatch for raw resource
+  references when a wrapper is not yet available.
+- `List[T]` generic paginated-collection type.
+- `CallOption` functional options replacing `*types.RequestParameters`.
+- Async polling on all statused resources:
+  `WaitUntilActive`, `WaitUntilStates`, `WaitUntilReady`,
+  `WaitUntilNotUsed`, `WaitUntilUsed`.
+- Typed enum constants in `pkg/types` (re-exported via `pkg/aruba`):
+  `BillingPeriod`, `Region`, `Zone`, `CloudServerFlavor`, `DBaaSFlavor`,
+  `DatabaseEngine`, `KubernetesVersion`, `NodePoolInstance`, `VolumeImage`,
+  `SubnetType`, `KeyAlgorithm`, `RuleProtocol`, IKE/ESP crypto aliases
+  (`IKEEncryption`, `IKEHash`, `IKEDHGroup`, `ESPEncryption`, `ESPHash`,
+  `PFSGroup`), `VPNType`, `VPNClientProtocol`, `HTTPVerb`,
+  `ContainerRegistrySizeFlavor`.
+- `KubernetesVersion1341` constant — Kubernetes 1.34.1.
+- `VolumeImage` constants for Aruba's stock BlockStorage templates.
+- `HTTPVerb` typed alias for `Job` scheduler.
+
+### Changed ⚠️ Breaking
+
+- **All service-client CRUD interfaces** (`CloudServersClient`,
+  `VolumesClient`, …) replaced with wrapper-based signatures. Direct
+  use of `internal/clients/` is no longer the primary public API.
+- `WithName(string)` renamed to `Named(string)` across the wrapper
+  layer for naming consistency.
+- Storage/size setters renamed with a `GB` suffix to match units:
+  `WithSize` → `WithSizeGB`, `Size()` → `SizeGB()` on `BlockStorage`,
+  `Snapshot`, `DBaaSBackup`, `KaaS`, and `DBaaS`.
+- VPN lifetime and DPD setters suffixed with `Seconds` and
+  standardized to `int`.
+- Source/destination/classifier setters renamed to preposition form:
+  `From*` / `To*` / `Of*`; classifiers become `OfType`, `OfFlavor`,
+  `OfEngine`.
+- `WithDefault(bool)` → `AsDefault()` / `NotDefault()`;
+  `WithBootable(bool)` → `SetBootable()` / `UnsetBootable()`.
+- `BillingPeriod` values translated to lowercase wire form on send.
+- DBaaS autoscaling split into three fields:
+  `Enabled`, `AvailableSpace`, `StepSize`.
+- Storage terminal state `Available` renamed to `Active` to match the
+  wire representation.
+- Examples entry point moved from `cmd/example/` to
+  `examples/all-resources/` and fully rewritten against the wrapper API.
+- Interface guards moved from package-level vars to test functions.
+- `WaitUntilState` renamed to `WaitUntilStates` (plural) to signal it
+  accepts a variadic state list.
+- `regionalMixin.location` renamed to `region`; consolidated to
+  `inRegion`.
+- `Region` struct renamed to `RegionInfo` in `pkg/types`.
+
+### Removed ⚠️ Breaking
+
+- `KubernetesVersion1313` — Kubernetes 1.31.3 is no longer in the live
+  catalog.
+- `restclient.WaitForResourceState` polling primitive; polling now lives
+  in wrapper `WaitUntil*` methods.
+- Client-side polling in `BlockStorage`, `VPC`, and `SecurityGroup`
+  `Create` paths.
+
+### Fixed
+
+- `Failed` state treated as a terminal error across all `WaitUntil*`
+  paths.
+- `vpnTunnelScopedMixin.intoVPNTunnel` now accepts the production
+  camelCase `vpnTunnels` URI segment (#239).
+- DBaaS billing plan, flavor, and node-pool name wire encoding; KMIP
+  `Active` accepted as `Ready` state; longer wait budget with
+  state-aware error propagation.
+- VPN tunnel / VPN route / VPC peering route URL paths (#235, #236).
+- `VPCPeeringRouteRequest` uses `RegionalResourceMetadataRequest`.
+- `CloudServerRequest` omits `ElasticIP` and `KeyPair` when unset.
+
+### Docs
+
+- Documentation site restructured into a guided learning path:
+  walkthrough guide + exhaustive resource reference (#225).
+- `pkg/aruba` wrapper-layer architecture and naming conventions
+  documented in `ai/ARCHITECTURE.md` and `ai/CONVENTIONS.md`.
+- Resource reference: tag format rule documented; links to runnable
+  examples added.
+- `ai/` guidance files (`DEVEX.md`, `REPO.md`, `TECH_DEBT.md`) and
+  `CLAUDE.md` added for contributor tooling.
+
+### Tests
+
+- Builder and group-accessor unit tests for `pkg/aruba` (#226).
+- Examples coverage excluded from Codecov metrics.
+
+---
+
+## [0.1.28] — 2026-04-29
+
+### Fixed
+
+- `VPCPeeringRouteRequest` now uses `RegionalResourceMetadataRequest`
+  instead of the base type; VPN enum constants added to `pkg/types`.
+- `CloudServerRequest` omits `ElasticIP` and `KeyPair` fields when not
+  set (omitempty alignment).
+
+### CI
+
+- Codecov configured to ignore `cmd/` directory from coverage reports.
+
+### Internal
+
+- gofmt alignment on VPN constants.
+
+---
+
+## [0.1.27] — 2026-04-24
+
+### Fixed
+
+- VPN tunnel, VPN route, and VPC peering route URL paths corrected.
+- `VPCPeeringRouteResponse` uses `ResourceMetadataResponse`.
+
+### Docs
+
+- README badges added (Build, Go Version, Release, Codecov, License)
+  and structure streamlined (#232).
+- README inaccuracies fixed: removed reference to non-existent
+  `NewFilterBuilder`; removed unused result variable in examples.
+
+### CI
+
+- `CODECOV_TOKEN` wired up in the CI workflow; coverage upload
+  parameters fixed.
+
+### Tests
+
+- Collection-path and metadata-validation tests for VPN tunnel, VPN
+  route, and VPC peering route resources.
+
+---
+
+## [0.1.26] — 2026-04-21
+
+### Fixed
+
+- Relaxed Create-response metadata validation: URI field is no longer
+  required to be non-empty (matches actual server behavior).
+
+---
+
+## [0.1.25] — 2026-04-20
+
+### Added
+
+- Validate `ID`, `URI`, and `Name` on Create responses.
+- Shared `internal/testutil` HTTP test helpers for resource client
+  error-path coverage (TD-020).
+
+### Fixed
+
+- Panic on `nil` injected dependencies in all multi-argument client
+  constructors.
+- `auth.saveTicket`: increment counter only after a successful
+  persistent write.
+- `restclient`: remove initial poll sleep; preserve final state on
+  timeout.
+- `logger`: WARN-level messages written to `os.Stderr` instead of
+  `os.Stdout`.
+- `async.DefaultWaitFor` timeout raised from 60 s → 600 s;
+  `async.DefaultRetries` raised to 60.
+- Nil guard added to `ParseResponseBody`; non-JSON error bodies logged
+  at DEBUG level instead of silently dropped.
+- `buildDetebaseClient` typo fixed to `buildDatabaseClient`.
+- `buildFileTokenRepository` argument order corrected.
+- Preloaded access token actually stored in
+  `NewTokenRepositoryWithAccessToken`.
+- Per-tenant mutex acquired before setting the last-used timestamp.
+
+### Docs
+
+- Added `CLAUDE.md`, `ai/` guidance files, and a tech-debt backlog
+  with effort/impact prioritization matrix.
+- `internal/impl/interceptor/standard`: `Bind` documented as
+  construction-only; closes TD-004.
+
+### Tests
+
+- Full error-path coverage matrix for all resource clients
+  (audit, compute, container, database, metric, network, project,
+  schedule, security, storage) migrated to `testutil` (TD-020,
+  #149, #150).
+
+### Internal
+
+- Compile-time interface assertions for all resource-level client
+  implementations and the logger.
+
+---
+
+## [0.1.24] — 2026-03-26
+
+### Fixed
+
+- `errorResponse` parsing correctly handles `validationErrors` and
+  `BadRequest` response shapes.
+
+---
+
+## [0.1.23] — 2026-03-25
+
+### Added
+
+- Multi-tenant client layer (`pkg/multitenant`) with a graceful
+  cleanup routine.
+
+### Fixed
+
+- Config struct is deep-copied before constructing the client,
+  preventing shared-state mutation.
+
+### Docs
+
+- Multi-tenancy guide and usage examples.
+
+### CI
+
+- golangci-lint upgraded to v2 via action v7.
+- gocyclo linter enabled; example packages excluded from lint.
+
+---
+
+## [0.1.22-alpha4] — 2026-03-23 *(pre-release)*
+
+### Internal
+
+- Fix `get` func in multi-tenant layer.
+
+---
+
+## [0.1.22-alpha2] — 2026-03-23 *(pre-release)*
+
+### Fixed
+
+- Deep-copy config before creating the client (regression from
+  alpha1).
+
+---
+
+## [0.1.22-alpha1] — 2026-03-12 *(pre-release)*
+
+- Pre-release iteration closing issues #94, #95, #96, #98.
+
+> Note: v0.1.22-alpha3 was skipped during release-CI iteration;
+> v0.1.22 stable was superseded by v0.1.23.
+
+---
+
+## [0.1.21] — 2026-02-08
+
+### Added
+
+- Token-issuer URL configurable at runtime (`WithTokenIssuerURL`
+  option update).
+
+### Docs
+
+- Italian translation fixes.
+
+---
+
+## [0.1.20] — 2026-01-22
+
+### Fixed
+
+- Typo in `kmsPropertiesResponse` type name.
+
+---
+
+## [0.1.19] — 2026-01-22
+
+### Added
+
+- KMIP certificate download endpoint.
+
+### Fixed
+
+- KMS billing-period type mismatch.
+
+### Docs
+
+- Docusaurus version list sorted in descending order.
+
+---
+
+## [0.1.18] — 2026-01-21
+
+### Docs
+
+- Removed hardcoded version string from Docusaurus config; latest
+  version is now selected automatically.
+
+---
+
+## [0.1.17] — 2026-01-21
+
+### Added
+
+- Nested KMS resource group: `Key` and `KMIP` sub-resources under KMS.
+
+---
+
+## [0.1.16] — 2026-01-15
+
+### Fixed
+
+- Missing `Zone` field on `DBaaSPropertiesRequest`.
+
+---
+
+## [0.1.15] — 2026-01-13
+
+### Docs
+
+- Doc-search rendering bug fixed.
+
+---
+
+## [0.1.14] — 2026-01-13
+
+### Added
+
+- Documentation site search support.
+- Italian language (`it`) added to the documentation site.
+- `CloudServer` `userData` properties.
+
+---
+
+## [0.1.13] — 2026-01-08
+
+### Fixed
+
+- CloudServer response serialization error.
+- Latest-version resolution bug in the compute client.
+
+---
+
+## [0.1.12] — 2026-01-07
+
+### Added
+
+- Advanced subnet configuration support.
+
+---
+
+## [0.1.11] — 2025-12-31
+
+### Fixed
+
+- Container registry response serialization error.
+
+---
+
+## [0.1.10] — 2025-12-31
+
+### CI
+
+- Docs-version pipeline fixed.
+
+---
+
+## [0.1.9] — 2025-12-31
+
+### Added
+
+- Container registry support in the client builder.
+
+### Docs
+
+- Multi-release documentation support.
+
+---
+
+## [0.1.8] — 2025-12-30
+
+### Docs
+
+- First iteration of the docs-version release pipeline.
+
+---
+
+## [0.1.7] — 2025-12-30
+
+### Added
+
+- KaaS: `kubeconfig` download and update-request fixes.
+- CloudServer: `power-on`, `power-off`, and `set-password` operations.
+
+> Note: v0.1.5 and v0.1.6 were aborted release-CI attempts and were
+> never published.
+
+---
+
+## [0.1.4] — 2025-12-29
+
+### Added
+
+- Full KaaS (Kubernetes-as-a-Service) feature set.
+
+---
+
+## [0.1.3] — 2025-12-22
+
+### Fixed
+
+- VPN tunnel type mismatch typo.
+
+---
+
+## [0.1.2] — 2025-12-19
+
+### Fixed
+
+- Snapshot success-state name typo.
+
+---
+
+## [0.1.1] — 2025-12-19
+
+### Fixed
+
+- BlockStorage type alignment.
+- Project response type.
+
+---
+
+## [0.1.0] — 2025-12-09
+
+Initial Alpha release of the Aruba Cloud SDK for Go.
+
+---
+
+<!-- compare links -->
+[Unreleased]: https://github.com/Arubacloud/sdk-go/compare/v0.1.28...HEAD
+[0.1.28]: https://github.com/Arubacloud/sdk-go/compare/v0.1.27...v0.1.28
+[0.1.27]: https://github.com/Arubacloud/sdk-go/compare/v0.1.26...v0.1.27
+[0.1.26]: https://github.com/Arubacloud/sdk-go/compare/v0.1.25...v0.1.26
+[0.1.25]: https://github.com/Arubacloud/sdk-go/compare/v0.1.24...v0.1.25
+[0.1.24]: https://github.com/Arubacloud/sdk-go/compare/v0.1.23...v0.1.24
+[0.1.23]: https://github.com/Arubacloud/sdk-go/compare/v0.1.21...v0.1.23
+[0.1.22-alpha4]: https://github.com/Arubacloud/sdk-go/compare/v0.1.22-alpha2...v0.1.22-alpha4
+[0.1.22-alpha2]: https://github.com/Arubacloud/sdk-go/compare/v0.1.22-alpha1...v0.1.22-alpha2
+[0.1.22-alpha1]: https://github.com/Arubacloud/sdk-go/compare/v0.1.21...v0.1.22-alpha1
+[0.1.21]: https://github.com/Arubacloud/sdk-go/compare/v0.1.20...v0.1.21
+[0.1.20]: https://github.com/Arubacloud/sdk-go/compare/v0.1.19...v0.1.20
+[0.1.19]: https://github.com/Arubacloud/sdk-go/compare/v0.1.18...v0.1.19
+[0.1.18]: https://github.com/Arubacloud/sdk-go/compare/v0.1.17...v0.1.18
+[0.1.17]: https://github.com/Arubacloud/sdk-go/compare/v0.1.16...v0.1.17
+[0.1.16]: https://github.com/Arubacloud/sdk-go/compare/v0.1.15...v0.1.16
+[0.1.15]: https://github.com/Arubacloud/sdk-go/compare/v0.1.14...v0.1.15
+[0.1.14]: https://github.com/Arubacloud/sdk-go/compare/v0.1.13...v0.1.14
+[0.1.13]: https://github.com/Arubacloud/sdk-go/compare/v0.1.12...v0.1.13
+[0.1.12]: https://github.com/Arubacloud/sdk-go/compare/v0.1.11...v0.1.12
+[0.1.11]: https://github.com/Arubacloud/sdk-go/compare/v0.1.10...v0.1.11
+[0.1.10]: https://github.com/Arubacloud/sdk-go/compare/v0.1.9...v0.1.10
+[0.1.9]: https://github.com/Arubacloud/sdk-go/compare/v0.1.8...v0.1.9
+[0.1.8]: https://github.com/Arubacloud/sdk-go/compare/v0.1.7...v0.1.8
+[0.1.7]: https://github.com/Arubacloud/sdk-go/compare/v0.1.4...v0.1.7
+[0.1.4]: https://github.com/Arubacloud/sdk-go/compare/v0.1.3...v0.1.4
+[0.1.3]: https://github.com/Arubacloud/sdk-go/compare/v0.1.2...v0.1.3
+[0.1.2]: https://github.com/Arubacloud/sdk-go/compare/v0.1.1...v0.1.2
+[0.1.1]: https://github.com/Arubacloud/sdk-go/compare/v0.1.0...v0.1.1
+[0.1.0]: https://github.com/Arubacloud/sdk-go/releases/tag/v0.1.0

--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@
 [![Codecov](https://codecov.io/gh/Arubacloud/sdk-go/branch/main/graph/badge.svg)](https://codecov.io/gh/Arubacloud/sdk-go)
 [![License](https://img.shields.io/github/license/Arubacloud/sdk-go)](LICENSE)
 
+See [`CHANGELOG.md`](CHANGELOG.md) for the full release history and the v0.1.x → v0.2.x branch policy.
+
 > **Note**: This SDK is currently in its **Alpha** stage. The API is not yet stable, and breaking changes may be introduced in future releases without prior notice.
 
 Official Go SDK for the Aruba Cloud API. Manage cloud resources — compute instances, VPCs, storage, databases, and more — from Go code.


### PR DESCRIPTION
## Summary
- Adds `CHANGELOG.md` at repo root covering every published release from **v0.1.0** (2025-12-09) through **v0.1.28** (2026-04-29), plus an `[Unreleased] — v0.2.0` section for the wrapper-layer redesign landing on `main`.
- Opens with a **Versioning & Branch Policy** table: `main` carries v0.2.x (breaking, active), `legacy` carries v0.1.x (maintenance, 6-month window).
- Follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) format with Added / Changed ⚠️ Breaking / Removed ⚠️ Breaking / Fixed / Docs / CI / Tests categories.
- Notes skipped releases (v0.1.5, v0.1.6 — aborted CI; v0.1.22-alpha3 — skipped during iteration).
- Adds a one-line `CHANGELOG.md` link in README.md, directly after the badges block.
- Every section ends with a GitHub compare link at the bottom of the file.

Closes #227 (CHANGELOG entry). The alpha version bump and tag remain a follow-up.

## Test plan
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test -race ./...`
- [x] `golangci-lint run --timeout=5m ./...`
- [x] CI matrix green (Test ×3 Go versions, Lint, Build ×5, Security)