### PR TITLE
fix(list)+feat(wrappers): JSON-safe List[T].Raw(), HTTP envelope on lists, RawJSON()/RawYAML() on all wrappers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,8 +26,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Added
+
+- `List[T]` now embeds `httpEnvelopeMixin`, exposing the same HTTP-envelope
+  accessors as single-resource wrappers — `StatusCode()`, `Headers()`,
+  `RawHTTP()`, `RawError()` — so list responses are fully introspectable on a
+  par with `Create`/`Get`/`Update` calls. (#298)
+- `types.ListResponse.BaseList()` returns the embedded pagination/total
+  metadata; promoted automatically onto every `*types.XxxList` via Go's
+  method-promotion rules. (#298)
+
 ### Fixed
 
+- `List[T].Raw()` previously returned the full `*types.Response[XxxList]`
+  envelope, which contains `*http.Response` whose `GetBody` is a function
+  field — `json.Marshal(list.Raw())` failed with
+  `json: unsupported type: func() (io.ReadCloser, error)` for every resource
+  list. `Raw()` now returns only the JSON-safe wire payload (`*types.XxxList`,
+  i.e. `resp.Data`). (#298)
 - `SecurityGroupsClient.Get`/`Update`/`Delete` rejected every ref produced by
   `aruba.SecurityGroupRef(...)` with `cannot determine security group ID from Ref "..."`,
   because the lookup expected a hyphenated `security-groups` segment that the Ref never

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
   marshalers for the typed response payload returned by `Raw()`. Return `nil`
   when the wrapper has no payload. YAML output uses `gopkg.in/yaml.v3`
   (promoted from indirect to direct dependency).
+- New documentation page **Working at Low Level** (EN + IT) collecting the
+  residual cases that require importing `pkg/types` or `pkg/async`:
+  non-promoted wire fields, structured validation errors, `LinkedResources()`
+  traversal, and concurrent/custom polling. The `pkg/async` deep-dive moved
+  here from `async.md`. Existing `response-handling.md` examples updated to
+  use single-import equivalents (`vpcList.Total()`, `RawJSON()`, etc.).
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 - `types.ListResponse.BaseList()` returns the embedded pagination/total
   metadata; promoted automatically onto every `*types.XxxList` via Go's
   method-promotion rules. (#298)
+- `RawJSON() []byte` / `RawYAML() []byte` on every resource wrapper (31
+  resources including `KmipCertificate`) and on `List[T]`. Convenience
+  marshalers for the typed response payload returned by `Raw()`. Return `nil`
+  when the wrapper has no payload. YAML output uses `gopkg.in/yaml.v3`
+  (promoted from indirect to direct dependency).
 
 ### Fixed
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -11,3 +11,4 @@ Detailed guidance is split across files in the `ai/` folder. Read only what is r
 | Implementing features, understanding design patterns, adding resources | [`ai/ARCHITECTURE.md`](ai/ARCHITECTURE.md) |
 | Naming, code style, type conventions, error handling rules | [`ai/CONVENTIONS.md`](ai/CONVENTIONS.md) |
 | Known bugs, risks, and refactoring backlog | [`ai/TECH_DEBT.md`](ai/TECH_DEBT.md) |
+| Single-import design / user-facing import boundaries | [`ai/ARCHITECTURE.md`](ai/ARCHITECTURE.md) |

--- a/ai/ARCHITECTURE.md
+++ b/ai/ARCHITECTURE.md
@@ -256,7 +256,7 @@ type Ref interface { URI() string; ID() string }
 
 ### `List[T Wrapper]` (`pkg/aruba/list.go`)
 
-Generic paginated container, constrained to `Wrapper { URI(); ID() }`. Embeds `httpEnvelopeMixin` (same HTTP envelope accessors as single-resource wrappers). Carries `items`, `total`, pagination link URLs (`self/prev/next/first/last`), `callerOpts`, `raw` (JSON-safe wire payload, a `*types.XxxList`), and a `refetch` callback. Navigation methods: `Items()`, `Total()`, `HasNext()`, `Next(ctx)`, `All(ctx, yield)`.
+Generic paginated container, constrained to `Wrapper { URI(); ID() }`. Embeds `httpEnvelopeMixin` (same HTTP envelope accessors as single-resource wrappers). Carries `items`, `total`, pagination link URLs (`self/prev/next/first/last`), `callerOpts`, `raw` (JSON-safe wire payload, a `*types.XxxList`), and a `refetch` callback. Navigation methods: `Items()`, `Total()`, `HasNext()`, `Next(ctx)`, `All(ctx, yield)`. Convenience marshalers `RawJSON() []byte` and `RawYAML() []byte` are available on `List[T]` and on every single-resource wrapper.
 
 Adapters construct lists via `newListFromResponse[T Wrapper, L listPayload](items, resp, opts, refetch)` — a generic helper that extracts pagination from `resp.Data.BaseList()` (promoted from the embedded `types.ListResponse`), stores `resp.Data` as the JSON-safe `raw` payload, and populates the HTTP envelope mixin. The low-level `newList(...)` constructor is preserved for use in unit tests.
 

--- a/ai/ARCHITECTURE.md
+++ b/ai/ARCHITECTURE.md
@@ -214,7 +214,7 @@ The mixins were split into three files by responsibility:
 | `zonalMixin` | `mixin_common.go` | Extends `regionalMixin` with an availability-zone pointer (wire field `dataCenter`). |
 | `responseMetadataMixin` | `mixin_common.go` | Holds the post-server `*types.ResourceMetadataResponse`; exposes `ID()`, `RespURI()`, `CreatedAt()`, `Version()`, etc. |
 | `linkedMixin` | `mixin_common.go` | Stores `[]types.LinkedResource` returned by the API. |
-| `httpEnvelopeMixin` | `mixin_common.go` | Captures StatusCode / Headers / RawBody / `*http.Response` / parsed ErrorResponse after every adapter call. |
+| `httpEnvelopeMixin` | `mixin_common.go` | Captures StatusCode / Headers / RawBody / `*http.Response` / parsed ErrorResponse after every adapter call. Embedded by every single-resource wrapper and by `List[T]`. |
 | `projectScopedMixin` | `mixin_scoped.go` | Direct child of a Project; `intoProject(Ref)` extracts `projectID` via `extractID`. |
 | `vpcScopedMixin` | `mixin_scoped.go` | Direct child of a VPC; inherits `projectID` from parent. |
 | `securityGroupScopedMixin` | `mixin_scoped.go` | Direct child of a SecurityGroup; inherits `vpcID` + `projectID`. |
@@ -256,7 +256,9 @@ type Ref interface { URI() string; ID() string }
 
 ### `List[T Wrapper]` (`pkg/aruba/list.go`)
 
-Generic paginated container, constrained to `Wrapper { URI(); ID() }`. Carries `items`, `total`, pagination link URLs (`self/prev/next/first/last`), `callerOpts`, `raw` HTTP envelope, and a `refetch` callback. Navigation methods: `Items()`, `Total()`, `HasNext()`, `Next(ctx)`, `All(ctx, yield)`. The `refetch` callback is structurally wired in every adapter but currently returns a "not yet wired" error — pagination requires re-calling `List` with updated `CallOption` paging parameters.
+Generic paginated container, constrained to `Wrapper { URI(); ID() }`. Embeds `httpEnvelopeMixin` (same HTTP envelope accessors as single-resource wrappers). Carries `items`, `total`, pagination link URLs (`self/prev/next/first/last`), `callerOpts`, `raw` (JSON-safe wire payload, a `*types.XxxList`), and a `refetch` callback. Navigation methods: `Items()`, `Total()`, `HasNext()`, `Next(ctx)`, `All(ctx, yield)`.
+
+Adapters construct lists via `newListFromResponse[T Wrapper, L listPayload](items, resp, opts, refetch)` — a generic helper that extracts pagination from `resp.Data.BaseList()` (promoted from the embedded `types.ListResponse`), stores `resp.Data` as the JSON-safe `raw` payload, and populates the HTTP envelope mixin. The low-level `newList(...)` constructor is preserved for use in unit tests.
 
 ### Wait helpers and async
 

--- a/ai/ARCHITECTURE.md
+++ b/ai/ARCHITECTURE.md
@@ -22,6 +22,16 @@ The public entry point is `NewClient(options *Options) (Client, error)` in `pkg/
 
 **Cross-client injection:** Some service clients receive other concrete impl clients at build time to enforce resource pre-conditions. For example, `SecurityGroupRulesClientImpl` holds a `*securityGroupsClientImpl` and calls `waitForSecurityGroupActive()` before creating a rule. These dependencies are always concrete types, not interfaces, because they call internal methods not on any interface.
 
+## Single-import design principle
+
+`pkg/aruba` is the user-facing entry point. The contract: importing only `github.com/Arubacloud/sdk-go/pkg/aruba` resolves ~99.9% of real-world use cases. This shapes three concrete patterns in the codebase:
+
+1. **Re-exported enums** — every wire-string enum from `pkg/types` is aliased in `pkg/aruba/aliases.go` (`type State = types.State`, plus matching constants `aruba.StateActive`, `aruba.RuleProtocolTCP`, etc.). When adding a new enum to `pkg/types`, add the matching alias in `aliases.go`.
+2. **Wrapper-side serialisation** — every wrapper and `List[T]` exposes `Raw()`, `RawJSON()`, `RawYAML()` (`pkg/aruba/raw_marshal.go`, `pkg/aruba/list.go`). Callers serialising responses for `--output json/yaml` never need to import `pkg/types`.
+3. **Wait helpers on the wrapper** — `WaitUntilReady`, `WaitUntilActive`, `WaitUntilStates` cover the polling surface. `pkg/async` is reserved for genuinely multi-import scenarios (concurrent waits, arbitrary-condition polling).
+
+The residual cases where users must reach into `pkg/types` or `pkg/async` — non-promoted wire fields, structured validation error types (`types.ValidationError`, `types.MetadataValidationError`), `LinkedResources()` traversal, and `pkg/async` background polling — are documented in `docs/website/docs/working-at-low-level.md`. When introducing new public surface, ask first whether it can be exposed via `pkg/aruba` (direct method, alias, or `Raw*` helper) before pushing callers into a second import.
+
 ## HTTP request lifecycle (`internal/restclient/`)
 
 `restclient.Client.DoRequest(ctx, method, path, body, queryParams, headers)` follows these steps:

--- a/ai/CONVENTIONS.md
+++ b/ai/CONVENTIONS.md
@@ -5,6 +5,7 @@
 - Public API surface lives in `pkg/` — types, interfaces, and the `NewClient` entry point
 - Concrete implementations live in `internal/` — not importable by external modules
 - Only interfaces and data types are exported; concrete impl structs are always unexported
+- **Prefer `aruba.X` over `types.X` in public surface.** When `pkg/aruba` needs to refer to a `pkg/types` enum or struct, alias it in `pkg/aruba/aliases.go` (`type Foo = types.Foo` plus matching constants). This preserves the single-import contract — see `ai/ARCHITECTURE.md` › "Single-import design principle".
 
 ## Naming
 

--- a/docs/website/docs/async.md
+++ b/docs/website/docs/async.md
@@ -207,78 +207,9 @@ All polling respects the `ctx` deadline and cancellation. If the context expires
 
 ---
 
-## Advanced: Background Polling with `pkg/async`
+## Advanced: concurrent and custom polling
 
-`WaitUntilReady`, `WaitUntilActive`, and `WaitUntilStates` block the calling goroutine. If you need to **start multiple waits concurrently**, or **poll an arbitrary condition** (not just a resource state), use the lower-level `pkg/async` package directly.
-
-`pkg/async` is a public package — import it alongside `pkg/aruba`:
-
-```go
-import (
-    "github.com/Arubacloud/sdk-go/pkg/aruba"
-    "github.com/Arubacloud/sdk-go/pkg/async"
-    "github.com/Arubacloud/sdk-go/pkg/types"
-)
-```
-
-### `WaitFor` — start a background future
-
-`async.WaitFor` launches a polling goroutine immediately and returns an `*async.AsyncClient[T]` (a future). You call `.Await(ctx)` later to block for the result:
-
-```go
-// Start polling VPC1 and VPC2 concurrently
-futureVPC1 := async.DefaultWaitFor(ctx,
-    func(ctx context.Context) (*types.Response[types.VPCResponse], error) {
-        return arubaClient.FromNetwork().VPCs().Get(ctx, vpc1)
-    },
-    func(resp *types.Response[types.VPCResponse]) (bool, error) {
-        if resp == nil || resp.Data == nil {
-            return false, nil
-        }
-        var state types.State
-        if resp.Data.Properties != nil && resp.Data.Properties.Status != nil &&
-            resp.Data.Properties.Status.State != nil {
-            state = *resp.Data.Properties.Status.State
-        }
-        return state == types.StateActive, nil
-    },
-)
-
-futureVPC2 := async.DefaultWaitFor(ctx, /* same pattern for vpc2 */)
-
-// Block for both results
-resp1, err1 := futureVPC1.Await(ctx)
-resp2, err2 := futureVPC2.Await(ctx)
-```
-
-`DefaultWaitFor` uses the package defaults: `DefaultRetries=60`, `DefaultBaseDelay=10s`, `DefaultTimeout=600s`. Use `async.WaitFor(ctx, retries, baseDelay, timeout, call, check)` to override.
-
-### `WaitFor` signature
-
-```go
-func WaitFor[T any](
-    ctx         context.Context,
-    retries     int,
-    baseDelay   time.Duration,
-    timeout     time.Duration,
-    call        func(ctx context.Context) (*types.Response[T], error),
-    check       func(*types.Response[T]) (bool, error),
-) *AsyncClient[T]
-```
-
-- `call` — the polling function, called once per iteration.
-- `check` — returns `(true, nil)` to signal success, `(true, error)` to signal terminal failure, `(false, nil)` to keep polling.
-- If `check` is `nil`, any non-nil `response.Data` is treated as success.
-
-### `AsyncClient.Await`
-
-```go
-func (f *AsyncClient[T]) Await(ctx context.Context) (*types.Response[T], error)
-```
-
-Blocks until the background goroutine sends its result or `ctx` is cancelled. Subsequent calls return the **cached** result immediately — safe to call multiple times.
-
-> `pkg/async` works directly with the `pkg/types` wire structs. This is the only layer of the SDK where you'll interact with `types.Response[T]` and `types.*Response` types directly.
+`WaitUntilReady`, `WaitUntilActive`, and `WaitUntilStates` block the calling goroutine. When you need to **start multiple waits concurrently**, or **poll an arbitrary condition** (not just a resource state), drop down to `pkg/async`. That layer works directly with `*types.Response[T]` and is documented separately — see [Working at Low Level](./working-at-low-level#background-polling-with-pkgasync).
 
 ---
 
@@ -286,3 +217,4 @@ Blocks until the background goroutine sends its result or `ctx` is cancelled. Su
 
 - [API Walkthrough](./walkthrough) — full Create + `WaitUntilReady` + Update + Delete lifecycle example
 - [Response Handling](./response-handling) — how `*aruba.HTTPError` propagates through `WaitUntilReady` when the API returns 4xx/5xx
+- [Working at Low Level](./working-at-low-level) — background polling with `pkg/async`, accessing non-promoted wire fields

--- a/docs/website/docs/response-handling.md
+++ b/docs/website/docs/response-handling.md
@@ -95,6 +95,18 @@ raw := vpc.Raw()                         // underlying wire struct
 fmt.Println(raw.Properties.IsDefault)    // field not on the wrapper
 ```
 
+### JSON / YAML convenience
+
+For CLI-style `--output json` / `--output yaml` flags, every wrapper exposes
+pre-marshaled byte slices:
+
+```go
+fmt.Println(string(vpc.RawJSON()))   // JSON-encoded *types.VPCResponse
+fmt.Println(string(vpc.RawYAML()))   // YAML-encoded *types.VPCResponse
+```
+
+Returns `nil` if the wrapper has not been populated yet (zero-value receiver).
+
 ## List Responses
 
 `List[T]` exposes the same introspection surface as single-resource wrappers:
@@ -113,6 +125,17 @@ fmt.Println("trace-id:", vpcList.Headers().Get("X-Trace-Id"))
 _, body := vpcList.RawHTTP()
 fmt.Println("raw body bytes:", len(body))
 ```
+
+### JSON / YAML convenience
+
+`List[T]` also exposes `RawJSON()` and `RawYAML()` for the typed list payload:
+
+```go
+fmt.Println(string(vpcList.RawJSON()))   // JSON-encoded *types.VPCList
+fmt.Println(string(vpcList.RawYAML()))   // YAML-encoded *types.VPCList
+```
+
+Returns `nil` when the list has no payload (`Raw() == nil`).
 
 `Raw()` returns only the JSON-safe payload (`*types.XxxList`). The HTTP envelope is exposed via separate accessors because `*http.Response` is not JSON-serialisable.
 

--- a/docs/website/docs/response-handling.md
+++ b/docs/website/docs/response-handling.md
@@ -95,6 +95,27 @@ raw := vpc.Raw()                         // underlying wire struct
 fmt.Println(raw.Properties.IsDefault)    // field not on the wrapper
 ```
 
+## List Responses
+
+`List[T]` exposes the same introspection surface as single-resource wrappers:
+
+```go
+vpcList, err := arubaClient.FromNetwork().VPCs().List(ctx, proj)
+if err != nil { /* … */ }
+
+// Wire payload — JSON-marshalable; contains pagination links and values.
+raw := vpcList.Raw().(*types.VPCList)
+fmt.Println("server total:", raw.Total)
+
+// HTTP envelope — same accessors as single-resource wrappers.
+fmt.Println("status:", vpcList.StatusCode())
+fmt.Println("trace-id:", vpcList.Headers().Get("X-Trace-Id"))
+_, body := vpcList.RawHTTP()
+fmt.Println("raw body bytes:", len(body))
+```
+
+`Raw()` returns only the JSON-safe payload (`*types.XxxList`). The HTTP envelope is exposed via separate accessors because `*http.Response` is not JSON-serialisable.
+
 ## Setter-Time Errors
 
 Fluent builder setters never return errors — instead they record them internally. The error surfaces the first time you call `Create` or `Update`. You can also check eagerly:

--- a/docs/website/docs/response-handling.md
+++ b/docs/website/docs/response-handling.md
@@ -101,23 +101,27 @@ For CLI-style `--output json` / `--output yaml` flags, every wrapper exposes
 pre-marshaled byte slices:
 
 ```go
-fmt.Println(string(vpc.RawJSON()))   // JSON-encoded *types.VPCResponse
-fmt.Println(string(vpc.RawYAML()))   // YAML-encoded *types.VPCResponse
+fmt.Println(string(vpc.RawJSON()))   // JSON-encoded payload
+fmt.Println(string(vpc.RawYAML()))   // YAML-encoded payload
 ```
 
 Returns `nil` if the wrapper has not been populated yet (zero-value receiver).
 
 ## List Responses
 
-`List[T]` exposes the same introspection surface as single-resource wrappers:
+`List[T]` exposes the same introspection surface as single-resource wrappers,
+all without ever importing `pkg/types`:
 
 ```go
 vpcList, err := arubaClient.FromNetwork().VPCs().List(ctx, proj)
 if err != nil { /* … */ }
 
-// Wire payload — JSON-marshalable; contains pagination links and values.
-raw := vpcList.Raw().(*types.VPCList)
-fmt.Println("server total:", raw.Total)
+// Pagination + counts — typed accessors on the wrapper.
+fmt.Println("server total:", vpcList.Total())
+if vpcList.HasNext() {
+    nextPage, _ := vpcList.Next(ctx)
+    _ = nextPage
+}
 
 // HTTP envelope — same accessors as single-resource wrappers.
 fmt.Println("status:", vpcList.StatusCode())
@@ -131,13 +135,16 @@ fmt.Println("raw body bytes:", len(body))
 `List[T]` also exposes `RawJSON()` and `RawYAML()` for the typed list payload:
 
 ```go
-fmt.Println(string(vpcList.RawJSON()))   // JSON-encoded *types.VPCList
-fmt.Println(string(vpcList.RawYAML()))   // YAML-encoded *types.VPCList
+fmt.Println(string(vpcList.RawJSON()))   // JSON-encoded payload
+fmt.Println(string(vpcList.RawYAML()))   // YAML-encoded payload
 ```
 
 Returns `nil` when the list has no payload (`Raw() == nil`).
 
-`Raw()` returns only the JSON-safe payload (`*types.XxxList`). The HTTP envelope is exposed via separate accessors because `*http.Response` is not JSON-serialisable.
+> **Reaching non-promoted fields.** If you need a field that isn't exposed by
+> the wrapper surface, see [Working at Low Level](./working-at-low-level) —
+> it covers the typed wire-struct cast and the few other escape hatches that
+> require importing `pkg/types`.
 
 ## Setter-Time Errors
 

--- a/docs/website/docs/working-at-low-level.md
+++ b/docs/website/docs/working-at-low-level.md
@@ -1,0 +1,268 @@
+# Working at Low Level
+
+## Why this page exists
+
+The SDK is designed around a **single-import principle**: importing only `github.com/Arubacloud/sdk-go/pkg/aruba` covers ~99.9% of real-world use cases.
+
+The wrapper surface — typed accessors, `WaitUntil*` helpers, `RawJSON()` / `RawYAML()` — is designed so you rarely need to reach into the underlying wire structs. For the 0.1% of cases where you do, this page collects every escape hatch that requires a second import.
+
+> These patterns are **intentional and supported** — they are escape hatches, not workarounds. When you hit a case not covered by the wrapper API, reach for these rather than opening a feature request.
+
+---
+
+## Accessing non-promoted wire fields with `Raw()`
+
+Every wrapper exposes a `Raw()` method that returns the underlying `*types.XxxResponse` struct. Use it when you need a field that hasn't been promoted to the wrapper surface:
+
+```go
+import (
+    "github.com/Arubacloud/sdk-go/pkg/aruba"
+    "github.com/Arubacloud/sdk-go/pkg/types"
+)
+
+vpc, err := arubaClient.FromNetwork().VPCs().Get(ctx, ref)
+if err != nil { /* … */ }
+
+raw := vpc.Raw()                          // *types.VPCResponse
+fmt.Println(raw.Properties.IsDefault)     // field not promoted to the wrapper
+```
+
+For lists, `Raw()` returns `any` and you type-assert to the concrete list type:
+
+```go
+vpcList, err := arubaClient.FromNetwork().VPCs().List(ctx, proj)
+if err != nil { /* … */ }
+
+raw := vpcList.Raw().(*types.VPCList)     // requires pkg/types import
+fmt.Println("server total:", raw.Total)   // same as vpcList.Total() — shown for illustration
+fmt.Println("self link:", raw.Self)
+```
+
+> **Prefer wrapper accessors for serialisation.** If your goal is JSON or YAML output, use `vpc.RawJSON()` / `vpc.RawYAML()` (or the `List[T]` equivalents) — no `pkg/types` import required.
+>
+> ```go
+> fmt.Println(string(vpcList.RawJSON()))  // JSON without pkg/types
+> fmt.Println(string(vpcList.RawYAML()))  // YAML without pkg/types
+> ```
+
+---
+
+## Inspecting structured validation errors
+
+`*aruba.HTTPError` is the error type for all 4xx/5xx responses. Its `ErrResp` field is a `*types.ErrorResponse` and holds structured RFC 7807 details — including a `[]types.ValidationError` slice for field-level 400 errors:
+
+```go
+import (
+    "errors"
+    "github.com/Arubacloud/sdk-go/pkg/aruba"
+    "github.com/Arubacloud/sdk-go/pkg/types"
+)
+
+_, err := arubaClient.FromNetwork().VPCs().Create(ctx, vpc)
+if err != nil {
+    var httpErr *aruba.HTTPError
+    if errors.As(err, &httpErr) && httpErr.ErrResp != nil {
+        fmt.Printf("title:  %s\n", derefStr(httpErr.ErrResp.Title))
+        fmt.Printf("detail: %s\n", derefStr(httpErr.ErrResp.Detail))
+
+        // Field-level validation errors — require types.ValidationError
+        for _, ve := range httpErr.ErrResp.Errors {
+            fmt.Printf("  field %s: %s\n", ve.Field, ve.Message)
+        }
+
+        // TraceID for support requests
+        fmt.Printf("trace-id: %s\n", derefStr(httpErr.ErrResp.TraceID))
+    }
+}
+```
+
+### `MetadataValidationError`
+
+A `*types.MetadataValidationError` is returned (alongside a non-nil wrapper) when an API response is missing required metadata fields (`id` or `uri`). Use `errors.As` to detect it:
+
+```go
+import (
+    "errors"
+    "github.com/Arubacloud/sdk-go/pkg/aruba"
+    "github.com/Arubacloud/sdk-go/pkg/types"
+)
+
+result, err := arubaClient.FromNetwork().VPCs().Create(ctx, vpc)
+if err != nil {
+    var mvErr *types.MetadataValidationError
+    if errors.As(err, &mvErr) {
+        // result is non-nil and partially hydrated; mvErr lists the missing fields
+        fmt.Printf("metadata incomplete: %v\n", mvErr)
+        fmt.Printf("ID so far: %s\n", result.ID())
+    }
+}
+```
+
+---
+
+## Iterating `LinkedResources()`
+
+Every resource wrapper exposes `LinkedResources()` which returns `[]types.LinkedResource`. Each entry has a `URI string` and a `StrictCorrelation bool`:
+
+```go
+import (
+    "github.com/Arubacloud/sdk-go/pkg/aruba"
+    "github.com/Arubacloud/sdk-go/pkg/types"
+)
+
+vpc, err := arubaClient.FromNetwork().VPCs().Get(ctx, ref)
+if err != nil { /* … */ }
+
+for _, lr := range vpc.LinkedResources() {
+    fmt.Println("linked URI:", lr.URI)
+    if lr.StrictCorrelation {
+        fmt.Println("  → strict correlation (lifecycle-linked)")
+    }
+}
+```
+
+> If you only need the linked URI strings — for example, to pass them back to another SDK call as `aruba.URI(lr.URI)` — you don't need `types.LinkedResource` at all:
+>
+> ```go
+> for _, lr := range vpc.LinkedResources() {
+>     ref := aruba.URI(lr.URI)   // no pkg/types import
+>     _ = ref
+> }
+> ```
+
+---
+
+## Inspecting request bodies before they are sent
+
+Every wrapper exposes `RawRequest()` which returns the wire-level request struct (`*types.XxxRequest`). This is useful for debugging or for feeding the request into another tool:
+
+```go
+import (
+    "encoding/json"
+    "github.com/Arubacloud/sdk-go/pkg/aruba"
+    "github.com/Arubacloud/sdk-go/pkg/types"
+)
+
+vpc := aruba.NewVPC().
+    IntoProject(proj).
+    Named("my-vpc").
+    InRegion(aruba.RegionITBGBergamo).
+    AsDefault()
+
+req := vpc.RawRequest()               // types.VPCRequest — requires pkg/types import
+b, _ := json.MarshalIndent(req, "", "  ")
+fmt.Println(string(b))
+```
+
+---
+
+## Background polling with `pkg/async` {#background-polling-with-pkgasync}
+
+`WaitUntilReady`, `WaitUntilActive`, and `WaitUntilStates` block the calling goroutine. If you need to **start multiple waits concurrently**, or **poll an arbitrary condition** (not just a resource state), use the lower-level `pkg/async` package directly.
+
+`pkg/async` is a public package — import it alongside `pkg/aruba`:
+
+```go
+import (
+    "github.com/Arubacloud/sdk-go/pkg/aruba"
+    "github.com/Arubacloud/sdk-go/pkg/async"
+    "github.com/Arubacloud/sdk-go/pkg/types"
+)
+```
+
+### `WaitFor` — start a background future
+
+`async.WaitFor` launches a polling goroutine immediately and returns an `*async.AsyncClient[T]` (a future). You call `.Await(ctx)` later to block for the result:
+
+```go
+// Start polling VPC1 and VPC2 concurrently
+futureVPC1 := async.DefaultWaitFor(ctx,
+    func(ctx context.Context) (*types.Response[types.VPCResponse], error) {
+        return arubaClient.FromNetwork().VPCs().Get(ctx, vpc1)
+    },
+    func(resp *types.Response[types.VPCResponse]) (bool, error) {
+        if resp == nil || resp.Data == nil {
+            return false, nil
+        }
+        var state types.State
+        if resp.Data.Properties != nil && resp.Data.Properties.Status != nil &&
+            resp.Data.Properties.Status.State != nil {
+            state = *resp.Data.Properties.Status.State
+        }
+        return state == types.StateActive, nil
+    },
+)
+
+futureVPC2 := async.DefaultWaitFor(ctx, /* same pattern for vpc2 */)
+
+// Block for both results
+resp1, err1 := futureVPC1.Await(ctx)
+resp2, err2 := futureVPC2.Await(ctx)
+```
+
+`DefaultWaitFor` uses the package defaults: `DefaultRetries=60`, `DefaultBaseDelay=10s`, `DefaultTimeout=600s`. Use `async.WaitFor(ctx, retries, baseDelay, timeout, call, check)` to override.
+
+### `WaitFor` signature
+
+```go
+func WaitFor[T any](
+    ctx         context.Context,
+    retries     int,
+    baseDelay   time.Duration,
+    timeout     time.Duration,
+    call        func(ctx context.Context) (*types.Response[T], error),
+    check       func(*types.Response[T]) (bool, error),
+) *AsyncClient[T]
+```
+
+- `call` — the polling function, called once per iteration.
+- `check` — returns `(true, nil)` to signal success, `(true, error)` to signal terminal failure, `(false, nil)` to keep polling.
+- If `check` is `nil`, any non-nil `response.Data` is treated as success.
+
+### `AsyncClient.Await`
+
+```go
+func (f *AsyncClient[T]) Await(ctx context.Context) (*types.Response[T], error)
+```
+
+Blocks until the background goroutine sends its result or `ctx` is cancelled. Subsequent calls return the **cached** result immediately — safe to call multiple times.
+
+> `pkg/async` works directly with the `pkg/types` wire structs. This is the only layer of the SDK where you'll interact with `types.Response[T]` and `types.*Response` types directly.
+
+---
+
+## What does NOT require `pkg/types`
+
+The following are all available via a single `pkg/aruba` import — no second import needed:
+
+| What you need | `pkg/aruba` surface |
+|---|---|
+| State constants (`StateActive`, `StateStopped`, …) | `aruba.StateActive`, `aruba.StateStopped`, … |
+| Region / zone constants | `aruba.RegionITBGBergamo`, `aruba.ZoneITBG1`, … |
+| Billing period | `aruba.BillingPeriodHour`, `aruba.BillingPeriodMonth`, … |
+| All compute, storage, network, security enums | See `pkg/aruba/aliases.go` |
+| Wait for state transitions | `wrapper.WaitUntilReady(ctx)`, `WaitUntilActive`, `WaitUntilStates` |
+| Serialise a response to JSON / YAML | `wrapper.RawJSON()`, `wrapper.RawYAML()` |
+| HTTP envelope introspection | `wrapper.StatusCode()`, `.Headers()`, `.RawHTTP()`, `.RawError()` |
+| Pagination | `list.Total()`, `.HasNext()`, `.Next(ctx)`, `.All(ctx, yield)` |
+| HTTP error details | `*aruba.HTTPError` — `StatusCode`, `ErrResp.Title`, `ErrResp.Detail`, `ErrResp.TraceID` |
+
+---
+
+## See Also
+
+- [Response Handling](./response-handling) — typed HTTP errors, envelope accessors, `RawJSON`/`RawYAML`
+- [Async / Await](./async) — `WaitUntilReady`, `WaitUntilStates`, polling options
+- [API Walkthrough](./walkthrough) — full Create + poll + Update + Delete lifecycle example
+
+---
+
+```go
+// Helper used in examples above
+func derefStr(s *string) string {
+    if s == nil {
+        return ""
+    }
+    return *s
+}
+```

--- a/docs/website/i18n/it/docusaurus-plugin-content-docs/current/async.md
+++ b/docs/website/i18n/it/docusaurus-plugin-content-docs/current/async.md
@@ -207,78 +207,9 @@ Tutto il polling rispetta la scadenza e la cancellazione del `ctx`. Se il contex
 
 ---
 
-## Avanzato: Polling in Background con `pkg/async`
+## Avanzato: polling concorrente e personalizzato
 
-`WaitUntilReady`, `WaitUntilActive` e `WaitUntilStates` bloccano la goroutine chiamante. Se devi **avviare più attese in modo concorrente**, o **fare il polling di una condizione arbitraria** (non solo uno stato di risorsa), usa direttamente il pacchetto `pkg/async` di livello inferiore.
-
-`pkg/async` è un pacchetto pubblico — importalo insieme a `pkg/aruba`:
-
-```go
-import (
-    "github.com/Arubacloud/sdk-go/pkg/aruba"
-    "github.com/Arubacloud/sdk-go/pkg/async"
-    "github.com/Arubacloud/sdk-go/pkg/types"
-)
-```
-
-### `WaitFor` — avvia un future in background
-
-`async.WaitFor` avvia immediatamente una goroutine di polling e restituisce un `*async.AsyncClient[T]` (un future). Chiami `.Await(ctx)` in seguito per bloccare e ottenere il risultato:
-
-```go
-// Avvia il polling di VPC1 e VPC2 in modo concorrente
-futureVPC1 := async.DefaultWaitFor(ctx,
-    func(ctx context.Context) (*types.Response[types.VPCResponse], error) {
-        return arubaClient.FromNetwork().VPCs().Get(ctx, vpc1)
-    },
-    func(resp *types.Response[types.VPCResponse]) (bool, error) {
-        if resp == nil || resp.Data == nil {
-            return false, nil
-        }
-        var state types.State
-        if resp.Data.Properties != nil && resp.Data.Properties.Status != nil &&
-            resp.Data.Properties.Status.State != nil {
-            state = *resp.Data.Properties.Status.State
-        }
-        return state == types.StateActive, nil
-    },
-)
-
-futureVPC2 := async.DefaultWaitFor(ctx, /* stesso pattern per vpc2 */)
-
-// Blocca e attendi entrambi i risultati
-resp1, err1 := futureVPC1.Await(ctx)
-resp2, err2 := futureVPC2.Await(ctx)
-```
-
-`DefaultWaitFor` usa i valori predefiniti del pacchetto: `DefaultRetries=60`, `DefaultBaseDelay=10s`, `DefaultTimeout=600s`. Usa `async.WaitFor(ctx, retries, baseDelay, timeout, call, check)` per sovrascriverli.
-
-### Firma di `WaitFor`
-
-```go
-func WaitFor[T any](
-    ctx         context.Context,
-    retries     int,
-    baseDelay   time.Duration,
-    timeout     time.Duration,
-    call        func(ctx context.Context) (*types.Response[T], error),
-    check       func(*types.Response[T]) (bool, error),
-) *AsyncClient[T]
-```
-
-- `call` — la funzione di polling, chiamata una volta per ogni iterazione.
-- `check` — restituisce `(true, nil)` per segnalare il successo, `(true, error)` per segnalare un fallimento terminale, `(false, nil)` per continuare il polling.
-- Se `check` è `nil`, qualsiasi `response.Data` non-nil viene trattato come successo.
-
-### `AsyncClient.Await`
-
-```go
-func (f *AsyncClient[T]) Await(ctx context.Context) (*types.Response[T], error)
-```
-
-Blocca finché la goroutine in background invia il suo risultato oppure il `ctx` viene cancellato. Chiamate successive restituiscono il risultato **in cache** immediatamente — sicuro da chiamare più volte.
-
-> `pkg/async` lavora direttamente con le struct wire di `pkg/types`. Questo è l'unico livello dell'SDK dove interagirai direttamente con `types.Response[T]` e i tipi `types.*Response`.
+`WaitUntilReady`, `WaitUntilActive` e `WaitUntilStates` bloccano la goroutine chiamante. Quando devi **avviare più attese in modo concorrente**, o **fare il polling di una condizione arbitraria** (non solo uno stato di risorsa), scendi al livello di `pkg/async`. Quel layer lavora direttamente con `*types.Response[T]` ed è documentato separatamente — consulta [Lavorare a Basso Livello](./working-at-low-level#background-polling-with-pkgasync).
 
 ---
 
@@ -286,3 +217,4 @@ Blocca finché la goroutine in background invia il suo risultato oppure il `ctx`
 
 - [Guida al Walkthrough API](./walkthrough) — esempio completo del ciclo di vita Create + `WaitUntilReady` + Update + Delete
 - [Gestione delle Risposte](./response-handling) — come `*aruba.HTTPError` si propaga attraverso `WaitUntilReady` quando l'API restituisce 4xx/5xx
+- [Lavorare a Basso Livello](./working-at-low-level) — polling in background con `pkg/async`, accesso ai campi wire non promossi

--- a/docs/website/i18n/it/docusaurus-plugin-content-docs/current/response-handling.md
+++ b/docs/website/i18n/it/docusaurus-plugin-content-docs/current/response-handling.md
@@ -25,7 +25,7 @@ Quando l'API restituisce una risposta 4xx o 5xx, l'SDK la racchiude in `*aruba.H
 ```go
 import "errors"
 
-vpc, err := arubaClient.FromNetwork().VPCs().Create(ctx, vpc)
+vpc, err := arubaClient.FromNetwork().VPCs().Get(ctx, ref)
 if err != nil {
     var httpErr *aruba.HTTPError
     if errors.As(err, &httpErr) {
@@ -77,7 +77,9 @@ proj, err := arubaClient.FromProject().Create(ctx, p)
 
 fmt.Println("Status:", proj.StatusCode())
 fmt.Println("Headers:", proj.Headers())
-fmt.Println("Raw body:", string(proj.RawHTTP()))
+rawResp, rawBody := proj.RawHTTP()
+fmt.Println("Raw body:", string(rawBody))
+fmt.Println("HTTP status:", rawResp.StatusCode)
 fmt.Println("Error body (if any):", proj.RawError())
 ```
 
@@ -92,6 +94,52 @@ if err != nil { /* … */ }
 raw := vpc.Raw()                         // struct wire sottostante
 fmt.Println(raw.Properties.IsDefault)    // campo non sul wrapper
 ```
+
+### Convenienza JSON / YAML
+
+Per flag CLI del tipo `--output json` / `--output yaml`, ogni wrapper espone byte slice pre-serializzati:
+
+```go
+fmt.Println(string(vpc.RawJSON()))   // payload codificato in JSON
+fmt.Println(string(vpc.RawYAML()))   // payload codificato in YAML
+```
+
+Restituisce `nil` se il wrapper non è ancora stato popolato (receiver con valore zero).
+
+## Risposte Lista
+
+`List[T]` espone la stessa superficie di introspezione dei wrapper a risorsa singola, senza mai dover importare `pkg/types`:
+
+```go
+vpcList, err := arubaClient.FromNetwork().VPCs().List(ctx, proj)
+if err != nil { /* … */ }
+
+// Paginazione e conteggi — accessor tipizzati sul wrapper.
+fmt.Println("server total:", vpcList.Total())
+if vpcList.HasNext() {
+    nextPage, _ := vpcList.Next(ctx)
+    _ = nextPage
+}
+
+// Envelope HTTP — stessi accessor dei wrapper a risorsa singola.
+fmt.Println("status:", vpcList.StatusCode())
+fmt.Println("trace-id:", vpcList.Headers().Get("X-Trace-Id"))
+_, body := vpcList.RawHTTP()
+fmt.Println("raw body bytes:", len(body))
+```
+
+### Convenienza JSON / YAML
+
+Anche `List[T]` espone `RawJSON()` e `RawYAML()` per il payload lista tipizzato:
+
+```go
+fmt.Println(string(vpcList.RawJSON()))   // payload codificato in JSON
+fmt.Println(string(vpcList.RawYAML()))   // payload codificato in YAML
+```
+
+Restituisce `nil` quando la lista non ha payload (`Raw() == nil`).
+
+> **Accedere ai campi wire non promossi.** Se hai bisogno di un campo non esposto dalla superficie del wrapper, consulta [Lavorare a Basso Livello](./working-at-low-level) — descrive il cast al tipo wire e le poche altre vie di uscita che richiedono l'importazione di `pkg/types`.
 
 ## Errori in Fase di Setter
 
@@ -114,7 +162,7 @@ if err := rule.Err(); err != nil {
 2. **Usa `errors.As(err, &httpErr)`** per ottenere dettagli strutturati sugli errori 4xx/5xx.
 3. **Controlla `httpErr.ErrResp.Errors`** per messaggi di validazione a livello di campo sugli errori 400.
 4. **Usa `httpErr.ErrResp.TraceID`** quando apri una richiesta di supporto.
-5. **Usa `.Raw()` con parsimonia** — preferisci gli accessori tipizzati del wrapper.
+5. **Usa `.Raw()` con parsimonia** — preferisci gli accessor tipizzati del wrapper.
 6. **Controlla `wrapper.Err()` prima di Create/Update** quando la catena di builder è lunga.
 
 ---

--- a/docs/website/i18n/it/docusaurus-plugin-content-docs/current/working-at-low-level.md
+++ b/docs/website/i18n/it/docusaurus-plugin-content-docs/current/working-at-low-level.md
@@ -1,0 +1,268 @@
+# Lavorare a Basso Livello
+
+## Perché questa pagina esiste
+
+L'SDK è progettato attorno a un **principio di import singolo**: importare solo `github.com/Arubacloud/sdk-go/pkg/aruba` copre circa il 99,9% dei casi d'uso reali.
+
+La superficie wrapper — accessor tipizzati, helper `WaitUntil*`, `RawJSON()` / `RawYAML()` — è progettata in modo che raramente sia necessario accedere direttamente alle struct wire sottostanti. Per lo 0,1% dei casi in cui è necessario farlo, questa pagina raccoglie tutte le vie di uscita che richiedono un secondo import.
+
+> Questi pattern sono **intenzionali e supportati** — sono vie di uscita, non workaround. Quando incontri un caso non coperto dalla superficie wrapper, usa questi invece di aprire una feature request.
+
+---
+
+## Accedere ai campi wire non promossi con `Raw()`
+
+Ogni wrapper espone un metodo `Raw()` che restituisce la struct `*types.XxxResponse` sottostante. Usalo quando hai bisogno di un campo non ancora promosso alla superficie del wrapper:
+
+```go
+import (
+    "github.com/Arubacloud/sdk-go/pkg/aruba"
+    "github.com/Arubacloud/sdk-go/pkg/types"
+)
+
+vpc, err := arubaClient.FromNetwork().VPCs().Get(ctx, ref)
+if err != nil { /* … */ }
+
+raw := vpc.Raw()                          // *types.VPCResponse
+fmt.Println(raw.Properties.IsDefault)     // campo non promosso al wrapper
+```
+
+Per le liste, `Raw()` restituisce `any` e devi fare il type assert al tipo lista concreto:
+
+```go
+vpcList, err := arubaClient.FromNetwork().VPCs().List(ctx, proj)
+if err != nil { /* … */ }
+
+raw := vpcList.Raw().(*types.VPCList)     // richiede l'import di pkg/types
+fmt.Println("server total:", raw.Total)   // equivalente a vpcList.Total() — mostrato per illustrazione
+fmt.Println("self link:", raw.Self)
+```
+
+> **Preferisci gli accessor del wrapper per la serializzazione.** Se il tuo obiettivo è l'output JSON o YAML, usa `vpc.RawJSON()` / `vpc.RawYAML()` (o i metodi equivalenti su `List[T]`) — senza bisogno di importare `pkg/types`.
+>
+> ```go
+> fmt.Println(string(vpcList.RawJSON()))  // JSON senza pkg/types
+> fmt.Println(string(vpcList.RawYAML()))  // YAML senza pkg/types
+> ```
+
+---
+
+## Ispezionare gli errori di validazione strutturati
+
+`*aruba.HTTPError` è il tipo di errore per tutte le risposte 4xx/5xx. Il suo campo `ErrResp` è un `*types.ErrorResponse` e contiene dettagli strutturati RFC 7807 — inclusa una slice `[]types.ValidationError` per gli errori 400 a livello di campo:
+
+```go
+import (
+    "errors"
+    "github.com/Arubacloud/sdk-go/pkg/aruba"
+    "github.com/Arubacloud/sdk-go/pkg/types"
+)
+
+_, err := arubaClient.FromNetwork().VPCs().Create(ctx, vpc)
+if err != nil {
+    var httpErr *aruba.HTTPError
+    if errors.As(err, &httpErr) && httpErr.ErrResp != nil {
+        fmt.Printf("title:  %s\n", derefStr(httpErr.ErrResp.Title))
+        fmt.Printf("detail: %s\n", derefStr(httpErr.ErrResp.Detail))
+
+        // Errori di validazione a livello di campo — richiedono types.ValidationError
+        for _, ve := range httpErr.ErrResp.Errors {
+            fmt.Printf("  campo %s: %s\n", ve.Field, ve.Message)
+        }
+
+        // TraceID per le richieste di supporto
+        fmt.Printf("trace-id: %s\n", derefStr(httpErr.ErrResp.TraceID))
+    }
+}
+```
+
+### `MetadataValidationError`
+
+Un `*types.MetadataValidationError` viene restituito (insieme a un wrapper non-nil) quando una risposta API manca dei campi di metadati obbligatori (`id` o `uri`). Usa `errors.As` per rilevarlo:
+
+```go
+import (
+    "errors"
+    "github.com/Arubacloud/sdk-go/pkg/aruba"
+    "github.com/Arubacloud/sdk-go/pkg/types"
+)
+
+result, err := arubaClient.FromNetwork().VPCs().Create(ctx, vpc)
+if err != nil {
+    var mvErr *types.MetadataValidationError
+    if errors.As(err, &mvErr) {
+        // result è non-nil e parzialmente idratato; mvErr elenca i campi mancanti
+        fmt.Printf("metadati incompleti: %v\n", mvErr)
+        fmt.Printf("ID finora: %s\n", result.ID())
+    }
+}
+```
+
+---
+
+## Iterare `LinkedResources()`
+
+Ogni wrapper di risorsa espone `LinkedResources()` che restituisce `[]types.LinkedResource`. Ogni elemento ha un `URI string` e un `StrictCorrelation bool`:
+
+```go
+import (
+    "github.com/Arubacloud/sdk-go/pkg/aruba"
+    "github.com/Arubacloud/sdk-go/pkg/types"
+)
+
+vpc, err := arubaClient.FromNetwork().VPCs().Get(ctx, ref)
+if err != nil { /* … */ }
+
+for _, lr := range vpc.LinkedResources() {
+    fmt.Println("linked URI:", lr.URI)
+    if lr.StrictCorrelation {
+        fmt.Println("  → correlazione stretta (lifecycle-linked)")
+    }
+}
+```
+
+> Se hai bisogno solo delle stringhe URI — ad esempio per passarle a un'altra chiamata SDK come `aruba.URI(lr.URI)` — non hai bisogno di `types.LinkedResource`:
+>
+> ```go
+> for _, lr := range vpc.LinkedResources() {
+>     ref := aruba.URI(lr.URI)   // senza import di pkg/types
+>     _ = ref
+> }
+> ```
+
+---
+
+## Ispezionare i body delle richieste prima dell'invio
+
+Ogni wrapper espone `RawRequest()` che restituisce la struct di richiesta a livello wire (`*types.XxxRequest`). È utile per il debug o per passare la richiesta a un altro strumento:
+
+```go
+import (
+    "encoding/json"
+    "github.com/Arubacloud/sdk-go/pkg/aruba"
+    "github.com/Arubacloud/sdk-go/pkg/types"
+)
+
+vpc := aruba.NewVPC().
+    IntoProject(proj).
+    Named("my-vpc").
+    InRegion(aruba.RegionITBGBergamo).
+    AsDefault()
+
+req := vpc.RawRequest()               // types.VPCRequest — richiede import di pkg/types
+b, _ := json.MarshalIndent(req, "", "  ")
+fmt.Println(string(b))
+```
+
+---
+
+## Polling in background con `pkg/async` {#background-polling-with-pkgasync}
+
+`WaitUntilReady`, `WaitUntilActive` e `WaitUntilStates` bloccano la goroutine chiamante. Se devi **avviare più attese in modo concorrente**, o **fare il polling di una condizione arbitraria** (non solo uno stato di risorsa), usa direttamente il pacchetto `pkg/async` di livello inferiore.
+
+`pkg/async` è un pacchetto pubblico — importalo insieme a `pkg/aruba`:
+
+```go
+import (
+    "github.com/Arubacloud/sdk-go/pkg/aruba"
+    "github.com/Arubacloud/sdk-go/pkg/async"
+    "github.com/Arubacloud/sdk-go/pkg/types"
+)
+```
+
+### `WaitFor` — avvia un future in background
+
+`async.WaitFor` avvia immediatamente una goroutine di polling e restituisce un `*async.AsyncClient[T]` (un future). Chiami `.Await(ctx)` in seguito per bloccare e ottenere il risultato:
+
+```go
+// Avvia il polling di VPC1 e VPC2 in modo concorrente
+futureVPC1 := async.DefaultWaitFor(ctx,
+    func(ctx context.Context) (*types.Response[types.VPCResponse], error) {
+        return arubaClient.FromNetwork().VPCs().Get(ctx, vpc1)
+    },
+    func(resp *types.Response[types.VPCResponse]) (bool, error) {
+        if resp == nil || resp.Data == nil {
+            return false, nil
+        }
+        var state types.State
+        if resp.Data.Properties != nil && resp.Data.Properties.Status != nil &&
+            resp.Data.Properties.Status.State != nil {
+            state = *resp.Data.Properties.Status.State
+        }
+        return state == types.StateActive, nil
+    },
+)
+
+futureVPC2 := async.DefaultWaitFor(ctx, /* stesso pattern per vpc2 */)
+
+// Blocca e attendi entrambi i risultati
+resp1, err1 := futureVPC1.Await(ctx)
+resp2, err2 := futureVPC2.Await(ctx)
+```
+
+`DefaultWaitFor` usa i valori predefiniti del pacchetto: `DefaultRetries=60`, `DefaultBaseDelay=10s`, `DefaultTimeout=600s`. Usa `async.WaitFor(ctx, retries, baseDelay, timeout, call, check)` per sovrascriverli.
+
+### Firma di `WaitFor`
+
+```go
+func WaitFor[T any](
+    ctx         context.Context,
+    retries     int,
+    baseDelay   time.Duration,
+    timeout     time.Duration,
+    call        func(ctx context.Context) (*types.Response[T], error),
+    check       func(*types.Response[T]) (bool, error),
+) *AsyncClient[T]
+```
+
+- `call` — la funzione di polling, chiamata una volta per ogni iterazione.
+- `check` — restituisce `(true, nil)` per segnalare il successo, `(true, error)` per segnalare un fallimento terminale, `(false, nil)` per continuare il polling.
+- Se `check` è `nil`, qualsiasi `response.Data` non-nil viene trattato come successo.
+
+### `AsyncClient.Await`
+
+```go
+func (f *AsyncClient[T]) Await(ctx context.Context) (*types.Response[T], error)
+```
+
+Blocca finché la goroutine in background invia il suo risultato oppure il `ctx` viene cancellato. Chiamate successive restituiscono il risultato **in cache** immediatamente — sicuro da chiamare più volte.
+
+> `pkg/async` lavora direttamente con le struct wire di `pkg/types`. Questo è l'unico livello dell'SDK dove interagirai direttamente con `types.Response[T]` e i tipi `types.*Response`.
+
+---
+
+## Cosa NON richiede `pkg/types`
+
+I seguenti elementi sono tutti disponibili con un singolo import di `pkg/aruba` — senza bisogno di un secondo import:
+
+| Cosa ti serve | Superficie `pkg/aruba` |
+|---|---|
+| Costanti di stato (`StateActive`, `StateStopped`, …) | `aruba.StateActive`, `aruba.StateStopped`, … |
+| Costanti regione / zona | `aruba.RegionITBGBergamo`, `aruba.ZoneITBG1`, … |
+| Periodo di fatturazione | `aruba.BillingPeriodHour`, `aruba.BillingPeriodMonth`, … |
+| Tutti gli enum compute, storage, network, security | Vedi `pkg/aruba/aliases.go` |
+| Attendere transizioni di stato | `wrapper.WaitUntilReady(ctx)`, `WaitUntilActive`, `WaitUntilStates` |
+| Serializzare una risposta in JSON / YAML | `wrapper.RawJSON()`, `wrapper.RawYAML()` |
+| Introspezione dell'envelope HTTP | `wrapper.StatusCode()`, `.Headers()`, `.RawHTTP()`, `.RawError()` |
+| Paginazione | `list.Total()`, `.HasNext()`, `.Next(ctx)`, `.All(ctx, yield)` |
+| Dettagli errore HTTP | `*aruba.HTTPError` — `StatusCode`, `ErrResp.Title`, `ErrResp.Detail`, `ErrResp.TraceID` |
+
+---
+
+## Vedi Anche
+
+- [Gestione delle Risposte](./response-handling) — errori HTTP tipizzati, accessor envelope, `RawJSON`/`RawYAML`
+- [Async / Await](./async) — `WaitUntilReady`, `WaitUntilStates`, opzioni di polling
+- [Guida al Walkthrough API](./walkthrough) — esempio completo del ciclo di vita Create + polling + Update + Delete
+
+---
+
+```go
+// Helper usato negli esempi sopra
+func derefStr(s *string) string {
+    if s == nil {
+        return ""
+    }
+    return *s
+}
+```

--- a/docs/website/sidebars.js
+++ b/docs/website/sidebars.js
@@ -46,6 +46,11 @@ const sidebars = {
     },
     {
       type: 'doc',
+      id: 'working-at-low-level',
+      label: 'Working at Low Level',
+    },
+    {
+      type: 'doc',
       id: 'multitenancy',
       label: 'Multitenancy',
     },

--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,7 @@ require (
 	github.com/stretchr/testify v1.11.1
 	go.uber.org/mock v0.6.0
 	golang.org/x/oauth2 v0.33.0
+	k8s.io/utils v0.0.0-20260507154919-ff6756f316d2
 )
 
 require (
@@ -31,7 +32,6 @@ require (
 	golang.org/x/net v0.42.0 // indirect
 	golang.org/x/text v0.27.0 // indirect
 	golang.org/x/time v0.12.0 // indirect
-	k8s.io/utils v0.0.0-20260507154919-ff6756f316d2 // indirect
 )
 
 require (
@@ -39,5 +39,5 @@ require (
 	github.com/hashicorp/vault/api v1.22.0
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/redis/go-redis/v9 v9.17.1
-	gopkg.in/yaml.v3 v3.0.1 // indirect
+	gopkg.in/yaml.v3 v3.0.1
 )

--- a/pkg/aruba/list.go
+++ b/pkg/aruba/list.go
@@ -2,9 +2,11 @@ package aruba
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 
 	"github.com/Arubacloud/sdk-go/pkg/types"
+	"gopkg.in/yaml.v3"
 )
 
 // Wrapper is the constraint for List items: every resource wrapper satisfies it.
@@ -150,6 +152,32 @@ func (l *List[T]) Cursor() (next, prev string) {
 // HTTP envelope (status, headers, raw body, error envelope) is exposed via
 // StatusCode(), Headers(), RawHTTP(), RawError() on the same list value.
 func (l *List[T]) Raw() any { return l.raw }
+
+// RawJSON returns the wire payload marshaled as JSON, or nil if the list has
+// no payload (Raw() == nil).
+func (l *List[T]) RawJSON() []byte {
+	if l.raw == nil {
+		return nil
+	}
+	b, err := json.Marshal(l.raw)
+	if err != nil {
+		return nil
+	}
+	return b
+}
+
+// RawYAML returns the wire payload marshaled as YAML, or nil if the list has
+// no payload (Raw() == nil).
+func (l *List[T]) RawYAML() []byte {
+	if l.raw == nil {
+		return nil
+	}
+	b, err := yaml.Marshal(l.raw)
+	if err != nil {
+		return nil
+	}
+	return b
+}
 
 // All iterates all pages, calling yield for each item. Iteration stops early
 // if yield returns false. Returns the first error encountered while fetching.

--- a/pkg/aruba/list.go
+++ b/pkg/aruba/list.go
@@ -3,6 +3,8 @@ package aruba
 import (
 	"context"
 	"fmt"
+
+	"github.com/Arubacloud/sdk-go/pkg/types"
 )
 
 // Wrapper is the constraint for List items: every resource wrapper satisfies it.
@@ -14,6 +16,8 @@ type Wrapper interface {
 // List is a paginated collection of resource wrappers. Per-resource clients
 // construct it after a server List call; callers use Next/Prev/All to iterate.
 type List[T Wrapper] struct {
+	httpEnvelopeMixin // StatusCode / Headers / RawHTTP / RawError — parity with single-resource wrappers
+
 	items      []T
 	total      int64
 	self       string
@@ -23,11 +27,51 @@ type List[T Wrapper] struct {
 	last       string
 	callerOpts []CallOption
 	refetch    func(ctx context.Context, url string) (*List[T], error)
-	raw        any
+	raw        any // JSON-safe payload only: *types.XxxList (resp.Data)
+}
+
+// listPayload is the type constraint satisfied by every per-resource list type
+// (e.g. types.VPCList, types.AlertsListResponse). All such types embed
+// types.ListResponse, which carries a BaseList() method that is automatically
+// promoted, so no per-type implementation is required.
+type listPayload interface {
+	BaseList() types.ListResponse
+}
+
+// newListFromResponse is the high-level constructor used by per-resource
+// adapters. It extracts pagination links from resp.Data.BaseList(), stores
+// resp.Data as the JSON-safe raw payload, and populates the HTTP envelope from
+// resp. Returns a usable empty list when resp or resp.Data is nil.
+func newListFromResponse[T Wrapper, L listPayload](
+	items []T,
+	resp *types.Response[L],
+	opts []CallOption,
+	refetch func(ctx context.Context, url string) (*List[T], error),
+) *List[T] {
+	l := &List[T]{
+		items:      items,
+		callerOpts: opts,
+		refetch:    refetch,
+	}
+	if resp == nil {
+		return l
+	}
+	populateHTTPEnvelope(&l.httpEnvelopeMixin, resp)
+	if resp.Data != nil {
+		l.raw = resp.Data
+		base := (*resp.Data).BaseList()
+		l.total = base.Total
+		l.self = base.Self
+		l.prev = base.Prev
+		l.next = base.Next
+		l.first = base.First
+		l.last = base.Last
+	}
+	return l
 }
 
 // newList constructs a List from a server reply. lr holds the pagination links,
-// raw is the full *types.Response[XxxList] stored as any for caller inspection,
+// raw is the JSON-safe wire payload (typically *types.XxxList, i.e. resp.Data),
 // and refetch is provided by the per-resource client to fetch adjacent pages.
 func newList[T Wrapper](
 	items []T,
@@ -100,8 +144,11 @@ func (l *List[T]) Cursor() (next, prev string) {
 	return l.next, l.prev
 }
 
-// Raw returns the raw server response as any. Cast to the concrete
-// *types.Response[XxxList] type to inspect response metadata.
+// Raw returns the JSON-marshal-safe wire payload, typically a *types.XxxList
+// containing pagination metadata and the typed Values slice. Cast to the
+// concrete *types.XxxList type to inspect fields not promoted to wrappers.
+// HTTP envelope (status, headers, raw body, error envelope) is exposed via
+// StatusCode(), Headers(), RawHTTP(), RawError() on the same list value.
 func (l *List[T]) Raw() any { return l.raw }
 
 // All iterates all pages, calling yield for each item. Iteration stops early

--- a/pkg/aruba/list_test.go
+++ b/pkg/aruba/list_test.go
@@ -2,7 +2,11 @@ package aruba
 
 import (
 	"context"
+	"encoding/json"
+	"net/http"
 	"testing"
+
+	"github.com/Arubacloud/sdk-go/pkg/types"
 )
 
 // testItem is a minimal Wrapper implementation for list tests.
@@ -157,5 +161,77 @@ func TestList_Raw(t *testing.T) {
 	got, ok := l.Raw().(struct{ n int })
 	if !ok || got.n != 42 {
 		t.Errorf("Raw() = %v", l.Raw())
+	}
+}
+
+// TestList_Raw_JSONMarshalable is the regression test for #298: prior to the
+// fix Raw() returned *types.Response[L] whose embedded *http.Response.GetBody
+// is a non-serialisable func, breaking json.Marshal. Raw() now returns only
+// the JSON-safe wire payload (*types.XxxList).
+func TestList_Raw_JSONMarshalable(t *testing.T) {
+	resp := &types.Response[types.VPCList]{
+		Data: &types.VPCList{
+			ListResponse: types.ListResponse{Total: 2, Self: "/self", Next: "/next"},
+			Values:       []types.VPCResponse{},
+		},
+		StatusCode: 200,
+	}
+	l := newListFromResponse[testItem, types.VPCList](nil, resp, nil, nil)
+
+	b, err := json.Marshal(l.Raw())
+	if err != nil {
+		t.Fatalf("json.Marshal(list.Raw()): %v", err)
+	}
+	var back types.VPCList
+	if err := json.Unmarshal(b, &back); err != nil {
+		t.Fatalf("json.Unmarshal: %v", err)
+	}
+	if back.Total != 2 || back.Self != "/self" || back.Next != "/next" {
+		t.Errorf("round-trip lost fields: %+v", back)
+	}
+}
+
+// TestList_HTTPEnvelopeAccessors verifies the accessors promoted from the
+// embedded httpEnvelopeMixin (parity with single-resource wrappers).
+func TestList_HTTPEnvelopeAccessors(t *testing.T) {
+	resp := &types.Response[types.VPCList]{
+		Data:       &types.VPCList{ListResponse: types.ListResponse{Total: 0}},
+		StatusCode: 200,
+		Headers:    http.Header{"X-Trace-Id": []string{"abc-123"}},
+		RawBody:    []byte(`{"total":0,"values":[]}`),
+	}
+	l := newListFromResponse[testItem, types.VPCList](nil, resp, nil, nil)
+
+	if l.StatusCode() != 200 {
+		t.Errorf("StatusCode() = %d, want 200", l.StatusCode())
+	}
+	if got := l.Headers().Get("X-Trace-Id"); got != "abc-123" {
+		t.Errorf("Headers X-Trace-Id = %q", got)
+	}
+	if _, body := l.RawHTTP(); string(body) != `{"total":0,"values":[]}` {
+		t.Errorf("RawHTTP body = %q", string(body))
+	}
+	if l.RawError() != nil {
+		t.Errorf("RawError() = %v, want nil for 2xx", l.RawError())
+	}
+}
+
+// TestList_NewListFromResponse_NilSafe ensures the helper tolerates a nil
+// response and a nil resp.Data.
+func TestList_NewListFromResponse_NilSafe(t *testing.T) {
+	l1 := newListFromResponse[testItem, types.VPCList](nil, nil, nil, nil)
+	if l1 == nil || l1.Total() != 0 || l1.HasNext() || l1.HasPrev() {
+		t.Errorf("nil resp produced bad list: %+v", l1)
+	}
+	l2 := newListFromResponse[testItem, types.VPCList](
+		nil,
+		&types.Response[types.VPCList]{StatusCode: 200},
+		nil, nil,
+	)
+	if l2.Raw() != nil {
+		t.Errorf("Raw() should be nil when resp.Data is nil, got %v", l2.Raw())
+	}
+	if l2.StatusCode() != 200 {
+		t.Errorf("StatusCode() = %d, want 200", l2.StatusCode())
 	}
 }

--- a/pkg/aruba/list_test.go
+++ b/pkg/aruba/list_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"github.com/Arubacloud/sdk-go/pkg/types"
+	"gopkg.in/yaml.v3"
 )
 
 // testItem is a minimal Wrapper implementation for list tests.
@@ -233,5 +234,61 @@ func TestList_NewListFromResponse_NilSafe(t *testing.T) {
 	}
 	if l2.StatusCode() != 200 {
 		t.Errorf("StatusCode() = %d, want 200", l2.StatusCode())
+	}
+}
+
+func TestList_RawJSON_RoundTrip(t *testing.T) {
+	resp := &types.Response[types.VPCList]{
+		Data: &types.VPCList{
+			ListResponse: types.ListResponse{Total: 3, Self: "/self", Next: "/next"},
+			Values:       []types.VPCResponse{},
+		},
+	}
+	l := newListFromResponse[testItem, types.VPCList](nil, resp, nil, nil)
+	b := l.RawJSON()
+	if len(b) == 0 {
+		t.Fatal("RawJSON() returned empty")
+	}
+	var back types.VPCList
+	if err := json.Unmarshal(b, &back); err != nil {
+		t.Fatalf("json.Unmarshal: %v", err)
+	}
+	if back.Total != 3 || back.Self != "/self" || back.Next != "/next" {
+		t.Errorf("round-trip lost fields: %+v", back)
+	}
+}
+
+func TestList_RawYAML_RoundTrip(t *testing.T) {
+	resp := &types.Response[types.VPCList]{
+		Data: &types.VPCList{
+			ListResponse: types.ListResponse{Total: 5, Self: "/s", Next: "/n"},
+			Values:       []types.VPCResponse{},
+		},
+	}
+	l := newListFromResponse[testItem, types.VPCList](nil, resp, nil, nil)
+	b := l.RawYAML()
+	if len(b) == 0 {
+		t.Fatal("RawYAML() returned empty")
+	}
+	var back types.VPCList
+	if err := yaml.Unmarshal(b, &back); err != nil {
+		t.Fatalf("yaml.Unmarshal: %v", err)
+	}
+	if back.Total != 5 || back.Self != "/s" || back.Next != "/n" {
+		t.Errorf("round-trip lost fields: %+v", back)
+	}
+}
+
+func TestList_RawJSON_NilSafe(t *testing.T) {
+	l := newListFromResponse[testItem, types.VPCList](nil, nil, nil, nil)
+	if b := l.RawJSON(); b != nil {
+		t.Errorf("RawJSON() = %q, want nil", b)
+	}
+}
+
+func TestList_RawYAML_NilSafe(t *testing.T) {
+	l := newListFromResponse[testItem, types.VPCList](nil, nil, nil, nil)
+	if b := l.RawYAML(); b != nil {
+		t.Errorf("RawYAML() = %q, want nil", b)
 	}
 }

--- a/pkg/aruba/raw_marshal.go
+++ b/pkg/aruba/raw_marshal.go
@@ -1,0 +1,34 @@
+package aruba
+
+import (
+	"encoding/json"
+
+	"gopkg.in/yaml.v3"
+)
+
+// marshalRawJSON returns v marshaled as JSON, or nil if v is nil or marshaling
+// fails. The error path is unreachable for the canonical *types.XxxResponse /
+// *types.XxxList shapes used by wrappers; the swallow keeps the public
+// signature ergonomic ([]byte instead of ([]byte, error)).
+func marshalRawJSON[T any](v *T) []byte {
+	if v == nil {
+		return nil
+	}
+	b, err := json.Marshal(v)
+	if err != nil {
+		return nil
+	}
+	return b
+}
+
+// marshalRawYAML mirrors marshalRawJSON but emits YAML via gopkg.in/yaml.v3.
+func marshalRawYAML[T any](v *T) []byte {
+	if v == nil {
+		return nil
+	}
+	b, err := yaml.Marshal(v)
+	if err != nil {
+		return nil
+	}
+	return b
+}

--- a/pkg/aruba/resource_alert.go
+++ b/pkg/aruba/resource_alert.go
@@ -37,6 +37,8 @@ func (a *Alert) URI() string { return "" }
 
 // Raw returns the underlying wire payload. Shadows responseMetadataMixin.Raw().
 func (a *Alert) Raw() *types.AlertResponse { return a.response }
+func (a *Alert) RawJSON() []byte           { return marshalRawJSON(a.response) }
+func (a *Alert) RawYAML() []byte           { return marshalRawYAML(a.response) }
 
 // EventID returns the event ID associated with this alert, or "" when unset.
 func (a *Alert) EventID() string {

--- a/pkg/aruba/resource_alert.go
+++ b/pkg/aruba/resource_alert.go
@@ -331,27 +331,7 @@ func (a *alertsClientAdapter) List(ctx context.Context, project Ref, opts ...Cal
 				pageItems = append(pageItems, al)
 			}
 		}
-		var total2 int64
-		var self2, prev2, next2, first2, last2 string
-		if pageResp != nil && pageResp.Data != nil {
-			total2 = pageResp.Data.Total
-			self2 = pageResp.Data.Self
-			prev2 = pageResp.Data.Prev
-			next2 = pageResp.Data.Next
-			first2 = pageResp.Data.First
-			last2 = pageResp.Data.Last
-		}
-		return newList(pageItems, total2, self2, prev2, next2, first2, last2, pageResp, opts, refetch), nil
+		return newListFromResponse(pageItems, pageResp, opts, refetch), nil
 	}
-	var total int64
-	var self, prev, next, first, last string
-	if resp != nil && resp.Data != nil {
-		total = resp.Data.Total
-		self = resp.Data.Self
-		prev = resp.Data.Prev
-		next = resp.Data.Next
-		first = resp.Data.First
-		last = resp.Data.Last
-	}
-	return newList(items, total, self, prev, next, first, last, resp, opts, refetch), nil
+	return newListFromResponse(items, resp, opts, refetch), nil
 }

--- a/pkg/aruba/resource_audit_event.go
+++ b/pkg/aruba/resource_audit_event.go
@@ -46,6 +46,8 @@ func (e *AuditEvent) CreatedAt() time.Time {
 
 // Raw returns the underlying wire payload. Shadows responseMetadataMixin.Raw().
 func (e *AuditEvent) Raw() *types.AuditEvent { return e.response }
+func (e *AuditEvent) RawJSON() []byte        { return marshalRawJSON(e.response) }
+func (e *AuditEvent) RawYAML() []byte        { return marshalRawYAML(e.response) }
 
 // SeverityLevel returns the event severity level, or "" when unset.
 func (e *AuditEvent) SeverityLevel() string {

--- a/pkg/aruba/resource_audit_event.go
+++ b/pkg/aruba/resource_audit_event.go
@@ -266,27 +266,7 @@ func (a *auditEventsClientAdapter) List(ctx context.Context, project Ref, opts .
 				pageItems = append(pageItems, ev)
 			}
 		}
-		var total2 int64
-		var self2, prev2, next2, first2, last2 string
-		if pageResp != nil && pageResp.Data != nil {
-			total2 = pageResp.Data.Total
-			self2 = pageResp.Data.Self
-			prev2 = pageResp.Data.Prev
-			next2 = pageResp.Data.Next
-			first2 = pageResp.Data.First
-			last2 = pageResp.Data.Last
-		}
-		return newList(pageItems, total2, self2, prev2, next2, first2, last2, pageResp, opts, refetch), nil
+		return newListFromResponse(pageItems, pageResp, opts, refetch), nil
 	}
-	var total int64
-	var self, prev, next, first, last string
-	if resp != nil && resp.Data != nil {
-		total = resp.Data.Total
-		self = resp.Data.Self
-		prev = resp.Data.Prev
-		next = resp.Data.Next
-		first = resp.Data.First
-		last = resp.Data.Last
-	}
-	return newList(items, total, self, prev, next, first, last, resp, opts, refetch), nil
+	return newListFromResponse(items, resp, opts, refetch), nil
 }

--- a/pkg/aruba/resource_block_storage.go
+++ b/pkg/aruba/resource_block_storage.go
@@ -532,29 +532,9 @@ func (a *volumesClientAdapter) List(ctx context.Context, project Ref, opts ...Ca
 				pageItems = append(pageItems, bs)
 			}
 		}
-		var total2 int64
-		var self2, prev2, next2, first2, last2 string
-		if pageResp != nil && pageResp.Data != nil {
-			total2 = pageResp.Data.Total
-			self2 = pageResp.Data.Self
-			prev2 = pageResp.Data.Prev
-			next2 = pageResp.Data.Next
-			first2 = pageResp.Data.First
-			last2 = pageResp.Data.Last
-		}
-		return newList(pageItems, total2, self2, prev2, next2, first2, last2, pageResp, opts, refetch), nil
+		return newListFromResponse(pageItems, pageResp, opts, refetch), nil
 	}
-	var total int64
-	var self, prev, next, first, last string
-	if resp != nil && resp.Data != nil {
-		total = resp.Data.Total
-		self = resp.Data.Self
-		prev = resp.Data.Prev
-		next = resp.Data.Next
-		first = resp.Data.First
-		last = resp.Data.Last
-	}
-	return newList(items, total, self, prev, next, first, last, resp, opts, refetch), nil
+	return newListFromResponse(items, resp, opts, refetch), nil
 }
 
 // blockStorageIDsFromRef extracts (projectID, blockStorageID) from a Ref.

--- a/pkg/aruba/resource_block_storage.go
+++ b/pkg/aruba/resource_block_storage.go
@@ -112,6 +112,8 @@ func (b *BlockStorage) BlockStorageID() string { return b.ID() }
 
 // Raw shadows responseMetadataMixin.Raw() with the typed BlockStorage response.
 func (b *BlockStorage) Raw() *types.BlockStorageResponse { return b.response }
+func (b *BlockStorage) RawJSON() []byte                  { return marshalRawJSON(b.response) }
+func (b *BlockStorage) RawYAML() []byte                  { return marshalRawYAML(b.response) }
 
 // RawRequest returns what toCreateRequest() would emit right now.
 func (b *BlockStorage) RawRequest() types.BlockStorageRequest { return b.toCreateRequest() }

--- a/pkg/aruba/resource_cloud_server.go
+++ b/pkg/aruba/resource_cloud_server.go
@@ -685,29 +685,9 @@ func (a *cloudServersClientAdapter) List(ctx context.Context, project Ref, opts 
 				pageItems = append(pageItems, cs)
 			}
 		}
-		var total2 int64
-		var self2, prev2, next2, first2, last2 string
-		if pageResp != nil && pageResp.Data != nil {
-			total2 = pageResp.Data.Total
-			self2 = pageResp.Data.Self
-			prev2 = pageResp.Data.Prev
-			next2 = pageResp.Data.Next
-			first2 = pageResp.Data.First
-			last2 = pageResp.Data.Last
-		}
-		return newList(pageItems, total2, self2, prev2, next2, first2, last2, pageResp, opts, refetch), nil
+		return newListFromResponse(pageItems, pageResp, opts, refetch), nil
 	}
-	var total int64
-	var self, prev, next, first, last string
-	if resp != nil && resp.Data != nil {
-		total = resp.Data.Total
-		self = resp.Data.Self
-		prev = resp.Data.Prev
-		next = resp.Data.Next
-		first = resp.Data.First
-		last = resp.Data.Last
-	}
-	return newList(items, total, self, prev, next, first, last, resp, opts, refetch), nil
+	return newListFromResponse(items, resp, opts, refetch), nil
 }
 
 // Internal action methods — satisfy cloudServerActions; called by *CloudServer action methods.

--- a/pkg/aruba/resource_cloud_server.go
+++ b/pkg/aruba/resource_cloud_server.go
@@ -177,6 +177,8 @@ func (cs *CloudServer) CloudServerID() string { return cs.ID() }
 
 // Raw shadows responseMetadataMixin.Raw() with the typed CloudServer response.
 func (cs *CloudServer) Raw() *types.CloudServerResponse { return cs.response }
+func (cs *CloudServer) RawJSON() []byte                 { return marshalRawJSON(cs.response) }
+func (cs *CloudServer) RawYAML() []byte                 { return marshalRawYAML(cs.response) }
 
 // RawRequest returns what toRequest() would emit right now.
 func (cs *CloudServer) RawRequest() types.CloudServerRequest { return cs.toRequest() }

--- a/pkg/aruba/resource_container_registry.go
+++ b/pkg/aruba/resource_container_registry.go
@@ -576,27 +576,7 @@ func (a *containerRegistriesClientAdapter) List(ctx context.Context, parent Ref,
 				pageItems = append(pageItems, cr)
 			}
 		}
-		var total2 int64
-		var self2, prev2, next2, first2, last2 string
-		if pageResp != nil && pageResp.Data != nil {
-			total2 = pageResp.Data.Total
-			self2 = pageResp.Data.Self
-			prev2 = pageResp.Data.Prev
-			next2 = pageResp.Data.Next
-			first2 = pageResp.Data.First
-			last2 = pageResp.Data.Last
-		}
-		return newList(pageItems, total2, self2, prev2, next2, first2, last2, pageResp, opts, refetch), nil
+		return newListFromResponse(pageItems, pageResp, opts, refetch), nil
 	}
-	var total int64
-	var self, prev, next, first, last string
-	if resp != nil && resp.Data != nil {
-		total = resp.Data.Total
-		self = resp.Data.Self
-		prev = resp.Data.Prev
-		next = resp.Data.Next
-		first = resp.Data.First
-		last = resp.Data.Last
-	}
-	return newList(items, total, self, prev, next, first, last, resp, opts, refetch), nil
+	return newListFromResponse(items, resp, opts, refetch), nil
 }

--- a/pkg/aruba/resource_container_registry.go
+++ b/pkg/aruba/resource_container_registry.go
@@ -155,6 +155,8 @@ func (r *ContainerRegistry) ContainerRegistryID() string { return r.ID() }
 
 // Raw shadows responseMetadataMixin.Raw() with the typed ContainerRegistry response.
 func (r *ContainerRegistry) Raw() *types.ContainerRegistryResponse { return r.response }
+func (r *ContainerRegistry) RawJSON() []byte                       { return marshalRawJSON(r.response) }
+func (r *ContainerRegistry) RawYAML() []byte                       { return marshalRawYAML(r.response) }
 
 // RawRequest returns what toRequest() would emit right now.
 func (r *ContainerRegistry) RawRequest() types.ContainerRegistryRequest { return r.toRequest() }

--- a/pkg/aruba/resource_database.go
+++ b/pkg/aruba/resource_database.go
@@ -98,6 +98,8 @@ func (d *Database) CreatedBy() string {
 
 // Raw shadows responseMetadataMixin.Raw() with the typed Database response.
 func (d *Database) Raw() *types.DatabaseResponse { return d.response }
+func (d *Database) RawJSON() []byte              { return marshalRawJSON(d.response) }
+func (d *Database) RawYAML() []byte              { return marshalRawYAML(d.response) }
 
 // RawRequest returns what toRequest() would emit right now.
 func (d *Database) RawRequest() types.DatabaseRequest { return d.toRequest() }

--- a/pkg/aruba/resource_database.go
+++ b/pkg/aruba/resource_database.go
@@ -361,29 +361,9 @@ func (a *databasesClientAdapter) List(ctx context.Context, dbaas Ref, opts ...Ca
 				pageItems = append(pageItems, db)
 			}
 		}
-		var total2 int64
-		var self2, prev2, next2, first2, last2 string
-		if pageResp != nil && pageResp.Data != nil {
-			total2 = pageResp.Data.Total
-			self2 = pageResp.Data.Self
-			prev2 = pageResp.Data.Prev
-			next2 = pageResp.Data.Next
-			first2 = pageResp.Data.First
-			last2 = pageResp.Data.Last
-		}
-		return newList(pageItems, total2, self2, prev2, next2, first2, last2, pageResp, opts, refetch), nil
+		return newListFromResponse(pageItems, pageResp, opts, refetch), nil
 	}
-	var total int64
-	var self, prev, next, first, last string
-	if resp != nil && resp.Data != nil {
-		total = resp.Data.Total
-		self = resp.Data.Self
-		prev = resp.Data.Prev
-		next = resp.Data.Next
-		first = resp.Data.First
-		last = resp.Data.Last
-	}
-	return newList(items, total, self, prev, next, first, last, resp, opts, refetch), nil
+	return newListFromResponse(items, resp, opts, refetch), nil
 }
 
 // databaseIDsFromRef extracts (projectID, dbaasID, databaseID) from a Ref.

--- a/pkg/aruba/resource_dbaas.go
+++ b/pkg/aruba/resource_dbaas.go
@@ -711,29 +711,9 @@ func (a *dbaasClientAdapter) List(ctx context.Context, project Ref, opts ...Call
 				pageItems = append(pageItems, d)
 			}
 		}
-		var total2 int64
-		var self2, prev2, next2, first2, last2 string
-		if pageResp != nil && pageResp.Data != nil {
-			total2 = pageResp.Data.Total
-			self2 = pageResp.Data.Self
-			prev2 = pageResp.Data.Prev
-			next2 = pageResp.Data.Next
-			first2 = pageResp.Data.First
-			last2 = pageResp.Data.Last
-		}
-		return newList(pageItems, total2, self2, prev2, next2, first2, last2, pageResp, opts, refetch), nil
+		return newListFromResponse(pageItems, pageResp, opts, refetch), nil
 	}
-	var total int64
-	var self, prev, next, first, last string
-	if resp != nil && resp.Data != nil {
-		total = resp.Data.Total
-		self = resp.Data.Self
-		prev = resp.Data.Prev
-		next = resp.Data.Next
-		first = resp.Data.First
-		last = resp.Data.Last
-	}
-	return newList(items, total, self, prev, next, first, last, resp, opts, refetch), nil
+	return newListFromResponse(items, resp, opts, refetch), nil
 }
 
 // dbaasIDsFromRef extracts (projectID, dbaasID) from a Ref.

--- a/pkg/aruba/resource_dbaas.go
+++ b/pkg/aruba/resource_dbaas.go
@@ -169,6 +169,8 @@ func (d *DBaaS) DBaaSID() string { return d.ID() }
 
 // Raw shadows responseMetadataMixin.Raw() with the typed DBaaS response.
 func (d *DBaaS) Raw() *types.DBaaSResponse { return d.response }
+func (d *DBaaS) RawJSON() []byte           { return marshalRawJSON(d.response) }
+func (d *DBaaS) RawYAML() []byte           { return marshalRawYAML(d.response) }
 
 // RawRequest returns what toRequest() would emit right now.
 func (d *DBaaS) RawRequest() types.DBaaSRequest { return d.toRequest() }

--- a/pkg/aruba/resource_dbaas_backup.go
+++ b/pkg/aruba/resource_dbaas_backup.go
@@ -435,27 +435,7 @@ func (a *dbaasBackupsClientAdapter) List(ctx context.Context, parent Ref, opts .
 				pageItems = append(pageItems, b)
 			}
 		}
-		var total2 int64
-		var self2, prev2, next2, first2, last2 string
-		if pageResp != nil && pageResp.Data != nil {
-			total2 = pageResp.Data.Total
-			self2 = pageResp.Data.Self
-			prev2 = pageResp.Data.Prev
-			next2 = pageResp.Data.Next
-			first2 = pageResp.Data.First
-			last2 = pageResp.Data.Last
-		}
-		return newList(pageItems, total2, self2, prev2, next2, first2, last2, pageResp, opts, refetch), nil
+		return newListFromResponse(pageItems, pageResp, opts, refetch), nil
 	}
-	var total int64
-	var self, prev, next, first, last string
-	if resp != nil && resp.Data != nil {
-		total = resp.Data.Total
-		self = resp.Data.Self
-		prev = resp.Data.Prev
-		next = resp.Data.Next
-		first = resp.Data.First
-		last = resp.Data.Last
-	}
-	return newList(items, total, self, prev, next, first, last, resp, opts, refetch), nil
+	return newListFromResponse(items, resp, opts, refetch), nil
 }

--- a/pkg/aruba/resource_dbaas_backup.go
+++ b/pkg/aruba/resource_dbaas_backup.go
@@ -110,6 +110,8 @@ func (b *DBaaSBackup) DBaaSBackupID() string { return b.ID() }
 
 // Raw shadows responseMetadataMixin.Raw() with the typed response.
 func (b *DBaaSBackup) Raw() *types.BackupResponse { return b.response }
+func (b *DBaaSBackup) RawJSON() []byte            { return marshalRawJSON(b.response) }
+func (b *DBaaSBackup) RawYAML() []byte            { return marshalRawYAML(b.response) }
 
 // RawRequest returns what toRequest() would emit right now.
 func (b *DBaaSBackup) RawRequest() types.BackupRequest { return b.toRequest() }

--- a/pkg/aruba/resource_elastic_ip.go
+++ b/pkg/aruba/resource_elastic_ip.go
@@ -78,6 +78,8 @@ func (e *ElasticIP) ElasticIPID() string { return e.ID() }
 
 // Raw shadows responseMetadataMixin.Raw() with the full ElasticIP response.
 func (e *ElasticIP) Raw() *types.ElasticIPResponse { return e.response }
+func (e *ElasticIP) RawJSON() []byte               { return marshalRawJSON(e.response) }
+func (e *ElasticIP) RawYAML() []byte               { return marshalRawYAML(e.response) }
 
 // RawRequest returns what toRequest() would emit right now.
 func (e *ElasticIP) RawRequest() types.ElasticIPRequest { return e.toRequest() }

--- a/pkg/aruba/resource_elastic_ip.go
+++ b/pkg/aruba/resource_elastic_ip.go
@@ -395,29 +395,9 @@ func (a *elasticIPsClientAdapter) List(ctx context.Context, project Ref, opts ..
 				pageItems = append(pageItems, e)
 			}
 		}
-		var total2 int64
-		var self2, prev2, next2, first2, last2 string
-		if pageResp != nil && pageResp.Data != nil {
-			total2 = pageResp.Data.Total
-			self2 = pageResp.Data.Self
-			prev2 = pageResp.Data.Prev
-			next2 = pageResp.Data.Next
-			first2 = pageResp.Data.First
-			last2 = pageResp.Data.Last
-		}
-		return newList(pageItems, total2, self2, prev2, next2, first2, last2, pageResp, opts, refetch), nil
+		return newListFromResponse(pageItems, pageResp, opts, refetch), nil
 	}
-	var total int64
-	var self, prev, next, first, last string
-	if resp != nil && resp.Data != nil {
-		total = resp.Data.Total
-		self = resp.Data.Self
-		prev = resp.Data.Prev
-		next = resp.Data.Next
-		first = resp.Data.First
-		last = resp.Data.Last
-	}
-	return newList(items, total, self, prev, next, first, last, resp, opts, refetch), nil
+	return newListFromResponse(items, resp, opts, refetch), nil
 }
 
 // elasticIPIDsFromRef extracts (projectID, elasticIPID) from a Ref. Tries typed

--- a/pkg/aruba/resource_grant.go
+++ b/pkg/aruba/resource_grant.go
@@ -455,27 +455,7 @@ func (a *grantsClientAdapter) List(ctx context.Context, parent Ref, opts ...Call
 				pageItems = append(pageItems, g)
 			}
 		}
-		var total2 int64
-		var self2, prev2, next2, first2, last2 string
-		if pageResp != nil && pageResp.Data != nil {
-			total2 = pageResp.Data.Total
-			self2 = pageResp.Data.Self
-			prev2 = pageResp.Data.Prev
-			next2 = pageResp.Data.Next
-			first2 = pageResp.Data.First
-			last2 = pageResp.Data.Last
-		}
-		return newList(pageItems, total2, self2, prev2, next2, first2, last2, pageResp, opts, refetch), nil
+		return newListFromResponse(pageItems, pageResp, opts, refetch), nil
 	}
-	var total int64
-	var self, prev, next, first, last string
-	if resp != nil && resp.Data != nil {
-		total = resp.Data.Total
-		self = resp.Data.Self
-		prev = resp.Data.Prev
-		next = resp.Data.Next
-		first = resp.Data.First
-		last = resp.Data.Last
-	}
-	return newList(items, total, self, prev, next, first, last, resp, opts, refetch), nil
+	return newListFromResponse(items, resp, opts, refetch), nil
 }

--- a/pkg/aruba/resource_grant.go
+++ b/pkg/aruba/resource_grant.go
@@ -126,6 +126,8 @@ func (g *Grant) CreatedBy() string {
 
 // Raw shadows responseMetadataMixin.Raw() with the typed Grant response.
 func (g *Grant) Raw() *types.GrantResponse { return g.response }
+func (g *Grant) RawJSON() []byte           { return marshalRawJSON(g.response) }
+func (g *Grant) RawYAML() []byte           { return marshalRawYAML(g.response) }
 
 // RawRequest returns what toRequest() would emit right now.
 func (g *Grant) RawRequest() types.GrantRequest { return g.toRequest() }

--- a/pkg/aruba/resource_job.go
+++ b/pkg/aruba/resource_job.go
@@ -143,6 +143,8 @@ func (j *Job) JobID() string { return j.ID() }
 
 // Raw shadows responseMetadataMixin.Raw() with the typed Job response.
 func (j *Job) Raw() *types.JobResponse { return j.response }
+func (j *Job) RawJSON() []byte         { return marshalRawJSON(j.response) }
+func (j *Job) RawYAML() []byte         { return marshalRawYAML(j.response) }
 
 // RawRequest returns what toRequest() would emit right now.
 func (j *Job) RawRequest() types.JobRequest { return j.toRequest() }

--- a/pkg/aruba/resource_job.go
+++ b/pkg/aruba/resource_job.go
@@ -548,27 +548,7 @@ func (a *jobsClientAdapter) List(ctx context.Context, parent Ref, opts ...CallOp
 				pageItems = append(pageItems, j)
 			}
 		}
-		var total2 int64
-		var self2, prev2, next2, first2, last2 string
-		if pageResp != nil && pageResp.Data != nil {
-			total2 = pageResp.Data.Total
-			self2 = pageResp.Data.Self
-			prev2 = pageResp.Data.Prev
-			next2 = pageResp.Data.Next
-			first2 = pageResp.Data.First
-			last2 = pageResp.Data.Last
-		}
-		return newList(pageItems, total2, self2, prev2, next2, first2, last2, pageResp, opts, refetch), nil
+		return newListFromResponse(pageItems, pageResp, opts, refetch), nil
 	}
-	var total int64
-	var self, prev, next, first, last string
-	if resp != nil && resp.Data != nil {
-		total = resp.Data.Total
-		self = resp.Data.Self
-		prev = resp.Data.Prev
-		next = resp.Data.Next
-		first = resp.Data.First
-		last = resp.Data.Last
-	}
-	return newList(items, total, self, prev, next, first, last, resp, opts, refetch), nil
+	return newListFromResponse(items, resp, opts, refetch), nil
 }

--- a/pkg/aruba/resource_kaas.go
+++ b/pkg/aruba/resource_kaas.go
@@ -804,29 +804,9 @@ func (a *kaasClientAdapter) List(ctx context.Context, parent Ref, opts ...CallOp
 				pageItems = append(pageItems, k)
 			}
 		}
-		var total2 int64
-		var self2, prev2, next2, first2, last2 string
-		if pageResp != nil && pageResp.Data != nil {
-			total2 = pageResp.Data.Total
-			self2 = pageResp.Data.Self
-			prev2 = pageResp.Data.Prev
-			next2 = pageResp.Data.Next
-			first2 = pageResp.Data.First
-			last2 = pageResp.Data.Last
-		}
-		return newList(pageItems, total2, self2, prev2, next2, first2, last2, pageResp, opts, refetch), nil
+		return newListFromResponse(pageItems, pageResp, opts, refetch), nil
 	}
-	var total int64
-	var self, prev, next, first, last string
-	if resp != nil && resp.Data != nil {
-		total = resp.Data.Total
-		self = resp.Data.Self
-		prev = resp.Data.Prev
-		next = resp.Data.Next
-		first = resp.Data.First
-		last = resp.Data.Last
-	}
-	return newList(items, total, self, prev, next, first, last, resp, opts, refetch), nil
+	return newListFromResponse(items, resp, opts, refetch), nil
 }
 
 // downloadKubeconfig satisfies kaasActions (lowercase, internal interface).

--- a/pkg/aruba/resource_kaas.go
+++ b/pkg/aruba/resource_kaas.go
@@ -272,6 +272,8 @@ func (k *KaaS) KaaSID() string { return k.ID() }
 
 // Raw shadows responseMetadataMixin.Raw() with the typed KaaS response.
 func (k *KaaS) Raw() *types.KaaSResponse { return k.response }
+func (k *KaaS) RawJSON() []byte          { return marshalRawJSON(k.response) }
+func (k *KaaS) RawYAML() []byte          { return marshalRawYAML(k.response) }
 
 // RawRequest returns what toRequest() would emit right now.
 func (k *KaaS) RawRequest() types.KaaSRequest { return k.toRequest() }

--- a/pkg/aruba/resource_key.go
+++ b/pkg/aruba/resource_key.go
@@ -389,27 +389,7 @@ func (a *keysClientAdapter) List(ctx context.Context, parent Ref, opts ...CallOp
 				pageItems = append(pageItems, k)
 			}
 		}
-		var total2 int64
-		var self2, prev2, next2, first2, last2 string
-		if pageResp != nil && pageResp.Data != nil {
-			total2 = pageResp.Data.Total
-			self2 = pageResp.Data.Self
-			prev2 = pageResp.Data.Prev
-			next2 = pageResp.Data.Next
-			first2 = pageResp.Data.First
-			last2 = pageResp.Data.Last
-		}
-		return newList(pageItems, total2, self2, prev2, next2, first2, last2, pageResp, opts, refetch), nil
+		return newListFromResponse(pageItems, pageResp, opts, refetch), nil
 	}
-	var total int64
-	var self, prev, next, first, last string
-	if resp != nil && resp.Data != nil {
-		total = resp.Data.Total
-		self = resp.Data.Self
-		prev = resp.Data.Prev
-		next = resp.Data.Next
-		first = resp.Data.First
-		last = resp.Data.Last
-	}
-	return newList(items, total, self, prev, next, first, last, resp, opts, refetch), nil
+	return newListFromResponse(items, resp, opts, refetch), nil
 }

--- a/pkg/aruba/resource_key.go
+++ b/pkg/aruba/resource_key.go
@@ -77,6 +77,8 @@ func (k *Key) URI() string {
 
 // Raw shadows responseMetadataMixin.Raw() with the typed Key response.
 func (k *Key) Raw() *types.KeyResponse { return k.response }
+func (k *Key) RawJSON() []byte         { return marshalRawJSON(k.response) }
+func (k *Key) RawYAML() []byte         { return marshalRawYAML(k.response) }
 
 // RawRequest returns what toRequest() would emit right now.
 func (k *Key) RawRequest() types.KeyRequest { return k.toRequest() }

--- a/pkg/aruba/resource_key_pair.go
+++ b/pkg/aruba/resource_key_pair.go
@@ -305,29 +305,9 @@ func (a *keyPairsClientAdapter) List(ctx context.Context, project Ref, opts ...C
 				pageItems = append(pageItems, kp)
 			}
 		}
-		var total2 int64
-		var self2, prev2, next2, first2, last2 string
-		if pageResp != nil && pageResp.Data != nil {
-			total2 = pageResp.Data.Total
-			self2 = pageResp.Data.Self
-			prev2 = pageResp.Data.Prev
-			next2 = pageResp.Data.Next
-			first2 = pageResp.Data.First
-			last2 = pageResp.Data.Last
-		}
-		return newList(pageItems, total2, self2, prev2, next2, first2, last2, pageResp, opts, refetch), nil
+		return newListFromResponse(pageItems, pageResp, opts, refetch), nil
 	}
-	var total int64
-	var self, prev, next, first, last string
-	if resp != nil && resp.Data != nil {
-		total = resp.Data.Total
-		self = resp.Data.Self
-		prev = resp.Data.Prev
-		next = resp.Data.Next
-		first = resp.Data.First
-		last = resp.Data.Last
-	}
-	return newList(items, total, self, prev, next, first, last, resp, opts, refetch), nil
+	return newListFromResponse(items, resp, opts, refetch), nil
 }
 
 // keyPairIDsFromRef extracts (projectID, keyPairID) from a Ref.

--- a/pkg/aruba/resource_key_pair.go
+++ b/pkg/aruba/resource_key_pair.go
@@ -73,6 +73,8 @@ func (k *KeyPair) KeyPairID() string { return k.ID() }
 
 // Raw shadows responseMetadataMixin.Raw() with the typed key-pair response.
 func (k *KeyPair) Raw() *types.KeyPairResponse { return k.response }
+func (k *KeyPair) RawJSON() []byte             { return marshalRawJSON(k.response) }
+func (k *KeyPair) RawYAML() []byte             { return marshalRawYAML(k.response) }
 
 // RawRequest returns what toRequest() would emit right now.
 func (k *KeyPair) RawRequest() types.KeyPairRequest { return k.toRequest() }

--- a/pkg/aruba/resource_kmip.go
+++ b/pkg/aruba/resource_kmip.go
@@ -135,6 +135,8 @@ func (km *Kmip) URI() string {
 
 // Raw shadows responseMetadataMixin.Raw() with the typed Kmip response.
 func (km *Kmip) Raw() *types.KmipResponse { return km.response }
+func (km *Kmip) RawJSON() []byte          { return marshalRawJSON(km.response) }
+func (km *Kmip) RawYAML() []byte          { return marshalRawYAML(km.response) }
 
 // RawRequest returns what toRequest() would emit right now.
 func (km *Kmip) RawRequest() types.KmipRequest { return km.toRequest() }
@@ -483,3 +485,5 @@ func (c *KmipCertificate) Raw() *types.KmipCertificateResponse {
 	}
 	return c.response
 }
+func (c *KmipCertificate) RawJSON() []byte { return marshalRawJSON(c.response) }
+func (c *KmipCertificate) RawYAML() []byte { return marshalRawYAML(c.response) }

--- a/pkg/aruba/resource_kmip.go
+++ b/pkg/aruba/resource_kmip.go
@@ -428,29 +428,9 @@ func (a *kmipsClientAdapter) List(ctx context.Context, parent Ref, opts ...CallO
 				pageItems = append(pageItems, km)
 			}
 		}
-		var total2 int64
-		var self2, prev2, next2, first2, last2 string
-		if pageResp != nil && pageResp.Data != nil {
-			total2 = pageResp.Data.Total
-			self2 = pageResp.Data.Self
-			prev2 = pageResp.Data.Prev
-			next2 = pageResp.Data.Next
-			first2 = pageResp.Data.First
-			last2 = pageResp.Data.Last
-		}
-		return newList(pageItems, total2, self2, prev2, next2, first2, last2, pageResp, opts, refetch), nil
+		return newListFromResponse(pageItems, pageResp, opts, refetch), nil
 	}
-	var total int64
-	var self, prev, next, first, last string
-	if resp != nil && resp.Data != nil {
-		total = resp.Data.Total
-		self = resp.Data.Self
-		prev = resp.Data.Prev
-		next = resp.Data.Next
-		first = resp.Data.First
-		last = resp.Data.Last
-	}
-	return newList(items, total, self, prev, next, first, last, resp, opts, refetch), nil
+	return newListFromResponse(items, resp, opts, refetch), nil
 }
 
 // Download retrieves the KMIP certificate key+cert pair for the given Ref.

--- a/pkg/aruba/resource_kms.go
+++ b/pkg/aruba/resource_kms.go
@@ -77,6 +77,8 @@ func (k *KMS) KMSID() string { return k.ID() }
 
 // Raw shadows responseMetadataMixin.Raw() with the typed KMS response.
 func (k *KMS) Raw() *types.KmsResponse { return k.response }
+func (k *KMS) RawJSON() []byte         { return marshalRawJSON(k.response) }
+func (k *KMS) RawYAML() []byte         { return marshalRawYAML(k.response) }
 
 // RawRequest returns what toRequest() would emit right now.
 func (k *KMS) RawRequest() types.KmsRequest { return k.toRequest() }

--- a/pkg/aruba/resource_kms.go
+++ b/pkg/aruba/resource_kms.go
@@ -398,27 +398,7 @@ func (a *kmsClientAdapter) List(ctx context.Context, parent Ref, opts ...CallOpt
 				pageItems = append(pageItems, k)
 			}
 		}
-		var total2 int64
-		var self2, prev2, next2, first2, last2 string
-		if pageResp != nil && pageResp.Data != nil {
-			total2 = pageResp.Data.Total
-			self2 = pageResp.Data.Self
-			prev2 = pageResp.Data.Prev
-			next2 = pageResp.Data.Next
-			first2 = pageResp.Data.First
-			last2 = pageResp.Data.Last
-		}
-		return newList(pageItems, total2, self2, prev2, next2, first2, last2, pageResp, opts, refetch), nil
+		return newListFromResponse(pageItems, pageResp, opts, refetch), nil
 	}
-	var total int64
-	var self, prev, next, first, last string
-	if resp != nil && resp.Data != nil {
-		total = resp.Data.Total
-		self = resp.Data.Self
-		prev = resp.Data.Prev
-		next = resp.Data.Next
-		first = resp.Data.First
-		last = resp.Data.Last
-	}
-	return newList(items, total, self, prev, next, first, last, resp, opts, refetch), nil
+	return newListFromResponse(items, resp, opts, refetch), nil
 }

--- a/pkg/aruba/resource_load_balancer.go
+++ b/pkg/aruba/resource_load_balancer.go
@@ -44,6 +44,8 @@ func (l *LoadBalancer) LoadBalancerID() string { return l.ID() }
 
 // Raw shadows responseMetadataMixin.Raw() with the full LoadBalancer response.
 func (l *LoadBalancer) Raw() *types.LoadBalancerResponse { return l.response }
+func (l *LoadBalancer) RawJSON() []byte                  { return marshalRawJSON(l.response) }
+func (l *LoadBalancer) RawYAML() []byte                  { return marshalRawYAML(l.response) }
 
 // Address returns the public IP address assigned to this Load Balancer, or "" if absent.
 func (l *LoadBalancer) Address() string {

--- a/pkg/aruba/resource_load_balancer.go
+++ b/pkg/aruba/resource_load_balancer.go
@@ -237,29 +237,9 @@ func (a *loadBalancersClientAdapter) List(ctx context.Context, project Ref, opts
 				pageItems = append(pageItems, lb)
 			}
 		}
-		var total2 int64
-		var self2, prev2, next2, first2, last2 string
-		if pageResp != nil && pageResp.Data != nil {
-			total2 = pageResp.Data.Total
-			self2 = pageResp.Data.Self
-			prev2 = pageResp.Data.Prev
-			next2 = pageResp.Data.Next
-			first2 = pageResp.Data.First
-			last2 = pageResp.Data.Last
-		}
-		return newList(pageItems, total2, self2, prev2, next2, first2, last2, pageResp, opts, refetch), nil
+		return newListFromResponse(pageItems, pageResp, opts, refetch), nil
 	}
-	var total int64
-	var self, prev, next, first, last string
-	if resp != nil && resp.Data != nil {
-		total = resp.Data.Total
-		self = resp.Data.Self
-		prev = resp.Data.Prev
-		next = resp.Data.Next
-		first = resp.Data.First
-		last = resp.Data.Last
-	}
-	return newList(items, total, self, prev, next, first, last, resp, opts, refetch), nil
+	return newListFromResponse(items, resp, opts, refetch), nil
 }
 
 // loadBalancerIDsFromRef extracts (projectID, loadBalancerID) from a Ref. Tries typed

--- a/pkg/aruba/resource_metric.go
+++ b/pkg/aruba/resource_metric.go
@@ -162,27 +162,7 @@ func (a *metricsClientAdapter) List(ctx context.Context, project Ref, opts ...Ca
 				pageItems = append(pageItems, met)
 			}
 		}
-		var total2 int64
-		var self2, prev2, next2, first2, last2 string
-		if pageResp != nil && pageResp.Data != nil {
-			total2 = pageResp.Data.Total
-			self2 = pageResp.Data.Self
-			prev2 = pageResp.Data.Prev
-			next2 = pageResp.Data.Next
-			first2 = pageResp.Data.First
-			last2 = pageResp.Data.Last
-		}
-		return newList(pageItems, total2, self2, prev2, next2, first2, last2, pageResp, opts, refetch), nil
+		return newListFromResponse(pageItems, pageResp, opts, refetch), nil
 	}
-	var total int64
-	var self, prev, next, first, last string
-	if resp != nil && resp.Data != nil {
-		total = resp.Data.Total
-		self = resp.Data.Self
-		prev = resp.Data.Prev
-		next = resp.Data.Next
-		first = resp.Data.First
-		last = resp.Data.Last
-	}
-	return newList(items, total, self, prev, next, first, last, resp, opts, refetch), nil
+	return newListFromResponse(items, resp, opts, refetch), nil
 }

--- a/pkg/aruba/resource_metric.go
+++ b/pkg/aruba/resource_metric.go
@@ -36,6 +36,8 @@ func (m *Metric) URI() string { return "" }
 
 // Raw returns the underlying wire payload. Shadows responseMetadataMixin.Raw().
 func (m *Metric) Raw() *types.MetricResponse { return m.response }
+func (m *Metric) RawJSON() []byte            { return marshalRawJSON(m.response) }
+func (m *Metric) RawYAML() []byte            { return marshalRawYAML(m.response) }
 
 // ReferenceID returns the metric reference ID, or "" when unset.
 func (m *Metric) ReferenceID() string {

--- a/pkg/aruba/resource_project.go
+++ b/pkg/aruba/resource_project.go
@@ -265,27 +265,7 @@ func (a *projectClientAdapter) List(ctx context.Context, opts ...CallOption) (*L
 				pageItems = append(pageItems, item)
 			}
 		}
-		var total2 int64
-		var self2, prev2, next2, first2, last2 string
-		if pageResp != nil && pageResp.Data != nil {
-			total2 = pageResp.Data.Total
-			self2 = pageResp.Data.Self
-			prev2 = pageResp.Data.Prev
-			next2 = pageResp.Data.Next
-			first2 = pageResp.Data.First
-			last2 = pageResp.Data.Last
-		}
-		return newList(pageItems, total2, self2, prev2, next2, first2, last2, pageResp, opts, refetch), nil
+		return newListFromResponse(pageItems, pageResp, opts, refetch), nil
 	}
-	var total int64
-	var self, prev, next, first, last string
-	if resp != nil && resp.Data != nil {
-		total = resp.Data.Total
-		self = resp.Data.Self
-		prev = resp.Data.Prev
-		next = resp.Data.Next
-		first = resp.Data.First
-		last = resp.Data.Last
-	}
-	return newList(items, total, self, prev, next, first, last, resp, opts, refetch), nil
+	return newListFromResponse(items, resp, opts, refetch), nil
 }

--- a/pkg/aruba/resource_security_group.go
+++ b/pkg/aruba/resource_security_group.go
@@ -78,6 +78,8 @@ func (sg *SecurityGroup) SecurityGroupID() string { return sg.ID() }
 
 // Raw shadows responseMetadataMixin.Raw() with the full SecurityGroup response.
 func (sg *SecurityGroup) Raw() *types.SecurityGroupResponse { return sg.response }
+func (sg *SecurityGroup) RawJSON() []byte                   { return marshalRawJSON(sg.response) }
+func (sg *SecurityGroup) RawYAML() []byte                   { return marshalRawYAML(sg.response) }
 
 // RawRequest returns what toRequest() would emit right now.
 func (sg *SecurityGroup) RawRequest() types.SecurityGroupRequest { return sg.toRequest() }

--- a/pkg/aruba/resource_security_group.go
+++ b/pkg/aruba/resource_security_group.go
@@ -378,29 +378,9 @@ func (a *securityGroupsClientAdapter) List(ctx context.Context, vpc Ref, opts ..
 				pageItems = append(pageItems, item)
 			}
 		}
-		var total2 int64
-		var self2, prev2, next2, first2, last2 string
-		if pageResp != nil && pageResp.Data != nil {
-			total2 = pageResp.Data.Total
-			self2 = pageResp.Data.Self
-			prev2 = pageResp.Data.Prev
-			next2 = pageResp.Data.Next
-			first2 = pageResp.Data.First
-			last2 = pageResp.Data.Last
-		}
-		return newList(pageItems, total2, self2, prev2, next2, first2, last2, pageResp, opts, refetch), nil
+		return newListFromResponse(pageItems, pageResp, opts, refetch), nil
 	}
-	var total int64
-	var self, prev, next, first, last string
-	if resp != nil && resp.Data != nil {
-		total = resp.Data.Total
-		self = resp.Data.Self
-		prev = resp.Data.Prev
-		next = resp.Data.Next
-		first = resp.Data.First
-		last = resp.Data.Last
-	}
-	return newList(items, total, self, prev, next, first, last, resp, opts, refetch), nil
+	return newListFromResponse(items, resp, opts, refetch), nil
 }
 
 // securityGroupIDsFromRef extracts (projectID, vpcID, securityGroupID) from a Ref.

--- a/pkg/aruba/resource_security_rule.go
+++ b/pkg/aruba/resource_security_rule.go
@@ -122,6 +122,8 @@ func (r *SecurityRule) SecurityRuleID() string { return r.ID() }
 
 // Raw shadows responseMetadataMixin.Raw() with the full SecurityRule response.
 func (r *SecurityRule) Raw() *types.SecurityRuleResponse { return r.response }
+func (r *SecurityRule) RawJSON() []byte                  { return marshalRawJSON(r.response) }
+func (r *SecurityRule) RawYAML() []byte                  { return marshalRawYAML(r.response) }
 
 // RawRequest returns what toRequest() would emit right now.
 func (r *SecurityRule) RawRequest() types.SecurityRuleRequest { return r.toRequest() }

--- a/pkg/aruba/resource_security_rule.go
+++ b/pkg/aruba/resource_security_rule.go
@@ -502,29 +502,9 @@ func (a *securityRulesClientAdapter) List(ctx context.Context, sg Ref, opts ...C
 				pageItems = append(pageItems, item)
 			}
 		}
-		var total2 int64
-		var self2, prev2, next2, first2, last2 string
-		if pageResp != nil && pageResp.Data != nil {
-			total2 = pageResp.Data.Total
-			self2 = pageResp.Data.Self
-			prev2 = pageResp.Data.Prev
-			next2 = pageResp.Data.Next
-			first2 = pageResp.Data.First
-			last2 = pageResp.Data.Last
-		}
-		return newList(pageItems, total2, self2, prev2, next2, first2, last2, pageResp, opts, refetch), nil
+		return newListFromResponse(pageItems, pageResp, opts, refetch), nil
 	}
-	var total int64
-	var self, prev, next, first, last string
-	if resp != nil && resp.Data != nil {
-		total = resp.Data.Total
-		self = resp.Data.Self
-		prev = resp.Data.Prev
-		next = resp.Data.Next
-		first = resp.Data.First
-		last = resp.Data.Last
-	}
-	return newList(items, total, self, prev, next, first, last, resp, opts, refetch), nil
+	return newListFromResponse(items, resp, opts, refetch), nil
 }
 
 // securityRuleIDsFromRef extracts (projectID, vpcID, securityGroupID, securityRuleID) from a Ref.

--- a/pkg/aruba/resource_snapshot.go
+++ b/pkg/aruba/resource_snapshot.go
@@ -90,6 +90,8 @@ func (s *Snapshot) SnapshotID() string { return s.ID() }
 
 // Raw shadows responseMetadataMixin.Raw() with the typed Snapshot response.
 func (s *Snapshot) Raw() *types.SnapshotResponse { return s.response }
+func (s *Snapshot) RawJSON() []byte              { return marshalRawJSON(s.response) }
+func (s *Snapshot) RawYAML() []byte              { return marshalRawYAML(s.response) }
 
 // RawRequest returns what toRequest() would emit right now.
 func (s *Snapshot) RawRequest() types.SnapshotRequest { return s.toRequest() }

--- a/pkg/aruba/resource_snapshot.go
+++ b/pkg/aruba/resource_snapshot.go
@@ -448,29 +448,9 @@ func (a *snapshotsClientAdapter) List(ctx context.Context, project Ref, opts ...
 				pageItems = append(pageItems, item)
 			}
 		}
-		var total2 int64
-		var self2, prev2, next2, first2, last2 string
-		if pageResp != nil && pageResp.Data != nil {
-			total2 = pageResp.Data.Total
-			self2 = pageResp.Data.Self
-			prev2 = pageResp.Data.Prev
-			next2 = pageResp.Data.Next
-			first2 = pageResp.Data.First
-			last2 = pageResp.Data.Last
-		}
-		return newList(pageItems, total2, self2, prev2, next2, first2, last2, pageResp, opts, refetch), nil
+		return newListFromResponse(pageItems, pageResp, opts, refetch), nil
 	}
-	var total int64
-	var self, prev, next, first, last string
-	if resp != nil && resp.Data != nil {
-		total = resp.Data.Total
-		self = resp.Data.Self
-		prev = resp.Data.Prev
-		next = resp.Data.Next
-		first = resp.Data.First
-		last = resp.Data.Last
-	}
-	return newList(items, total, self, prev, next, first, last, resp, opts, refetch), nil
+	return newListFromResponse(items, resp, opts, refetch), nil
 }
 
 // snapshotIDsFromRef extracts (projectID, snapshotID) from a Ref.

--- a/pkg/aruba/resource_storage_backup.go
+++ b/pkg/aruba/resource_storage_backup.go
@@ -444,29 +444,9 @@ func (a *storageBackupsClientAdapter) List(ctx context.Context, project Ref, opt
 				pageItems = append(pageItems, item)
 			}
 		}
-		var total2 int64
-		var self2, prev2, next2, first2, last2 string
-		if pageResp != nil && pageResp.Data != nil {
-			total2 = pageResp.Data.Total
-			self2 = pageResp.Data.Self
-			prev2 = pageResp.Data.Prev
-			next2 = pageResp.Data.Next
-			first2 = pageResp.Data.First
-			last2 = pageResp.Data.Last
-		}
-		return newList(pageItems, total2, self2, prev2, next2, first2, last2, pageResp, opts, refetch), nil
+		return newListFromResponse(pageItems, pageResp, opts, refetch), nil
 	}
-	var total int64
-	var self, prev, next, first, last string
-	if resp != nil && resp.Data != nil {
-		total = resp.Data.Total
-		self = resp.Data.Self
-		prev = resp.Data.Prev
-		next = resp.Data.Next
-		first = resp.Data.First
-		last = resp.Data.Last
-	}
-	return newList(items, total, self, prev, next, first, last, resp, opts, refetch), nil
+	return newListFromResponse(items, resp, opts, refetch), nil
 }
 
 // backupIDsFromRef extracts (projectID, backupID) from a Ref.

--- a/pkg/aruba/resource_storage_backup.go
+++ b/pkg/aruba/resource_storage_backup.go
@@ -104,6 +104,8 @@ func (b *StorageBackup) BackupID() string { return b.ID() }
 
 // Raw shadows responseMetadataMixin.Raw() with the typed response.
 func (b *StorageBackup) Raw() *types.StorageBackupResponse { return b.response }
+func (b *StorageBackup) RawJSON() []byte                   { return marshalRawJSON(b.response) }
+func (b *StorageBackup) RawYAML() []byte                   { return marshalRawYAML(b.response) }
 
 // RawRequest returns what toRequest() would emit right now.
 func (b *StorageBackup) RawRequest() types.StorageBackupRequest { return b.toRequest() }

--- a/pkg/aruba/resource_storage_restore.go
+++ b/pkg/aruba/resource_storage_restore.go
@@ -80,6 +80,8 @@ func (r *StorageRestore) RestoreID() string { return r.ID() }
 
 // Raw shadows responseMetadataMixin.Raw() with the typed restore response.
 func (r *StorageRestore) Raw() *types.StorageRestoreResponse { return r.response }
+func (r *StorageRestore) RawJSON() []byte                    { return marshalRawJSON(r.response) }
+func (r *StorageRestore) RawYAML() []byte                    { return marshalRawYAML(r.response) }
 
 // RawRequest returns what toRequest() would emit right now.
 func (r *StorageRestore) RawRequest() types.StorageRestoreRequest { return r.toRequest() }

--- a/pkg/aruba/resource_storage_restore.go
+++ b/pkg/aruba/resource_storage_restore.go
@@ -394,29 +394,9 @@ func (a *storageRestoresClientAdapter) List(ctx context.Context, backup Ref, opt
 				pageItems = append(pageItems, item)
 			}
 		}
-		var total2 int64
-		var self2, prev2, next2, first2, last2 string
-		if pageResp != nil && pageResp.Data != nil {
-			total2 = pageResp.Data.Total
-			self2 = pageResp.Data.Self
-			prev2 = pageResp.Data.Prev
-			next2 = pageResp.Data.Next
-			first2 = pageResp.Data.First
-			last2 = pageResp.Data.Last
-		}
-		return newList(pageItems, total2, self2, prev2, next2, first2, last2, pageResp, opts, refetch), nil
+		return newListFromResponse(pageItems, pageResp, opts, refetch), nil
 	}
-	var total int64
-	var self, prev, next, first, last string
-	if resp != nil && resp.Data != nil {
-		total = resp.Data.Total
-		self = resp.Data.Self
-		prev = resp.Data.Prev
-		next = resp.Data.Next
-		first = resp.Data.First
-		last = resp.Data.Last
-	}
-	return newList(items, total, self, prev, next, first, last, resp, opts, refetch), nil
+	return newListFromResponse(items, resp, opts, refetch), nil
 }
 
 // restoreIDsFromRef extracts (projectID, backupID, restoreID) from a Ref.

--- a/pkg/aruba/resource_subnet.go
+++ b/pkg/aruba/resource_subnet.go
@@ -436,29 +436,9 @@ func (a *subnetsClientAdapter) List(ctx context.Context, vpc Ref, opts ...CallOp
 				pageItems = append(pageItems, item)
 			}
 		}
-		var total2 int64
-		var self2, prev2, next2, first2, last2 string
-		if pageResp != nil && pageResp.Data != nil {
-			total2 = pageResp.Data.Total
-			self2 = pageResp.Data.Self
-			prev2 = pageResp.Data.Prev
-			next2 = pageResp.Data.Next
-			first2 = pageResp.Data.First
-			last2 = pageResp.Data.Last
-		}
-		return newList(pageItems, total2, self2, prev2, next2, first2, last2, pageResp, opts, refetch), nil
+		return newListFromResponse(pageItems, pageResp, opts, refetch), nil
 	}
-	var total int64
-	var self, prev, next, first, last string
-	if resp != nil && resp.Data != nil {
-		total = resp.Data.Total
-		self = resp.Data.Self
-		prev = resp.Data.Prev
-		next = resp.Data.Next
-		first = resp.Data.First
-		last = resp.Data.Last
-	}
-	return newList(items, total, self, prev, next, first, last, resp, opts, refetch), nil
+	return newListFromResponse(items, resp, opts, refetch), nil
 }
 
 // subnetIDsFromRef extracts (projectID, vpcID, subnetID) from a Ref. Tries typed

--- a/pkg/aruba/resource_subnet.go
+++ b/pkg/aruba/resource_subnet.go
@@ -94,6 +94,8 @@ func (s *Subnet) SubnetID() string { return s.ID() }
 
 // Raw shadows responseMetadataMixin.Raw() with the full subnet response.
 func (s *Subnet) Raw() *types.SubnetResponse { return s.response }
+func (s *Subnet) RawJSON() []byte            { return marshalRawJSON(s.response) }
+func (s *Subnet) RawYAML() []byte            { return marshalRawYAML(s.response) }
 
 // RawRequest returns what toRequest() would emit right now.
 func (s *Subnet) RawRequest() types.SubnetRequest { return s.toRequest() }

--- a/pkg/aruba/resource_user.go
+++ b/pkg/aruba/resource_user.go
@@ -415,27 +415,7 @@ func (a *usersClientAdapter) List(ctx context.Context, dbaas Ref, opts ...CallOp
 				pageItems = append(pageItems, item)
 			}
 		}
-		var total2 int64
-		var self2, prev2, next2, first2, last2 string
-		if pageResp != nil && pageResp.Data != nil {
-			total2 = pageResp.Data.Total
-			self2 = pageResp.Data.Self
-			prev2 = pageResp.Data.Prev
-			next2 = pageResp.Data.Next
-			first2 = pageResp.Data.First
-			last2 = pageResp.Data.Last
-		}
-		return newList(pageItems, total2, self2, prev2, next2, first2, last2, pageResp, opts, refetch), nil
+		return newListFromResponse(pageItems, pageResp, opts, refetch), nil
 	}
-	var total int64
-	var self, prev, next, first, last string
-	if resp != nil && resp.Data != nil {
-		total = resp.Data.Total
-		self = resp.Data.Self
-		prev = resp.Data.Prev
-		next = resp.Data.Next
-		first = resp.Data.First
-		last = resp.Data.Last
-	}
-	return newList(items, total, self, prev, next, first, last, resp, opts, refetch), nil
+	return newListFromResponse(items, resp, opts, refetch), nil
 }

--- a/pkg/aruba/resource_user.go
+++ b/pkg/aruba/resource_user.go
@@ -104,6 +104,8 @@ func (u *User) CreatedBy() string {
 
 // Raw shadows responseMetadataMixin.Raw() with the typed User response.
 func (u *User) Raw() *types.UserResponse { return u.response }
+func (u *User) RawJSON() []byte          { return marshalRawJSON(u.response) }
+func (u *User) RawYAML() []byte          { return marshalRawYAML(u.response) }
 
 // RawRequest returns the wire body that would be sent on Create/Update. It
 // includes the base64-encoded password if WithPassword was called — by design,

--- a/pkg/aruba/resource_vpc.go
+++ b/pkg/aruba/resource_vpc.go
@@ -86,6 +86,8 @@ func (v *VPC) VPCID() string { return v.ID() }
 
 // Raw shadows the promoted responseMetadataMixin.Raw() returning the full response.
 func (v *VPC) Raw() *types.VPCResponse { return v.response }
+func (v *VPC) RawJSON() []byte         { return marshalRawJSON(v.response) }
+func (v *VPC) RawYAML() []byte         { return marshalRawYAML(v.response) }
 
 // RawRequest returns the wire-level request that toRequest() would emit.
 func (v *VPC) RawRequest() types.VPCRequest { return v.toRequest() }

--- a/pkg/aruba/resource_vpc.go
+++ b/pkg/aruba/resource_vpc.go
@@ -375,29 +375,9 @@ func (a *vpcsClientAdapter) List(ctx context.Context, project Ref, opts ...CallO
 				pageItems = append(pageItems, item)
 			}
 		}
-		var total2 int64
-		var self2, prev2, next2, first2, last2 string
-		if pageResp != nil && pageResp.Data != nil {
-			total2 = pageResp.Data.Total
-			self2 = pageResp.Data.Self
-			prev2 = pageResp.Data.Prev
-			next2 = pageResp.Data.Next
-			first2 = pageResp.Data.First
-			last2 = pageResp.Data.Last
-		}
-		return newList(pageItems, total2, self2, prev2, next2, first2, last2, pageResp, opts, refetch), nil
+		return newListFromResponse(pageItems, pageResp, opts, refetch), nil
 	}
-	var total int64
-	var self, prev, next, first, last string
-	if resp != nil && resp.Data != nil {
-		total = resp.Data.Total
-		self = resp.Data.Self
-		prev = resp.Data.Prev
-		next = resp.Data.Next
-		first = resp.Data.First
-		last = resp.Data.Last
-	}
-	return newList(items, total, self, prev, next, first, last, resp, opts, refetch), nil
+	return newListFromResponse(items, resp, opts, refetch), nil
 }
 
 // vpcIDsFromRef extracts (projectID, vpcID) from a Ref. Tries typed assertions

--- a/pkg/aruba/resource_vpc_peering.go
+++ b/pkg/aruba/resource_vpc_peering.go
@@ -87,6 +87,8 @@ func (p *VPCPeering) VPCPeeringID() string { return p.ID() }
 
 // Raw shadows responseMetadataMixin.Raw() with the full VPCPeering response.
 func (p *VPCPeering) Raw() *types.VPCPeeringResponse { return p.response }
+func (p *VPCPeering) RawJSON() []byte                { return marshalRawJSON(p.response) }
+func (p *VPCPeering) RawYAML() []byte                { return marshalRawYAML(p.response) }
 
 // RawRequest returns what toRequest() would emit right now.
 func (p *VPCPeering) RawRequest() types.VPCPeeringRequest { return p.toRequest() }

--- a/pkg/aruba/resource_vpc_peering.go
+++ b/pkg/aruba/resource_vpc_peering.go
@@ -396,29 +396,9 @@ func (a *vpcPeeringsClientAdapter) List(ctx context.Context, vpc Ref, opts ...Ca
 				pageItems = append(pageItems, item)
 			}
 		}
-		var total2 int64
-		var self2, prev2, next2, first2, last2 string
-		if pageResp != nil && pageResp.Data != nil {
-			total2 = pageResp.Data.Total
-			self2 = pageResp.Data.Self
-			prev2 = pageResp.Data.Prev
-			next2 = pageResp.Data.Next
-			first2 = pageResp.Data.First
-			last2 = pageResp.Data.Last
-		}
-		return newList(pageItems, total2, self2, prev2, next2, first2, last2, pageResp, opts, refetch), nil
+		return newListFromResponse(pageItems, pageResp, opts, refetch), nil
 	}
-	var total int64
-	var self, prev, next, first, last string
-	if resp != nil && resp.Data != nil {
-		total = resp.Data.Total
-		self = resp.Data.Self
-		prev = resp.Data.Prev
-		next = resp.Data.Next
-		first = resp.Data.First
-		last = resp.Data.Last
-	}
-	return newList(items, total, self, prev, next, first, last, resp, opts, refetch), nil
+	return newListFromResponse(items, resp, opts, refetch), nil
 }
 
 // vpcPeeringIDsFromRef extracts (projectID, vpcID, vpcPeeringID) from a Ref.

--- a/pkg/aruba/resource_vpc_peering_route.go
+++ b/pkg/aruba/resource_vpc_peering_route.go
@@ -437,29 +437,9 @@ func (a *vpcPeeringRoutesClientAdapter) List(ctx context.Context, peering Ref, o
 				pageItems = append(pageItems, item)
 			}
 		}
-		var total2 int64
-		var self2, prev2, next2, first2, last2 string
-		if pageResp != nil && pageResp.Data != nil {
-			total2 = pageResp.Data.Total
-			self2 = pageResp.Data.Self
-			prev2 = pageResp.Data.Prev
-			next2 = pageResp.Data.Next
-			first2 = pageResp.Data.First
-			last2 = pageResp.Data.Last
-		}
-		return newList(pageItems, total2, self2, prev2, next2, first2, last2, pageResp, opts, refetch), nil
+		return newListFromResponse(pageItems, pageResp, opts, refetch), nil
 	}
-	var total int64
-	var self, prev, next, first, last string
-	if resp != nil && resp.Data != nil {
-		total = resp.Data.Total
-		self = resp.Data.Self
-		prev = resp.Data.Prev
-		next = resp.Data.Next
-		first = resp.Data.First
-		last = resp.Data.Last
-	}
-	return newList(items, total, self, prev, next, first, last, resp, opts, refetch), nil
+	return newListFromResponse(items, resp, opts, refetch), nil
 }
 
 // vpcPeeringRouteIDsFromRef extracts (projectID, vpcID, vpcPeeringID, vpcPeeringRouteID) from a Ref.

--- a/pkg/aruba/resource_vpc_peering_route.go
+++ b/pkg/aruba/resource_vpc_peering_route.go
@@ -90,6 +90,8 @@ func (r *VPCPeeringRoute) VPCPeeringRouteID() string { return r.ID() }
 
 // Raw shadows responseMetadataMixin.Raw() with the typed VPC peering route response.
 func (r *VPCPeeringRoute) Raw() *types.VPCPeeringRouteResponse { return r.response }
+func (r *VPCPeeringRoute) RawJSON() []byte                     { return marshalRawJSON(r.response) }
+func (r *VPCPeeringRoute) RawYAML() []byte                     { return marshalRawYAML(r.response) }
 
 // RawRequest returns what toRequest() would emit right now.
 func (r *VPCPeeringRoute) RawRequest() types.VPCPeeringRouteRequest { return r.toRequest() }

--- a/pkg/aruba/resource_vpc_test.go
+++ b/pkg/aruba/resource_vpc_test.go
@@ -657,6 +657,36 @@ func TestVPCsClientAdapter_List_TwoItems(t *testing.T) {
 // strPtr is a test helper local to this file.
 func strPtr(s string) *string { return &s }
 
+func TestVPC_RawJSON_RoundTrip(t *testing.T) {
+	v := &VPC{}
+	wire := vpcTestResponse("vpc-1", "my-vpc", "/projects/p/providers/Aruba.Network/vpcs/vpc-1", "p")
+	v.fromResponse(wire)
+	b := v.RawJSON()
+	if len(b) == 0 {
+		t.Fatal("RawJSON() returned empty")
+	}
+	var back types.VPCResponse
+	if err := json.Unmarshal(b, &back); err != nil {
+		t.Fatalf("json.Unmarshal: %v", err)
+	}
+	if back.Metadata.ID == nil || *back.Metadata.ID != "vpc-1" {
+		t.Errorf("round-trip lost ID: %+v", back.Metadata)
+	}
+	if back.Metadata.Name == nil || *back.Metadata.Name != "my-vpc" {
+		t.Errorf("round-trip lost Name: %+v", back.Metadata)
+	}
+}
+
+func TestVPC_RawJSON_NilSafe(t *testing.T) {
+	v := &VPC{}
+	if v.RawJSON() != nil {
+		t.Error("RawJSON() on zero-value VPC should return nil")
+	}
+	if v.RawYAML() != nil {
+		t.Error("RawYAML() on zero-value VPC should return nil")
+	}
+}
+
 func TestVPCsClientAdapter_Create_WithBuilderError(t *testing.T) {
 	callCount := 0
 	adapter := buildVPCTestAdapter(t, func(w http.ResponseWriter, _ *http.Request) {

--- a/pkg/aruba/resource_vpn_route.go
+++ b/pkg/aruba/resource_vpn_route.go
@@ -82,6 +82,8 @@ func (r *VPNRoute) VPNRouteID() string { return r.ID() }
 
 // Raw shadows responseMetadataMixin.Raw() with the typed VPN route response.
 func (r *VPNRoute) Raw() *types.VPNRouteResponse { return r.response }
+func (r *VPNRoute) RawJSON() []byte              { return marshalRawJSON(r.response) }
+func (r *VPNRoute) RawYAML() []byte              { return marshalRawYAML(r.response) }
 
 // RawRequest returns what toRequest() would emit right now.
 func (r *VPNRoute) RawRequest() types.VPNRouteRequest { return r.toRequest() }

--- a/pkg/aruba/resource_vpn_route.go
+++ b/pkg/aruba/resource_vpn_route.go
@@ -393,29 +393,9 @@ func (a *vpnRoutesClientAdapter) List(ctx context.Context, tunnel Ref, opts ...C
 				pageItems = append(pageItems, item)
 			}
 		}
-		var total2 int64
-		var self2, prev2, next2, first2, last2 string
-		if pageResp != nil && pageResp.Data != nil {
-			total2 = pageResp.Data.Total
-			self2 = pageResp.Data.Self
-			prev2 = pageResp.Data.Prev
-			next2 = pageResp.Data.Next
-			first2 = pageResp.Data.First
-			last2 = pageResp.Data.Last
-		}
-		return newList(pageItems, total2, self2, prev2, next2, first2, last2, pageResp, opts, refetch), nil
+		return newListFromResponse(pageItems, pageResp, opts, refetch), nil
 	}
-	var total int64
-	var self, prev, next, first, last string
-	if resp != nil && resp.Data != nil {
-		total = resp.Data.Total
-		self = resp.Data.Self
-		prev = resp.Data.Prev
-		next = resp.Data.Next
-		first = resp.Data.First
-		last = resp.Data.Last
-	}
-	return newList(items, total, self, prev, next, first, last, resp, opts, refetch), nil
+	return newListFromResponse(items, resp, opts, refetch), nil
 }
 
 // vpnRouteIDsFromRef extracts (projectID, vpnTunnelID, vpnRouteID) from a Ref.

--- a/pkg/aruba/resource_vpn_tunnel.go
+++ b/pkg/aruba/resource_vpn_tunnel.go
@@ -145,6 +145,8 @@ func (t *VPNTunnel) VPNTunnelID() string { return t.ID() }
 
 // Raw shadows responseMetadataMixin.Raw() with the typed VPN tunnel response.
 func (t *VPNTunnel) Raw() *types.VPNTunnelResponse { return t.response }
+func (t *VPNTunnel) RawJSON() []byte               { return marshalRawJSON(t.response) }
+func (t *VPNTunnel) RawYAML() []byte               { return marshalRawYAML(t.response) }
 
 // RawRequest returns what toRequest() would emit right now.
 func (t *VPNTunnel) RawRequest() types.VPNTunnelRequest { return t.toRequest() }

--- a/pkg/aruba/resource_vpn_tunnel.go
+++ b/pkg/aruba/resource_vpn_tunnel.go
@@ -500,29 +500,9 @@ func (a *vpnTunnelsClientAdapter) List(ctx context.Context, project Ref, opts ..
 				pageItems = append(pageItems, item)
 			}
 		}
-		var total2 int64
-		var self2, prev2, next2, first2, last2 string
-		if pageResp != nil && pageResp.Data != nil {
-			total2 = pageResp.Data.Total
-			self2 = pageResp.Data.Self
-			prev2 = pageResp.Data.Prev
-			next2 = pageResp.Data.Next
-			first2 = pageResp.Data.First
-			last2 = pageResp.Data.Last
-		}
-		return newList(pageItems, total2, self2, prev2, next2, first2, last2, pageResp, opts, refetch), nil
+		return newListFromResponse(pageItems, pageResp, opts, refetch), nil
 	}
-	var total int64
-	var self, prev, next, first, last string
-	if resp != nil && resp.Data != nil {
-		total = resp.Data.Total
-		self = resp.Data.Self
-		prev = resp.Data.Prev
-		next = resp.Data.Next
-		first = resp.Data.First
-		last = resp.Data.Last
-	}
-	return newList(items, total, self, prev, next, first, last, resp, opts, refetch), nil
+	return newListFromResponse(items, resp, opts, refetch), nil
 }
 
 // vpnTunnelIDsFromRef extracts (projectID, vpnTunnelID) from a Ref.

--- a/pkg/types/resource.go
+++ b/pkg/types/resource.go
@@ -139,6 +139,11 @@ type ListResponse struct {
 	Last string `json:"last"`
 }
 
+// BaseList returns the embedded pagination/total metadata. Promoted onto every
+// per-resource list payload (VPCList, AlertsListResponse, …) via Go's method-
+// promotion rules, so a generic helper can extract pagination fields uniformly.
+func (lr ListResponse) BaseList() ListResponse { return lr }
+
 // Response wraps an HTTP response with parsed data
 type Response[T any] struct {
 	// Data contains the parsed response body (for 2xx responses)


### PR DESCRIPTION
## Summary

- **Fixes #298** — `List[T].Raw()` previously returned `*types.Response[XxxList]` which embeds `*http.Response` (a non-JSON-serialisable type due to `GetBody func() (io.ReadCloser, error)`). `Raw()` now returns only the JSON-safe `*types.XxxList` (i.e. `resp.Data`).
- **HTTP envelope on `List[T]`** — embeds `httpEnvelopeMixin` for parity with single-resource wrappers; exposes `StatusCode()`, `Headers()`, `RawHTTP()`, `RawError()` on list responses.
- **`BaseList()` method-promotion** — `types.ListResponse.BaseList()` propagates pagination fields to all 31 per-resource list types via Go method-promotion; enables the `newListFromResponse` generic helper.
- **Pagination-extraction boilerplate removed** — ~500 lines of duplicated 11-line pagination-extraction blocks across 31 adapter files replaced by a single `newListFromResponse[T, L]` call per adapter.
- **`RawJSON()` / `RawYAML()` on every wrapper** — every resource wrapper (31 resources + `KmipCertificate`) and `List[T]` now expose `RawJSON() []byte` and `RawYAML() []byte`. Convenience marshalers for `--output json` / `--output yaml` CLI flags. Returns `nil` when the wrapper has no payload.
- **Single-import docs** — new **Working at Low Level** page (EN + IT) collects the residual cases requiring `pkg/types` / `pkg/async`. Existing `response-handling.md` examples now use single-import equivalents (`vpcList.Total()`, `RawJSON()`, etc.). `ai/ARCHITECTURE.md` and `ai/CONVENTIONS.md` document the single-import design principle for contributors.

## Closes

Closes #298

## Test plan

- [ ] `make verify` passes (lint + full test suite with race detection)
- [ ] `TestList_Raw_JSONMarshalable` — regression for #298: `json.Marshal(list.Raw())` no longer fails
- [ ] `TestList_HTTPEnvelopeAccessors` — StatusCode/Headers/RawHTTP/RawError on lists
- [ ] `TestList_NewListFromResponse_NilSafe` — nil resp and nil resp.Data handled gracefully
- [ ] `TestList_RawJSON_RoundTrip` / `TestList_RawYAML_RoundTrip` — round-trip coverage for `List[T]`
- [ ] `TestList_RawJSON_NilSafe` / `TestList_RawYAML_NilSafe` — nil-safe behavior for `List[T]`
- [ ] `TestVPC_RawJSON_RoundTrip` / `TestVPC_RawJSON_NilSafe` — representative single-resource wrapper coverage
- [ ] `Raw().(*types.XxxList)` cast pattern appears only inside `working-at-low-level.md` (grep audit)

🤖 Generated with [Claude Code](https://claude.com/claude-code)