### PR TITLE
docs(website): point footer changelog link to CHANGELOG.md

### DIFF
--- a/docs/website/docusaurus.config.js
+++ b/docs/website/docusaurus.config.js
@@ -168,7 +168,7 @@ const config = {
               },
               {
                 label: 'Changelog',
-                href: 'https://github.com/Arubacloud/sdk-go/releases',
+                href: 'https://github.com/Arubacloud/sdk-go/blob/main/CHANGELOG.md',
               },
             ],
           },


### PR DESCRIPTION
## Summary

- Replaces the footer "Changelog" link from the GitHub releases page to the direct `CHANGELOG.md` file URL (`https://github.com/Arubacloud/sdk-go/blob/main/CHANGELOG.md`)

## Test plan

- [ ] Verify the footer link on the docs website points to `CHANGELOG.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)