### PR TITLE
fix(uri-segments): align Ref/path casing to api.arubacloud.com docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,30 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ---
 
+## [Unreleased]
+
+### Fixed
+
+- `SecurityGroupsClient.Get`/`Update`/`Delete` rejected every ref produced by
+  `aruba.SecurityGroupRef(...)` with `cannot determine security group ID from Ref "..."`,
+  because the lookup expected a hyphenated `security-groups` segment that the Ref never
+  emits and the live API never returns. The lookup now uses the documented `securityGroups`
+  segment as the single canonical form. (#297)
+
+### Changed
+
+- URI path segments across all Ref helpers, internal client paths, and ref-parsing helpers
+  now match the canonical casing documented at <https://api.arubacloud.com/docs/>. Affected
+  segments: `securityGroups` (was `securitygroups`), `securityRules` (was `securityrules`),
+  `loadBalancers` (was `loadbalancers`), `keyPairs` (was `keypairs`), `blockStorages` (was
+  `blockstorages`). The Aruba API is case-insensitive on path routing, so outgoing requests
+  behave identically; this is purely an alignment to the published API spec. Hyphenated
+  test-only fallbacks (`security-groups`, `security-rules`, `vpn-tunnels`, `peerings`) and
+  duplicate-form lookups have been removed — each resource now has a single canonical URI
+  segment.
+
+---
+
 ## [0.2.3] — 2026-05-22
 
 > **Minor release.** Adds `WaitUntilGone` teardown polling and a typed `State` API;

--- a/ai/CONVENTIONS.md
+++ b/ai/CONVENTIONS.md
@@ -160,3 +160,10 @@ Setter signatures take the alias type, not `string`.
 - Resources that embed `statusMixin` (`pkg/aruba/mixin_status.go`) get `WaitUntilActive`, `WaitUntilReady`, and `WaitUntilStates(ctx, targets, opts...)` for free.
 - Adapters install a `refresh` closure after `Create` / `Get` / `List` — without it, `WaitUntilStates` returns an immediate error.
 - Family B resources without `statusMixin` define their own `WaitUntil*` that drive `pkg/async.WaitFor` directly (e.g. `*Kmip.WaitUntilCertificateAvailable` in `resource_kmip.go`).
+
+### URI segment casing
+
+- URI segments use the **exact casing published at <https://api.arubacloud.com/docs/>**. Examples: `securityGroups`, `securityRules`, `loadBalancers`, `keyPairs`, `blockStorages`, `vpnTunnels`, `vpcPeerings`.
+- Each resource has **one canonical segment**. `*IDsFromRef` helpers and scoped-mixin lookups use that single form — no fallbacks, no alternative spellings.
+- `parseURIIDs` in `pkg/aruba/ref.go` preserves case; never normalise segment keys to lowercase.
+- Ref helper templates (`<Resource>Ref(...)`) and `internal/clients/<domain>/path.go` constants must use the same canonical segment so outgoing requests and incoming `Metadata.URI` values remain self-consistent.

--- a/internal/clients/compute/path.go
+++ b/internal/clients/compute/path.go
@@ -10,6 +10,6 @@ const (
 	CloudServerPasswordPath = "/projects/%s/providers/Aruba.Compute/cloudServers/%s/password"
 
 	// KeyPair paths
-	KeyPairsPath = "/projects/%s/providers/Aruba.Compute/keypairs"
-	KeyPairPath  = "/projects/%s/providers/Aruba.Compute/keypairs/%s"
+	KeyPairsPath = "/projects/%s/providers/Aruba.Compute/keyPairs"
+	KeyPairPath  = "/projects/%s/providers/Aruba.Compute/keyPairs/%s"
 )

--- a/internal/clients/container/containerregistry_test.go
+++ b/internal/clients/container/containerregistry_test.go
@@ -33,13 +33,13 @@ func TestListContainerRegistry(t *testing.T) {
 									URI: *ptr.To("/projects/test-project/providers/Aruba.Network/vpcs/vpc-1/subnets/subnet-124"),
 								},
 								SecurityGroup: types.ReferenceResource{
-									URI: *ptr.To("/projects/test-project/providers/Aruba.Network/vpcs/vpc-1/securitygroups/sg-67890"),
+									URI: *ptr.To("/projects/test-project/providers/Aruba.Network/vpcs/vpc-1/securityGroups/sg-67890"),
 								},
 								PublicIp: types.ReferenceResource{
 									URI: *ptr.To("/projects/test-project/providers/Aruba.Network/elasticips/eip-12345"),
 								},
 								BlockStorage: types.ReferenceResource{
-									URI: *ptr.To("/projects/test-project/providers/Aruba.Storage/blockstorages/bs-54321"),
+									URI: *ptr.To("/projects/test-project/providers/Aruba.Storage/blockStorages/bs-54321"),
 								},
 								BillingPlan: func() *types.BillingPlan {
 									v := types.BillingPeriodHour
@@ -92,10 +92,10 @@ func TestListContainerRegistry(t *testing.T) {
 		if resp.Data.Values[0].Properties.Subnet.URI != "/projects/test-project/providers/Aruba.Network/vpcs/vpc-1/subnets/subnet-124" {
 			t.Errorf("expected Subnet URI")
 		}
-		if resp.Data.Values[0].Properties.SecurityGroup.URI != "/projects/test-project/providers/Aruba.Network/vpcs/vpc-1/securitygroups/sg-67890" {
+		if resp.Data.Values[0].Properties.SecurityGroup.URI != "/projects/test-project/providers/Aruba.Network/vpcs/vpc-1/securityGroups/sg-67890" {
 			t.Errorf("expected SecurityGroup URI")
 		}
-		if resp.Data.Values[0].Properties.BlockStorage.URI != "/projects/test-project/providers/Aruba.Storage/blockstorages/bs-54321" {
+		if resp.Data.Values[0].Properties.BlockStorage.URI != "/projects/test-project/providers/Aruba.Storage/blockStorages/bs-54321" {
 			t.Errorf("expected BlockStorage URI")
 		}
 		if resp.Data.Values[0].Properties.BillingPlan == nil || resp.Data.Values[0].Properties.BillingPlan.BillingPeriod == nil || *resp.Data.Values[0].Properties.BillingPlan.BillingPeriod != "Hour" {
@@ -201,13 +201,13 @@ func TestGetContainerRegistry(t *testing.T) {
 							URI: *ptr.To("/projects/test-project/providers/Aruba.Network/vpcs/vpc-1/subnets/subnet-124"),
 						},
 						SecurityGroup: types.ReferenceResource{
-							URI: *ptr.To("/projects/test-project/providers/Aruba.Network/vpcs/vpc-1/securitygroups/sg-67890"),
+							URI: *ptr.To("/projects/test-project/providers/Aruba.Network/vpcs/vpc-1/securityGroups/sg-67890"),
 						},
 						PublicIp: types.ReferenceResource{
 							URI: *ptr.To("/projects/test-project/providers/Aruba.Network/elasticips/eip-12345"),
 						},
 						BlockStorage: types.ReferenceResource{
-							URI: *ptr.To("/projects/test-project/providers/Aruba.Storage/blockstorages/bs-54321"),
+							URI: *ptr.To("/projects/test-project/providers/Aruba.Storage/blockStorages/bs-54321"),
 						},
 						BillingPlan: func() *types.BillingPlan {
 							v := types.BillingPeriodHour
@@ -249,10 +249,10 @@ func TestGetContainerRegistry(t *testing.T) {
 		if resp.Data.Properties.Subnet.URI != "/projects/test-project/providers/Aruba.Network/vpcs/vpc-1/subnets/subnet-124" {
 			t.Errorf("expected Subnet URI")
 		}
-		if resp.Data.Properties.SecurityGroup.URI != "/projects/test-project/providers/Aruba.Network/vpcs/vpc-1/securitygroups/sg-67890" {
+		if resp.Data.Properties.SecurityGroup.URI != "/projects/test-project/providers/Aruba.Network/vpcs/vpc-1/securityGroups/sg-67890" {
 			t.Errorf("expected SecurityGroup URI")
 		}
-		if resp.Data.Properties.BlockStorage.URI != "/projects/test-project/providers/Aruba.Storage/blockstorages/bs-54321" {
+		if resp.Data.Properties.BlockStorage.URI != "/projects/test-project/providers/Aruba.Storage/blockStorages/bs-54321" {
 			t.Errorf("expected BlockStorage URI")
 		}
 		if resp.Data.Properties.BillingPlan == nil || resp.Data.Properties.BillingPlan.BillingPeriod == nil || *resp.Data.Properties.BillingPlan.BillingPeriod != "Hour" {
@@ -360,13 +360,13 @@ func TestCreateContainerRegistry(t *testing.T) {
 							URI: *ptr.To("/projects/test-project/providers/Aruba.Network/vpcs/vpc-1/subnets/subnet-124"),
 						},
 						SecurityGroup: types.ReferenceResource{
-							URI: *ptr.To("/projects/test-project/providers/Aruba.Network/vpcs/vpc-1/securitygroups/sg-67890"),
+							URI: *ptr.To("/projects/test-project/providers/Aruba.Network/vpcs/vpc-1/securityGroups/sg-67890"),
 						},
 						PublicIp: types.ReferenceResource{
 							URI: *ptr.To("/projects/test-project/providers/Aruba.Network/elasticips/eip-12345"),
 						},
 						BlockStorage: types.ReferenceResource{
-							URI: *ptr.To("/projects/test-project/providers/Aruba.Storage/blockstorages/bs-54321"),
+							URI: *ptr.To("/projects/test-project/providers/Aruba.Storage/blockStorages/bs-54321"),
 						},
 						BillingPlan: func() *types.BillingPlan {
 							v := types.BillingPeriodHour
@@ -399,8 +399,8 @@ func TestCreateContainerRegistry(t *testing.T) {
 				PublicIp:      types.ReferenceResource{URI: "/projects/test-project/providers/Aruba.Network/elasticips/eip-12345"},
 				VPC:           types.ReferenceResource{URI: "/projects/test-project/providers/Aruba.Network/vpcs/vpc-1"},
 				Subnet:        types.ReferenceResource{URI: "/projects/test-project/providers/Aruba.Network/vpcs/vpc-1/subnets/subnet-124"},
-				SecurityGroup: types.ReferenceResource{URI: "/projects/test-project/providers/Aruba.Network/vpcs/vpc-1/securitygroups/sg-67890"},
-				BlockStorage:  types.ReferenceResource{URI: "/projects/test-project/providers/Aruba.Storage/blockstorages/bs-54321"},
+				SecurityGroup: types.ReferenceResource{URI: "/projects/test-project/providers/Aruba.Network/vpcs/vpc-1/securityGroups/sg-67890"},
+				BlockStorage:  types.ReferenceResource{URI: "/projects/test-project/providers/Aruba.Storage/blockStorages/bs-54321"},
 				BillingPlan: func() *types.BillingPlan {
 					v := types.BillingPeriod("Hour")
 					return &types.BillingPlan{BillingPeriod: &v}
@@ -429,10 +429,10 @@ func TestCreateContainerRegistry(t *testing.T) {
 		if resp.Data.Properties.Subnet.URI != "/projects/test-project/providers/Aruba.Network/vpcs/vpc-1/subnets/subnet-124" {
 			t.Errorf("expected Subnet URI")
 		}
-		if resp.Data.Properties.SecurityGroup.URI != "/projects/test-project/providers/Aruba.Network/vpcs/vpc-1/securitygroups/sg-67890" {
+		if resp.Data.Properties.SecurityGroup.URI != "/projects/test-project/providers/Aruba.Network/vpcs/vpc-1/securityGroups/sg-67890" {
 			t.Errorf("expected SecurityGroup URI")
 		}
-		if resp.Data.Properties.BlockStorage.URI != "/projects/test-project/providers/Aruba.Storage/blockstorages/bs-54321" {
+		if resp.Data.Properties.BlockStorage.URI != "/projects/test-project/providers/Aruba.Storage/blockStorages/bs-54321" {
 			t.Errorf("expected BlockStorage URI")
 		}
 		if resp.Data.Properties.BillingPlan == nil || resp.Data.Properties.BillingPlan.BillingPeriod == nil || *resp.Data.Properties.BillingPlan.BillingPeriod != "Hour" {
@@ -601,13 +601,13 @@ func TestUpdateContainerRegistry(t *testing.T) {
 							URI: *ptr.To("/projects/test-project/providers/Aruba.Network/vpcs/vpc-1/subnets/subnet-124"),
 						},
 						SecurityGroup: types.ReferenceResource{
-							URI: *ptr.To("/projects/test-project/providers/Aruba.Network/vpcs/vpc-1/securitygroups/sg-67890"),
+							URI: *ptr.To("/projects/test-project/providers/Aruba.Network/vpcs/vpc-1/securityGroups/sg-67890"),
 						},
 						PublicIp: types.ReferenceResource{
 							URI: *ptr.To("/projects/test-project/providers/Aruba.Network/elasticips/eip-12345"),
 						},
 						BlockStorage: types.ReferenceResource{
-							URI: *ptr.To("/projects/test-project/providers/Aruba.Storage/blockstorages/bs-54321"),
+							URI: *ptr.To("/projects/test-project/providers/Aruba.Storage/blockStorages/bs-54321"),
 						},
 						BillingPlan: func() *types.BillingPlan {
 							v := types.BillingPeriodHour
@@ -640,8 +640,8 @@ func TestUpdateContainerRegistry(t *testing.T) {
 				PublicIp:      types.ReferenceResource{URI: "/projects/test-project/providers/Aruba.Network/elasticips/eip-12345"},
 				VPC:           types.ReferenceResource{URI: "/projects/test-project/providers/Aruba.Network/vpcs/vpc-1"},
 				Subnet:        types.ReferenceResource{URI: "/projects/test-project/providers/Aruba.Network/vpcs/vpc-1/subnets/subnet-124"},
-				SecurityGroup: types.ReferenceResource{URI: "/projects/test-project/providers/Aruba.Network/vpcs/vpc-1/securitygroups/sg-67890"},
-				BlockStorage:  types.ReferenceResource{URI: "/projects/test-project/providers/Aruba.Storage/blockstorages/bs-54321"},
+				SecurityGroup: types.ReferenceResource{URI: "/projects/test-project/providers/Aruba.Network/vpcs/vpc-1/securityGroups/sg-67890"},
+				BlockStorage:  types.ReferenceResource{URI: "/projects/test-project/providers/Aruba.Storage/blockStorages/bs-54321"},
 				BillingPlan: func() *types.BillingPlan {
 					v := types.BillingPeriod("Hour")
 					return &types.BillingPlan{BillingPeriod: &v}
@@ -670,10 +670,10 @@ func TestUpdateContainerRegistry(t *testing.T) {
 		if resp.Data.Properties.Subnet.URI != "/projects/test-project/providers/Aruba.Network/vpcs/vpc-1/subnets/subnet-124" {
 			t.Errorf("expected Subnet URI")
 		}
-		if resp.Data.Properties.SecurityGroup.URI != "/projects/test-project/providers/Aruba.Network/vpcs/vpc-1/securitygroups/sg-67890" {
+		if resp.Data.Properties.SecurityGroup.URI != "/projects/test-project/providers/Aruba.Network/vpcs/vpc-1/securityGroups/sg-67890" {
 			t.Errorf("expected SecurityGroup URI")
 		}
-		if resp.Data.Properties.BlockStorage.URI != "/projects/test-project/providers/Aruba.Storage/blockstorages/bs-54321" {
+		if resp.Data.Properties.BlockStorage.URI != "/projects/test-project/providers/Aruba.Storage/blockStorages/bs-54321" {
 			t.Errorf("expected BlockStorage URI")
 		}
 		if resp.Data.Properties.BillingPlan == nil || resp.Data.Properties.BillingPlan.BillingPeriod == nil || *resp.Data.Properties.BillingPlan.BillingPeriod != "Hour" {

--- a/internal/clients/network/path.go
+++ b/internal/clients/network/path.go
@@ -11,20 +11,20 @@ const (
 	SubnetPath  = "/projects/%s/providers/Aruba.Network/vpcs/%s/subnets/%s"
 
 	// Security Group paths (nested under VPC)
-	SecurityGroupsPath = "/projects/%s/providers/Aruba.Network/vpcs/%s/securitygroups"
-	SecurityGroupPath  = "/projects/%s/providers/Aruba.Network/vpcs/%s/securitygroups/%s"
+	SecurityGroupsPath = "/projects/%s/providers/Aruba.Network/vpcs/%s/securityGroups"
+	SecurityGroupPath  = "/projects/%s/providers/Aruba.Network/vpcs/%s/securityGroups/%s"
 
 	// Security Group Rule paths (nested under VPC and Security Group)
-	SecurityGroupRulesPath = "/projects/%s/providers/Aruba.Network/vpcs/%s/securitygroups/%s/securityrules"
-	SecurityGroupRulePath  = "/projects/%s/providers/Aruba.Network/vpcs/%s/securitygroups/%s/securityrules/%s"
+	SecurityGroupRulesPath = "/projects/%s/providers/Aruba.Network/vpcs/%s/securityGroups/%s/securityRules"
+	SecurityGroupRulePath  = "/projects/%s/providers/Aruba.Network/vpcs/%s/securityGroups/%s/securityRules/%s"
 
 	// Elastic IP paths
 	ElasticIPsPath = "/projects/%s/providers/Aruba.Network/elasticIps"
 	ElasticIPPath  = "/projects/%s/providers/Aruba.Network/elasticIps/%s"
 
 	// Load Balancer paths
-	LoadBalancersPath = "/projects/%s/providers/Aruba.Network/loadbalancers"
-	LoadBalancerPath  = "/projects/%s/providers/Aruba.Network/loadbalancers/%s"
+	LoadBalancersPath = "/projects/%s/providers/Aruba.Network/loadBalancers"
+	LoadBalancerPath  = "/projects/%s/providers/Aruba.Network/loadBalancers/%s"
 
 	// VPC Peering Connection paths
 	VPCPeeringsPath = "/projects/%s/providers/Aruba.Network/vpcs/%s/vpcPeerings"

--- a/internal/clients/network/security-group-rule_test.go
+++ b/internal/clients/network/security-group-rule_test.go
@@ -262,7 +262,7 @@ func TestCreateSecurityGroupRule(t *testing.T) {
 			}
 			w.Header().Set("Content-Type", "application/json")
 			w.WriteHeader(http.StatusCreated)
-			fmt.Fprint(w, `{"metadata":{"id":"rule-1","name":"my-rule","uri":"/projects/p/providers/Aruba.Network/vpcs/v/securitygroups/sg/securityrules/rule-1"}}`)
+			fmt.Fprint(w, `{"metadata":{"id":"rule-1","name":"my-rule","uri":"/projects/p/providers/Aruba.Network/vpcs/v/securityGroups/sg/securityRules/rule-1"}}`)
 		})
 		c := testutil.NewClient(t, server.URL)
 		svc := NewSecurityGroupRulesClientImpl(c, NewSecurityGroupsClientImpl(c, NewVPCsClientImpl(c)))

--- a/internal/clients/network/security-group_test.go
+++ b/internal/clients/network/security-group_test.go
@@ -244,7 +244,7 @@ func TestCreateSecurityGroup(t *testing.T) {
 			}
 			w.Header().Set("Content-Type", "application/json")
 			w.WriteHeader(http.StatusCreated)
-			fmt.Fprint(w, `{"metadata":{"id":"sg-1","name":"my-sg","uri":"/projects/p/providers/Aruba.Network/vpcs/v/securitygroups/sg-1"}}`)
+			fmt.Fprint(w, `{"metadata":{"id":"sg-1","name":"my-sg","uri":"/projects/p/providers/Aruba.Network/vpcs/v/securityGroups/sg-1"}}`)
 		})
 		c := testutil.NewClient(t, server.URL)
 		svc := NewSecurityGroupsClientImpl(c, NewVPCsClientImpl(c))

--- a/internal/clients/storage/backup_test.go
+++ b/internal/clients/storage/backup_test.go
@@ -17,7 +17,7 @@ func TestListBackups(t *testing.T) {
 		server := testutil.NewMockServer(t, func(w http.ResponseWriter, r *http.Request) {
 			w.Header().Set("Content-Type", "application/json")
 			w.WriteHeader(http.StatusOK)
-			fmt.Fprint(w, `{"total":1,"values":[{"metadata":{"name":"test-backup"},"properties":{"type":"Full","sourceVolume":{"uri":"/projects/test-project/providers/Aruba.Storage/blockstorages/volume-123"},"retentionDays":10,"billingPeriod":"Monthly"},"status":{"state":"active"}}]}`)
+			fmt.Fprint(w, `{"total":1,"values":[{"metadata":{"name":"test-backup"},"properties":{"type":"Full","sourceVolume":{"uri":"/projects/test-project/providers/Aruba.Storage/blockStorages/volume-123"},"retentionDays":10,"billingPeriod":"Monthly"},"status":{"state":"active"}}]}`)
 		})
 		c := testutil.NewClient(t, server.URL)
 		svc := NewBackupClientImpl(c)
@@ -122,7 +122,7 @@ func TestGetBackup(t *testing.T) {
 		server := testutil.NewMockServer(t, func(w http.ResponseWriter, r *http.Request) {
 			w.Header().Set("Content-Type", "application/json")
 			w.WriteHeader(http.StatusOK)
-			fmt.Fprint(w, `{"metadata":{"name":"test-backup","id":"backup-123"},"properties":{"type":"Full","sourceVolume":{"uri":"/projects/test-project/providers/Aruba.Storage/blockstorages/volume-123"},"retentionDays":10,"billingPeriod":"Monthly"},"status":{"state":"active"}}`)
+			fmt.Fprint(w, `{"metadata":{"name":"test-backup","id":"backup-123"},"properties":{"type":"Full","sourceVolume":{"uri":"/projects/test-project/providers/Aruba.Storage/blockStorages/volume-123"},"retentionDays":10,"billingPeriod":"Monthly"},"status":{"state":"active"}}`)
 		})
 		c := testutil.NewClient(t, server.URL)
 		svc := NewBackupClientImpl(c)
@@ -236,7 +236,7 @@ func TestCreateBackup(t *testing.T) {
 		server := testutil.NewMockServer(t, func(w http.ResponseWriter, r *http.Request) {
 			w.Header().Set("Content-Type", "application/json")
 			w.WriteHeader(http.StatusCreated)
-			fmt.Fprint(w, `{"metadata":{"name":"new-backup","id":"backup-456","uri":"/projects/test-project/providers/Aruba.Storage/backups/backup-456"},"properties":{"type":"Full","sourceVolume":{"uri":"/projects/test-project/providers/Aruba.Storage/blockstorages/volume-456"},"retentionDays":20,"billingPeriod":"Yearly"},"status":{"state":"creating"}}`)
+			fmt.Fprint(w, `{"metadata":{"name":"new-backup","id":"backup-456","uri":"/projects/test-project/providers/Aruba.Storage/backups/backup-456"},"properties":{"type":"Full","sourceVolume":{"uri":"/projects/test-project/providers/Aruba.Storage/blockStorages/volume-456"},"retentionDays":20,"billingPeriod":"Yearly"},"status":{"state":"creating"}}`)
 		})
 		c := testutil.NewClient(t, server.URL)
 		svc := NewBackupClientImpl(c)
@@ -246,7 +246,7 @@ func TestCreateBackup(t *testing.T) {
 			},
 			Properties: types.StorageBackupPropertiesRequest{
 				StorageBackupType: types.StorageBackupTypeFull,
-				Origin:            types.ReferenceResource{URI: "/projects/test-project/providers/Aruba.Storage/blockstorages/volume-456"},
+				Origin:            types.ReferenceResource{URI: "/projects/test-project/providers/Aruba.Storage/blockStorages/volume-456"},
 				RetentionDays:     ptr.To(20),
 				BillingPeriod:     (*types.BillingPeriod)(ptr.To("Yearly")),
 			},
@@ -402,7 +402,7 @@ func TestUpdateBackup(t *testing.T) {
 		server := testutil.NewMockServer(t, func(w http.ResponseWriter, r *http.Request) {
 			w.Header().Set("Content-Type", "application/json")
 			w.WriteHeader(http.StatusOK)
-			fmt.Fprint(w, `{"metadata":{"name":"updated-backup","id":"backup-123"},"properties":{"type":"Incremental","sourceVolume":{"uri":"/projects/test-project/providers/Aruba.Storage/blockstorages/volume-123"},"retentionDays":30,"billingPeriod":"Monthly"},"status":{"state":"updating"}}`)
+			fmt.Fprint(w, `{"metadata":{"name":"updated-backup","id":"backup-123"},"properties":{"type":"Incremental","sourceVolume":{"uri":"/projects/test-project/providers/Aruba.Storage/blockStorages/volume-123"},"retentionDays":30,"billingPeriod":"Monthly"},"status":{"state":"updating"}}`)
 		})
 		c := testutil.NewClient(t, server.URL)
 		svc := NewBackupClientImpl(c)
@@ -412,7 +412,7 @@ func TestUpdateBackup(t *testing.T) {
 			},
 			Properties: types.StorageBackupPropertiesRequest{
 				StorageBackupType: types.StorageBackupTypeIncremental,
-				Origin:            types.ReferenceResource{URI: "/projects/test-project/providers/Aruba.Storage/blockstorages/volume-123"},
+				Origin:            types.ReferenceResource{URI: "/projects/test-project/providers/Aruba.Storage/blockStorages/volume-123"},
 				RetentionDays:     ptr.To(30),
 				BillingPeriod:     (*types.BillingPeriod)(ptr.To("Monthly")),
 			},

--- a/internal/clients/storage/path.go
+++ b/internal/clients/storage/path.go
@@ -4,8 +4,8 @@ package storage
 const (
 
 	// Storage Bucket paths
-	BlockStoragesPath = "/projects/%s/providers/Aruba.Storage/blockstorages"
-	BlockStoragePath  = "/projects/%s/providers/Aruba.Storage/blockstorages/%s"
+	BlockStoragesPath = "/projects/%s/providers/Aruba.Storage/blockStorages"
+	BlockStoragePath  = "/projects/%s/providers/Aruba.Storage/blockStorages/%s"
 
 	//Snapshot paths
 	SnapshotsPath = "/projects/%s/providers/Aruba.Storage/snapshots"

--- a/internal/clients/storage/restore_test.go
+++ b/internal/clients/storage/restore_test.go
@@ -24,7 +24,7 @@ func TestListRestores(t *testing.T) {
 		server := testutil.NewMockServer(t, func(w http.ResponseWriter, r *http.Request) {
 			w.Header().Set("Content-Type", "application/json")
 			w.WriteHeader(http.StatusOK)
-			fmt.Fprint(w, `{"total":1,"values":[{"metadata":{"name":"test-restore"},"properties":{"destinationVolume":{"uri":"/projects/test-project/providers/Aruba.Storage/blockstorages/vol-789"}}}]}`)
+			fmt.Fprint(w, `{"total":1,"values":[{"metadata":{"name":"test-restore"},"properties":{"destinationVolume":{"uri":"/projects/test-project/providers/Aruba.Storage/blockStorages/vol-789"}}}]}`)
 		})
 		svc := newRestoreSvc(t, server.URL)
 		resp, err := svc.List(context.Background(), "test-project", "backup-123", nil)
@@ -132,7 +132,7 @@ func TestGetRestore(t *testing.T) {
 		server := testutil.NewMockServer(t, func(w http.ResponseWriter, r *http.Request) {
 			w.Header().Set("Content-Type", "application/json")
 			w.WriteHeader(http.StatusOK)
-			fmt.Fprint(w, `{"metadata":{"name":"test-restore","id":"restore-123"},"properties":{"destinationVolume":{"uri":"/projects/test-project/providers/Aruba.Storage/blockstorages/vol-789"}}}`)
+			fmt.Fprint(w, `{"metadata":{"name":"test-restore","id":"restore-123"},"properties":{"destinationVolume":{"uri":"/projects/test-project/providers/Aruba.Storage/blockStorages/vol-789"}}}`)
 		})
 		svc := newRestoreSvc(t, server.URL)
 		resp, err := svc.Get(context.Background(), "test-project", "backup-123", "restore-123", nil)
@@ -245,7 +245,7 @@ func TestCreateRestore(t *testing.T) {
 		server := testutil.NewMockServer(t, func(w http.ResponseWriter, r *http.Request) {
 			w.Header().Set("Content-Type", "application/json")
 			w.WriteHeader(http.StatusCreated)
-			fmt.Fprint(w, `{"metadata":{"name":"new-restore","id":"restore-456","uri":"/projects/test-project/providers/Aruba.Storage/restores/restore-456"},"properties":{"destinationVolume":{"uri":"/projects/test-project/providers/Aruba.Storage/blockstorages/vol-789"}},"status":{"state":"creating"}}`)
+			fmt.Fprint(w, `{"metadata":{"name":"new-restore","id":"restore-456","uri":"/projects/test-project/providers/Aruba.Storage/restores/restore-456"},"properties":{"destinationVolume":{"uri":"/projects/test-project/providers/Aruba.Storage/blockStorages/vol-789"}},"status":{"state":"creating"}}`)
 		})
 		svc := newRestoreSvc(t, server.URL)
 		body := types.StorageRestoreRequest{
@@ -253,7 +253,7 @@ func TestCreateRestore(t *testing.T) {
 				ResourceMetadataRequest: types.ResourceMetadataRequest{Name: "new-restore"},
 			},
 			Properties: types.StorageRestorePropertiesRequest{
-				Target: types.ReferenceResource{URI: "/projects/test-project/providers/Aruba.Storage/blockstorages/vol-789"},
+				Target: types.ReferenceResource{URI: "/projects/test-project/providers/Aruba.Storage/blockStorages/vol-789"},
 			},
 		}
 		resp, err := svc.Create(context.Background(), "test-project", "backup-123", body, nil)
@@ -415,7 +415,7 @@ func TestUpdateRestore(t *testing.T) {
 		server := testutil.NewMockServer(t, func(w http.ResponseWriter, r *http.Request) {
 			w.Header().Set("Content-Type", "application/json")
 			w.WriteHeader(http.StatusOK)
-			fmt.Fprint(w, `{"metadata":{"name":"updated-restore","id":"restore-123"},"properties":{"destinationVolume":{"uri":"/projects/test-project/providers/Aruba.Storage/blockstorages/vol-789"}},"status":{"state":"updating"}}`)
+			fmt.Fprint(w, `{"metadata":{"name":"updated-restore","id":"restore-123"},"properties":{"destinationVolume":{"uri":"/projects/test-project/providers/Aruba.Storage/blockStorages/vol-789"}},"status":{"state":"updating"}}`)
 		})
 		svc := newRestoreSvc(t, server.URL)
 		body := types.StorageRestoreRequest{
@@ -423,7 +423,7 @@ func TestUpdateRestore(t *testing.T) {
 				ResourceMetadataRequest: types.ResourceMetadataRequest{Name: "updated-restore"},
 			},
 			Properties: types.StorageRestorePropertiesRequest{
-				Target: types.ReferenceResource{URI: "/projects/test-project/providers/Aruba.Storage/blockstorages/vol-789"},
+				Target: types.ReferenceResource{URI: "/projects/test-project/providers/Aruba.Storage/blockStorages/vol-789"},
 			},
 		}
 		resp, err := svc.Update(context.Background(), "test-project", "backup-123", "restore-123", body, nil)

--- a/internal/clients/storage/storage_test.go
+++ b/internal/clients/storage/storage_test.go
@@ -731,7 +731,7 @@ func TestGetSnapshot(t *testing.T) {
 		server := testutil.NewMockServer(t, func(w http.ResponseWriter, r *http.Request) {
 			w.Header().Set("Content-Type", "application/json")
 			w.WriteHeader(http.StatusOK)
-			fmt.Fprint(w, `{"metadata":{"name":"my-snapshot","id":"snap-123"},"properties":{"sizeGb":150,"billingPeriod":"Hour","dataCenter":"it-eur-1","type":"Performance","volume":{"uri":"/projects/test-project/providers/Aruba.Storage/blockstorages/vol-123","name":"source-volume"}},"status":{"state":"available"}}`)
+			fmt.Fprint(w, `{"metadata":{"name":"my-snapshot","id":"snap-123"},"properties":{"sizeGb":150,"billingPeriod":"Hour","dataCenter":"it-eur-1","type":"Performance","volume":{"uri":"/projects/test-project/providers/Aruba.Storage/blockStorages/vol-123","name":"source-volume"}},"status":{"state":"available"}}`)
 		})
 		svc := newSnapshotSvc(t, server.URL)
 		resp, err := svc.Get(context.Background(), "test-project", "snap-123", nil)

--- a/pkg/aruba/aliases.go
+++ b/pkg/aruba/aliases.go
@@ -419,7 +419,7 @@ type AcceptHeader = types.AcceptHeader
 // IKEEncryption is the encryption algorithm for IKESettings.Encryption.
 // Values are StrongSwan wire identifiers. The authoritative list is at:
 //
-//	GET /providers/Aruba.Network/vpn-tunnels
+//	GET /providers/Aruba.Network/vpnTunnels
 type IKEEncryption = types.IKEEncryption
 
 const (
@@ -543,7 +543,7 @@ const (
 // ESPEncryption is the encryption algorithm for ESPSettings.Encryption.
 // Values are StrongSwan wire identifiers. The authoritative list is at:
 //
-//	GET /providers/Aruba.Network/vpn-tunnels
+//	GET /providers/Aruba.Network/vpnTunnels
 type ESPEncryption = types.ESPEncryption
 
 const (

--- a/pkg/aruba/mixin_scoped.go
+++ b/pkg/aruba/mixin_scoped.go
@@ -97,7 +97,7 @@ func (m *securityGroupScopedMixin) intoSecurityGroup(parent Ref) {
 			return p.SecurityGroupID(), true
 		}
 		return "", false
-	}, "security-groups")
+	}, "securityGroups")
 	if !ok {
 		m.errSink.addErr(fmt.Errorf("IntoSecurityGroup: cannot determine security group ID from Ref %q", parent.URI()))
 	}
@@ -346,14 +346,7 @@ func (m *vpnTunnelScopedMixin) intoVPNTunnel(parent Ref) {
 			return p.VPNTunnelID(), true
 		}
 		return "", false
-	}, "vpn-tunnels")
-	if !ok {
-		// Production URI uses "vpnTunnels" (camelCase); mixin/test form uses "vpn-tunnels".
-		if v := parseURIIDs(parent.URI())["vpnTunnels"]; v != "" {
-			tunnelID = v
-			ok = true
-		}
-	}
+	}, "vpnTunnels")
 	if !ok {
 		m.errSink.addErr(fmt.Errorf("IntoVPNTunnel: cannot determine VPN tunnel ID from Ref %q", parent.URI()))
 	}
@@ -398,14 +391,7 @@ func (m *vpcPeeringScopedMixin) intoVPCPeering(parent Ref) {
 			return p.VPCPeeringID(), true
 		}
 		return "", false
-	}, "peerings")
-	if !ok {
-		// Production URI uses "vpcPeerings" (camelCase); mixin/test form uses "peerings".
-		if v := parseURIIDs(parent.URI())["vpcPeerings"]; v != "" {
-			peeringID = v
-			ok = true
-		}
-	}
+	}, "vpcPeerings")
 	if !ok {
 		m.errSink.addErr(fmt.Errorf("IntoVPCPeering: cannot determine VPC peering ID from Ref %q", parent.URI()))
 	}

--- a/pkg/aruba/mixin_scoped_test.go
+++ b/pkg/aruba/mixin_scoped_test.go
@@ -111,7 +111,7 @@ func (p typedSGParent) SecurityGroupID() string { return p.sgID }
 func (p typedSGParent) VPCID() string           { return p.vpcID }
 func (p typedSGParent) ProjectID() string       { return p.projectID }
 func (p typedSGParent) URI() string {
-	return "/projects/" + p.projectID + "/network/vpcs/" + p.vpcID + "/security-groups/" + p.sgID
+	return "/projects/" + p.projectID + "/providers/Aruba.Network/vpcs/" + p.vpcID + "/securityGroups/" + p.sgID
 }
 func (p typedSGParent) ID() string { return p.sgID }
 
@@ -137,7 +137,7 @@ func TestSecurityGroupScopedMixin_TypedRef(t *testing.T) {
 func TestSecurityGroupScopedMixin_URIFallback(t *testing.T) {
 	errs := &errMixin{}
 	m := bindSecurityGroupScoped(errs)
-	m.intoSecurityGroup(URI("/projects/proj-2/network/vpcs/vpc-2/security-groups/sg-2"))
+	m.intoSecurityGroup(URI("/projects/proj-2/providers/Aruba.Network/vpcs/vpc-2/securityGroups/sg-2"))
 
 	if m.SecurityGroupID() != "sg-2" || m.VPCID() != "vpc-2" || m.ProjectID() != "proj-2" {
 		t.Errorf("got sg=%q vpc=%q proj=%q", m.SecurityGroupID(), m.VPCID(), m.ProjectID())
@@ -210,7 +210,7 @@ func TestKMSScopedMixin_URIFallback(t *testing.T) {
 func TestVPNTunnelScopedMixin_URIFallback(t *testing.T) {
 	errs := &errMixin{}
 	m := bindVPNTunnelScoped(errs)
-	m.intoVPNTunnel(URI("/projects/proj-1/network/vpn-tunnels/t-1"))
+	m.intoVPNTunnel(URI("/projects/proj-1/providers/Aruba.Network/vpnTunnels/t-1"))
 
 	if m.VPNTunnelID() != "t-1" || m.ProjectID() != "proj-1" {
 		t.Errorf("got tunnel=%q proj=%q", m.VPNTunnelID(), m.ProjectID())
@@ -237,7 +237,7 @@ func TestVPNTunnelScopedMixin_URIFallback_CamelCase(t *testing.T) {
 func TestVPCPeeringScopedMixin_URIFallback(t *testing.T) {
 	errs := &errMixin{}
 	m := bindVPCPeeringScoped(errs)
-	m.intoVPCPeering(URI("/projects/proj-1/network/vpcs/vpc-1/peerings/peer-1"))
+	m.intoVPCPeering(URI("/projects/proj-1/providers/Aruba.Network/vpcs/vpc-1/vpcPeerings/peer-1"))
 
 	if m.VPCPeeringID() != "peer-1" || m.VPCID() != "vpc-1" || m.ProjectID() != "proj-1" {
 		t.Errorf("got peering=%q vpc=%q proj=%q", m.VPCPeeringID(), m.VPCID(), m.ProjectID())

--- a/pkg/aruba/ref.go
+++ b/pkg/aruba/ref.go
@@ -41,8 +41,8 @@ var namespaceSegments = map[string]bool{
 
 // parseURIIDs splits a URI path into resource-type → id pairs, skipping namespace prefixes.
 //
-// Example: "/projects/p/network/vpcs/v/security-groups/s"
-// → {"projects":"p","vpcs":"v","security-groups":"s"}
+// Example: "/projects/p/providers/Aruba.Network/vpcs/v/securityGroups/s"
+// → {"projects":"p","providers":"Aruba.Network","vpcs":"v","securityGroups":"s"}
 func parseURIIDs(uri string) map[string]string {
 	result := make(map[string]string)
 	parts := strings.Split(strings.TrimPrefix(uri, "/"), "/")

--- a/pkg/aruba/ref_test.go
+++ b/pkg/aruba/ref_test.go
@@ -28,24 +28,24 @@ func TestParseURIIDs(t *testing.T) {
 			want: map[string]string{"projects": "p", "vpcs": "v"},
 		},
 		{
-			uri:  "/projects/p/network/vpcs/v/security-groups/s",
-			want: map[string]string{"projects": "p", "vpcs": "v", "security-groups": "s"},
+			uri:  "/projects/p/providers/Aruba.Network/vpcs/v/securityGroups/s",
+			want: map[string]string{"projects": "p", "providers": "Aruba.Network", "vpcs": "v", "securityGroups": "s"},
 		},
 		{
-			uri:  "/projects/p/network/vpcs/v/security-groups/s/rules/r",
-			want: map[string]string{"projects": "p", "vpcs": "v", "security-groups": "s", "rules": "r"},
+			uri:  "/projects/p/providers/Aruba.Network/vpcs/v/securityGroups/s/rules/r",
+			want: map[string]string{"projects": "p", "providers": "Aruba.Network", "vpcs": "v", "securityGroups": "s", "rules": "r"},
 		},
 		{
-			uri:  "/projects/p/network/vpcs/v/peerings/pr",
-			want: map[string]string{"projects": "p", "vpcs": "v", "peerings": "pr"},
+			uri:  "/projects/p/providers/Aruba.Network/vpcs/v/vpcPeerings/pr",
+			want: map[string]string{"projects": "p", "providers": "Aruba.Network", "vpcs": "v", "vpcPeerings": "pr"},
 		},
 		{
-			uri:  "/projects/p/network/vpcs/v/peerings/pr/routes/r",
-			want: map[string]string{"projects": "p", "vpcs": "v", "peerings": "pr", "routes": "r"},
+			uri:  "/projects/p/providers/Aruba.Network/vpcs/v/vpcPeerings/pr/routes/r",
+			want: map[string]string{"projects": "p", "providers": "Aruba.Network", "vpcs": "v", "vpcPeerings": "pr", "routes": "r"},
 		},
 		{
-			uri:  "/projects/p/network/vpn-tunnels/t",
-			want: map[string]string{"projects": "p", "vpn-tunnels": "t"},
+			uri:  "/projects/p/providers/Aruba.Network/vpnTunnels/t",
+			want: map[string]string{"projects": "p", "providers": "Aruba.Network", "vpnTunnels": "t"},
 		},
 		{
 			uri:  "/projects/p/database/dbaas/d/databases/db",
@@ -84,8 +84,8 @@ func TestParseURIIDs(t *testing.T) {
 // missingSegmentReturnsEmpty verifies that a URI lacking an expected segment returns an empty entry.
 func TestParseURIIDsMissingSegment(t *testing.T) {
 	got := parseURIIDs("/projects/p/network/vpcs/v")
-	if _, ok := got["security-groups"]; ok {
-		t.Error("expected no security-groups key in map")
+	if _, ok := got["securityGroups"]; ok {
+		t.Error("expected no securityGroups key in map")
 	}
 	if got["vpcs"] != "v" {
 		t.Errorf("vpcs = %q, want %q", got["vpcs"], "v")

--- a/pkg/aruba/resource_block_storage.go
+++ b/pkg/aruba/resource_block_storage.go
@@ -564,7 +564,7 @@ func blockStorageIDsFromRef(ref Ref) (projectID, blockStorageID string, err erro
 			return w.BlockStorageID(), true
 		}
 		return "", false
-	}, "blockstorages")
+	}, "blockStorages")
 	if !ok || bid == "" {
 		return "", "", fmt.Errorf("cannot determine BlockStorage ID from Ref %q", ref.URI())
 	}

--- a/pkg/aruba/resource_block_storage_test.go
+++ b/pkg/aruba/resource_block_storage_test.go
@@ -293,13 +293,13 @@ func blockStorageTestResponse(id, name, uri, projectID string) *types.BlockStora
 
 func TestBlockStorage_FromResponseHydration(t *testing.T) {
 	bs := &BlockStorage{}
-	resp := blockStorageTestResponse("bs-1", "my-bs", "/projects/p1/providers/Aruba.Storage/blockstorages/bs-1", "p1")
+	resp := blockStorageTestResponse("bs-1", "my-bs", "/projects/p1/providers/Aruba.Storage/blockStorages/bs-1", "p1")
 	bs.fromResponse(resp)
 
 	if bs.ID() != "bs-1" {
 		t.Errorf("ID() = %q", bs.ID())
 	}
-	if bs.URI() != "/projects/p1/providers/Aruba.Storage/blockstorages/bs-1" {
+	if bs.URI() != "/projects/p1/providers/Aruba.Storage/blockStorages/bs-1" {
 		t.Errorf("URI() = %q", bs.URI())
 	}
 	if bs.BlockStorageID() != "bs-1" {
@@ -370,7 +370,7 @@ func TestBlockStorage_FromResponsePartial(t *testing.T) {
 
 func TestBlockStorage_FromResponseURIBackfill(t *testing.T) {
 	id := "bs-99"
-	uri := "/projects/p-uri/providers/Aruba.Storage/blockstorages/bs-99"
+	uri := "/projects/p-uri/providers/Aruba.Storage/blockStorages/bs-99"
 	state := types.State("")
 	resp := &types.BlockStorageResponse{
 		Metadata: types.ResourceMetadataResponse{
@@ -394,7 +394,7 @@ func TestBlockStorage_FromResponseURIBackfill(t *testing.T) {
 
 func TestBlockStorage_RefSatisfaction(t *testing.T) {
 	bs := &BlockStorage{}
-	bs.fromResponse(blockStorageTestResponse("bs-99", "n", "/projects/p99/providers/Aruba.Storage/blockstorages/bs-99", "p99"))
+	bs.fromResponse(blockStorageTestResponse("bs-99", "n", "/projects/p99/providers/Aruba.Storage/blockStorages/bs-99", "p99"))
 
 	// withBlockStorageID typed path
 	bid, ok := extractID(bs, func(r Ref) (string, bool) {
@@ -402,7 +402,7 @@ func TestBlockStorage_RefSatisfaction(t *testing.T) {
 			return w.BlockStorageID(), true
 		}
 		return "", false
-	}, "blockstorages")
+	}, "blockStorages")
 	if !ok || bid != "bs-99" {
 		t.Errorf("extractID via withBlockStorageID = (%q, %v)", bid, ok)
 	}
@@ -425,7 +425,7 @@ func TestBlockStorage_RefSatisfaction(t *testing.T) {
 
 func TestBlockStorageIDsFromRef_TypedRef(t *testing.T) {
 	bs := &BlockStorage{}
-	bs.fromResponse(blockStorageTestResponse("bid", "n", "/projects/p/providers/Aruba.Storage/blockstorages/bid", "p"))
+	bs.fromResponse(blockStorageTestResponse("bid", "n", "/projects/p/providers/Aruba.Storage/blockStorages/bid", "p"))
 	pid, bid, err := blockStorageIDsFromRef(bs)
 	if err != nil || pid != "p" || bid != "bid" {
 		t.Errorf("blockStorageIDsFromRef typed = (%q, %q, %v)", pid, bid, err)
@@ -433,7 +433,7 @@ func TestBlockStorageIDsFromRef_TypedRef(t *testing.T) {
 }
 
 func TestBlockStorageIDsFromRef_URIRef(t *testing.T) {
-	ref := URI("/projects/p/providers/Aruba.Storage/blockstorages/bs-1")
+	ref := URI("/projects/p/providers/Aruba.Storage/blockStorages/bs-1")
 	pid, bid, err := blockStorageIDsFromRef(ref)
 	if err != nil || pid != "p" || bid != "bs-1" {
 		t.Errorf("blockStorageIDsFromRef URI = (%q, %q, %v)", pid, bid, err)
@@ -443,12 +443,12 @@ func TestBlockStorageIDsFromRef_URIRef(t *testing.T) {
 func TestBlockStorageIDsFromRef_BadURI_MissingBlockStorage(t *testing.T) {
 	_, _, err := blockStorageIDsFromRef(URI("/projects/p/providers/Aruba.Storage/something/else"))
 	if err == nil {
-		t.Error("expected error for URI without /blockstorages/<id>")
+		t.Error("expected error for URI without /blockStorages/<id>")
 	}
 }
 
 func TestBlockStorageIDsFromRef_BadURI_MissingProject(t *testing.T) {
-	_, _, err := blockStorageIDsFromRef(URI("/providers/Aruba.Storage/blockstorages/bs-1"))
+	_, _, err := blockStorageIDsFromRef(URI("/providers/Aruba.Storage/blockStorages/bs-1"))
 	if err == nil {
 		t.Error("expected error for URI without /projects/<id>")
 	}
@@ -472,7 +472,7 @@ func buildVolumesTestAdapter(t *testing.T, handler http.HandlerFunc) *volumesCli
 }
 
 const blockStorageSuccessBody = `{` +
-	`"metadata":{"id":"bs-1","name":"my-bs","uri":"/projects/p/providers/Aruba.Storage/blockstorages/bs-1","project":{"id":"p"}},` +
+	`"metadata":{"id":"bs-1","name":"my-bs","uri":"/projects/p/providers/Aruba.Storage/blockStorages/bs-1","project":{"id":"p"}},` +
 	`"properties":{"sizeGB":20,"type":"Standard","billingPeriod":"Hour","zone":"ITBG-1"},` +
 	`"status":{"state":"Active"}}`
 
@@ -482,7 +482,7 @@ func TestVolumesClientAdapter_Create_Success(t *testing.T) {
 		if err := json.NewDecoder(r.Body).Decode(&gotBody); err != nil {
 			t.Errorf("decode request body: %v", err)
 		}
-		if !containsSubstring(r.URL.Path, "blockstorages") {
+		if !containsSubstring(r.URL.Path, "blockStorages") {
 			t.Errorf("path %q should contain 'blockstorages'", r.URL.Path)
 		}
 		w.Header().Set("Content-Type", "application/json")
@@ -541,7 +541,7 @@ func TestVolumesClientAdapter_Create_MetadataValidationError(t *testing.T) {
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusCreated)
 		// Missing "id" field — triggers MetadataValidationError
-		fmt.Fprint(w, `{"metadata":{"name":"bs","uri":"/projects/p/providers/Aruba.Storage/blockstorages/x"},"properties":{},"status":{}}`)
+		fmt.Fprint(w, `{"metadata":{"name":"bs","uri":"/projects/p/providers/Aruba.Storage/blockStorages/x"},"properties":{},"status":{}}`)
 	})
 
 	bs := NewBlockStorage().IntoProject(URI("/projects/p")).
@@ -592,7 +592,7 @@ func TestVolumesClientAdapter_Get_URIRef(t *testing.T) {
 		fmt.Fprint(w, blockStorageSuccessBody)
 	})
 
-	ref := URI("/projects/p/providers/Aruba.Storage/blockstorages/bs-1")
+	ref := URI("/projects/p/providers/Aruba.Storage/blockStorages/bs-1")
 	result, err := adapter.Get(context.Background(), ref)
 	if err != nil {
 		t.Fatalf("Get error: %v", err)
@@ -603,7 +603,7 @@ func TestVolumesClientAdapter_Get_URIRef(t *testing.T) {
 	if result.ProjectID() != "p" {
 		t.Errorf("ProjectID() = %q", result.ProjectID())
 	}
-	if !containsSubstring(capturedPath, "blockstorages") {
+	if !containsSubstring(capturedPath, "blockStorages") {
 		t.Errorf("path %q should contain 'blockstorages'", capturedPath)
 	}
 }
@@ -616,7 +616,7 @@ func TestVolumesClientAdapter_Get_TypedRef(t *testing.T) {
 	})
 
 	existing := &BlockStorage{}
-	existing.fromResponse(blockStorageTestResponse("bs-1", "n", "/projects/p/providers/Aruba.Storage/blockstorages/bs-1", "p"))
+	existing.fromResponse(blockStorageTestResponse("bs-1", "n", "/projects/p/providers/Aruba.Storage/blockStorages/bs-1", "p"))
 
 	result, err := adapter.Get(context.Background(), existing)
 	if err != nil {
@@ -633,11 +633,11 @@ func TestVolumesClientAdapter_Update_Success(t *testing.T) {
 		_ = json.NewDecoder(r.Body).Decode(&capturedBody)
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
-		fmt.Fprint(w, `{"metadata":{"id":"bs-1","name":"my-bs","uri":"/projects/p/providers/Aruba.Storage/blockstorages/bs-1","project":{"id":"p"}},"properties":{"sizeGB":40,"type":"Standard","billingPeriod":"Hour"},"status":{}}`)
+		fmt.Fprint(w, `{"metadata":{"id":"bs-1","name":"my-bs","uri":"/projects/p/providers/Aruba.Storage/blockStorages/bs-1","project":{"id":"p"}},"properties":{"sizeGB":40,"type":"Standard","billingPeriod":"Hour"},"status":{}}`)
 	})
 
 	bs := &BlockStorage{}
-	bs.fromResponse(blockStorageTestResponse("bs-1", "my-bs", "/projects/p/providers/Aruba.Storage/blockstorages/bs-1", "p"))
+	bs.fromResponse(blockStorageTestResponse("bs-1", "my-bs", "/projects/p/providers/Aruba.Storage/blockStorages/bs-1", "p"))
 	bs.WithSizeGB(40)
 
 	result, err := adapter.Update(context.Background(), bs)
@@ -702,7 +702,7 @@ func TestVolumesClientAdapter_Delete_Success(t *testing.T) {
 		w.WriteHeader(http.StatusNoContent)
 	})
 
-	err := adapter.Delete(context.Background(), URI("/projects/p/providers/Aruba.Storage/blockstorages/bs-1"))
+	err := adapter.Delete(context.Background(), URI("/projects/p/providers/Aruba.Storage/blockStorages/bs-1"))
 	if err != nil {
 		t.Fatalf("Delete error: %v", err)
 	}
@@ -715,7 +715,7 @@ func TestVolumesClientAdapter_Delete_NonTwoXX(t *testing.T) {
 		fmt.Fprint(w, testutil.ErrorBodyJSON("Not Found", "block storage not found", 404))
 	})
 
-	err := adapter.Delete(context.Background(), URI("/projects/p/providers/Aruba.Storage/blockstorages/missing"))
+	err := adapter.Delete(context.Background(), URI("/projects/p/providers/Aruba.Storage/blockStorages/missing"))
 	if err == nil {
 		t.Fatal("expected error on 404")
 	}
@@ -733,8 +733,8 @@ func TestVolumesClientAdapter_List_TwoItems(t *testing.T) {
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
 		fmt.Fprint(w, `{"total":2,"self":"","prev":"","next":"","first":"","last":"","values":[`+
-			`{"metadata":{"id":"bs-1","name":"n1","uri":"/projects/p/providers/Aruba.Storage/blockstorages/bs-1","project":{"id":"p"}},"properties":{"sizeGB":10,"type":"Standard","billingPeriod":"Hour"},"status":{}},`+
-			`{"metadata":{"id":"bs-2","name":"n2","uri":"/projects/p/providers/Aruba.Storage/blockstorages/bs-2","project":{"id":"p"}},"properties":{"sizeGB":20,"type":"Performance","billingPeriod":"Month"},"status":{}}`+
+			`{"metadata":{"id":"bs-1","name":"n1","uri":"/projects/p/providers/Aruba.Storage/blockStorages/bs-1","project":{"id":"p"}},"properties":{"sizeGB":10,"type":"Standard","billingPeriod":"Hour"},"status":{}},`+
+			`{"metadata":{"id":"bs-2","name":"n2","uri":"/projects/p/providers/Aruba.Storage/blockStorages/bs-2","project":{"id":"p"}},"properties":{"sizeGB":20,"type":"Performance","billingPeriod":"Month"},"status":{}}`+
 			`]}`)
 	})
 
@@ -821,7 +821,7 @@ func TestVolumesClientAdapter_Get_NonTwoXX(t *testing.T) {
 		fmt.Fprint(w, testutil.ErrorBodyJSON("Not Found", "block storage not found", 404))
 	})
 
-	ref := URI("/projects/p/providers/Aruba.Storage/blockstorages/missing")
+	ref := URI("/projects/p/providers/Aruba.Storage/blockStorages/missing")
 	_, err := adapter.Get(context.Background(), ref)
 	if err == nil {
 		t.Fatal("expected error on 404")
@@ -843,7 +843,7 @@ func TestVolumesClientAdapter_Update_NonTwoXX(t *testing.T) {
 	})
 
 	bs := &BlockStorage{}
-	bs.fromResponse(blockStorageTestResponse("bs-1", "my-bs", "/projects/p/providers/Aruba.Storage/blockstorages/bs-1", "p"))
+	bs.fromResponse(blockStorageTestResponse("bs-1", "my-bs", "/projects/p/providers/Aruba.Storage/blockStorages/bs-1", "p"))
 	bs.WithSizeGB(99999)
 
 	_, err := adapter.Update(context.Background(), bs)
@@ -979,7 +979,7 @@ func TestVolumesClientAdapter_Get_InjectsRefresh(t *testing.T) {
 		fmt.Fprint(w, blockStorageSuccessBody)
 	})
 	adapter := newVolumesClientAdapter(testutil.NewClient(t, server.URL))
-	bs, err := adapter.Get(context.Background(), URI("/projects/p/providers/Aruba.Storage/blockstorages/bs-1"))
+	bs, err := adapter.Get(context.Background(), URI("/projects/p/providers/Aruba.Storage/blockStorages/bs-1"))
 	if err != nil {
 		t.Fatalf("Get error: %v", err)
 	}

--- a/pkg/aruba/resource_cloud_server_test.go
+++ b/pkg/aruba/resource_cloud_server_test.go
@@ -146,8 +146,8 @@ func TestCloudServer_WithBootVolume_EmptyURI(t *testing.T) {
 }
 
 func TestCloudServer_WithKeyPair_URIRef(t *testing.T) {
-	cs := NewCloudServer().WithKeyPair(URI("/projects/p/providers/Aruba.Compute/keypairs/kp-1"))
-	if cs.KeyPair() != "/projects/p/providers/Aruba.Compute/keypairs/kp-1" {
+	cs := NewCloudServer().WithKeyPair(URI("/projects/p/providers/Aruba.Compute/keyPairs/kp-1"))
+	if cs.KeyPair() != "/projects/p/providers/Aruba.Compute/keyPairs/kp-1" {
 		t.Errorf("KeyPair() = %q", cs.KeyPair())
 	}
 	if cs.Err() != nil {

--- a/pkg/aruba/resource_container_registry_test.go
+++ b/pkg/aruba/resource_container_registry_test.go
@@ -32,9 +32,9 @@ func TestContainerRegistry_FluentSetters(t *testing.T) {
 
 	vpcURI := URI("/projects/p-1/providers/Aruba.Network/vpcs/vpc-1")
 	subnetURI := URI("/projects/p-1/providers/Aruba.Network/vpcs/vpc-1/subnets/sn-1")
-	sgURI := URI("/projects/p-1/providers/Aruba.Network/vpcs/vpc-1/securitygroups/sg-1")
+	sgURI := URI("/projects/p-1/providers/Aruba.Network/vpcs/vpc-1/securityGroups/sg-1")
 	eipURI := URI("/projects/p-1/providers/Aruba.Network/elasticips/eip-1")
-	bsURI := URI("/projects/p-1/providers/Aruba.Storage/blockstorages/bs-1")
+	bsURI := URI("/projects/p-1/providers/Aruba.Storage/blockStorages/bs-1")
 
 	cr := NewContainerRegistry().
 		IntoProject(proj).
@@ -243,7 +243,7 @@ func TestContainerRegistry_WithSubnet_EmptyURI(t *testing.T) {
 // --------------------------------------------------------------------------
 
 func TestContainerRegistry_WithSecurityGroup_URIRef(t *testing.T) {
-	uri := "/projects/p-1/providers/Aruba.Network/vpcs/vpc-1/securitygroups/sg-1"
+	uri := "/projects/p-1/providers/Aruba.Network/vpcs/vpc-1/securityGroups/sg-1"
 	cr := NewContainerRegistry().WithSecurityGroup(URI(uri))
 	if cr.SecurityGroup() != uri {
 		t.Errorf("SecurityGroup() = %q", cr.SecurityGroup())
@@ -254,7 +254,7 @@ func TestContainerRegistry_WithSecurityGroup_URIRef(t *testing.T) {
 }
 
 func TestContainerRegistry_WithSecurityGroup_TypedRef(t *testing.T) {
-	ref := URI("/projects/p-1/providers/Aruba.Network/vpcs/vpc-1/securitygroups/sg-1")
+	ref := URI("/projects/p-1/providers/Aruba.Network/vpcs/vpc-1/securityGroups/sg-1")
 	cr := NewContainerRegistry().WithSecurityGroup(ref)
 	if cr.SecurityGroup() != ref.URI() {
 		t.Errorf("SecurityGroup() = %q, want %q", cr.SecurityGroup(), ref.URI())
@@ -276,7 +276,7 @@ func TestContainerRegistry_WithSecurityGroup_EmptyURI(t *testing.T) {
 // --------------------------------------------------------------------------
 
 func TestContainerRegistry_WithBlockStorage_URIRef(t *testing.T) {
-	uri := "/projects/p-1/providers/Aruba.Storage/blockstorages/bs-1"
+	uri := "/projects/p-1/providers/Aruba.Storage/blockStorages/bs-1"
 	cr := NewContainerRegistry().WithBlockStorage(URI(uri))
 	if cr.BlockStorage() != uri {
 		t.Errorf("BlockStorage() = %q", cr.BlockStorage())
@@ -287,7 +287,7 @@ func TestContainerRegistry_WithBlockStorage_URIRef(t *testing.T) {
 }
 
 func TestContainerRegistry_WithBlockStorage_TypedRef(t *testing.T) {
-	ref := URI("/projects/p-1/providers/Aruba.Storage/blockstorages/bs-1")
+	ref := URI("/projects/p-1/providers/Aruba.Storage/blockStorages/bs-1")
 	cr := NewContainerRegistry().WithBlockStorage(ref)
 	if cr.BlockStorage() != ref.URI() {
 		t.Errorf("BlockStorage() = %q, want %q", cr.BlockStorage(), ref.URI())
@@ -343,9 +343,9 @@ func TestContainerRegistry_WithBillingPeriod(t *testing.T) {
 func TestContainerRegistry_ToRequest(t *testing.T) {
 	vpcURI := "/projects/p/providers/Aruba.Network/vpcs/vpc-1"
 	subnetURI := "/projects/p/providers/Aruba.Network/vpcs/vpc-1/subnets/sn-1"
-	sgURI := "/projects/p/providers/Aruba.Network/vpcs/vpc-1/securitygroups/sg-1"
+	sgURI := "/projects/p/providers/Aruba.Network/vpcs/vpc-1/securityGroups/sg-1"
 	eipURI := "/projects/p/providers/Aruba.Network/elasticips/eip-1"
-	bsURI := "/projects/p/providers/Aruba.Storage/blockstorages/bs-1"
+	bsURI := "/projects/p/providers/Aruba.Storage/blockStorages/bs-1"
 
 	cr := NewContainerRegistry().Named(
 		"reg-rt").
@@ -428,9 +428,9 @@ func containerRegistryTestResponse(name string) *types.ContainerRegistryResponse
 	size := "Small"
 	vpcURI := "/projects/p/providers/Aruba.Network/vpcs/vpc-1"
 	subnetURI := "/projects/p/providers/Aruba.Network/vpcs/vpc-1/subnets/sn-1"
-	sgURI := "/projects/p/providers/Aruba.Network/vpcs/vpc-1/securitygroups/sg-1"
+	sgURI := "/projects/p/providers/Aruba.Network/vpcs/vpc-1/securityGroups/sg-1"
 	eipURI := "/projects/p/providers/Aruba.Network/elasticips/eip-1"
-	bsURI := "/projects/p/providers/Aruba.Storage/blockstorages/bs-1"
+	bsURI := "/projects/p/providers/Aruba.Storage/blockStorages/bs-1"
 	return &types.ContainerRegistryResponse{
 		Metadata: types.ResourceMetadataResponse{
 			ID:               &id,
@@ -497,13 +497,13 @@ func TestContainerRegistry_FromResponseHydration(t *testing.T) {
 	if cr.Subnet() != "/projects/p/providers/Aruba.Network/vpcs/vpc-1/subnets/sn-1" {
 		t.Errorf("Subnet() = %q", cr.Subnet())
 	}
-	if cr.SecurityGroup() != "/projects/p/providers/Aruba.Network/vpcs/vpc-1/securitygroups/sg-1" {
+	if cr.SecurityGroup() != "/projects/p/providers/Aruba.Network/vpcs/vpc-1/securityGroups/sg-1" {
 		t.Errorf("SecurityGroup() = %q", cr.SecurityGroup())
 	}
 	if cr.ElasticIP() != "/projects/p/providers/Aruba.Network/elasticips/eip-1" {
 		t.Errorf("PublicIP() = %q", cr.ElasticIP())
 	}
-	if cr.BlockStorage() != "/projects/p/providers/Aruba.Storage/blockstorages/bs-1" {
+	if cr.BlockStorage() != "/projects/p/providers/Aruba.Storage/blockStorages/bs-1" {
 		t.Errorf("BlockStorage() = %q", cr.BlockStorage())
 	}
 	if cr.AdminUsername() != "admin" {
@@ -626,9 +626,9 @@ const containerRegistrySuccessBody = `{` +
 	`"properties":{` +
 	`"vpc":{"uri":"/projects/p/providers/Aruba.Network/vpcs/vpc-1"},` +
 	`"subnet":{"uri":"/projects/p/providers/Aruba.Network/vpcs/vpc-1/subnets/sn-1"},` +
-	`"securityGroup":{"uri":"/projects/p/providers/Aruba.Network/vpcs/vpc-1/securitygroups/sg-1"},` +
+	`"securityGroup":{"uri":"/projects/p/providers/Aruba.Network/vpcs/vpc-1/securityGroups/sg-1"},` +
 	`"publicIp":{"uri":"/projects/p/providers/Aruba.Network/elasticips/eip-1"},` +
-	`"blockStorage":{"uri":"/projects/p/providers/Aruba.Storage/blockstorages/bs-1"},` +
+	`"blockStorage":{"uri":"/projects/p/providers/Aruba.Storage/blockStorages/bs-1"},` +
 	`"adminUser":{"username":"admin"},"size":"Small","billingPlan":{"billingPeriod":"Hour"}` +
 	`},` +
 	`"status":{"state":"Active"}}`
@@ -657,9 +657,9 @@ func TestContainerRegistriesClientAdapter_Create_Success(t *testing.T) {
 		InRegion(RegionITBGBergamo).
 		WithVPC(URI("/projects/p/providers/Aruba.Network/vpcs/vpc-1")).
 		WithSubnet(URI("/projects/p/providers/Aruba.Network/vpcs/vpc-1/subnets/sn-1")).
-		WithSecurityGroup(URI("/projects/p/providers/Aruba.Network/vpcs/vpc-1/securitygroups/sg-1")).
+		WithSecurityGroup(URI("/projects/p/providers/Aruba.Network/vpcs/vpc-1/securityGroups/sg-1")).
 		WithElasticIP(URI("/projects/p/providers/Aruba.Network/elasticips/eip-1")).
-		WithBlockStorage(URI("/projects/p/providers/Aruba.Storage/blockstorages/bs-1")).
+		WithBlockStorage(URI("/projects/p/providers/Aruba.Storage/blockStorages/bs-1")).
 		WithAdminUsername("admin").
 		OfSize(ContainerRegistrySizeFlavorSmall).
 		WithBillingPeriod(BillingPeriodHour)
@@ -756,9 +756,9 @@ func TestContainerRegistriesClientAdapter_Create_NonTwoXX(t *testing.T) {
 func TestContainerRegistriesClientAdapter_Create_WithBodyRefs_ViaFake(t *testing.T) {
 	vpcURI := "/projects/p/providers/Aruba.Network/vpcs/vpc-1"
 	subnetURI := "/projects/p/providers/Aruba.Network/vpcs/vpc-1/subnets/sn-1"
-	sgURI := "/projects/p/providers/Aruba.Network/vpcs/vpc-1/securitygroups/sg-1"
+	sgURI := "/projects/p/providers/Aruba.Network/vpcs/vpc-1/securityGroups/sg-1"
 	eipURI := "/projects/p/providers/Aruba.Network/elasticips/eip-1"
-	bsURI := "/projects/p/providers/Aruba.Storage/blockstorages/bs-1"
+	bsURI := "/projects/p/providers/Aruba.Storage/blockStorages/bs-1"
 
 	var captured types.ContainerRegistryRequest
 	resp := &types.Response[types.ContainerRegistryResponse]{

--- a/pkg/aruba/resource_kaas_test.go
+++ b/pkg/aruba/resource_kaas_test.go
@@ -472,7 +472,7 @@ func kaasTestResponse(name string) *types.KaaSResponse {
 	vpcURI := "/projects/p/providers/Aruba.Network/vpcs/vpc-1"
 	subnetURI := "/projects/p/providers/Aruba.Network/vpcs/vpc-1/subnets/sn-1"
 	sgName := "sg-name"
-	sgURI := "/projects/p/providers/Aruba.Network/vpcs/vpc-1/securitygroups/sg-1"
+	sgURI := "/projects/p/providers/Aruba.Network/vpcs/vpc-1/securityGroups/sg-1"
 	nodeCIDRAddr := "10.100.0.0/16"
 	nodeCIDRName := "node-cidr"
 	podCIDRAddr := "10.200.0.0/16"

--- a/pkg/aruba/resource_key_pair.go
+++ b/pkg/aruba/resource_key_pair.go
@@ -337,7 +337,7 @@ func keyPairIDsFromRef(ref Ref) (projectID, keyPairID string, err error) {
 			return w.KeyPairID(), true
 		}
 		return "", false
-	}, "keypairs")
+	}, "keyPairs")
 	if !ok || kid == "" {
 		return "", "", fmt.Errorf("cannot determine KeyPair ID from Ref %q", ref.URI())
 	}

--- a/pkg/aruba/resource_key_pair_test.go
+++ b/pkg/aruba/resource_key_pair_test.go
@@ -171,13 +171,13 @@ func keyPairTestResponse(id, name, uri string) *types.KeyPairResponse {
 
 func TestKeyPair_FromResponseHydration(t *testing.T) {
 	kp := &KeyPair{}
-	resp := keyPairTestResponse("kp-1", "allow-ssh", "/projects/p/providers/Aruba.Compute/keypairs/kp-1")
+	resp := keyPairTestResponse("kp-1", "allow-ssh", "/projects/p/providers/Aruba.Compute/keyPairs/kp-1")
 	kp.fromResponse(resp)
 
 	if kp.ID() != "kp-1" {
 		t.Errorf("ID() = %q", kp.ID())
 	}
-	if kp.URI() != "/projects/p/providers/Aruba.Compute/keypairs/kp-1" {
+	if kp.URI() != "/projects/p/providers/Aruba.Compute/keyPairs/kp-1" {
 		t.Errorf("URI() = %q", kp.URI())
 	}
 	if kp.KeyPairID() != "kp-1" {
@@ -206,7 +206,7 @@ func TestKeyPair_FromResponseHydration(t *testing.T) {
 
 func TestKeyPair_FromResponseURIBackfill(t *testing.T) {
 	id := "kp-99"
-	uri := "/projects/p-uri/providers/Aruba.Compute/keypairs/kp-99"
+	uri := "/projects/p-uri/providers/Aruba.Compute/keyPairs/kp-99"
 	resp := &types.KeyPairResponse{
 		Metadata: types.ResourceMetadataResponse{
 			ID:  &id,
@@ -241,7 +241,7 @@ func TestKeyPair_FromResponse_NilSafe(t *testing.T) {
 
 func TestKeyPair_RefSatisfaction(t *testing.T) {
 	kp := &KeyPair{}
-	kp.fromResponse(keyPairTestResponse("kp-99", "n", "/projects/p99/providers/Aruba.Compute/keypairs/kp-99"))
+	kp.fromResponse(keyPairTestResponse("kp-99", "n", "/projects/p99/providers/Aruba.Compute/keyPairs/kp-99"))
 
 	// withKeyPairID typed path
 	kid, ok := extractID(kp, func(ref Ref) (string, bool) {
@@ -249,7 +249,7 @@ func TestKeyPair_RefSatisfaction(t *testing.T) {
 			return w.KeyPairID(), true
 		}
 		return "", false
-	}, "keypairs")
+	}, "keyPairs")
 	if !ok || kid != "kp-99" {
 		t.Errorf("extractID via withKeyPairID = (%q, %v)", kid, ok)
 	}
@@ -272,7 +272,7 @@ func TestKeyPair_RefSatisfaction(t *testing.T) {
 
 func TestKeyPairIDsFromRef_TypedRef(t *testing.T) {
 	kp := &KeyPair{}
-	kp.fromResponse(keyPairTestResponse("kp-1", "n", "/projects/p/providers/Aruba.Compute/keypairs/kp-1"))
+	kp.fromResponse(keyPairTestResponse("kp-1", "n", "/projects/p/providers/Aruba.Compute/keyPairs/kp-1"))
 	pid, kid, err := keyPairIDsFromRef(kp)
 	if err != nil || pid != "p" || kid != "kp-1" {
 		t.Errorf("keyPairIDsFromRef typed = (%q, %q, %v)", pid, kid, err)
@@ -280,7 +280,7 @@ func TestKeyPairIDsFromRef_TypedRef(t *testing.T) {
 }
 
 func TestKeyPairIDsFromRef_URIRef(t *testing.T) {
-	ref := URI("/projects/p/providers/Aruba.Compute/keypairs/kp-1")
+	ref := URI("/projects/p/providers/Aruba.Compute/keyPairs/kp-1")
 	pid, kid, err := keyPairIDsFromRef(ref)
 	if err != nil || pid != "p" || kid != "kp-1" {
 		t.Errorf("keyPairIDsFromRef URI = (%q, %q, %v)", pid, kid, err)
@@ -290,12 +290,12 @@ func TestKeyPairIDsFromRef_URIRef(t *testing.T) {
 func TestKeyPairIDsFromRef_BadURI_MissingKeyPair(t *testing.T) {
 	_, _, err := keyPairIDsFromRef(URI("/projects/p/providers/Aruba.Compute"))
 	if err == nil {
-		t.Error("expected error for URI without /keypairs/<id>")
+		t.Error("expected error for URI without /keyPairs/<id>")
 	}
 }
 
 func TestKeyPairIDsFromRef_BadURI_MissingProject(t *testing.T) {
-	_, _, err := keyPairIDsFromRef(URI("/providers/Aruba.Compute/keypairs/kp-1"))
+	_, _, err := keyPairIDsFromRef(URI("/providers/Aruba.Compute/keyPairs/kp-1"))
 	if err == nil {
 		t.Error("expected error for URI without /projects/<id>")
 	}
@@ -319,7 +319,7 @@ func buildKeyPairsTestAdapter(t *testing.T, handler http.HandlerFunc) *keyPairsC
 }
 
 const keyPairSuccessBody = `{` +
-	`"metadata":{"id":"kp-1","name":"allow-ssh","uri":"/projects/p/providers/Aruba.Compute/keypairs/kp-1"},` +
+	`"metadata":{"id":"kp-1","name":"allow-ssh","uri":"/projects/p/providers/Aruba.Compute/keyPairs/kp-1"},` +
 	`"properties":{"value":"ssh-rsa AAAA..."}}`
 
 func TestKeyPairsClientAdapter_Create_Success(t *testing.T) {
@@ -328,7 +328,7 @@ func TestKeyPairsClientAdapter_Create_Success(t *testing.T) {
 		if err := json.NewDecoder(r.Body).Decode(&gotBody); err != nil {
 			t.Errorf("decode request body: %v", err)
 		}
-		if !containsSubstring(r.URL.Path, "keypairs") {
+		if !containsSubstring(r.URL.Path, "keyPairs") {
 			t.Errorf("path %q should contain 'keypairs'", r.URL.Path)
 		}
 		w.Header().Set("Content-Type", "application/json")
@@ -385,7 +385,7 @@ func TestKeyPairsClientAdapter_Create_MetadataValidationError(t *testing.T) {
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusCreated)
 		// Missing "id" field — triggers MetadataValidationError
-		fmt.Fprint(w, `{"metadata":{"name":"kp","uri":"/projects/p/providers/Aruba.Compute/keypairs/x"},"properties":{}}`)
+		fmt.Fprint(w, `{"metadata":{"name":"kp","uri":"/projects/p/providers/Aruba.Compute/keyPairs/x"},"properties":{}}`)
 	})
 
 	kp := NewKeyPair().IntoProject(URI("/projects/p")).
@@ -436,7 +436,7 @@ func TestKeyPairsClientAdapter_Get_URIRef(t *testing.T) {
 		fmt.Fprint(w, keyPairSuccessBody)
 	})
 
-	ref := URI("/projects/p/providers/Aruba.Compute/keypairs/kp-1")
+	ref := URI("/projects/p/providers/Aruba.Compute/keyPairs/kp-1")
 	result, err := adapter.Get(context.Background(), ref)
 	if err != nil {
 		t.Fatalf("Get error: %v", err)
@@ -447,7 +447,7 @@ func TestKeyPairsClientAdapter_Get_URIRef(t *testing.T) {
 	if result.ProjectID() != "p" {
 		t.Errorf("ProjectID() = %q", result.ProjectID())
 	}
-	if !containsSubstring(capturedPath, "keypairs") {
+	if !containsSubstring(capturedPath, "keyPairs") {
 		t.Errorf("path %q should contain 'keypairs'", capturedPath)
 	}
 }
@@ -460,7 +460,7 @@ func TestKeyPairsClientAdapter_Get_TypedRef(t *testing.T) {
 	})
 
 	existing := &KeyPair{}
-	existing.fromResponse(keyPairTestResponse("kp-1", "n", "/projects/p/providers/Aruba.Compute/keypairs/kp-1"))
+	existing.fromResponse(keyPairTestResponse("kp-1", "n", "/projects/p/providers/Aruba.Compute/keyPairs/kp-1"))
 
 	result, err := adapter.Get(context.Background(), existing)
 	if err != nil {
@@ -482,7 +482,7 @@ func TestKeyPairsClientAdapter_Delete_Success(t *testing.T) {
 		w.WriteHeader(http.StatusNoContent)
 	})
 
-	err := adapter.Delete(context.Background(), URI("/projects/p/providers/Aruba.Compute/keypairs/kp-1"))
+	err := adapter.Delete(context.Background(), URI("/projects/p/providers/Aruba.Compute/keyPairs/kp-1"))
 	if err != nil {
 		t.Fatalf("Delete error: %v", err)
 	}
@@ -495,7 +495,7 @@ func TestKeyPairsClientAdapter_Delete_NonTwoXX(t *testing.T) {
 		fmt.Fprint(w, testutil.ErrorBodyJSON("Not Found", "key pair not found", 404))
 	})
 
-	err := adapter.Delete(context.Background(), URI("/projects/p/providers/Aruba.Compute/keypairs/missing"))
+	err := adapter.Delete(context.Background(), URI("/projects/p/providers/Aruba.Compute/keyPairs/missing"))
 	if err == nil {
 		t.Fatal("expected error on 404")
 	}
@@ -513,8 +513,8 @@ func TestKeyPairsClientAdapter_List_TwoItems(t *testing.T) {
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
 		fmt.Fprint(w, `{"total":2,"self":"","prev":"","next":"","first":"","last":"","values":[`+
-			`{"metadata":{"id":"kp-1","name":"n1","uri":"/projects/p/providers/Aruba.Compute/keypairs/kp-1"},"properties":{"value":"ssh-rsa AAAA..."}},`+
-			`{"metadata":{"id":"kp-2","name":"n2","uri":"/projects/p/providers/Aruba.Compute/keypairs/kp-2"},"properties":{"value":"ssh-rsa BBBB..."}}`+
+			`{"metadata":{"id":"kp-1","name":"n1","uri":"/projects/p/providers/Aruba.Compute/keyPairs/kp-1"},"properties":{"value":"ssh-rsa AAAA..."}},`+
+			`{"metadata":{"id":"kp-2","name":"n2","uri":"/projects/p/providers/Aruba.Compute/keyPairs/kp-2"},"properties":{"value":"ssh-rsa BBBB..."}}`+
 			`]}`)
 	})
 
@@ -565,7 +565,7 @@ func TestKeyPairsClientAdapter_Get_NonTwoXX(t *testing.T) {
 		fmt.Fprint(w, testutil.ErrorBodyJSON("Not Found", "key pair not found", 404))
 	})
 
-	ref := URI("/projects/p/providers/Aruba.Compute/keypairs/kp-missing")
+	ref := URI("/projects/p/providers/Aruba.Compute/keyPairs/kp-missing")
 	result, err := adapter.Get(context.Background(), ref)
 	if err == nil {
 		t.Fatal("expected error on 404")

--- a/pkg/aruba/resource_load_balancer.go
+++ b/pkg/aruba/resource_load_balancer.go
@@ -11,7 +11,7 @@ import (
 
 // LoadBalancerRef returns a Ref that points to the LoadBalancer with the given IDs.
 func LoadBalancerRef(projectID, lbID string) Ref {
-	return URI(fmt.Sprintf("/projects/%s/providers/Aruba.Network/loadbalancers/%s", projectID, lbID))
+	return URI(fmt.Sprintf("/projects/%s/providers/Aruba.Network/loadBalancers/%s", projectID, lbID))
 }
 
 // ---- Wrapper ----
@@ -270,7 +270,7 @@ func loadBalancerIDsFromRef(ref Ref) (projectID, loadBalancerID string, err erro
 			return w.LoadBalancerID(), true
 		}
 		return "", false
-	}, "loadbalancers")
+	}, "loadBalancers")
 	if !ok || lid == "" {
 		return "", "", fmt.Errorf("cannot determine load balancer ID from Ref %q", ref.URI())
 	}

--- a/pkg/aruba/resource_load_balancer_test.go
+++ b/pkg/aruba/resource_load_balancer_test.go
@@ -55,13 +55,13 @@ func loadBalancerTestResponse(id, name, uri, projectID string) *types.LoadBalanc
 
 func TestLoadBalancer_FromResponseHydration(t *testing.T) {
 	lb := &LoadBalancer{}
-	resp := loadBalancerTestResponse("lb-1", "my-lb", "/projects/p1/providers/Aruba.Network/loadbalancers/lb-1", "p1")
+	resp := loadBalancerTestResponse("lb-1", "my-lb", "/projects/p1/providers/Aruba.Network/loadBalancers/lb-1", "p1")
 	lb.fromResponse(resp)
 
 	if lb.ID() != "lb-1" {
 		t.Errorf("ID() = %q", lb.ID())
 	}
-	if lb.URI() != "/projects/p1/providers/Aruba.Network/loadbalancers/lb-1" {
+	if lb.URI() != "/projects/p1/providers/Aruba.Network/loadBalancers/lb-1" {
 		t.Errorf("URI() = %q", lb.URI())
 	}
 	if lb.LoadBalancerID() != "lb-1" {
@@ -119,7 +119,7 @@ func TestLoadBalancer_FromResponsePartial(t *testing.T) {
 }
 
 func TestLoadBalancer_FromResponseProjectIDFromURI(t *testing.T) {
-	uri := "/projects/p2/providers/Aruba.Network/loadbalancers/lb-2"
+	uri := "/projects/p2/providers/Aruba.Network/loadBalancers/lb-2"
 	id := "lb-2"
 	name := "uri-lb"
 	resp := &types.LoadBalancerResponse{
@@ -143,7 +143,7 @@ func TestLoadBalancer_RawNilUntilHydrated(t *testing.T) {
 	if lb.Raw() != nil {
 		t.Error("Raw() must be nil before fromResponse is called")
 	}
-	resp := loadBalancerTestResponse("lb-1", "n", "/projects/p/providers/Aruba.Network/loadbalancers/lb-1", "p")
+	resp := loadBalancerTestResponse("lb-1", "n", "/projects/p/providers/Aruba.Network/loadBalancers/lb-1", "p")
 	lb.fromResponse(resp)
 	if lb.Raw() != resp {
 		t.Error("Raw() must return the exact resp pointer after fromResponse")
@@ -156,7 +156,7 @@ func TestLoadBalancer_RawNilUntilHydrated(t *testing.T) {
 
 func TestLoadBalancer_RefSatisfaction(t *testing.T) {
 	lb := &LoadBalancer{}
-	lb.fromResponse(loadBalancerTestResponse("lb-99", "n", "/projects/p99/providers/Aruba.Network/loadbalancers/lb-99", "p99"))
+	lb.fromResponse(loadBalancerTestResponse("lb-99", "n", "/projects/p99/providers/Aruba.Network/loadBalancers/lb-99", "p99"))
 
 	// withLoadBalancerID typed path
 	lid, ok := extractID(lb, func(r Ref) (string, bool) {
@@ -164,7 +164,7 @@ func TestLoadBalancer_RefSatisfaction(t *testing.T) {
 			return w.LoadBalancerID(), true
 		}
 		return "", false
-	}, "loadbalancers")
+	}, "loadBalancers")
 	if !ok || lid != "lb-99" {
 		t.Errorf("extractID via withLoadBalancerID = (%q, %v)", lid, ok)
 	}
@@ -187,7 +187,7 @@ func TestLoadBalancer_RefSatisfaction(t *testing.T) {
 
 func TestLoadBalancerIDsFromRef_TypedRef(t *testing.T) {
 	lb := &LoadBalancer{}
-	lb.fromResponse(loadBalancerTestResponse("lb-1", "n", "/projects/p/providers/Aruba.Network/loadbalancers/lb-1", "p"))
+	lb.fromResponse(loadBalancerTestResponse("lb-1", "n", "/projects/p/providers/Aruba.Network/loadBalancers/lb-1", "p"))
 	pid, lid, err := loadBalancerIDsFromRef(lb)
 	if err != nil || pid != "p" || lid != "lb-1" {
 		t.Errorf("loadBalancerIDsFromRef typed = (%q, %q, %v)", pid, lid, err)
@@ -195,7 +195,7 @@ func TestLoadBalancerIDsFromRef_TypedRef(t *testing.T) {
 }
 
 func TestLoadBalancerIDsFromRef_URIRef(t *testing.T) {
-	ref := URI("/projects/p/providers/Aruba.Network/loadbalancers/lb-1")
+	ref := URI("/projects/p/providers/Aruba.Network/loadBalancers/lb-1")
 	pid, lid, err := loadBalancerIDsFromRef(ref)
 	if err != nil || pid != "p" || lid != "lb-1" {
 		t.Errorf("loadBalancerIDsFromRef URI = (%q, %q, %v)", pid, lid, err)
@@ -205,12 +205,12 @@ func TestLoadBalancerIDsFromRef_URIRef(t *testing.T) {
 func TestLoadBalancerIDsFromRef_BadURI(t *testing.T) {
 	_, _, err := loadBalancerIDsFromRef(URI("/something/else"))
 	if err == nil {
-		t.Error("expected error for URI without /loadbalancers/<id>")
+		t.Error("expected error for URI without /loadBalancers/<id>")
 	}
 }
 
 func TestLoadBalancerIDsFromRef_NoProject(t *testing.T) {
-	_, _, err := loadBalancerIDsFromRef(URI("/loadbalancers/lb-1"))
+	_, _, err := loadBalancerIDsFromRef(URI("/loadBalancers/lb-1"))
 	if err == nil {
 		t.Error("expected error for URI without /projects/<id>")
 	}
@@ -227,7 +227,7 @@ func buildLoadBalancerTestAdapter(t *testing.T, handler http.HandlerFunc) *loadB
 }
 
 const loadBalancerSuccessBody = `{` +
-	`"metadata":{"id":"lb-1","name":"my-lb","uri":"/projects/p/providers/Aruba.Network/loadbalancers/lb-1","project":{"id":"p"}},` +
+	`"metadata":{"id":"lb-1","name":"my-lb","uri":"/projects/p/providers/Aruba.Network/loadBalancers/lb-1","project":{"id":"p"}},` +
 	`"properties":{"address":"10.0.0.1"},` +
 	`"status":{"state":"Active"}}`
 
@@ -240,7 +240,7 @@ func TestLoadBalancersClientAdapter_Get_URIRef(t *testing.T) {
 		fmt.Fprint(w, loadBalancerSuccessBody)
 	})
 
-	ref := URI("/projects/p/providers/Aruba.Network/loadbalancers/lb-1")
+	ref := URI("/projects/p/providers/Aruba.Network/loadBalancers/lb-1")
 	result, err := adapter.Get(context.Background(), ref)
 	if err != nil {
 		t.Fatalf("Get error: %v", err)
@@ -257,7 +257,7 @@ func TestLoadBalancersClientAdapter_Get_URIRef(t *testing.T) {
 	if result.StatusCode() != http.StatusOK {
 		t.Errorf("StatusCode() = %d", result.StatusCode())
 	}
-	wantPath := "/projects/p/providers/Aruba.Network/loadbalancers/lb-1"
+	wantPath := "/projects/p/providers/Aruba.Network/loadBalancers/lb-1"
 	if capturedPath != wantPath {
 		t.Errorf("path = %q, want %q", capturedPath, wantPath)
 	}
@@ -271,7 +271,7 @@ func TestLoadBalancersClientAdapter_Get_TypedRef(t *testing.T) {
 	})
 
 	existing := &LoadBalancer{}
-	existing.fromResponse(loadBalancerTestResponse("lb-1", "n", "/projects/p/providers/Aruba.Network/loadbalancers/lb-1", "p"))
+	existing.fromResponse(loadBalancerTestResponse("lb-1", "n", "/projects/p/providers/Aruba.Network/loadBalancers/lb-1", "p"))
 
 	result, err := adapter.Get(context.Background(), existing)
 	if err != nil {
@@ -289,7 +289,7 @@ func TestLoadBalancersClientAdapter_Get_NonTwoXX(t *testing.T) {
 		fmt.Fprint(w, testutil.ErrorBodyJSON("Not Found", "load balancer not found", 404))
 	})
 
-	ref := URI("/projects/p/providers/Aruba.Network/loadbalancers/lb-missing")
+	ref := URI("/projects/p/providers/Aruba.Network/loadBalancers/lb-missing")
 	result, err := adapter.Get(context.Background(), ref)
 	if err == nil {
 		t.Fatal("expected error on 404")
@@ -330,8 +330,8 @@ func TestLoadBalancersClientAdapter_List_TwoItems(t *testing.T) {
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
 		fmt.Fprint(w, `{"total":2,"self":"","prev":"","next":"","first":"","last":"","values":[`+
-			`{"metadata":{"id":"lb-1","name":"lb-a","uri":"/projects/p/providers/Aruba.Network/loadbalancers/lb-1","project":{"id":"p"}},"properties":{"address":"10.0.0.1"},"status":{"state":"Active"}},`+
-			`{"metadata":{"id":"lb-2","name":"lb-b","uri":"/projects/p/providers/Aruba.Network/loadbalancers/lb-2","project":{"id":"p"}},"properties":{"address":"10.0.0.2"},"status":{"state":"Inactive"}}`+
+			`{"metadata":{"id":"lb-1","name":"lb-a","uri":"/projects/p/providers/Aruba.Network/loadBalancers/lb-1","project":{"id":"p"}},"properties":{"address":"10.0.0.1"},"status":{"state":"Active"}},`+
+			`{"metadata":{"id":"lb-2","name":"lb-b","uri":"/projects/p/providers/Aruba.Network/loadBalancers/lb-2","project":{"id":"p"}},"properties":{"address":"10.0.0.2"},"status":{"state":"Inactive"}}`+
 			`]}`)
 	})
 
@@ -432,7 +432,7 @@ func TestLoadBalancersClientAdapter_Get_TransportError(t *testing.T) {
 		conn.Close()
 	})
 	adapter := newLoadBalancersClientAdapter(testutil.NewClient(t, server.URL))
-	result, err := adapter.Get(context.Background(), URI("/projects/p/providers/Aruba.Network/loadbalancers/lb-1"))
+	result, err := adapter.Get(context.Background(), URI("/projects/p/providers/Aruba.Network/loadBalancers/lb-1"))
 	if err == nil {
 		t.Fatal("expected transport error")
 	}
@@ -498,7 +498,7 @@ func TestLoadBalancersClientAdapter_Get_InjectsRefresh(t *testing.T) {
 		fmt.Fprint(w, loadBalancerSuccessBody)
 	})
 	adapter := newLoadBalancersClientAdapter(testutil.NewClient(t, server.URL))
-	lb, err := adapter.Get(context.Background(), URI("/projects/p/providers/Aruba.Network/loadbalancers/lb-1"))
+	lb, err := adapter.Get(context.Background(), URI("/projects/p/providers/Aruba.Network/loadBalancers/lb-1"))
 	if err != nil {
 		t.Fatalf("Get error: %v", err)
 	}
@@ -509,12 +509,12 @@ func TestLoadBalancersClientAdapter_Get_InjectsRefresh(t *testing.T) {
 
 func TestLoadBalancerRef(t *testing.T) {
 	ref := LoadBalancerRef("p-1", "lb-1")
-	want := "/projects/p-1/providers/Aruba.Network/loadbalancers/lb-1"
+	want := "/projects/p-1/providers/Aruba.Network/loadBalancers/lb-1"
 	if ref.URI() != want {
 		t.Errorf("LoadBalancerRef URI = %q, want %q", ref.URI(), want)
 	}
 	ids := parseURIIDs(ref.URI())
-	if ids["projects"] != "p-1" || ids["loadbalancers"] != "lb-1" {
+	if ids["projects"] != "p-1" || ids["loadBalancers"] != "lb-1" {
 		t.Errorf("parseURIIDs = %v", ids)
 	}
 }

--- a/pkg/aruba/resource_security_group.go
+++ b/pkg/aruba/resource_security_group.go
@@ -12,7 +12,7 @@ import (
 
 // SecurityGroupRef returns a Ref that points to the SecurityGroup nested under a VPC.
 func SecurityGroupRef(projectID, vpcID, sgID string) Ref {
-	return URI(fmt.Sprintf("/projects/%s/providers/Aruba.Network/vpcs/%s/securitygroups/%s", projectID, vpcID, sgID))
+	return URI(fmt.Sprintf("/projects/%s/providers/Aruba.Network/vpcs/%s/securityGroups/%s", projectID, vpcID, sgID))
 }
 
 // ---- Wrapper ----
@@ -411,7 +411,7 @@ func securityGroupIDsFromRef(ref Ref) (projectID, vpcID, securityGroupID string,
 			return w.SecurityGroupID(), true
 		}
 		return "", false
-	}, "security-groups")
+	}, "securityGroups")
 	if !ok || sgid == "" {
 		return "", "", "", fmt.Errorf("cannot determine security group ID from Ref %q", ref.URI())
 	}

--- a/pkg/aruba/resource_security_group_test.go
+++ b/pkg/aruba/resource_security_group_test.go
@@ -141,13 +141,13 @@ func securityGroupTestResponse(id, name, uri, projectID string) *types.SecurityG
 
 func TestSecurityGroup_FromResponseHydration(t *testing.T) {
 	sg := &SecurityGroup{}
-	resp := securityGroupTestResponse("sg-1", "my-sg", "/projects/p1/network/vpcs/v1/security-groups/sg-1", "p1")
+	resp := securityGroupTestResponse("sg-1", "my-sg", "/projects/p1/providers/Aruba.Network/vpcs/v1/securityGroups/sg-1", "p1")
 	sg.fromResponse(resp)
 
 	if sg.ID() != "sg-1" {
 		t.Errorf("ID() = %q", sg.ID())
 	}
-	if sg.URI() != "/projects/p1/network/vpcs/v1/security-groups/sg-1" {
+	if sg.URI() != "/projects/p1/providers/Aruba.Network/vpcs/v1/securityGroups/sg-1" {
 		t.Errorf("URI() = %q", sg.URI())
 	}
 	if sg.SecurityGroupID() != "sg-1" {
@@ -206,7 +206,7 @@ func TestSecurityGroup_FromResponsePartial(t *testing.T) {
 }
 
 func TestSecurityGroup_FromResponseURIBackfill(t *testing.T) {
-	uri := "/projects/p2/network/vpcs/v2/security-groups/sg-2"
+	uri := "/projects/p2/providers/Aruba.Network/vpcs/v2/securityGroups/sg-2"
 	id := "sg-2"
 	name := "uri-sg"
 	resp := &types.SecurityGroupResponse{
@@ -234,7 +234,7 @@ func TestSecurityGroup_FromResponseURIBackfill(t *testing.T) {
 
 func TestSecurityGroup_RefSatisfaction(t *testing.T) {
 	sg := &SecurityGroup{}
-	sg.fromResponse(securityGroupTestResponse("sg-99", "n", "/projects/p99/network/vpcs/v99/security-groups/sg-99", "p99"))
+	sg.fromResponse(securityGroupTestResponse("sg-99", "n", "/projects/p99/providers/Aruba.Network/vpcs/v99/securityGroups/sg-99", "p99"))
 
 	// withSecurityGroupID typed path
 	sid, ok := extractID(sg, func(r Ref) (string, bool) {
@@ -242,7 +242,7 @@ func TestSecurityGroup_RefSatisfaction(t *testing.T) {
 			return w.SecurityGroupID(), true
 		}
 		return "", false
-	}, "security-groups")
+	}, "securityGroups")
 	if !ok || sid != "sg-99" {
 		t.Errorf("extractID via withSecurityGroupID = (%q, %v)", sid, ok)
 	}
@@ -276,7 +276,7 @@ func TestSecurityGroup_RefSatisfaction(t *testing.T) {
 
 func TestSecurityGroupIDsFromRef_TypedRef(t *testing.T) {
 	sg := &SecurityGroup{}
-	sg.fromResponse(securityGroupTestResponse("sg-1", "n", "/projects/p/network/vpcs/v/security-groups/sg-1", "p"))
+	sg.fromResponse(securityGroupTestResponse("sg-1", "n", "/projects/p/providers/Aruba.Network/vpcs/v/securityGroups/sg-1", "p"))
 	pid, vid, sgid, err := securityGroupIDsFromRef(sg)
 	if err != nil || pid != "p" || vid != "v" || sgid != "sg-1" {
 		t.Errorf("securityGroupIDsFromRef typed = (%q, %q, %q, %v)", pid, vid, sgid, err)
@@ -284,7 +284,7 @@ func TestSecurityGroupIDsFromRef_TypedRef(t *testing.T) {
 }
 
 func TestSecurityGroupIDsFromRef_URIRef_APIForm(t *testing.T) {
-	ref := URI("/projects/p/providers/Aruba.Network/vpcs/v/security-groups/sg-1")
+	ref := URI("/projects/p/providers/Aruba.Network/vpcs/v/securityGroups/sg-1")
 	pid, vid, sgid, err := securityGroupIDsFromRef(ref)
 	if err != nil || pid != "p" || vid != "v" || sgid != "sg-1" {
 		t.Errorf("securityGroupIDsFromRef API form = (%q, %q, %q, %v)", pid, vid, sgid, err)
@@ -292,7 +292,7 @@ func TestSecurityGroupIDsFromRef_URIRef_APIForm(t *testing.T) {
 }
 
 func TestSecurityGroupIDsFromRef_URIRef_NetworkForm(t *testing.T) {
-	ref := URI("/projects/p/network/vpcs/v/security-groups/sg-1")
+	ref := URI("/projects/p/providers/Aruba.Network/vpcs/v/securityGroups/sg-1")
 	pid, vid, sgid, err := securityGroupIDsFromRef(ref)
 	if err != nil || pid != "p" || vid != "v" || sgid != "sg-1" {
 		t.Errorf("securityGroupIDsFromRef network form = (%q, %q, %q, %v)", pid, vid, sgid, err)
@@ -300,9 +300,9 @@ func TestSecurityGroupIDsFromRef_URIRef_NetworkForm(t *testing.T) {
 }
 
 func TestSecurityGroupIDsFromRef_BadURI_MissingSG(t *testing.T) {
-	_, _, _, err := securityGroupIDsFromRef(URI("/projects/p/network/vpcs/v"))
+	_, _, _, err := securityGroupIDsFromRef(URI("/projects/p/providers/Aruba.Network/vpcs/v"))
 	if err == nil {
-		t.Error("expected error for URI without /security-groups/<id>")
+		t.Error("expected error for URI without /securityGroups/<id>")
 	}
 }
 
@@ -324,7 +324,7 @@ func buildSecurityGroupTestAdapter(t *testing.T, handler http.HandlerFunc) *secu
 }
 
 const securityGroupSuccessBody = `{` +
-	`"metadata":{"id":"sg-1","name":"my-sg","uri":"/projects/p/network/vpcs/v/security-groups/sg-1","project":{"id":"p"}},` +
+	`"metadata":{"id":"sg-1","name":"my-sg","uri":"/projects/p/providers/Aruba.Network/vpcs/v/securityGroups/sg-1","project":{"id":"p"}},` +
 	`"properties":{"default":false},` +
 	`"status":{"state":"Active"}}`
 
@@ -390,7 +390,7 @@ func TestSecurityGroupsClientAdapter_Create_MetadataValidationError(t *testing.T
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusCreated)
 		// Missing "id" field — triggers MetadataValidationError
-		fmt.Fprint(w, `{"metadata":{"name":"sg","uri":"/projects/p/network/vpcs/v/security-groups/x"},"properties":{},"status":{}}`)
+		fmt.Fprint(w, `{"metadata":{"name":"sg","uri":"/projects/p/providers/Aruba.Network/vpcs/v/securityGroups/x"},"properties":{},"status":{}}`)
 	})
 
 	vpc := &VPC{}
@@ -465,7 +465,7 @@ func TestSecurityGroupsClientAdapter_Get_URIRef(t *testing.T) {
 		fmt.Fprint(w, securityGroupSuccessBody)
 	})
 
-	ref := URI("/projects/p/network/vpcs/v/security-groups/sg-1")
+	ref := URI("/projects/p/providers/Aruba.Network/vpcs/v/securityGroups/sg-1")
 	result, err := adapter.Get(context.Background(), ref)
 	if err != nil {
 		t.Fatalf("Get error: %v", err)
@@ -482,8 +482,8 @@ func TestSecurityGroupsClientAdapter_Get_URIRef(t *testing.T) {
 	if result.StatusCode() != http.StatusOK {
 		t.Errorf("StatusCode() = %d", result.StatusCode())
 	}
-	if !strings.Contains(capturedPath, "securitygroups") {
-		t.Errorf("path = %q, expected securitygroups segment", capturedPath)
+	if !strings.Contains(capturedPath, "securityGroups") {
+		t.Errorf("path = %q, expected securityGroups segment", capturedPath)
 	}
 }
 
@@ -495,7 +495,7 @@ func TestSecurityGroupsClientAdapter_Get_TypedRef(t *testing.T) {
 	})
 
 	existing := &SecurityGroup{}
-	existing.fromResponse(securityGroupTestResponse("sg-1", "n", "/projects/p/network/vpcs/v/security-groups/sg-1", "p"))
+	existing.fromResponse(securityGroupTestResponse("sg-1", "n", "/projects/p/providers/Aruba.Network/vpcs/v/securityGroups/sg-1", "p"))
 
 	result, err := adapter.Get(context.Background(), existing)
 	if err != nil {
@@ -512,11 +512,11 @@ func TestSecurityGroupsClientAdapter_Update_Success(t *testing.T) {
 		_ = json.NewDecoder(r.Body).Decode(&capturedBody)
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
-		fmt.Fprint(w, `{"metadata":{"id":"sg-1","name":"renamed","uri":"/projects/p/network/vpcs/v/security-groups/sg-1","project":{"id":"p"}},"properties":{"default":true},"status":{}}`)
+		fmt.Fprint(w, `{"metadata":{"id":"sg-1","name":"renamed","uri":"/projects/p/providers/Aruba.Network/vpcs/v/securityGroups/sg-1","project":{"id":"p"}},"properties":{"default":true},"status":{}}`)
 	})
 
 	sg := &SecurityGroup{}
-	sg.fromResponse(securityGroupTestResponse("sg-1", "orig", "/projects/p/network/vpcs/v/security-groups/sg-1", "p"))
+	sg.fromResponse(securityGroupTestResponse("sg-1", "orig", "/projects/p/providers/Aruba.Network/vpcs/v/securityGroups/sg-1", "p"))
 	sg.Named("renamed").AsDefault()
 
 	result, err := adapter.Update(context.Background(), sg)
@@ -538,7 +538,7 @@ func TestSecurityGroupsClientAdapter_Update_NoID(t *testing.T) {
 		w.WriteHeader(http.StatusOK)
 	})
 
-	sg := NewSecurityGroup().IntoVPC(URI("/projects/p/network/vpcs/v")).
+	sg := NewSecurityGroup().IntoVPC(URI("/projects/p/providers/Aruba.Network/vpcs/v")).
 		Named("x")
 	_, err := adapter.Update(context.Background(), sg)
 	if err == nil {
@@ -596,7 +596,7 @@ func TestSecurityGroupsClientAdapter_Delete_Success(t *testing.T) {
 		w.WriteHeader(http.StatusNoContent)
 	})
 
-	err := adapter.Delete(context.Background(), URI("/projects/p/network/vpcs/v/security-groups/sg-1"))
+	err := adapter.Delete(context.Background(), URI("/projects/p/providers/Aruba.Network/vpcs/v/securityGroups/sg-1"))
 	if err != nil {
 		t.Fatalf("Delete error: %v", err)
 	}
@@ -609,7 +609,7 @@ func TestSecurityGroupsClientAdapter_Delete_NonTwoXX(t *testing.T) {
 		fmt.Fprint(w, testutil.ErrorBodyJSON("Not Found", "security group not found", 404))
 	})
 
-	err := adapter.Delete(context.Background(), URI("/projects/p/network/vpcs/v/security-groups/missing"))
+	err := adapter.Delete(context.Background(), URI("/projects/p/providers/Aruba.Network/vpcs/v/securityGroups/missing"))
 	if err == nil {
 		t.Fatal("expected error on 404")
 	}
@@ -637,7 +637,7 @@ func TestSecurityGroupsClientAdapter_Get_NonTwoXX(t *testing.T) {
 		fmt.Fprint(w, testutil.ErrorBodyJSON("Not Found", "security group not found", 404))
 	})
 
-	ref := URI("/projects/p/network/vpcs/v/security-groups/missing")
+	ref := URI("/projects/p/providers/Aruba.Network/vpcs/v/securityGroups/missing")
 	result, err := adapter.Get(context.Background(), ref)
 	if err == nil {
 		t.Fatal("expected error on 404")
@@ -662,7 +662,7 @@ func TestSecurityGroupsClientAdapter_Update_NonTwoXX(t *testing.T) {
 	})
 
 	sg := &SecurityGroup{}
-	sg.fromResponse(securityGroupTestResponse("sg-1", "my-sg", "/projects/p/providers/Aruba.Network/vpcs/v/securitygroups/sg-1", "p"))
+	sg.fromResponse(securityGroupTestResponse("sg-1", "my-sg", "/projects/p/providers/Aruba.Network/vpcs/v/securityGroups/sg-1", "p"))
 	_, err := adapter.Update(context.Background(), sg)
 	var httpErr *HTTPError
 	if !errors.As(err, &httpErr) {
@@ -677,7 +677,7 @@ func TestSecurityGroupsClientAdapter_List_NonTwoXX(t *testing.T) {
 		fmt.Fprint(w, testutil.ErrorBodyJSON("Forbidden", "access denied", 403))
 	})
 
-	_, err := adapter.List(context.Background(), URI("/projects/p/network/vpcs/v"))
+	_, err := adapter.List(context.Background(), URI("/projects/p/providers/Aruba.Network/vpcs/v"))
 	var httpErr *HTTPError
 	if !errors.As(err, &httpErr) {
 		t.Fatalf("expected *HTTPError, got %T: %v", err, err)
@@ -685,16 +685,16 @@ func TestSecurityGroupsClientAdapter_List_NonTwoXX(t *testing.T) {
 }
 
 func TestSecurityGroupIDsFromRef_BadURI_MissingVPC(t *testing.T) {
-	// URI has security-groups segment but no vpcs segment
-	_, _, _, err := securityGroupIDsFromRef(URI("/projects/p/security-groups/sg"))
+	// URI has securityGroups segment but no vpcs segment
+	_, _, _, err := securityGroupIDsFromRef(URI("/projects/p/securityGroups/sg"))
 	if err == nil {
 		t.Error("expected error for URI without /vpcs/<id>")
 	}
 }
 
 func TestSecurityGroupIDsFromRef_BadURI_MissingProject(t *testing.T) {
-	// URI has security-groups+vpcs segments but no projects segment
-	_, _, _, err := securityGroupIDsFromRef(URI("/providers/Aruba.Network/vpcs/v/security-groups/sg"))
+	// URI has securityGroups+vpcs segments but no projects segment
+	_, _, _, err := securityGroupIDsFromRef(URI("/providers/Aruba.Network/vpcs/v/securityGroups/sg"))
 	if err == nil {
 		t.Error("expected error for URI without /projects/<id>")
 	}
@@ -727,7 +727,7 @@ func TestSecurityGroupsClientAdapter_Get_TransportError(t *testing.T) {
 		conn.Close()
 	})
 	adapter := newSecurityGroupsClientAdapter(testutil.NewClient(t, server.URL))
-	result, err := adapter.Get(context.Background(), URI("/projects/p/network/vpcs/v/security-groups/sg"))
+	result, err := adapter.Get(context.Background(), URI("/projects/p/providers/Aruba.Network/vpcs/v/securityGroups/sg"))
 	if err == nil {
 		t.Fatal("expected transport error")
 	}
@@ -762,7 +762,7 @@ func TestSecurityGroupsClientAdapter_Update_TransportError(t *testing.T) {
 	})
 	adapter := newSecurityGroupsClientAdapter(testutil.NewClient(t, server.URL))
 	sg := &SecurityGroup{}
-	sg.fromResponse(securityGroupTestResponse("sg-1", "sg-a", "/projects/p/network/vpcs/v/security-groups/sg-1", "p"))
+	sg.fromResponse(securityGroupTestResponse("sg-1", "sg-a", "/projects/p/providers/Aruba.Network/vpcs/v/securityGroups/sg-1", "p"))
 	_, err := adapter.Update(context.Background(), sg)
 	if err == nil {
 		t.Fatal("expected transport error")
@@ -780,7 +780,7 @@ func TestSecurityGroupsClientAdapter_Delete_TransportError(t *testing.T) {
 		conn.Close()
 	})
 	adapter := newSecurityGroupsClientAdapter(testutil.NewClient(t, server.URL))
-	err := adapter.Delete(context.Background(), URI("/projects/p/network/vpcs/v/security-groups/sg"))
+	err := adapter.Delete(context.Background(), URI("/projects/p/providers/Aruba.Network/vpcs/v/securityGroups/sg"))
 	if err == nil {
 		t.Fatal("expected transport error")
 	}
@@ -849,12 +849,12 @@ func TestSecurityGroupsClientAdapter_List_TwoItems(t *testing.T) {
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
 		fmt.Fprint(w, `{"total":2,"self":"","prev":"","next":"","first":"","last":"","values":[`+
-			`{"metadata":{"id":"sg-1","name":"sg-a","uri":"/projects/p/network/vpcs/v/security-groups/sg-1","project":{"id":"p"}},"properties":{"default":false},"status":{"state":"Active"}},`+
-			`{"metadata":{"id":"sg-2","name":"sg-b","uri":"/projects/p/network/vpcs/v/security-groups/sg-2","project":{"id":"p"}},"properties":{"default":true},"status":{"state":"Inactive"}}`+
+			`{"metadata":{"id":"sg-1","name":"sg-a","uri":"/projects/p/providers/Aruba.Network/vpcs/v/securityGroups/sg-1","project":{"id":"p"}},"properties":{"default":false},"status":{"state":"Active"}},`+
+			`{"metadata":{"id":"sg-2","name":"sg-b","uri":"/projects/p/providers/Aruba.Network/vpcs/v/securityGroups/sg-2","project":{"id":"p"}},"properties":{"default":true},"status":{"state":"Inactive"}}`+
 			`]}`)
 	})
 
-	list, err := adapter.List(context.Background(), URI("/projects/p/network/vpcs/v"))
+	list, err := adapter.List(context.Background(), URI("/projects/p/providers/Aruba.Network/vpcs/v"))
 	if err != nil {
 		t.Fatalf("List error: %v", err)
 	}
@@ -900,7 +900,7 @@ func TestSecurityGroupsClientAdapter_Get_InjectsRefresh(t *testing.T) {
 		fmt.Fprint(w, securityGroupSuccessBody)
 	})
 	adapter := newSecurityGroupsClientAdapter(testutil.NewClient(t, server.URL))
-	sg, err := adapter.Get(context.Background(), URI("/projects/p/network/vpcs/v/security-groups/sg-1"))
+	sg, err := adapter.Get(context.Background(), URI("/projects/p/providers/Aruba.Network/vpcs/v/securityGroups/sg-1"))
 	if err != nil {
 		t.Fatalf("Get error: %v", err)
 	}
@@ -911,12 +911,22 @@ func TestSecurityGroupsClientAdapter_Get_InjectsRefresh(t *testing.T) {
 
 func TestSecurityGroupRef(t *testing.T) {
 	ref := SecurityGroupRef("p-1", "vpc-1", "sg-1")
-	want := "/projects/p-1/providers/Aruba.Network/vpcs/vpc-1/securitygroups/sg-1"
+	want := "/projects/p-1/providers/Aruba.Network/vpcs/vpc-1/securityGroups/sg-1"
 	if ref.URI() != want {
 		t.Errorf("SecurityGroupRef URI = %q, want %q", ref.URI(), want)
 	}
 	ids := parseURIIDs(ref.URI())
-	if ids["projects"] != "p-1" || ids["vpcs"] != "vpc-1" || ids["securitygroups"] != "sg-1" {
+	if ids["projects"] != "p-1" || ids["vpcs"] != "vpc-1" || ids["securityGroups"] != "sg-1" {
 		t.Errorf("parseURIIDs = %v", ids)
+	}
+}
+
+func TestSecurityGroupIDsFromRef_URIRef_DocsForm(t *testing.T) {
+	// Exact shape produced by SecurityGroupRef and documented at
+	// https://api.arubacloud.com/docs/documents/network/get-security-group/
+	ref := SecurityGroupRef("p", "v", "sg-1")
+	pid, vid, sgid, err := securityGroupIDsFromRef(ref)
+	if err != nil || pid != "p" || vid != "v" || sgid != "sg-1" {
+		t.Fatalf("SecurityGroupRef → securityGroupIDsFromRef round-trip failed: (%q, %q, %q, %v)", pid, vid, sgid, err)
 	}
 }

--- a/pkg/aruba/resource_security_rule.go
+++ b/pkg/aruba/resource_security_rule.go
@@ -11,7 +11,7 @@ import (
 
 // SecurityRuleRef returns a Ref that points to the SecurityRule nested under a SecurityGroup.
 func SecurityRuleRef(projectID, vpcID, sgID, ruleID string) Ref {
-	return URI(fmt.Sprintf("/projects/%s/providers/Aruba.Network/vpcs/%s/securitygroups/%s/securityrules/%s", projectID, vpcID, sgID, ruleID))
+	return URI(fmt.Sprintf("/projects/%s/providers/Aruba.Network/vpcs/%s/securityGroups/%s/securityRules/%s", projectID, vpcID, sgID, ruleID))
 }
 
 // ---- Wrapper ----
@@ -239,13 +239,7 @@ func (r *SecurityRule) fromResponse(resp *types.SecurityRuleResponse) {
 			r.projectID = ids["projects"]
 		}
 		if r.securityGroupID == "" {
-			// Production URI uses "securitygroups"; wrapper-test URIs use "security-groups".
-			if v := ids["securitygroups"]; v != "" {
-				r.securityGroupID = v
-			}
-			if r.securityGroupID == "" {
-				r.securityGroupID = ids["security-groups"]
-			}
+			r.securityGroupID = ids["securityGroups"]
 		}
 	}
 }
@@ -534,21 +528,14 @@ func (a *securityRulesClientAdapter) List(ctx context.Context, sg Ref, opts ...C
 }
 
 // securityRuleIDsFromRef extracts (projectID, vpcID, securityGroupID, securityRuleID) from a Ref.
-// Tries typed assertions first, then falls back to URI path parsing (both hyphenated and no-hyphen forms).
+// Tries typed assertions first, then falls back to URI path parsing.
 func securityRuleIDsFromRef(ref Ref) (projectID, vpcID, securityGroupID, securityRuleID string, err error) {
 	rid, ok := extractID(ref, func(r Ref) (string, bool) {
 		if w, ok := r.(withSecurityRuleID); ok {
 			return w.SecurityRuleID(), true
 		}
 		return "", false
-	}, "security-rules")
-	if !ok || rid == "" {
-		m := parseURIIDs(ref.URI())
-		if v := m["securityrules"]; v != "" {
-			rid = v
-			ok = true
-		}
-	}
+	}, "securityRules")
 	if !ok || rid == "" {
 		return "", "", "", "", fmt.Errorf("cannot determine security rule ID from Ref %q", ref.URI())
 	}
@@ -557,14 +544,7 @@ func securityRuleIDsFromRef(ref Ref) (projectID, vpcID, securityGroupID, securit
 			return w.SecurityGroupID(), true
 		}
 		return "", false
-	}, "security-groups")
-	if !ok || sgid == "" {
-		m := parseURIIDs(ref.URI())
-		if v := m["securitygroups"]; v != "" {
-			sgid = v
-			ok = true
-		}
-	}
+	}, "securityGroups")
 	if !ok || sgid == "" {
 		return "", "", "", "", fmt.Errorf("cannot determine security group ID from Ref %q", ref.URI())
 	}

--- a/pkg/aruba/resource_security_rule_test.go
+++ b/pkg/aruba/resource_security_rule_test.go
@@ -25,7 +25,7 @@ var _ Ref = (*SecurityRule)(nil)
 
 func TestSecurityRule_FluentSetters(t *testing.T) {
 	sg := &SecurityGroup{}
-	sg.fromResponse(securityGroupTestResponse("sg-1", "my-sg", "/projects/p1/network/vpcs/v1/security-groups/sg-1", "p1"))
+	sg.fromResponse(securityGroupTestResponse("sg-1", "my-sg", "/projects/p1/providers/Aruba.Network/vpcs/v1/securityGroups/sg-1", "p1"))
 
 	rule := NewSecurityRule().
 		IntoSecurityGroup(sg).
@@ -93,7 +93,7 @@ func TestSecurityRule_FluentSetters(t *testing.T) {
 
 func TestSecurityRule_IntoSecurityGroup_TypedRef(t *testing.T) {
 	sg := &SecurityGroup{}
-	sg.fromResponse(securityGroupTestResponse("sg-1", "my-sg", "/projects/p1/network/vpcs/v1/security-groups/sg-1", "p1"))
+	sg.fromResponse(securityGroupTestResponse("sg-1", "my-sg", "/projects/p1/providers/Aruba.Network/vpcs/v1/securityGroups/sg-1", "p1"))
 
 	rule := NewSecurityRule().IntoSecurityGroup(sg)
 
@@ -116,7 +116,7 @@ func TestSecurityRule_IntoSecurityGroup_TypedRef(t *testing.T) {
 // --------------------------------------------------------------------------
 
 func TestSecurityRule_IntoSecurityGroup_URIRef(t *testing.T) {
-	rule := NewSecurityRule().IntoSecurityGroup(URI("/projects/p/network/vpcs/v/security-groups/sg"))
+	rule := NewSecurityRule().IntoSecurityGroup(URI("/projects/p/providers/Aruba.Network/vpcs/v/securityGroups/sg"))
 
 	if rule.SecurityGroupID() != "sg" {
 		t.Errorf("SecurityGroupID() = %q", rule.SecurityGroupID())
@@ -148,7 +148,7 @@ func TestSecurityRule_IntoSecurityGroup_BadRef(t *testing.T) {
 // --------------------------------------------------------------------------
 
 func TestSecurityRule_TargetMutuallyExclusive_CIDRThenSG(t *testing.T) {
-	otherSG := URI("/projects/p/network/vpcs/v/security-groups/sg-other")
+	otherSG := URI("/projects/p/providers/Aruba.Network/vpcs/v/securityGroups/sg-other")
 	rule := NewSecurityRule().
 		WithTargetCIDR("10.0.0.0/8").
 		WithTargetSecurityGroup(otherSG)
@@ -166,7 +166,7 @@ func TestSecurityRule_TargetMutuallyExclusive_CIDRThenSG(t *testing.T) {
 }
 
 func TestSecurityRule_TargetMutuallyExclusive_SGThenCIDR(t *testing.T) {
-	otherSG := URI("/projects/p/network/vpcs/v/security-groups/sg-other")
+	otherSG := URI("/projects/p/providers/Aruba.Network/vpcs/v/securityGroups/sg-other")
 	rule := NewSecurityRule().
 		WithTargetSecurityGroup(otherSG).
 		WithTargetCIDR("10.0.0.0/8")
@@ -279,7 +279,7 @@ func TestSecurityRule_FromResponseHydration(t *testing.T) {
 	resp := securityRuleTestResponse(
 		"r-1",
 		"allow-ssh",
-		"/projects/p1/providers/Aruba.Network/vpcs/v1/securitygroups/sg-1/securityrules/r-1",
+		"/projects/p1/providers/Aruba.Network/vpcs/v1/securityGroups/sg-1/securityRules/r-1",
 		"p1",
 	)
 	rule := &SecurityRule{}
@@ -353,7 +353,7 @@ func TestSecurityRule_FromResponsePartial(t *testing.T) {
 }
 
 func TestSecurityRule_FromResponseURIBackfill_HyphenForm(t *testing.T) {
-	uri := "/projects/p2/network/vpcs/v2/security-groups/sg-2/security-rules/r-2"
+	uri := "/projects/p2/providers/Aruba.Network/vpcs/v2/securityGroups/sg-2/securityRules/r-2"
 	id := "r-2"
 	name := "rule-uri"
 	resp := &types.SecurityRuleResponse{
@@ -386,7 +386,7 @@ func TestSecurityRule_RefSatisfaction(t *testing.T) {
 	rule.fromResponse(securityRuleTestResponse(
 		"r-99",
 		"n",
-		"/projects/p99/network/vpcs/v99/security-groups/sg-99/security-rules/r-99",
+		"/projects/p99/providers/Aruba.Network/vpcs/v99/securityGroups/sg-99/securityRules/r-99",
 		"p99",
 	))
 
@@ -395,7 +395,7 @@ func TestSecurityRule_RefSatisfaction(t *testing.T) {
 			return w.SecurityRuleID(), true
 		}
 		return "", false
-	}, "security-rules")
+	}, "securityRules")
 	if !ok || sid != "r-99" {
 		t.Errorf("extractID via withSecurityRuleID = (%q, %v)", sid, ok)
 	}
@@ -405,7 +405,7 @@ func TestSecurityRule_RefSatisfaction(t *testing.T) {
 			return w.SecurityGroupID(), true
 		}
 		return "", false
-	}, "security-groups")
+	}, "securityGroups")
 	if !ok || sgid != "sg-99" {
 		t.Errorf("extractID via withSecurityGroupID = (%q, %v)", sgid, ok)
 	}
@@ -440,7 +440,7 @@ func TestSecurityRuleIDsFromRef_TypedRef(t *testing.T) {
 	rule.fromResponse(securityRuleTestResponse(
 		"r-1",
 		"n",
-		"/projects/p/network/vpcs/v/security-groups/sg/security-rules/r-1",
+		"/projects/p/providers/Aruba.Network/vpcs/v/securityGroups/sg/securityRules/r-1",
 		"p",
 	))
 	pid, vid, sgid, rid, err := securityRuleIDsFromRef(rule)
@@ -450,7 +450,7 @@ func TestSecurityRuleIDsFromRef_TypedRef(t *testing.T) {
 }
 
 func TestSecurityRuleIDsFromRef_URIRef_APIForm(t *testing.T) {
-	ref := URI("/projects/p/providers/Aruba.Network/vpcs/v/securitygroups/sg/securityrules/r")
+	ref := URI("/projects/p/providers/Aruba.Network/vpcs/v/securityGroups/sg/securityRules/r")
 	pid, vid, sgid, rid, err := securityRuleIDsFromRef(ref)
 	if err != nil || pid != "p" || vid != "v" || sgid != "sg" || rid != "r" {
 		t.Errorf("securityRuleIDsFromRef API form = (%q, %q, %q, %q, %v)", pid, vid, sgid, rid, err)
@@ -458,7 +458,7 @@ func TestSecurityRuleIDsFromRef_URIRef_APIForm(t *testing.T) {
 }
 
 func TestSecurityRuleIDsFromRef_URIRef_HyphenForm(t *testing.T) {
-	ref := URI("/projects/p/network/vpcs/v/security-groups/sg/security-rules/r")
+	ref := URI("/projects/p/providers/Aruba.Network/vpcs/v/securityGroups/sg/securityRules/r")
 	pid, vid, sgid, rid, err := securityRuleIDsFromRef(ref)
 	if err != nil || pid != "p" || vid != "v" || sgid != "sg" || rid != "r" {
 		t.Errorf("securityRuleIDsFromRef hyphen form = (%q, %q, %q, %q, %v)", pid, vid, sgid, rid, err)
@@ -466,7 +466,7 @@ func TestSecurityRuleIDsFromRef_URIRef_HyphenForm(t *testing.T) {
 }
 
 func TestSecurityRuleIDsFromRef_BadURI_MissingRule(t *testing.T) {
-	_, _, _, _, err := securityRuleIDsFromRef(URI("/projects/p/network/vpcs/v/security-groups/sg"))
+	_, _, _, _, err := securityRuleIDsFromRef(URI("/projects/p/providers/Aruba.Network/vpcs/v/securityGroups/sg"))
 	if err == nil {
 		t.Error("expected error for URI without rule segment")
 	}
@@ -490,7 +490,7 @@ func buildSecurityRuleTestAdapter(t *testing.T, handler http.HandlerFunc) *secur
 }
 
 const securityRuleSuccessBody = `{` +
-	`"metadata":{"id":"r-1","name":"allow-ssh","uri":"/projects/p/network/vpcs/v/securitygroups/sg/securityrules/r-1","project":{"id":"p"}},` +
+	`"metadata":{"id":"r-1","name":"allow-ssh","uri":"/projects/p/providers/Aruba.Network/vpcs/v/securityGroups/sg/securityRules/r-1","project":{"id":"p"}},` +
 	`"properties":{"direction":"Ingress","protocol":"TCP","port":"22","target":{"kind":"Ip","value":"0.0.0.0/0"}},` +
 	`"status":{"state":"Active"}}`
 
@@ -506,7 +506,7 @@ func TestSecurityGroupRulesClientAdapter_Create_Success(t *testing.T) {
 	})
 
 	sg := &SecurityGroup{}
-	sg.fromResponse(securityGroupTestResponse("sg", "my-sg", "/projects/p/providers/Aruba.Network/vpcs/v/securitygroups/sg", "p"))
+	sg.fromResponse(securityGroupTestResponse("sg", "my-sg", "/projects/p/providers/Aruba.Network/vpcs/v/securityGroups/sg", "p"))
 
 	rule := NewSecurityRule().
 		IntoSecurityGroup(sg).
@@ -560,11 +560,11 @@ func TestSecurityGroupRulesClientAdapter_Create_MetadataValidationError(t *testi
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusCreated)
 		// Missing "id" field — triggers MetadataValidationError
-		fmt.Fprint(w, `{"metadata":{"name":"rule","uri":"/projects/p/network/vpcs/v/securitygroups/sg/securityrules/x"},"properties":{},"status":{}}`)
+		fmt.Fprint(w, `{"metadata":{"name":"rule","uri":"/projects/p/providers/Aruba.Network/vpcs/v/securityGroups/sg/securityRules/x"},"properties":{},"status":{}}`)
 	})
 
 	sg := &SecurityGroup{}
-	sg.fromResponse(securityGroupTestResponse("sg", "my-sg", "/projects/p/providers/Aruba.Network/vpcs/v/securitygroups/sg", "p"))
+	sg.fromResponse(securityGroupTestResponse("sg", "my-sg", "/projects/p/providers/Aruba.Network/vpcs/v/securityGroups/sg", "p"))
 
 	rule := NewSecurityRule().IntoSecurityGroup(sg).
 		Named("rule")
@@ -589,7 +589,7 @@ func TestSecurityGroupRulesClientAdapter_Create_NonTwoXX(t *testing.T) {
 	})
 
 	sg := &SecurityGroup{}
-	sg.fromResponse(securityGroupTestResponse("sg", "my-sg", "/projects/p/providers/Aruba.Network/vpcs/v/securitygroups/sg", "p"))
+	sg.fromResponse(securityGroupTestResponse("sg", "my-sg", "/projects/p/providers/Aruba.Network/vpcs/v/securityGroups/sg", "p"))
 
 	rule := NewSecurityRule().IntoSecurityGroup(sg)
 	result, err := adapter.Create(context.Background(), rule)
@@ -617,7 +617,7 @@ func TestSecurityGroupRulesClientAdapter_Get_URIRef(t *testing.T) {
 		fmt.Fprint(w, securityRuleSuccessBody)
 	})
 
-	ref := URI("/projects/p/network/vpcs/v/securitygroups/sg/security-rules/r-1")
+	ref := URI("/projects/p/providers/Aruba.Network/vpcs/v/securityGroups/sg/securityRules/r-1")
 	result, err := adapter.Get(context.Background(), ref)
 	if err != nil {
 		t.Fatalf("Get error: %v", err)
@@ -637,8 +637,8 @@ func TestSecurityGroupRulesClientAdapter_Get_URIRef(t *testing.T) {
 	if result.StatusCode() != http.StatusOK {
 		t.Errorf("StatusCode() = %d", result.StatusCode())
 	}
-	if !strings.Contains(capturedPath, "securityrules") {
-		t.Errorf("path = %q, expected securityrules segment", capturedPath)
+	if !strings.Contains(capturedPath, "securityRules") {
+		t.Errorf("path = %q, expected securityRules segment", capturedPath)
 	}
 }
 
@@ -653,7 +653,7 @@ func TestSecurityGroupRulesClientAdapter_Get_TypedRef(t *testing.T) {
 	existing.fromResponse(securityRuleTestResponse(
 		"r-1",
 		"allow-ssh",
-		"/projects/p/network/vpcs/v/security-groups/sg/security-rules/r-1",
+		"/projects/p/providers/Aruba.Network/vpcs/v/securityGroups/sg/securityRules/r-1",
 		"p",
 	))
 
@@ -672,14 +672,14 @@ func TestSecurityGroupRulesClientAdapter_Update_Success(t *testing.T) {
 		_ = json.NewDecoder(r.Body).Decode(&capturedBody)
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
-		fmt.Fprint(w, `{"metadata":{"id":"r-1","name":"allow-https","uri":"/projects/p/network/vpcs/v/securitygroups/sg/securityrules/r-1","project":{"id":"p"}},"properties":{"direction":"Ingress","protocol":"TCP","port":"443"},"status":{}}`)
+		fmt.Fprint(w, `{"metadata":{"id":"r-1","name":"allow-https","uri":"/projects/p/providers/Aruba.Network/vpcs/v/securityGroups/sg/securityRules/r-1","project":{"id":"p"}},"properties":{"direction":"Ingress","protocol":"TCP","port":"443"},"status":{}}`)
 	})
 
 	rule := &SecurityRule{}
 	rule.fromResponse(securityRuleTestResponse(
 		"r-1",
 		"allow-ssh",
-		"/projects/p/network/vpcs/v/security-groups/sg/security-rules/r-1",
+		"/projects/p/providers/Aruba.Network/vpcs/v/securityGroups/sg/securityRules/r-1",
 		"p",
 	))
 	rule.Named("allow-https").WithPort("443")
@@ -707,7 +707,7 @@ func TestSecurityGroupRulesClientAdapter_Update_NoID(t *testing.T) {
 	})
 
 	sg := &SecurityGroup{}
-	sg.fromResponse(securityGroupTestResponse("sg", "my-sg", "/projects/p/network/vpcs/v/securitygroups/sg", "p"))
+	sg.fromResponse(securityGroupTestResponse("sg", "my-sg", "/projects/p/providers/Aruba.Network/vpcs/v/securityGroups/sg", "p"))
 
 	rule := NewSecurityRule().IntoSecurityGroup(sg).
 		Named("x")
@@ -767,7 +767,7 @@ func TestSecurityGroupRulesClientAdapter_Delete_Success(t *testing.T) {
 		w.WriteHeader(http.StatusNoContent)
 	})
 
-	err := adapter.Delete(context.Background(), URI("/projects/p/network/vpcs/v/securitygroups/sg/securityrules/r-1"))
+	err := adapter.Delete(context.Background(), URI("/projects/p/providers/Aruba.Network/vpcs/v/securityGroups/sg/securityRules/r-1"))
 	if err != nil {
 		t.Fatalf("Delete error: %v", err)
 	}
@@ -780,7 +780,7 @@ func TestSecurityGroupRulesClientAdapter_Delete_NonTwoXX(t *testing.T) {
 		fmt.Fprint(w, testutil.ErrorBodyJSON("Not Found", "security rule not found", 404))
 	})
 
-	err := adapter.Delete(context.Background(), URI("/projects/p/network/vpcs/v/securitygroups/sg/securityrules/missing"))
+	err := adapter.Delete(context.Background(), URI("/projects/p/providers/Aruba.Network/vpcs/v/securityGroups/sg/securityRules/missing"))
 	if err == nil {
 		t.Fatal("expected error on 404")
 	}
@@ -831,7 +831,7 @@ func TestSecurityGroupRulesClientAdapter_Get_NonTwoXX(t *testing.T) {
 		fmt.Fprint(w, testutil.ErrorBodyJSON("Not Found", "security rule not found", 404))
 	})
 
-	ref := URI("/projects/p/network/vpcs/v/securitygroups/sg/securityrules/missing")
+	ref := URI("/projects/p/providers/Aruba.Network/vpcs/v/securityGroups/sg/securityRules/missing")
 	result, err := adapter.Get(context.Background(), ref)
 	if err == nil {
 		t.Fatal("expected error on 404")
@@ -859,7 +859,7 @@ func TestSecurityGroupRulesClientAdapter_Update_NonTwoXX(t *testing.T) {
 	rule.fromResponse(securityRuleTestResponse(
 		"r-1",
 		"allow-ssh",
-		"/projects/p/network/vpcs/v/security-groups/sg/security-rules/r-1",
+		"/projects/p/providers/Aruba.Network/vpcs/v/securityGroups/sg/securityRules/r-1",
 		"p",
 	))
 	_, err := adapter.Update(context.Background(), rule)
@@ -876,7 +876,7 @@ func TestSecurityGroupRulesClientAdapter_List_NonTwoXX(t *testing.T) {
 		fmt.Fprint(w, testutil.ErrorBodyJSON("Forbidden", "access denied", 403))
 	})
 
-	sg := URI("/projects/p/network/vpcs/v/security-groups/sg")
+	sg := URI("/projects/p/providers/Aruba.Network/vpcs/v/securityGroups/sg")
 	_, err := adapter.List(context.Background(), sg)
 	var httpErr *HTTPError
 	if !errors.As(err, &httpErr) {
@@ -888,8 +888,8 @@ func TestSecurityGroupRulesClientAdapter_List_NonTwoXX(t *testing.T) {
 }
 
 func TestSecurityRuleIDsFromRef_BadURI_MissingSecurityGroup(t *testing.T) {
-	// URI has security-rules but no security-groups segment
-	_, _, _, _, err := securityRuleIDsFromRef(URI("/projects/p/network/vpcs/v/security-rules/r"))
+	// URI has securityRules but no securityGroups segment
+	_, _, _, _, err := securityRuleIDsFromRef(URI("/projects/p/providers/Aruba.Network/vpcs/v/securityRules/r"))
 	if err == nil {
 		t.Error("expected error for URI without security group segment")
 	}
@@ -897,7 +897,7 @@ func TestSecurityRuleIDsFromRef_BadURI_MissingSecurityGroup(t *testing.T) {
 
 func TestSecurityRuleIDsFromRef_BadURI_MissingVPC(t *testing.T) {
 	// URI has rules+sg but no vpcs
-	_, _, _, _, err := securityRuleIDsFromRef(URI("/projects/p/security-groups/sg/security-rules/r"))
+	_, _, _, _, err := securityRuleIDsFromRef(URI("/projects/p/securityGroups/sg/securityRules/r"))
 	if err == nil {
 		t.Error("expected error for URI without /vpcs/<id>")
 	}
@@ -905,7 +905,7 @@ func TestSecurityRuleIDsFromRef_BadURI_MissingVPC(t *testing.T) {
 
 func TestSecurityRuleIDsFromRef_BadURI_MissingProject(t *testing.T) {
 	// URI has rules+sg+vpcs but no projects
-	_, _, _, _, err := securityRuleIDsFromRef(URI("/providers/Aruba.Network/vpcs/v/security-groups/sg/security-rules/r"))
+	_, _, _, _, err := securityRuleIDsFromRef(URI("/providers/Aruba.Network/vpcs/v/securityGroups/sg/securityRules/r"))
 	if err == nil {
 		t.Error("expected error for URI without /projects/<id>")
 	}
@@ -956,7 +956,7 @@ func TestSecurityGroupRulesClientAdapter_Get_TransportError(t *testing.T) {
 		conn.Close()
 	})
 	adapter := newSecurityRulesClientAdapter(testutil.NewClient(t, server.URL))
-	result, err := adapter.Get(context.Background(), URI("/projects/p/network/vpcs/v/security-groups/sg/security-rules/r"))
+	result, err := adapter.Get(context.Background(), URI("/projects/p/providers/Aruba.Network/vpcs/v/securityGroups/sg/securityRules/r"))
 	if err == nil {
 		t.Fatal("expected transport error")
 	}
@@ -991,7 +991,7 @@ func TestSecurityGroupRulesClientAdapter_Update_TransportError(t *testing.T) {
 	})
 	adapter := newSecurityRulesClientAdapter(testutil.NewClient(t, server.URL))
 	rule := &SecurityRule{}
-	rule.fromResponse(securityRuleTestResponse("r-1", "rule-a", "/projects/p/network/vpcs/v/securitygroups/sg/securityrules/r-1", "p"))
+	rule.fromResponse(securityRuleTestResponse("r-1", "rule-a", "/projects/p/providers/Aruba.Network/vpcs/v/securityGroups/sg/securityRules/r-1", "p"))
 	_, err := adapter.Update(context.Background(), rule)
 	if err == nil {
 		t.Fatal("expected transport error")
@@ -1009,7 +1009,7 @@ func TestSecurityGroupRulesClientAdapter_Delete_TransportError(t *testing.T) {
 		conn.Close()
 	})
 	adapter := newSecurityRulesClientAdapter(testutil.NewClient(t, server.URL))
-	err := adapter.Delete(context.Background(), URI("/projects/p/network/vpcs/v/security-groups/sg/security-rules/r"))
+	err := adapter.Delete(context.Background(), URI("/projects/p/providers/Aruba.Network/vpcs/v/securityGroups/sg/securityRules/r"))
 	if err == nil {
 		t.Fatal("expected transport error")
 	}
@@ -1041,7 +1041,7 @@ func TestSecurityGroupRulesClientAdapter_List_TransportError(t *testing.T) {
 		conn.Close()
 	})
 	adapter := newSecurityRulesClientAdapter(testutil.NewClient(t, server.URL))
-	_, err := adapter.List(context.Background(), URI("/projects/p/network/vpcs/v/security-groups/sg"))
+	_, err := adapter.List(context.Background(), URI("/projects/p/providers/Aruba.Network/vpcs/v/securityGroups/sg"))
 	if err == nil {
 		t.Fatal("expected transport error")
 	}
@@ -1057,7 +1057,7 @@ func TestSecurityGroupRulesClientAdapter_List_AncestorIDBackfill(t *testing.T) {
 			`]}`)
 	})
 
-	list, err := adapter.List(context.Background(), URI("/projects/proj-x/network/vpcs/vpc-x/security-groups/sg-x"))
+	list, err := adapter.List(context.Background(), URI("/projects/proj-x/providers/Aruba.Network/vpcs/vpc-x/securityGroups/sg-x"))
 	if err != nil {
 		t.Fatalf("List error: %v", err)
 	}
@@ -1081,12 +1081,12 @@ func TestSecurityGroupRulesClientAdapter_List_TwoItems(t *testing.T) {
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
 		fmt.Fprint(w, `{"total":2,"self":"","prev":"","next":"","first":"","last":"","values":[`+
-			`{"metadata":{"id":"r-1","name":"rule-a","uri":"/projects/p/network/vpcs/v/securitygroups/sg/securityrules/r-1","project":{"id":"p"}},"properties":{"direction":"Ingress","protocol":"TCP","port":"22"},"status":{"state":"Active"}},`+
-			`{"metadata":{"id":"r-2","name":"rule-b","uri":"/projects/p/network/vpcs/v/securitygroups/sg/securityrules/r-2","project":{"id":"p"}},"properties":{"direction":"Egress","protocol":"UDP","port":"53"},"status":{"state":"Active"}}`+
+			`{"metadata":{"id":"r-1","name":"rule-a","uri":"/projects/p/providers/Aruba.Network/vpcs/v/securityGroups/sg/securityRules/r-1","project":{"id":"p"}},"properties":{"direction":"Ingress","protocol":"TCP","port":"22"},"status":{"state":"Active"}},`+
+			`{"metadata":{"id":"r-2","name":"rule-b","uri":"/projects/p/providers/Aruba.Network/vpcs/v/securityGroups/sg/securityRules/r-2","project":{"id":"p"}},"properties":{"direction":"Egress","protocol":"UDP","port":"53"},"status":{"state":"Active"}}`+
 			`]}`)
 	})
 
-	sg := URI("/projects/p/network/vpcs/v/security-groups/sg")
+	sg := URI("/projects/p/providers/Aruba.Network/vpcs/v/securityGroups/sg")
 	list, err := adapter.List(context.Background(), sg)
 	if err != nil {
 		t.Fatalf("List error: %v", err)
@@ -1136,7 +1136,7 @@ func TestSecurityGroupRulesClientAdapter_Get_InjectsRefresh(t *testing.T) {
 		fmt.Fprint(w, securityRuleSuccessBody)
 	})
 	adapter := newSecurityRulesClientAdapter(testutil.NewClient(t, server.URL))
-	rule, err := adapter.Get(context.Background(), URI("/projects/p/network/vpcs/v/securitygroups/sg/security-rules/r-1"))
+	rule, err := adapter.Get(context.Background(), URI("/projects/p/providers/Aruba.Network/vpcs/v/securityGroups/sg/securityRules/r-1"))
 	if err != nil {
 		t.Fatalf("Get error: %v", err)
 	}
@@ -1147,12 +1147,12 @@ func TestSecurityGroupRulesClientAdapter_Get_InjectsRefresh(t *testing.T) {
 
 func TestSecurityRuleRef(t *testing.T) {
 	ref := SecurityRuleRef("p-1", "vpc-1", "sg-1", "rule-1")
-	want := "/projects/p-1/providers/Aruba.Network/vpcs/vpc-1/securitygroups/sg-1/securityrules/rule-1"
+	want := "/projects/p-1/providers/Aruba.Network/vpcs/vpc-1/securityGroups/sg-1/securityRules/rule-1"
 	if ref.URI() != want {
 		t.Errorf("SecurityRuleRef URI = %q, want %q", ref.URI(), want)
 	}
 	ids := parseURIIDs(ref.URI())
-	if ids["projects"] != "p-1" || ids["securitygroups"] != "sg-1" || ids["securityrules"] != "rule-1" {
+	if ids["projects"] != "p-1" || ids["securityGroups"] != "sg-1" || ids["securityRules"] != "rule-1" {
 		t.Errorf("parseURIIDs = %v", ids)
 	}
 }

--- a/pkg/aruba/resource_snapshot_test.go
+++ b/pkg/aruba/resource_snapshot_test.go
@@ -103,7 +103,7 @@ func TestSnapshot_IntoProject_BadRef(t *testing.T) {
 // --------------------------------------------------------------------------
 
 func TestSnapshot_FromVolume_URIRef(t *testing.T) {
-	volURI := "/projects/p/providers/Aruba.Storage/blockstorages/bs-1"
+	volURI := "/projects/p/providers/Aruba.Storage/blockStorages/bs-1"
 	snap := NewSnapshot().FromVolume(URI(volURI))
 	if snap.VolumeURI() != volURI {
 		t.Errorf("VolumeURI() = %q", snap.VolumeURI())
@@ -116,7 +116,7 @@ func TestSnapshot_FromVolume_URIRef(t *testing.T) {
 func TestSnapshot_FromVolume_TypedRef(t *testing.T) {
 	// Simulate a typed BlockStorage with a known URI.
 	bs := &BlockStorage{}
-	bs.fromResponse(blockStorageTestResponse("bs-42", "n", "/projects/p/providers/Aruba.Storage/blockstorages/bs-42", "p"))
+	bs.fromResponse(blockStorageTestResponse("bs-42", "n", "/projects/p/providers/Aruba.Storage/blockStorages/bs-42", "p"))
 
 	snap := NewSnapshot().FromVolume(bs)
 	if snap.VolumeURI() != bs.URI() {
@@ -142,7 +142,7 @@ func TestSnapshot_FromVolume_EmptyURI(t *testing.T) {
 // --------------------------------------------------------------------------
 
 func TestSnapshot_ToRequestRoundTrip(t *testing.T) {
-	volURI := "/projects/p/providers/Aruba.Storage/blockstorages/bs-1"
+	volURI := "/projects/p/providers/Aruba.Storage/blockStorages/bs-1"
 	snap := NewSnapshot().Named(
 		"snap-rt").
 		AddTag("t1").AddTag("t2").
@@ -193,7 +193,7 @@ func snapshotTestResponse(id, name, uri, projectID string) *types.SnapshotRespon
 	sizeGB := int32(20)
 	boot := true
 	zone := ZoneITBG1
-	volURI := "/projects/p/providers/Aruba.Storage/blockstorages/bs-1"
+	volURI := "/projects/p/providers/Aruba.Storage/blockStorages/bs-1"
 	return &types.SnapshotResponse{
 		Metadata: types.ResourceMetadataResponse{
 			ID:               &id,
@@ -268,7 +268,7 @@ func TestSnapshot_FromResponseHydration(t *testing.T) {
 	if !snap.Bootable() {
 		t.Error("Bootable() should be true")
 	}
-	if snap.VolumeURI() != "/projects/p/providers/Aruba.Storage/blockstorages/bs-1" {
+	if snap.VolumeURI() != "/projects/p/providers/Aruba.Storage/blockStorages/bs-1" {
 		t.Errorf("VolumeURI() = %q", snap.VolumeURI())
 	}
 	if snap.ProjectID() != "p1" {
@@ -565,7 +565,7 @@ func TestSnapshotsClientAdapter_Create_NonTwoXX(t *testing.T) {
 // TestSnapshotsClientAdapter_Create_WithVolume uses the fake low-level client
 // to assert the Volume.URI is wired correctly in the request body.
 func TestSnapshotsClientAdapter_Create_WithVolume(t *testing.T) {
-	volURI := "/projects/p/providers/Aruba.Storage/blockstorages/bs-1"
+	volURI := "/projects/p/providers/Aruba.Storage/blockStorages/bs-1"
 	var capturedBody types.SnapshotRequest
 
 	snapResp := snapshotTestResponse("snap-1", "my-snap", "/projects/p/providers/Aruba.Storage/snapshots/snap-1", "p")

--- a/pkg/aruba/resource_storage_backup_test.go
+++ b/pkg/aruba/resource_storage_backup_test.go
@@ -111,7 +111,7 @@ func TestStorageBackup_IntoProject_BadRef(t *testing.T) {
 // --------------------------------------------------------------------------
 
 func TestStorageBackup_FromVolume_URIRef(t *testing.T) {
-	volURI := "/projects/p/providers/Aruba.Storage/blockstorages/bs-1"
+	volURI := "/projects/p/providers/Aruba.Storage/blockStorages/bs-1"
 	bkp := NewStorageBackup().FromVolume(URI(volURI))
 	if bkp.OriginURI() != volURI {
 		t.Errorf("OriginURI() = %q", bkp.OriginURI())
@@ -123,7 +123,7 @@ func TestStorageBackup_FromVolume_URIRef(t *testing.T) {
 
 func TestStorageBackup_FromVolume_TypedRef(t *testing.T) {
 	bs := &BlockStorage{}
-	bs.fromResponse(blockStorageTestResponse("bs-42", "n", "/projects/p/providers/Aruba.Storage/blockstorages/bs-42", "p"))
+	bs.fromResponse(blockStorageTestResponse("bs-42", "n", "/projects/p/providers/Aruba.Storage/blockStorages/bs-42", "p"))
 
 	bkp := NewStorageBackup().FromVolume(bs)
 	if bkp.OriginURI() != bs.URI() {
@@ -164,7 +164,7 @@ func TestStorageBackup_OfType_Enum(t *testing.T) {
 // --------------------------------------------------------------------------
 
 func TestStorageBackup_ToRequestRoundTrip(t *testing.T) {
-	volURI := "/projects/p/providers/Aruba.Storage/blockstorages/bs-1"
+	volURI := "/projects/p/providers/Aruba.Storage/blockStorages/bs-1"
 	bkp := NewStorageBackup().Named(
 		"bkp-rt").
 		AddTag("t1").AddTag("t2").
@@ -227,7 +227,7 @@ func storageBackupTestResponse(id, name, uri, projectID string) *types.StorageBa
 	state := types.State("Active")
 	billingPeriod := BillingPeriodHour
 	retentionDays := 30
-	originURI := "/projects/p/providers/Aruba.Storage/blockstorages/bs-1"
+	originURI := "/projects/p/providers/Aruba.Storage/blockStorages/bs-1"
 	return &types.StorageBackupResponse{
 		Metadata: types.ResourceMetadataResponse{
 			ID:               &id,
@@ -286,7 +286,7 @@ func TestStorageBackup_FromResponseHydration(t *testing.T) {
 	if bkp.Type() != StorageBackupTypeFull {
 		t.Errorf("Type() = %q", bkp.Type())
 	}
-	if bkp.OriginURI() != "/projects/p/providers/Aruba.Storage/blockstorages/bs-1" {
+	if bkp.OriginURI() != "/projects/p/providers/Aruba.Storage/blockStorages/bs-1" {
 		t.Errorf("OriginURI() = %q", bkp.OriginURI())
 	}
 	if bkp.RetentionDays() != 30 {
@@ -453,7 +453,7 @@ func buildStorageBackupsTestAdapter(t *testing.T, handler http.HandlerFunc) *sto
 
 const storageBackupSuccessBody = `{` +
 	`"metadata":{"id":"bkp-1","name":"my-backup","uri":"/projects/p/providers/Aruba.Storage/backups/bkp-1","project":{"id":"p"}},` +
-	`"properties":{"type":"Full","sourceVolume":{"uri":"/projects/p/providers/Aruba.Storage/blockstorages/bs-1"},"retentionDays":30,"billingPeriod":"Hour"},` +
+	`"properties":{"type":"Full","sourceVolume":{"uri":"/projects/p/providers/Aruba.Storage/blockStorages/bs-1"},"retentionDays":30,"billingPeriod":"Hour"},` +
 	`"status":{"state":"Active"}}`
 
 func TestStorageBackupsClientAdapter_Create_Success(t *testing.T) {
@@ -500,7 +500,7 @@ func TestStorageBackupsClientAdapter_Create_Success(t *testing.T) {
 }
 
 func TestStorageBackupsClientAdapter_Create_FromVolume(t *testing.T) {
-	volURI := "/projects/p/providers/Aruba.Storage/blockstorages/bs-1"
+	volURI := "/projects/p/providers/Aruba.Storage/blockStorages/bs-1"
 	var capturedBody types.StorageBackupRequest
 
 	bkpResp := storageBackupTestResponse("bkp-1", "my-backup", "/projects/p/providers/Aruba.Storage/backups/bkp-1", "p")
@@ -883,8 +883,8 @@ func TestStorageBackupsClientAdapter_List_TwoItems(t *testing.T) {
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
 		fmt.Fprint(w, `{"total":2,"self":"","prev":"","next":"","first":"","last":"","values":[`+
-			`{"metadata":{"id":"bkp-1","name":"n1","uri":"/projects/p/providers/Aruba.Storage/backups/bkp-1","project":{"id":"p"}},"properties":{"type":"Full","sourceVolume":{"uri":"/projects/p/providers/Aruba.Storage/blockstorages/bs-1"},"retentionDays":10},"status":{}},`+
-			`{"metadata":{"id":"bkp-2","name":"n2","uri":"/projects/p/providers/Aruba.Storage/backups/bkp-2","project":{"id":"p"}},"properties":{"type":"Incremental","sourceVolume":{"uri":"/projects/p/providers/Aruba.Storage/blockstorages/bs-2"},"retentionDays":20},"status":{}}`+
+			`{"metadata":{"id":"bkp-1","name":"n1","uri":"/projects/p/providers/Aruba.Storage/backups/bkp-1","project":{"id":"p"}},"properties":{"type":"Full","sourceVolume":{"uri":"/projects/p/providers/Aruba.Storage/blockStorages/bs-1"},"retentionDays":10},"status":{}},`+
+			`{"metadata":{"id":"bkp-2","name":"n2","uri":"/projects/p/providers/Aruba.Storage/backups/bkp-2","project":{"id":"p"}},"properties":{"type":"Incremental","sourceVolume":{"uri":"/projects/p/providers/Aruba.Storage/blockStorages/bs-2"},"retentionDays":20},"status":{}}`+
 			`]}`)
 	})
 

--- a/pkg/aruba/resource_storage_restore_test.go
+++ b/pkg/aruba/resource_storage_restore_test.go
@@ -33,7 +33,7 @@ func TestStorageRestore_FluentSetters(t *testing.T) {
 		AddTag("storage").
 		AddTag("restore"). // dedupe
 		InRegion(RegionITBGBergamo).
-		ToVolume(URI("/projects/p/providers/Aruba.Storage/blockstorages/bs-1"))
+		ToVolume(URI("/projects/p/providers/Aruba.Storage/blockStorages/bs-1"))
 
 	if r.Name() != "my-restore" {
 		t.Errorf("Name() = %q", r.Name())
@@ -44,7 +44,7 @@ func TestStorageRestore_FluentSetters(t *testing.T) {
 	if r.Region() != RegionITBGBergamo {
 		t.Errorf("Region() = %q", r.Region())
 	}
-	if r.TargetURI() != "/projects/p/providers/Aruba.Storage/blockstorages/bs-1" {
+	if r.TargetURI() != "/projects/p/providers/Aruba.Storage/blockStorages/bs-1" {
 		t.Errorf("TargetURI() = %q", r.TargetURI())
 	}
 	if r.BackupID() != "bkp-1" {
@@ -113,7 +113,7 @@ func TestStorageRestore_IntoBackup_BadRef(t *testing.T) {
 // --------------------------------------------------------------------------
 
 func TestStorageRestore_ToVolume_URIRef(t *testing.T) {
-	volURI := "/projects/p/providers/Aruba.Storage/blockstorages/bs-1"
+	volURI := "/projects/p/providers/Aruba.Storage/blockStorages/bs-1"
 	r := NewStorageRestore().ToVolume(URI(volURI))
 	if r.TargetURI() != volURI {
 		t.Errorf("TargetURI() = %q", r.TargetURI())
@@ -125,7 +125,7 @@ func TestStorageRestore_ToVolume_URIRef(t *testing.T) {
 
 func TestStorageRestore_ToVolume_TypedRef(t *testing.T) {
 	bs := &BlockStorage{}
-	bs.fromResponse(blockStorageTestResponse("bs-42", "n", "/projects/p/providers/Aruba.Storage/blockstorages/bs-42", "p"))
+	bs.fromResponse(blockStorageTestResponse("bs-42", "n", "/projects/p/providers/Aruba.Storage/blockStorages/bs-42", "p"))
 
 	r := NewStorageRestore().ToVolume(bs)
 	if r.TargetURI() != bs.URI() {
@@ -151,7 +151,7 @@ func TestStorageRestore_ToVolume_EmptyURI(t *testing.T) {
 // --------------------------------------------------------------------------
 
 func TestStorageRestore_ToRequestRoundTrip(t *testing.T) {
-	volURI := "/projects/p/providers/Aruba.Storage/blockstorages/bs-1"
+	volURI := "/projects/p/providers/Aruba.Storage/blockStorages/bs-1"
 	r := NewStorageRestore().Named(
 		"rt-restore").
 		AddTag("t1").AddTag("t2").
@@ -209,7 +209,7 @@ func storageRestoreTestResponse(id, name, uri, targetURI string) *types.StorageR
 }
 
 func TestStorageRestore_FromResponseHydration(t *testing.T) {
-	targetURI := "/projects/p/providers/Aruba.Storage/blockstorages/bs-1"
+	targetURI := "/projects/p/providers/Aruba.Storage/blockStorages/bs-1"
 	r := &StorageRestore{}
 	r.backupID = "bkp-1" // pre-set to simulate IntoBackup
 	resp := storageRestoreTestResponse("r-1", "my-restore", "/projects/p/providers/Aruba.Storage/backups/bkp-1/restores/r-1", targetURI)
@@ -287,7 +287,7 @@ func TestStorageRestore_FromResponse_NilSafe(t *testing.T) {
 
 func TestStorageRestore_RefSatisfaction(t *testing.T) {
 	r := &StorageRestore{}
-	r.fromResponse(storageRestoreTestResponse("r-99", "n", "/projects/p99/providers/Aruba.Storage/backups/bkp-99/restores/r-99", "/projects/p/providers/Aruba.Storage/blockstorages/bs-1"))
+	r.fromResponse(storageRestoreTestResponse("r-99", "n", "/projects/p99/providers/Aruba.Storage/backups/bkp-99/restores/r-99", "/projects/p/providers/Aruba.Storage/blockStorages/bs-1"))
 
 	// withRestoreID typed path
 	rid, ok := extractID(r, func(ref Ref) (string, bool) {
@@ -412,7 +412,7 @@ func buildStorageRestoresTestAdapter(t *testing.T, handler http.HandlerFunc) *st
 
 const storageRestoreSuccessBody = `{` +
 	`"metadata":{"id":"r-1","name":"my-restore","uri":"/projects/p/providers/Aruba.Storage/backups/bkp-1/restores/r-1"},` +
-	`"properties":{"destinationVolume":{"uri":"/projects/p/providers/Aruba.Storage/blockstorages/bs-1"}},` +
+	`"properties":{"destinationVolume":{"uri":"/projects/p/providers/Aruba.Storage/blockStorages/bs-1"}},` +
 	`"status":{"state":"Active"}}`
 
 func TestStorageRestoresClientAdapter_Create_Success(t *testing.T) {
@@ -436,7 +436,7 @@ func TestStorageRestoresClientAdapter_Create_Success(t *testing.T) {
 		IntoBackup(bkp).
 		Named("my-restore").
 		InRegion(RegionITBGBergamo).
-		ToVolume(URI("/projects/p/providers/Aruba.Storage/blockstorages/bs-1"))
+		ToVolume(URI("/projects/p/providers/Aruba.Storage/blockStorages/bs-1"))
 
 	result, err := adapter.Create(context.Background(), r)
 	if err != nil {
@@ -454,7 +454,7 @@ func TestStorageRestoresClientAdapter_Create_Success(t *testing.T) {
 	if gotBody.Metadata.Name != "my-restore" {
 		t.Errorf("request Name = %q", gotBody.Metadata.Name)
 	}
-	if gotBody.Properties.Target.URI != "/projects/p/providers/Aruba.Storage/blockstorages/bs-1" {
+	if gotBody.Properties.Target.URI != "/projects/p/providers/Aruba.Storage/blockStorages/bs-1" {
 		t.Errorf("request Target.URI = %q", gotBody.Properties.Target.URI)
 	}
 }
@@ -600,7 +600,7 @@ func TestStorageRestoresClientAdapter_Get_TypedRef(t *testing.T) {
 }
 
 func TestStorageRestoresClientAdapter_Update_Success(t *testing.T) {
-	targetURI := "/projects/p/providers/Aruba.Storage/blockstorages/bs-new"
+	targetURI := "/projects/p/providers/Aruba.Storage/blockStorages/bs-new"
 	var capturedBody types.StorageRestoreRequest
 
 	respBody := storageRestoreTestResponse("r-1", "my-restore", "/projects/p/providers/Aruba.Storage/backups/bkp-1/restores/r-1", targetURI)
@@ -618,7 +618,7 @@ func TestStorageRestoresClientAdapter_Update_Success(t *testing.T) {
 	adapter := &storageRestoresClientAdapter{low: fake}
 
 	r := &StorageRestore{}
-	r.fromResponse(storageRestoreTestResponse("r-1", "my-restore", "/projects/p/providers/Aruba.Storage/backups/bkp-1/restores/r-1", "/projects/p/providers/Aruba.Storage/blockstorages/bs-1"))
+	r.fromResponse(storageRestoreTestResponse("r-1", "my-restore", "/projects/p/providers/Aruba.Storage/backups/bkp-1/restores/r-1", "/projects/p/providers/Aruba.Storage/blockStorages/bs-1"))
 	r.backupID = "bkp-1"
 	r.projectID = "p"
 	r.ToVolume(URI(targetURI))
@@ -770,7 +770,7 @@ func TestStorageRestoresClientAdapter_Get_NonTwoXX(t *testing.T) {
 }
 
 func TestStorageRestoresClientAdapter_Update_NonTwoXX(t *testing.T) {
-	targetURI := "/projects/p/providers/Aruba.Storage/blockstorages/bs-new"
+	targetURI := "/projects/p/providers/Aruba.Storage/blockStorages/bs-new"
 	fake := &fakeStorageRestoreLowLevel{
 		updateFunc: func(_ context.Context, _, _, _ string, _ types.StorageRestoreRequest, _ *types.RequestParameters) (*types.Response[types.StorageRestoreResponse], error) {
 			return &types.Response[types.StorageRestoreResponse]{
@@ -867,8 +867,8 @@ func TestStorageRestoresClientAdapter_List_TwoItems(t *testing.T) {
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
 		fmt.Fprint(w, `{"total":2,"self":"","prev":"","next":"","first":"","last":"","values":[`+
-			`{"metadata":{"id":"r-1","name":"n1","uri":"/projects/p/providers/Aruba.Storage/backups/bkp-1/restores/r-1"},"properties":{"destinationVolume":{"uri":"/projects/p/providers/Aruba.Storage/blockstorages/bs-1"}},"status":{}},`+
-			`{"metadata":{"id":"r-2","name":"n2","uri":"/projects/p/providers/Aruba.Storage/backups/bkp-1/restores/r-2"},"properties":{"destinationVolume":{"uri":"/projects/p/providers/Aruba.Storage/blockstorages/bs-2"}},"status":{}}`+
+			`{"metadata":{"id":"r-1","name":"n1","uri":"/projects/p/providers/Aruba.Storage/backups/bkp-1/restores/r-1"},"properties":{"destinationVolume":{"uri":"/projects/p/providers/Aruba.Storage/blockStorages/bs-1"}},"status":{}},`+
+			`{"metadata":{"id":"r-2","name":"n2","uri":"/projects/p/providers/Aruba.Storage/backups/bkp-1/restores/r-2"},"properties":{"destinationVolume":{"uri":"/projects/p/providers/Aruba.Storage/blockStorages/bs-2"}},"status":{}}`+
 			`]}`)
 	})
 
@@ -889,10 +889,10 @@ func TestStorageRestoresClientAdapter_List_TwoItems(t *testing.T) {
 	if items[0].ID() != "r-1" || items[0].Name() != "n1" {
 		t.Errorf("items[0] = {%q, %q}", items[0].ID(), items[0].Name())
 	}
-	if items[0].TargetURI() != "/projects/p/providers/Aruba.Storage/blockstorages/bs-1" {
+	if items[0].TargetURI() != "/projects/p/providers/Aruba.Storage/blockStorages/bs-1" {
 		t.Errorf("items[0].TargetURI() = %q", items[0].TargetURI())
 	}
-	if items[1].ID() != "r-2" || items[1].TargetURI() != "/projects/p/providers/Aruba.Storage/blockstorages/bs-2" {
+	if items[1].ID() != "r-2" || items[1].TargetURI() != "/projects/p/providers/Aruba.Storage/blockStorages/bs-2" {
 		t.Errorf("items[1] ID=%q TargetURI=%q", items[1].ID(), items[1].TargetURI())
 	}
 	if items[0].BackupID() != "bkp-1" {

--- a/pkg/aruba/resource_vpc_peering.go
+++ b/pkg/aruba/resource_vpc_peering.go
@@ -422,27 +422,13 @@ func (a *vpcPeeringsClientAdapter) List(ctx context.Context, vpc Ref, opts ...Ca
 }
 
 // vpcPeeringIDsFromRef extracts (projectID, vpcID, vpcPeeringID) from a Ref.
-// Accepts the production camelCase segment "vpcPeerings" and the mixin/test form "peerings".
 func vpcPeeringIDsFromRef(ref Ref) (projectID, vpcID, vpcPeeringID string, err error) {
 	pid, ok := extractID(ref, func(r Ref) (string, bool) {
 		if w, ok := r.(withVPCPeeringID); ok {
 			return w.VPCPeeringID(), true
 		}
 		return "", false
-	}, "vpc-peerings")
-	if !ok || pid == "" {
-		m := parseURIIDs(ref.URI())
-		if v := m["vpcPeerings"]; v != "" {
-			pid = v
-			ok = true
-		}
-		if pid == "" {
-			if v := m["peerings"]; v != "" {
-				pid = v
-				ok = true
-			}
-		}
-	}
+	}, "vpcPeerings")
 	if !ok || pid == "" {
 		return "", "", "", fmt.Errorf("cannot determine VPC peering ID from Ref %q", ref.URI())
 	}

--- a/pkg/aruba/resource_vpc_peering_route.go
+++ b/pkg/aruba/resource_vpc_peering_route.go
@@ -180,13 +180,7 @@ func (r *VPCPeeringRoute) fromResponse(resp *types.VPCPeeringRouteResponse) {
 			r.projectID = ids["projects"]
 		}
 		if r.vpcPeeringID == "" {
-			// Production URI uses "vpcPeerings"; mixin/test URIs use "peerings".
-			if v := ids["vpcPeerings"]; v != "" {
-				r.vpcPeeringID = v
-			}
-			if r.vpcPeeringID == "" {
-				r.vpcPeeringID = ids["peerings"]
-			}
+			r.vpcPeeringID = ids["vpcPeerings"]
 		}
 	}
 }
@@ -469,21 +463,13 @@ func (a *vpcPeeringRoutesClientAdapter) List(ctx context.Context, peering Ref, o
 }
 
 // vpcPeeringRouteIDsFromRef extracts (projectID, vpcID, vpcPeeringID, vpcPeeringRouteID) from a Ref.
-// Accepts the production camelCase segment "vpcPeeringRoutes" and the test form "vpc-peering-routes".
-// For the peering parent, accepts both "vpcPeerings" and "peerings".
 func vpcPeeringRouteIDsFromRef(ref Ref) (projectID, vpcID, vpcPeeringID, vpcPeeringRouteID string, err error) {
 	rid, ok := extractID(ref, func(r Ref) (string, bool) {
 		if w, ok := r.(withVPCPeeringRouteID); ok {
 			return w.VPCPeeringRouteID(), true
 		}
 		return "", false
-	}, "vpc-peering-routes")
-	if !ok {
-		if v := parseURIIDs(ref.URI())["vpcPeeringRoutes"]; v != "" {
-			rid = v
-			ok = true
-		}
-	}
+	}, "vpcPeeringRoutes")
 	if !ok {
 		return "", "", "", "", fmt.Errorf("cannot determine VPC peering route ID from Ref %q", ref.URI())
 	}
@@ -492,17 +478,7 @@ func vpcPeeringRouteIDsFromRef(ref Ref) (projectID, vpcID, vpcPeeringID, vpcPeer
 			return w.VPCPeeringID(), true
 		}
 		return "", false
-	}, "vpc-peerings")
-	if !ok {
-		m := parseURIIDs(ref.URI())
-		if v := m["vpcPeerings"]; v != "" {
-			pid = v
-			ok = true
-		} else if v := m["peerings"]; v != "" {
-			pid = v
-			ok = true
-		}
-	}
+	}, "vpcPeerings")
 	if !ok {
 		return "", "", "", "", fmt.Errorf("cannot determine VPC peering ID from Ref %q", ref.URI())
 	}

--- a/pkg/aruba/resource_vpc_peering_route_test.go
+++ b/pkg/aruba/resource_vpc_peering_route_test.go
@@ -110,23 +110,6 @@ func TestVPCPeeringRoute_IntoVPCPeering_TypedRef(t *testing.T) {
 // IntoVPCPeering — URI Ref (lowercase/mixin form)
 // --------------------------------------------------------------------------
 
-func TestVPCPeeringRoute_IntoVPCPeering_URIRef_LowerCase(t *testing.T) {
-	r := NewVPCPeeringRoute().IntoVPCPeering(URI("/projects/p/network/vpcs/v/peerings/peer"))
-
-	if r.VPCPeeringID() != "peer" {
-		t.Errorf("VPCPeeringID() = %q", r.VPCPeeringID())
-	}
-	if r.VPCID() != "v" {
-		t.Errorf("VPCID() = %q", r.VPCID())
-	}
-	if r.ProjectID() != "p" {
-		t.Errorf("ProjectID() = %q", r.ProjectID())
-	}
-	if r.Err() != nil {
-		t.Errorf("Err() = %v", r.Err())
-	}
-}
-
 // --------------------------------------------------------------------------
 // IntoVPCPeering — URI Ref (camelCase/production form — validates mixin extension)
 // --------------------------------------------------------------------------
@@ -326,7 +309,7 @@ func TestVPCPeeringRoute_FromResponsePartial(t *testing.T) {
 }
 
 func TestVPCPeeringRoute_FromResponseURIBackfill_HyphenForm(t *testing.T) {
-	uri := "/projects/p2/network/vpcs/v2/peerings/peer-2/vpc-peering-routes/route-2"
+	uri := "/projects/p2/providers/Aruba.Network/vpcs/v2/vpcPeerings/peer-2/vpcPeeringRoutes/route-2"
 	id := "route-2"
 	name := "uri-route"
 	resp := &types.VPCPeeringRouteResponse{
@@ -366,7 +349,7 @@ func TestVPCPeeringRoute_RefSatisfaction(t *testing.T) {
 			return w.VPCPeeringRouteID(), true
 		}
 		return "", false
-	}, "vpc-peering-routes")
+	}, "vpcPeeringRoutes")
 	if !ok || rid != "route-99" {
 		t.Errorf("extractID via withVPCPeeringRouteID = (%q, %v)", rid, ok)
 	}
@@ -377,7 +360,7 @@ func TestVPCPeeringRoute_RefSatisfaction(t *testing.T) {
 			return w.VPCPeeringID(), true
 		}
 		return "", false
-	}, "vpc-peerings")
+	}, "vpcPeerings")
 	if !ok || pid != "peer-99" {
 		t.Errorf("extractID via withVPCPeeringID = (%q, %v)", pid, ok)
 	}
@@ -412,7 +395,7 @@ func TestVPCPeeringRoute_RefSatisfaction(t *testing.T) {
 func TestVPCPeeringRouteIDsFromRef_TypedRef(t *testing.T) {
 	r := &VPCPeeringRoute{}
 	r.fromResponse(vpcPeeringRouteTestResponse("route-1", "n",
-		"/projects/p/network/vpcs/v/peerings/peer-1/vpc-peering-routes/route-1", "p"))
+		"/projects/p/providers/Aruba.Network/vpcs/v/vpcPeerings/peer-1/vpcPeeringRoutes/route-1", "p"))
 	projID, vid, peerid, rid, err := vpcPeeringRouteIDsFromRef(r)
 	if err != nil || projID != "p" || vid != "v" || peerid != "peer-1" || rid != "route-1" {
 		t.Errorf("vpcPeeringRouteIDsFromRef typed = (%q, %q, %q, %q, %v)", projID, vid, peerid, rid, err)
@@ -424,14 +407,6 @@ func TestVPCPeeringRouteIDsFromRef_URIRef_CamelCase(t *testing.T) {
 	projID, vid, peerid, rid, err := vpcPeeringRouteIDsFromRef(ref)
 	if err != nil || projID != "p" || vid != "v" || peerid != "peer-1" || rid != "route-1" {
 		t.Errorf("vpcPeeringRouteIDsFromRef camelCase = (%q, %q, %q, %q, %v)", projID, vid, peerid, rid, err)
-	}
-}
-
-func TestVPCPeeringRouteIDsFromRef_URIRef_LowerCase(t *testing.T) {
-	ref := URI("/projects/p/network/vpcs/v/peerings/peer-1/vpc-peering-routes/route-1")
-	projID, vid, peerid, rid, err := vpcPeeringRouteIDsFromRef(ref)
-	if err != nil || projID != "p" || vid != "v" || peerid != "peer-1" || rid != "route-1" {
-		t.Errorf("vpcPeeringRouteIDsFromRef lowercase = (%q, %q, %q, %q, %v)", projID, vid, peerid, rid, err)
 	}
 }
 
@@ -689,7 +664,7 @@ func TestVPCPeeringRoutesClientAdapter_Update_NoID(t *testing.T) {
 	})
 
 	r := NewVPCPeeringRoute().
-		IntoVPCPeering(URI("/projects/p/network/vpcs/v/peerings/peer-1")).
+		IntoVPCPeering(URI("/projects/p/providers/Aruba.Network/vpcs/v/vpcPeerings/peer-1")).
 		Named("x")
 
 	_, err := adapter.Update(context.Background(), r)
@@ -850,16 +825,16 @@ func TestVPCPeeringRoutesClientAdapter_List_NonTwoXX(t *testing.T) {
 }
 
 func TestVPCPeeringRouteIDsFromRef_BadURI_MissingVPC(t *testing.T) {
-	// URI has vpc-peering-routes+vpc-peerings but no vpcs segment
-	_, _, _, _, err := vpcPeeringRouteIDsFromRef(URI("/projects/p/vpc-peerings/peer/vpc-peering-routes/route"))
+	// URI has vpcPeeringRoutes+vpcPeerings but no vpcs segment
+	_, _, _, _, err := vpcPeeringRouteIDsFromRef(URI("/projects/p/vpcPeerings/peer/vpcPeeringRoutes/route"))
 	if err == nil {
 		t.Error("expected error for URI without /vpcs/<id>")
 	}
 }
 
 func TestVPCPeeringRouteIDsFromRef_BadURI_MissingProject(t *testing.T) {
-	// URI has vpc-peering-routes+vpc-peerings+vpcs but no projects
-	_, _, _, _, err := vpcPeeringRouteIDsFromRef(URI("/providers/Aruba.Network/vpcs/v/vpc-peerings/peer/vpc-peering-routes/route"))
+	// URI has vpcPeeringRoutes+vpcPeerings+vpcs but no projects
+	_, _, _, _, err := vpcPeeringRouteIDsFromRef(URI("/providers/Aruba.Network/vpcs/v/vpcPeerings/peer/vpcPeeringRoutes/route"))
 	if err == nil {
 		t.Error("expected error for URI without /projects/<id>")
 	}
@@ -911,7 +886,7 @@ func TestVPCPeeringRoutesClientAdapter_Get_TransportError(t *testing.T) {
 	})
 	adapter := newVPCPeeringRoutesClientAdapter(testutil.NewClient(t, server.URL))
 	result, err := adapter.Get(context.Background(),
-		URI("/projects/p/providers/Aruba.Network/vpcs/v/vpc-peerings/peer/vpc-peering-routes/route"))
+		URI("/projects/p/providers/Aruba.Network/vpcs/v/vpcPeerings/peer/vpcPeeringRoutes/route"))
 	if err == nil {
 		t.Fatal("expected transport error")
 	}
@@ -966,7 +941,7 @@ func TestVPCPeeringRoutesClientAdapter_Delete_TransportError(t *testing.T) {
 	})
 	adapter := newVPCPeeringRoutesClientAdapter(testutil.NewClient(t, server.URL))
 	err := adapter.Delete(context.Background(),
-		URI("/projects/p/providers/Aruba.Network/vpcs/v/vpc-peerings/peer/vpc-peering-routes/route"))
+		URI("/projects/p/providers/Aruba.Network/vpcs/v/vpcPeerings/peer/vpcPeeringRoutes/route"))
 	if err == nil {
 		t.Fatal("expected transport error")
 	}
@@ -999,7 +974,7 @@ func TestVPCPeeringRoutesClientAdapter_List_TransportError(t *testing.T) {
 	})
 	adapter := newVPCPeeringRoutesClientAdapter(testutil.NewClient(t, server.URL))
 	_, err := adapter.List(context.Background(),
-		URI("/projects/p/providers/Aruba.Network/vpcs/v/vpc-peerings/peer"))
+		URI("/projects/p/providers/Aruba.Network/vpcs/v/vpcPeerings/peer"))
 	if err == nil {
 		t.Fatal("expected transport error")
 	}
@@ -1016,7 +991,7 @@ func TestVPCPeeringRoutesClientAdapter_List_AncestorIDBackfill(t *testing.T) {
 	})
 
 	list, err := adapter.List(context.Background(),
-		URI("/projects/proj-x/providers/Aruba.Network/vpcs/vpc-x/vpc-peerings/peer-x"))
+		URI("/projects/proj-x/providers/Aruba.Network/vpcs/vpc-x/vpcPeerings/peer-x"))
 	if err != nil {
 		t.Fatalf("List error: %v", err)
 	}

--- a/pkg/aruba/resource_vpc_peering_test.go
+++ b/pkg/aruba/resource_vpc_peering_test.go
@@ -296,7 +296,7 @@ func TestVPCPeering_FromResponsePartial(t *testing.T) {
 }
 
 func TestVPCPeering_FromResponseURIBackfill(t *testing.T) {
-	uri := "/projects/p2/network/vpcs/v2/peerings/peer-2"
+	uri := "/projects/p2/providers/Aruba.Network/vpcs/v2/vpcPeerings/peer-2"
 	id := "peer-2"
 	name := "uri-peering"
 	resp := &types.VPCPeeringResponse{
@@ -333,7 +333,7 @@ func TestVPCPeering_RefSatisfaction(t *testing.T) {
 			return w.VPCPeeringID(), true
 		}
 		return "", false
-	}, "vpc-peerings")
+	}, "vpcPeerings")
 	if !ok || pid != "peer-99" {
 		t.Errorf("extractID via withVPCPeeringID = (%q, %v)", pid, ok)
 	}
@@ -368,7 +368,7 @@ func TestVPCPeering_RefSatisfaction(t *testing.T) {
 func TestVPCPeeringIDsFromRef_TypedRef(t *testing.T) {
 	p := &VPCPeering{}
 	p.fromResponse(vpcPeeringTestResponse("peer-1", "n",
-		"/projects/p/network/vpcs/v/peerings/peer-1", "p"))
+		"/projects/p/providers/Aruba.Network/vpcs/v/vpcPeerings/peer-1", "p"))
 	pid, vid, peerid, err := vpcPeeringIDsFromRef(p)
 	if err != nil || pid != "p" || vid != "v" || peerid != "peer-1" {
 		t.Errorf("vpcPeeringIDsFromRef typed = (%q, %q, %q, %v)", pid, vid, peerid, err)
@@ -380,14 +380,6 @@ func TestVPCPeeringIDsFromRef_URIRef_CamelCase(t *testing.T) {
 	pid, vid, peerid, err := vpcPeeringIDsFromRef(ref)
 	if err != nil || pid != "p" || vid != "v" || peerid != "peer-1" {
 		t.Errorf("vpcPeeringIDsFromRef camelCase = (%q, %q, %q, %v)", pid, vid, peerid, err)
-	}
-}
-
-func TestVPCPeeringIDsFromRef_URIRef_LowerCase(t *testing.T) {
-	ref := URI("/projects/p/network/vpcs/v/peerings/peer-1")
-	pid, vid, peerid, err := vpcPeeringIDsFromRef(ref)
-	if err != nil || pid != "p" || vid != "v" || peerid != "peer-1" {
-		t.Errorf("vpcPeeringIDsFromRef lowercase = (%q, %q, %q, %v)", pid, vid, peerid, err)
 	}
 }
 
@@ -775,16 +767,16 @@ func TestVPCPeeringsClientAdapter_List_NonTwoXX(t *testing.T) {
 }
 
 func TestVPCPeeringIDsFromRef_BadURI_MissingVPC(t *testing.T) {
-	// URI has vpc-peerings but no vpcs segment
-	_, _, _, err := vpcPeeringIDsFromRef(URI("/projects/p/vpc-peerings/peer"))
+	// URI has vpcPeerings but no vpcs segment
+	_, _, _, err := vpcPeeringIDsFromRef(URI("/projects/p/vpcPeerings/peer"))
 	if err == nil {
 		t.Error("expected error for URI without /vpcs/<id>")
 	}
 }
 
 func TestVPCPeeringIDsFromRef_BadURI_MissingProject(t *testing.T) {
-	// URI has vpc-peerings+vpcs but no projects
-	_, _, _, err := vpcPeeringIDsFromRef(URI("/providers/Aruba.Network/vpcs/v/vpc-peerings/peer"))
+	// URI has vpcPeerings+vpcs but no projects
+	_, _, _, err := vpcPeeringIDsFromRef(URI("/providers/Aruba.Network/vpcs/v/vpcPeerings/peer"))
 	if err == nil {
 		t.Error("expected error for URI without /projects/<id>")
 	}
@@ -835,7 +827,7 @@ func TestVPCPeeringsClientAdapter_Get_TransportError(t *testing.T) {
 		conn.Close()
 	})
 	adapter := newVPCPeeringsClientAdapter(testutil.NewClient(t, server.URL))
-	result, err := adapter.Get(context.Background(), URI("/projects/p/providers/Aruba.Network/vpcs/v/vpc-peerings/peer"))
+	result, err := adapter.Get(context.Background(), URI("/projects/p/providers/Aruba.Network/vpcs/v/vpcPeerings/peer"))
 	if err == nil {
 		t.Fatal("expected transport error")
 	}
@@ -888,7 +880,7 @@ func TestVPCPeeringsClientAdapter_Delete_TransportError(t *testing.T) {
 		conn.Close()
 	})
 	adapter := newVPCPeeringsClientAdapter(testutil.NewClient(t, server.URL))
-	err := adapter.Delete(context.Background(), URI("/projects/p/providers/Aruba.Network/vpcs/v/vpc-peerings/peer"))
+	err := adapter.Delete(context.Background(), URI("/projects/p/providers/Aruba.Network/vpcs/v/vpcPeerings/peer"))
 	if err == nil {
 		t.Fatal("expected transport error")
 	}

--- a/pkg/aruba/resource_vpn_route.go
+++ b/pkg/aruba/resource_vpn_route.go
@@ -145,12 +145,7 @@ func (r *VPNRoute) fromResponse(resp *types.VPNRouteResponse) {
 			r.projectID = ids["projects"]
 		}
 		if r.vpnTunnelID == "" {
-			// Production URI uses "vpnTunnels"; mixin/test form uses "vpn-tunnels".
-			if v := ids["vpnTunnels"]; v != "" {
-				r.vpnTunnelID = v
-			} else {
-				r.vpnTunnelID = ids["vpn-tunnels"]
-			}
+			r.vpnTunnelID = ids["vpnTunnels"]
 		}
 	}
 }
@@ -424,20 +419,13 @@ func (a *vpnRoutesClientAdapter) List(ctx context.Context, tunnel Ref, opts ...C
 }
 
 // vpnRouteIDsFromRef extracts (projectID, vpnTunnelID, vpnRouteID) from a Ref.
-// Accepts camelCase segments ("vpnTunnels", "vpnRoutes") and kebab-case forms.
 func vpnRouteIDsFromRef(ref Ref) (projectID, vpnTunnelID, vpnRouteID string, err error) {
 	rid, ok := extractID(ref, func(r Ref) (string, bool) {
 		if w, ok := r.(withVPNRouteID); ok {
 			return w.VPNRouteID(), true
 		}
 		return "", false
-	}, "vpn-routes")
-	if !ok {
-		if v := parseURIIDs(ref.URI())["vpnRoutes"]; v != "" {
-			rid = v
-			ok = true
-		}
-	}
+	}, "vpnRoutes")
 	if !ok || rid == "" {
 		return "", "", "", fmt.Errorf("cannot determine VPN route ID from Ref %q", ref.URI())
 	}
@@ -446,13 +434,7 @@ func vpnRouteIDsFromRef(ref Ref) (projectID, vpnTunnelID, vpnRouteID string, err
 			return w.VPNTunnelID(), true
 		}
 		return "", false
-	}, "vpn-tunnels")
-	if !ok {
-		if v := parseURIIDs(ref.URI())["vpnTunnels"]; v != "" {
-			tid = v
-			ok = true
-		}
-	}
+	}, "vpnTunnels")
 	if !ok || tid == "" {
 		return "", "", "", fmt.Errorf("cannot determine VPN tunnel ID from Ref %q", ref.URI())
 	}

--- a/pkg/aruba/resource_vpn_route_test.go
+++ b/pkg/aruba/resource_vpn_route_test.go
@@ -118,17 +118,6 @@ func TestVPNRoute_IntoVPNTunnel_URIRef_CamelCase(t *testing.T) {
 // IntoVPNTunnel — URI Ref (kebab form; mixin test form)
 // --------------------------------------------------------------------------
 
-func TestVPNRoute_IntoVPNTunnel_URIRef_KebabCase(t *testing.T) {
-	r := NewVPNRoute().IntoVPNTunnel(URI("/projects/p/network/vpn-tunnels/t-1"))
-
-	if r.Err() != nil {
-		t.Fatalf("unexpected Err() = %v", r.Err())
-	}
-	if r.VPNTunnelID() != "t-1" {
-		t.Errorf("VPNTunnelID() = %q", r.VPNTunnelID())
-	}
-}
-
 // --------------------------------------------------------------------------
 // IntoVPNTunnel — bad Ref
 // --------------------------------------------------------------------------
@@ -201,7 +190,7 @@ func TestVPNRoute_RefSatisfaction(t *testing.T) {
 			return w.VPNRouteID(), true
 		}
 		return "", false
-	}, "vpn-routes")
+	}, "vpnRoutes")
 	if !ok || rid != "r-1" {
 		t.Errorf("extractID via withVPNRouteID = (%q, %v)", rid, ok)
 	}
@@ -211,7 +200,7 @@ func TestVPNRoute_RefSatisfaction(t *testing.T) {
 			return w.VPNTunnelID(), true
 		}
 		return "", false
-	}, "vpn-tunnels")
+	}, "vpnTunnels")
 	if !ok || tid != "t-1" {
 		t.Errorf("extractID via withVPNTunnelID = (%q, %v)", tid, ok)
 	}
@@ -345,28 +334,6 @@ func TestVPNRoute_FromResponseURIBackfill_CamelCase(t *testing.T) {
 	}
 }
 
-func TestVPNRoute_FromResponseURIBackfill_KebabCase(t *testing.T) {
-	uri := "/projects/p3/network/vpn-tunnels/t-3/vpn-routes/r-3"
-	id := "r-3"
-	name := "kebab-route"
-	resp := &types.VPNRouteResponse{
-		Metadata: types.ResourceMetadataResponse{
-			ID:   &id,
-			URI:  &uri,
-			Name: &name,
-		},
-	}
-	r := &VPNRoute{}
-	r.fromResponse(resp)
-
-	if r.ProjectID() != "p3" {
-		t.Errorf("ProjectID() via URI fallback = %q", r.ProjectID())
-	}
-	if r.vpnTunnelID != "t-3" {
-		t.Errorf("vpnTunnelID via URI fallback = %q", r.vpnTunnelID)
-	}
-}
-
 // --------------------------------------------------------------------------
 // vpnRouteIDsFromRef helper
 // --------------------------------------------------------------------------
@@ -388,14 +355,6 @@ func TestVPNRouteIDsFromRef_URIRef_CamelCase(t *testing.T) {
 	pid, tid, rid, err := vpnRouteIDsFromRef(ref)
 	if err != nil || pid != "p" || tid != "t-1" || rid != "r-1" {
 		t.Errorf("vpnRouteIDsFromRef camelCase = (%q, %q, %q, %v)", pid, tid, rid, err)
-	}
-}
-
-func TestVPNRouteIDsFromRef_URIRef_KebabCase(t *testing.T) {
-	ref := URI("/projects/p/network/vpn-tunnels/t-1/vpn-routes/r-1")
-	pid, tid, rid, err := vpnRouteIDsFromRef(ref)
-	if err != nil || pid != "p" || tid != "t-1" || rid != "r-1" {
-		t.Errorf("vpnRouteIDsFromRef kebab = (%q, %q, %q, %v)", pid, tid, rid, err)
 	}
 }
 
@@ -797,16 +756,16 @@ func TestVPNRoutesClientAdapter_List_NonTwoXX(t *testing.T) {
 }
 
 func TestVPNRouteIDsFromRef_BadURI_MissingTunnelID(t *testing.T) {
-	// URI has vpn-routes but no vpn-tunnels segment
-	_, _, _, err := vpnRouteIDsFromRef(URI("/projects/p/vpn-routes/route"))
+	// URI has vpnRoutes but no vpnTunnels segment
+	_, _, _, err := vpnRouteIDsFromRef(URI("/projects/p/vpnRoutes/route"))
 	if err == nil {
 		t.Error("expected error for URI without vpn tunnel segment")
 	}
 }
 
 func TestVPNRouteIDsFromRef_BadURI_MissingProjectID(t *testing.T) {
-	// URI has vpn-routes+vpn-tunnels but no projects
-	_, _, _, err := vpnRouteIDsFromRef(URI("/providers/Aruba.Network/vpn-tunnels/t/vpn-routes/route"))
+	// URI has vpnRoutes+vpnTunnels but no projects
+	_, _, _, err := vpnRouteIDsFromRef(URI("/providers/Aruba.Network/vpnTunnels/t/vpnRoutes/route"))
 	if err == nil {
 		t.Error("expected error for URI without /projects/<id>")
 	}
@@ -858,7 +817,7 @@ func TestVPNRoutesClientAdapter_Get_TransportError(t *testing.T) {
 	})
 	adapter := newVPNRoutesClientAdapter(testutil.NewClient(t, server.URL))
 	result, err := adapter.Get(context.Background(),
-		URI("/projects/p/providers/Aruba.Network/vpn-tunnels/t/vpn-routes/r"))
+		URI("/projects/p/providers/Aruba.Network/vpnTunnels/t/vpnRoutes/r"))
 	if err == nil {
 		t.Fatal("expected transport error")
 	}
@@ -913,7 +872,7 @@ func TestVPNRoutesClientAdapter_Delete_TransportError(t *testing.T) {
 	})
 	adapter := newVPNRoutesClientAdapter(testutil.NewClient(t, server.URL))
 	err := adapter.Delete(context.Background(),
-		URI("/projects/p/providers/Aruba.Network/vpn-tunnels/t/vpn-routes/r"))
+		URI("/projects/p/providers/Aruba.Network/vpnTunnels/t/vpnRoutes/r"))
 	if err == nil {
 		t.Fatal("expected transport error")
 	}
@@ -946,7 +905,7 @@ func TestVPNRoutesClientAdapter_List_TransportError(t *testing.T) {
 	})
 	adapter := newVPNRoutesClientAdapter(testutil.NewClient(t, server.URL))
 	_, err := adapter.List(context.Background(),
-		URI("/projects/p/providers/Aruba.Network/vpn-tunnels/t"))
+		URI("/projects/p/providers/Aruba.Network/vpnTunnels/t"))
 	if err == nil {
 		t.Fatal("expected transport error")
 	}
@@ -963,7 +922,7 @@ func TestVPNRoutesClientAdapter_List_AncestorIDBackfill(t *testing.T) {
 	})
 
 	list, err := adapter.List(context.Background(),
-		URI("/projects/proj-x/providers/Aruba.Network/vpn-tunnels/tunnel-x"))
+		URI("/projects/proj-x/providers/Aruba.Network/vpnTunnels/tunnel-x"))
 	if err != nil {
 		t.Fatalf("List error: %v", err)
 	}

--- a/pkg/aruba/resource_vpn_tunnel.go
+++ b/pkg/aruba/resource_vpn_tunnel.go
@@ -526,7 +526,6 @@ func (a *vpnTunnelsClientAdapter) List(ctx context.Context, project Ref, opts ..
 }
 
 // vpnTunnelIDsFromRef extracts (projectID, vpnTunnelID) from a Ref.
-// Accepts the production camelCase segment "vpnTunnels" and the mixin/test form "vpn-tunnels".
 func vpnTunnelIDsFromRef(ref Ref) (projectID, vpnTunnelID string, err error) {
 	tid, ok := extractID(ref, func(r Ref) (string, bool) {
 		if w, ok := r.(withVPNTunnelID); ok {
@@ -534,12 +533,6 @@ func vpnTunnelIDsFromRef(ref Ref) (projectID, vpnTunnelID string, err error) {
 		}
 		return "", false
 	}, "vpnTunnels")
-	if !ok || tid == "" {
-		if v := parseURIIDs(ref.URI())["vpn-tunnels"]; v != "" {
-			tid = v
-			ok = true
-		}
-	}
 	if !ok || tid == "" {
 		return "", "", fmt.Errorf("cannot determine VPN tunnel ID from Ref %q", ref.URI())
 	}

--- a/pkg/aruba/resource_vpn_tunnel_test.go
+++ b/pkg/aruba/resource_vpn_tunnel_test.go
@@ -619,7 +619,7 @@ func TestVPNTunnel_RefSatisfaction(t *testing.T) {
 			return w.VPNTunnelID(), true
 		}
 		return "", false
-	}, "vpn-tunnels")
+	}, "vpnTunnels")
 	if !ok || tid != "t-99" {
 		t.Errorf("extractID via withVPNTunnelID = (%q, %v)", tid, ok)
 	}
@@ -655,14 +655,6 @@ func TestVPNTunnelIDsFromRef_URIRef_CamelCase(t *testing.T) {
 	pid, tid, err := vpnTunnelIDsFromRef(ref)
 	if err != nil || pid != "p" || tid != "t-1" {
 		t.Errorf("vpnTunnelIDsFromRef camelCase = (%q, %q, %v)", pid, tid, err)
-	}
-}
-
-func TestVPNTunnelIDsFromRef_URIRef_KebabCase(t *testing.T) {
-	ref := URI("/projects/p/providers/Aruba.Network/vpn-tunnels/t-1")
-	pid, tid, err := vpnTunnelIDsFromRef(ref)
-	if err != nil || pid != "p" || tid != "t-1" {
-		t.Errorf("vpnTunnelIDsFromRef kebab-case = (%q, %q, %v)", pid, tid, err)
 	}
 }
 


### PR DESCRIPTION
## Summary

- Fixes `SecurityGroupsClient.Get`/`Update`/`Delete` always failing with `cannot determine security group ID from Ref "..."` when using refs produced by `aruba.SecurityGroupRef(...)` — the lookup expected `security-groups` (hyphenated) but the Ref emits and the live API returns `securityGroups` (camelCase per docs).
- Comprehensive audit of all URI segments across the SDK: `securityGroups`, `securityRules`, `loadBalancers`, `keyPairs`, `blockStorages` now use the exact casing documented at <https://api.arubacloud.com/docs/>. Internal path constants, Ref helpers, `*IDsFromRef` helpers, scoped-mixin lookups, `fromResponse` URI parsing, and all test fixtures are aligned.
- Removed all hyphenated/legacy fallback lookups (`security-groups`, `security-rules`, `vpn-tunnels`, `peerings`). Each resource now has a single canonical URI segment.

## Test plan

- [ ] `make verify` passes (lint + race-detected tests + build) — confirmed locally
- [ ] `TestSecurityGroupIDsFromRef_URIRef_DocsForm` — new regression test covering the exact round-trip `SecurityGroupRef(...)` → `securityGroupIDsFromRef(...)` that was broken
- [ ] All existing `*IDsFromRef`, `fromResponse`, scoped-mixin, and adapter tests continue to pass with the updated canonical segments

Closes #297