### PR TITLE
feat(wrappers)!: redesign fluent setter vocabulary to natural-language taxonomy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,7 +38,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
   |---|---|
   | `IntoProject` / `IntoVPC` / `IntoKMS` / … | `InProject` / `InVPC` / `InKMS` / … |
   | `AddTag(s)` / `RemoveTag(s)` / `ReplaceTags(…)` | `Tagged(…)` / `Untagged(…)` / `RetaggedAs(…)` — variadic |
-  | `WithBillingPeriod(BillingPeriodHour\|Month\|Year)` | `BilledHourly()` / `BilledMonthly()` / `BilledYearly()` |
+  | `WithBillingPeriod(BillingPeriod)` | `BilledBy(BillingPeriod)` |
   | `WithSizeGB(n)` | `SizedGB(n)` |
   | `SetBootable()` / `UnsetBootable()` | `AsBootable()` / `NotBootable()` |
   | `Bootable()` getter | `IsBootable()` |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,47 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Changed (Breaking)
+
+- **Fluent setter vocabulary redesigned** (`pkg/aruba`) — all wrapper setters now follow a
+  natural-language taxonomy. Every call site in tests and examples has been updated in the
+  same commit; the SDK is Alpha/unstable so breaking changes are expected.
+
+  Key renames (full list in `ai/CONVENTIONS.md`):
+
+  | Old name | New name |
+  |---|---|
+  | `IntoProject` / `IntoVPC` / `IntoKMS` / … | `InProject` / `InVPC` / `InKMS` / … |
+  | `AddTag(s)` / `RemoveTag(s)` / `ReplaceTags(…)` | `Tagged(…)` / `Untagged(…)` / `RetaggedAs(…)` — variadic |
+  | `WithBillingPeriod(BillingPeriodHour\|Month\|Year)` | `BilledHourly()` / `BilledMonthly()` / `BilledYearly()` |
+  | `WithSizeGB(n)` | `SizedGB(n)` |
+  | `SetBootable()` / `UnsetBootable()` | `AsBootable()` / `NotBootable()` |
+  | `Bootable()` getter | `IsBootable()` |
+  | `WithBootVolume(v)` | `BootingFrom(v)` |
+  | `WithKeyPair(kp)` | `UsingKeyPair(kp)` |
+  | `AddSubnet(s)` | `OnSubnets(s …)` — variadic, plural |
+  | `AddSecurityGroup(sg)` | `WithSecurityGroups(sg …)` — variadic, plural |
+  | `WithVPCPreset(bool)` | `WithVPCPreset()` / `WithoutVPCPreset()` |
+  | `WithHA(bool)` | `HighlyAvailable()` |
+  | `AddNodePool(np)` | `WithNodePools(np …)` — variadic, plural |
+  | `ClearNodePools()` | `WithoutNodePools()` |
+  | `SetNodePools(…)` | removed (use `ReplaceNodePools`) |
+  | `WithEnabled(bool)` | `Enabled()` / `Disabled()` |
+  | `Enabled()` getter (Job) | `IsEnabled()` |
+  | `AddStep(s)` | `WithSteps(s …)` — variadic, plural |
+  | `OfResource(r)` (JobStep) | `Targeting(r)` |
+  | `WithUsername(u)` (Grant) | `ForUser(u)` |
+  | `WithRoleName(r)` (Grant) | `OfRole(r)` |
+  | `WithPreset(bool)` (VPC) | `WithPreset()` / `WithoutPreset()` |
+  | `WithRemoteVPC(v)` | `PeeredWith(v)` |
+  | `WithTargetCIDR(c)` | `TargetingCIDR(c)` |
+  | `WithTargetSecurityGroup(sg)` | `TargetingSecurityGroup(sg)` |
+  | `WithRetentionDays(n)` | `RetainedForDays(n)` |
+  | `IntoBackup(b)` (StorageRestore) | `FromBackup(b)` |
+  | `WithDescription(s)` (Project) | `DescribedAs(s)` |
+  | `AddRoute(addr,gw)` (SubnetDHCP) | `WithRoutes(…SubnetDHCPRoute)` — variadic, plural |
+  | `AddDNS(ip)` (SubnetDHCP) | `WithDNSServers(…string)` — variadic, plural |
+
 ### Added
 
 - `List[T]` now embeds `httpEnvelopeMixin`, exposing the same HTTP-envelope

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Official Go SDK for the Aruba Cloud API. Manage cloud resources — compute inst
 
 ## Highlights
 
-- **Fluent builder API** — construct any resource with chained, type-safe setters: `aruba.NewVPC().IntoProject(p).Named("prod")...`
+- **Fluent builder API** — construct any resource with chained, type-safe setters: `aruba.NewVPC().InProject(p).Named("prod")...`
 - **Single import** — `pkg/aruba` re-exports every typed enum and factory; `pkg/types` is reserved for advanced escape hatches.
 - **Built-in async polling** — `wrapper.WaitUntilReady(ctx)` covers 95% of long-running operations; specialized waits cover the rest.
 - **Configurable authentication** — OAuth2 client credentials by default, plus static tokens and Vault-backed credential storage.
@@ -60,8 +60,8 @@ func main() {
 
 	proj := aruba.NewProject().
 		Named("my-first-project").
-		WithDescription("Created from the Go SDK Quick Start").
-		AddTag("go-sdk")
+		DescribedAs("Created from the Go SDK Quick Start").
+		Tagged("go-sdk")
 
 	if _, err := arubaClient.FromProject().Create(ctx, proj); err != nil {
 		log.Fatalf("create project: %v", err)
@@ -178,7 +178,7 @@ Most cloud resources reach their terminal state asynchronously. Every wrapper th
 
 ```go
 vpc, err := arubaClient.FromNetwork().VPCs().Create(ctx,
-    aruba.NewVPC().IntoProject(proj).Named("prod-vpc"))
+    aruba.NewVPC().InProject(proj).Named("prod-vpc"))
 if err != nil { log.Fatal(err) }
 
 if err := vpc.WaitUntilReady(ctx); err != nil {
@@ -224,11 +224,11 @@ Typed constants for regions, zones, flavors, billing periods, Kubernetes version
 
 ```go
 cs := aruba.NewCloudServer().
-    IntoProject(proj).
+    InProject(proj).
     InRegion(aruba.RegionITBGBergamo).
     InZone(aruba.ZoneITBG1).
     OfFlavor(aruba.CloudServerFlavorCSO4A8).
-    WithBillingPeriod(aruba.BillingPeriodHour)
+    BilledHourly()
 ```
 
 When the wrapper doesn't yet expose a wire field, fall back via `wrapper.Raw()`:

--- a/README.md
+++ b/README.md
@@ -60,8 +60,8 @@ func main() {
 
 	proj := aruba.NewProject().
 		Named("my-first-project").
-		DescribedAs("Created from the Go SDK Quick Start").
-		Tagged("go-sdk")
+		Tagged("go-sdk").
+		DescribedAs("Created from the Go SDK Quick Start")
 
 	if _, err := arubaClient.FromProject().Create(ctx, proj); err != nil {
 		log.Fatalf("create project: %v", err)
@@ -178,7 +178,7 @@ Most cloud resources reach their terminal state asynchronously. Every wrapper th
 
 ```go
 vpc, err := arubaClient.FromNetwork().VPCs().Create(ctx,
-    aruba.NewVPC().InProject(proj).Named("prod-vpc"))
+    aruba.NewVPC().Named("prod-vpc").InProject(proj))
 if err != nil { log.Fatal(err) }
 
 if err := vpc.WaitUntilReady(ctx); err != nil {
@@ -224,10 +224,10 @@ Typed constants for regions, zones, flavors, billing periods, Kubernetes version
 
 ```go
 cs := aruba.NewCloudServer().
+    OfFlavor(aruba.CloudServerFlavorCSO4A8).
     InProject(proj).
     InRegion(aruba.RegionITBGBergamo).
     InZone(aruba.ZoneITBG1).
-    OfFlavor(aruba.CloudServerFlavorCSO4A8).
     BilledBy(aruba.BillingPeriodHour)
 ```
 

--- a/README.md
+++ b/README.md
@@ -228,7 +228,7 @@ cs := aruba.NewCloudServer().
     InRegion(aruba.RegionITBGBergamo).
     InZone(aruba.ZoneITBG1).
     OfFlavor(aruba.CloudServerFlavorCSO4A8).
-    BilledHourly()
+    BilledBy(aruba.BillingPeriodHour)
 ```
 
 When the wrapper doesn't yet expose a wire field, fall back via `wrapper.Raw()`:

--- a/ai/ARCHITECTURE.md
+++ b/ai/ARCHITECTURE.md
@@ -312,7 +312,7 @@ if err := X.Err(); err != nil { return X, err }
 
 Followed by per-adapter friendly validation. Family B resources with deep parent chains do the most validation (Database, Key, Kmip, User, Grant check ProjectID, parent-scope ID, and name individually). Family A adapters mostly only check `ProjectID() != ""`.
 
-Sub-builder errors are drained into the parent's `errMixin` at attachment time (e.g. `WithIKESettings(*VPNIKE)` in `resource_vpn_tunnel.go`), so `job.AddStep(step)` propagates any accumulated step errors into the job.
+Sub-builder errors are drained into the parent's `errMixin` at attachment time (e.g. `WithIKESettings(*VPNIKE)` in `resource_vpn_tunnel.go`), so `job.WithSteps(step)` propagates any accumulated step errors into the job.
 
 ### Client integration
 
@@ -333,14 +333,14 @@ Call chain: `arubaClient.FromCompute().CloudServers().Create(ctx, cs)` → `clou
 - SecurityRule → SecurityGroup → VPC → Project.
 - VPCPeeringRoute → VPCPeering → VPC → Project.
 
-**Body-side parent refs (vs. path-side):** Snapshot, StorageBackup, StorageRestore, DBaaSBackup are `IntoProject(...)` but reference their source resource in the wire body via `FromVolume(Ref)` / `FromDBaaS(Ref)` / `FromDatabase(Ref)`. An empty URI from the `Ref` goes onto the error sink, not the wire.
+**Body-side parent refs (vs. path-side):** Snapshot, StorageBackup, StorageRestore, DBaaSBackup are `InProject(...)` but reference their source resource in the wire body via `FromVolume(Ref)` / `FromDBaaS(Ref)` / `FromDatabase(Ref)`. An empty URI from the `Ref` goes onto the error sink, not the wire.
 
 **Job lifecycle quirk:** Jobs embed `statusMixin` (Family A) and support the standard `WaitUntilActive` / `WaitUntilReady` / `WaitUntilStates`. The quirk: jobs persist as historical records after `Delete` — the API does not return 404; the job record transitions to a terminal state (`StateError` or `StateFailed`). `WaitUntilStates(ctx, []types.State{types.StateDeleted})` will exhaust the wait budget if `Deleted` is not a state the API actually emits. See `examples/all-resources/resource_job.go` for the canonical usage pattern.
 
 **Shape-collapsing setters** — one wrapper method sets multiple wire fields:
 - `*Job.OneShotAt(t)` sets `JobType=OneShot` + `ScheduleAt`; `*Job.WithCron(expr)` + `RecurringUntil(t)` set `JobType=Recurring` + `Cron` + `ExecuteUntil`. All three are mode-locked via `requireMode` in `resource_job.go`.
 - `*VPNTunnel.WithIKESettings/ESPSettings/PSKSettings/IPConfig` each attach a sub-builder and drain its `errMixin` into the tunnel (see `resource_vpn_tunnel.go`).
-- `*SecurityRule.WithTargetCIDR` / `WithTargetSecurityGroup` set the same wire `target` field but stamp different `Kind` values; calling both records an error (see `resource_security_rule.go`).
+- `*SecurityRule.TargetingCIDR` / `TargetingSecurityGroup` set the same wire `target` field but stamp different `Kind` values; calling both records an error (see `resource_security_rule.go`).
 - `*NodePool.WithAutoscaling(min, max)` sets `autoscaling=true` + `minCount` + `maxCount` in one call (see `resource_kaas_nodepool.go`).
 
-**Sub-builders without an adapter** — used only inside a parent, no CRUD: `JobStep` (inside `Job.AddStep`), `NodePool` (inside `KaaS.AddNodePool`), `VPNIKE` / `VPNESP` / `VPNPSK` / `VPNIPConfig` (inside `VPNTunnel`), `SubnetDHCP` (inside `Subnet`). Each has its own `errMixin` drained into the parent at attachment time.
+**Sub-builders without an adapter** — used only inside a parent, no CRUD: `JobStep` (inside `Job.WithSteps`), `NodePool` (inside `KaaS.WithNodePools`), `VPNIKE` / `VPNESP` / `VPNPSK` / `VPNIPConfig` (inside `VPNTunnel`), `SubnetDHCP` (inside `Subnet`). Each has its own `errMixin` drained into the parent at attachment time.

--- a/ai/CONVENTIONS.md
+++ b/ai/CONVENTIONS.md
@@ -125,6 +125,32 @@ All chainable setters follow `func (rcv *T) Verb(...) *T` and return the receive
 
 **Important:** bare `Set*` is reserved for non-chainable, side-effecting action methods (`*CloudServer.SetPassword(ctx, pw, opts...)` in `resource_cloud_server.go`) — never use it for a builder setter.
 
+### Canonical chain order
+
+Every builder chain should read like a natural English sentence — imagine an *Eloquent Old Grandma* at a cloud booking office placing an order: "I'd like a CloudServer of flavor Ubuntu 24.04, named 'my-server-01', tagged 'prod', in project Foo, in region Italy, booting from volume V, with VPC X, billed hourly."
+
+Setters cluster into 13 ordered buckets. Within a chain, appear top-to-bottom in this order; skip buckets that don't apply.
+
+| # | Bucket | Setters |
+|---|---|---|
+| 1 | **noun** | `New<X>()` |
+| 2 | **classifier** | `OfFlavor`, `OfType`, `OfEngine`, `OfSize`, `OfAlgorithm`, `OfInstance`, `OfRole` |
+| 3 | **name** | `Named` |
+| 4 | **labels** | `Tagged(…)` — variadic, **single call** |
+| 5 | **containment** | `InProject`, `InVPC`, `InSecurityGroup`, `InDBaaS`, `InDatabase`, `InKMS`, `InVPNTunnel`, `InVPCPeering` |
+| 6 | **geography** | `InRegion`, `InZone` |
+| 7 | **descriptive scalars** | `SizedGB`, `WithCIDR`, `WithKubernetesVersion`, `WithPodCIDR`, `WithNodeCIDR`, `WithPublicKey`, `WithAdminUsername`, `WithUsername`, `WithPassword`, `WithUserData`, `DescribedAs`, `RetainedForDays`, `WithMaxStorageQuotaGB`, `WithAutoscaling`, `WithCron`, `RecurringUntil`, `OneShotAt`, `WithAction`, `WithVerb`, `WithPort`, `WithProtocol`, `WithDirection`, `WithPeerClientPublicIP` |
+| 8 | **origin** | `FromImage`, `FromVolume`, `FromBackup`, `FromSnapshot`, `FromDBaaS`, `FromDatabase`, `BootingFrom` |
+| 9 | **attached config** | `WithVPC`, `WithSubnet`, `WithSecurityGroup`, `WithSecurityGroups`, `WithElasticIP`, `WithBlockStorage`, `WithDHCP`, `WithNodePools`, `WithSteps`, `WithIKESettings`, `WithESPSettings`, `WithPSKSettings`, `WithPeerVPC`, `WithTarget` |
+| 10 | **network placement** | `OnSubnets` |
+| 11 | **active relationship** | `UsingKeyPair`, `Targeting`, `TargetingCIDR`, `ForUser`, `ToVolume` |
+| 12 | **boolean / policy state** | `Enabled`/`Disabled`, `HighlyAvailable`, `AsBootable`/`NotBootable`, `AsDefault`/`NotDefault`, `WithPreset`/`WithoutPreset`, `WithoutAutoscaling` |
+| 13 | **billing** | `BilledBy(period)` |
+
+**Variadic-collapse rule:** when the same variadic setter would be called twice on the same builder, collapse to a single call — `Tagged("a").Tagged("b")` → `Tagged("a", "b")`. Applies to `Tagged`, `WithDNSServers`, and any other plural-named collection setter.
+
+Per-resource canonical chains are exercised in `examples/all-resources/` — treat those files as the executable specification of the correct ordering.
+
 ### Wire-level translation rules
 
 The wrapper API never echoes a wire field name verbatim if a clearer Go-idiomatic name exists:

--- a/ai/CONVENTIONS.md
+++ b/ai/CONVENTIONS.md
@@ -116,8 +116,8 @@ All chainable setters follow `func (rcv *T) Verb(...) *T` and return the receive
 | participial (`<Verb>ing…`) | active relationship | `BootingFrom`, `UsingKeyPair`, `Targeting`, `PeeredWith` |
 | `On<Noun>` | network placement | `OnSubnets` |
 | `Tagged` / `Untagged` / `RetaggedAs` | tag-set mutation — variadic, append / remove / replace | `Tagged("prod","sdk")` |
-| `SizedGB(int)` / `RetainedForDays(int)` / `DescribedAs(string)` | descriptive value phrases | `SizedGB(20)` |
-| no-arg adjective/participle | boolean state | `Enabled()`, `Disabled()`, `HighlyAvailable()`, `BilledHourly()` |
+| `SizedGB(int)` / `RetainedForDays(int)` / `DescribedAs(string)` / `BilledBy(BillingPeriod)` | descriptive value phrases | `SizedGB(20)`, `BilledBy(BillingPeriodHour)` |
+| no-arg adjective/participle | boolean state | `Enabled()`, `Disabled()`, `HighlyAvailable()` |
 | `As<Adj>()` / `Not<Adj>()` + `Is<Adj>()` getter | tri-state `*bool` idiom | `AsDefault`/`NotDefault`/`IsDefault`, `AsBootable`/`NotBootable`/`IsBootable` |
 | `With<X>()` / `Without<X>()` | no-arg boolean pair | `WithPreset`/`WithoutPreset`, `WithoutAutoscaling`, `WithoutNodePools` |
 
@@ -142,7 +142,7 @@ Public callers never pass raw strings. Every domain that accepts an enum has typ
 | Domain | Alias prefix | Typical setter |
 |---|---|---|
 | Geography | `aruba.Region*`, `aruba.Zone*` | `InRegion(...)`, `InZone(...)` |
-| Billing | `aruba.BillingPeriod*` | `BilledHourly()` / `BilledMonthly()` / `BilledYearly()` |
+| Billing | `aruba.BillingPeriod*` | `BilledBy(BillingPeriod)` |
 | Compute | `aruba.CloudServerFlavor*`, `aruba.VolumeImage*` | `OfFlavor(...)`, `FromImage(...)` |
 | Storage | `aruba.BlockStorageType*`, `aruba.StorageBackupType*` | `OfType(...)` |
 | Database | `aruba.DatabaseEngine*`, `aruba.DBaaSFlavor*` | `OfEngine(...)`, `OfFlavor(...)` |

--- a/ai/CONVENTIONS.md
+++ b/ai/CONVENTIONS.md
@@ -106,25 +106,30 @@ A per-resource `<resource>IDsFromRef(ref Ref)` helper lives at the bottom and is
 
 All chainable setters follow `func (rcv *T) Verb(...) *T` and return the receiver. Verbs cluster into a fixed vocabulary:
 
-| Verb prefix | Use | Example |
+| Connector | Role | Example |
 |---|---|---|
-| `Named(...)` | set the resource name | `*Database.Named("mydb")` |
-| `With<Prop>(...)` | generic scalar property setter | `*KaaS.WithKubernetesVersion(v)` |
-| `Into<Parent>(...)` | bind to parent via `Ref` | `*Database.IntoDBaaS(d)` |
-| `In<Region\|Zone>(...)` | geographical placement | `*VPC.InRegion(aruba.RegionITBGBergamo)` |
-| `Of<Type\|Flavor\|...>(...)` | typing / sizing / affinity | `*CloudServer.OfFlavor(aruba.CloudServerFlavorCSO2A4)` |
-| `From<Source>(...)` | source / origin `Ref` | `*Snapshot.FromVolume(bs)` |
-| `Add<X>(...)` / `Replace<X>s(...)` / `Remove<X>(...)` | collection mutation | `*VPNTunnel.AddTag("env=prod")` |
-| `Set<X>()` / `Unset<X>()` | explicit boolean toggle (builder) | `*BlockStorage.SetBootable()` |
-| `Is<X>()` (read) / `As<X>()`, `Not<X>()` (write) | paired-bool idiom for `*bool` fields | `*SecurityGroup.AsDefault()`, `*VPC.NotDefault()` |
+| `New<Resource>()` + `.Named(name)` | construct, then name | `NewCloudServer().Named("web-01")` |
+| `In<Parent>` / `In<Geo>` | containment & placement | `InProject`, `InVPC`, `InRegion`, `InZone` |
+| `Of<Classifier>` | type / sizing class / role | `OfFlavor`, `OfType`, `OfEngine`, `OfSize`, `OfAlgorithm`, `OfInstance`, `OfRole` |
+| `From<Source>` | source / origin | `FromImage`, `FromSnapshot`, `FromVolume`, `FromBackup`, `FromDBaaS`, `FromDatabase` |
+| `With<Noun>` | accompaniment / attached typed config | `WithVPC`, `WithElasticIP`, `WithCIDR`, `WithKubernetesVersion` |
+| participial (`<Verb>ing…`) | active relationship | `BootingFrom`, `UsingKeyPair`, `Targeting`, `PeeredWith` |
+| `On<Noun>` | network placement | `OnSubnets` |
+| `Tagged` / `Untagged` / `RetaggedAs` | tag-set mutation — variadic, append / remove / replace | `Tagged("prod","sdk")` |
+| `SizedGB(int)` / `RetainedForDays(int)` / `DescribedAs(string)` | descriptive value phrases | `SizedGB(20)` |
+| no-arg adjective/participle | boolean state | `Enabled()`, `Disabled()`, `HighlyAvailable()`, `BilledHourly()` |
+| `As<Adj>()` / `Not<Adj>()` + `Is<Adj>()` getter | tri-state `*bool` idiom | `AsDefault`/`NotDefault`/`IsDefault`, `AsBootable`/`NotBootable`/`IsBootable` |
+| `With<X>()` / `Without<X>()` | no-arg boolean pair | `WithPreset`/`WithoutPreset`, `WithoutAutoscaling`, `WithoutNodePools` |
 
-**Important:** `Set*` on its own (not `Unset*`) is reserved for non-chainable, side-effecting action methods (`*CloudServer.SetPassword(ctx, pw, opts...)` in `resource_cloud_server.go`) — never use it for a builder setter.
+**Collection setters** (`OnSubnets`, `WithSecurityGroups`, `WithNodePools`, `WithSteps`, `WithRoutes`, `WithDNSServers`) are variadic and plural-named — a single call can carry one or many items, and repeated calls append. `Replace<Plural>` does wholesale replacement; `Without<Plural>()` clears.
+
+**Important:** bare `Set*` is reserved for non-chainable, side-effecting action methods (`*CloudServer.SetPassword(ctx, pw, opts...)` in `resource_cloud_server.go`) — never use it for a builder setter.
 
 ### Wire-level translation rules
 
 The wrapper API never echoes a wire field name verbatim if a clearer Go-idiomatic name exists:
 
-- **Units explicit in the method name:** `WithSizeGB(int)` (wire field `size` / JSON `sizeGb`) on `*BlockStorage` and `*DBaaS`.
+- **Units explicit in the method name:** `SizedGB(int)` (wire field `size` / JSON `sizeGb`) on `*BlockStorage` and `*DBaaS`.
 - **Paired-bool idiom for tri-state `*bool` flags:** `IsDefault()` read + `AsDefault()` / `NotDefault()` write on SecurityGroup, VPC, Subnet, Project — preserves the `nil` / `false` / `true` distinction across the wire.
 - **`Ref`-accepting setters hide URI assembly:** `FromVolume(Ref)`, `FromSnapshot(Ref)`, `FromDBaaS(Ref)`, `FromDatabase(Ref)` — an empty URI from the `Ref` goes on the error sink, not on the wire.
 - **Sub-builder errors propagate:** `WithIKESettings(*VPNIKE)` drains the sub-builder's `errMixin` into the tunnel's accumulator (`resource_vpn_tunnel.go`).
@@ -137,7 +142,7 @@ Public callers never pass raw strings. Every domain that accepts an enum has typ
 | Domain | Alias prefix | Typical setter |
 |---|---|---|
 | Geography | `aruba.Region*`, `aruba.Zone*` | `InRegion(...)`, `InZone(...)` |
-| Billing | `aruba.BillingPeriod*` | `WithBillingPeriod(...)` |
+| Billing | `aruba.BillingPeriod*` | `BilledHourly()` / `BilledMonthly()` / `BilledYearly()` |
 | Compute | `aruba.CloudServerFlavor*`, `aruba.VolumeImage*` | `OfFlavor(...)`, `FromImage(...)` |
 | Storage | `aruba.BlockStorageType*`, `aruba.StorageBackupType*` | `OfType(...)` |
 | Database | `aruba.DatabaseEngine*`, `aruba.DBaaSFlavor*` | `OfEngine(...)`, `OfFlavor(...)` |

--- a/docs/website/docs/intro.md
+++ b/docs/website/docs/intro.md
@@ -57,9 +57,8 @@ func main() {
 		ctx,
 		aruba.NewProject().
 			Named("my-first-project").
-			DescribedAs("A project with the Go SDK").
-			Tagged("go-sdk").
-			Tagged("quick-start"))
+			Tagged("go-sdk", "quick-start").
+			DescribedAs("A project with the Go SDK"))
 	if err != nil {
 		log.Fatalf("Error creating project: %v", err)
 	}

--- a/docs/website/docs/intro.md
+++ b/docs/website/docs/intro.md
@@ -57,9 +57,9 @@ func main() {
 		ctx,
 		aruba.NewProject().
 			Named("my-first-project").
-			WithDescription("A project with the Go SDK").
-			AddTag("go-sdk").
-			AddTag("quick-start"))
+			DescribedAs("A project with the Go SDK").
+			Tagged("go-sdk").
+			Tagged("quick-start"))
 	if err != nil {
 		log.Fatalf("Error creating project: %v", err)
 	}

--- a/docs/website/docs/resources.md
+++ b/docs/website/docs/resources.md
@@ -64,8 +64,8 @@ proj, err := arubaClient.FromProject().Create(
     ctx,
     aruba.NewProject().
         Named("my-project").
-        DescribedAs("Production project").
         Tagged("env-prod").
+        DescribedAs("Production project").
         NotDefault())
 if err != nil {
     log.Fatalf("Create project: %v", err)
@@ -142,17 +142,17 @@ A Cloud Server depends on network resources (VPC, Subnet, Security Group), an El
 cs, err := arubaClient.FromCompute().CloudServers().Create(
     ctx,
     aruba.NewCloudServer().
-        InProject(proj).
+        OfFlavor(aruba.CloudServerFlavorCSO2A4).
         Named("my-server").
         Tagged("env-prod").
+        InProject(proj).
         InRegion(aruba.RegionITBGBergamo).
         InZone(aruba.ZoneITBG1).
-        OfFlavor(aruba.CloudServerFlavorCSO2A4).
+        BootingFrom(blockStorage).
         WithVPC(vpc).
         OnSubnets(subnet).
         WithSecurityGroups(sg).
         WithElasticIP(eip).
-        BootingFrom(blockStorage).
         UsingKeyPair(keyPair))
 if err != nil {
     log.Fatalf("Create Cloud Server: %v", err)
@@ -206,8 +206,8 @@ arubaClient.FromCompute().KeyPairs()
 kp, err := arubaClient.FromCompute().KeyPairs().Create(
     ctx,
     aruba.NewKeyPair().
-        InProject(proj).
         Named("my-keypair").
+        InProject(proj).
         InRegion(aruba.RegionITBGBergamo).
         WithPublicKey("ssh-rsa AAAAB3NzaC1yc2E..."))
 if err != nil {
@@ -244,23 +244,23 @@ arubaClient.FromContainer().KaaS()
 k, err := arubaClient.FromContainer().KaaS().Create(
     ctx,
     aruba.NewKaaS().
-        InProject(proj).
         Named("my-cluster").
         Tagged("env-prod").
+        InProject(proj).
         InRegion(aruba.RegionITBGBergamo).
+        WithKubernetesVersion(aruba.KubernetesVersion1323).
+        WithPodCIDR("10.200.0.0/16").
+        WithNodeCIDR("10.100.0.0/16", "node-cidr").
         WithVPC(vpc).
         WithSubnet(subnet).
         WithSecurityGroup(sg).
-        WithNodeCIDR("10.100.0.0/16", "node-cidr").
-        WithPodCIDR("10.200.0.0/16").
-        WithKubernetesVersion(aruba.KubernetesVersion1323).
-        HighlyAvailable().
-        BilledBy(aruba.BillingPeriodHour).
         WithNodePools(aruba.NewNodePool().
-            Named("default-pool").
-            WithCount(3).
             OfInstance(aruba.NodePoolInstanceK4A8).
-            InZone(aruba.ZoneITBG1)))
+            Named("default-pool").
+            InZone(aruba.ZoneITBG1).
+            WithCount(3)).
+        HighlyAvailable().
+        BilledBy(aruba.BillingPeriodHour))
 if err != nil {
     log.Fatalf("Create KaaS: %v", err)
 }
@@ -318,16 +318,16 @@ arubaClient.FromContainer().ContainerRegistry()
 reg, err := arubaClient.FromContainer().ContainerRegistry().Create(
     ctx,
     aruba.NewContainerRegistry().
-        InProject(proj).
+        OfSize(aruba.ContainerRegistrySizeFlavorSmall).
         Named("my-registry").
         Tagged("env-prod").
+        InProject(proj).
+        WithAdminUsername("admin").
         WithVPC(vpc).
         WithSubnet(subnet).
         WithSecurityGroup(sg).
         WithElasticIP(eip).
         WithBlockStorage(blockStorage).
-        WithAdminUsername("admin").
-        OfSize(aruba.ContainerRegistrySizeFlavorSmall).
         BilledBy(aruba.BillingPeriodHour))
 if err != nil {
     log.Fatalf("Create ContainerRegistry: %v", err)
@@ -371,19 +371,19 @@ arubaClient.FromDatabase().DBaaS()
 db, err := arubaClient.FromDatabase().DBaaS().Create(
     ctx,
     aruba.NewDBaaS().
-        InProject(proj).
-        Named("my-database").
-        Tagged("env-prod").
-        InRegion(aruba.RegionITBGBergamo).
-        InZone(aruba.ZoneITBG1).
         OfEngine(aruba.DatabaseEngineMySQL80).
         OfFlavor(aruba.DBaaSFlavorDBO2A4).
+        Named("my-database").
+        Tagged("env-prod").
+        InProject(proj).
+        InRegion(aruba.RegionITBGBergamo).
+        InZone(aruba.ZoneITBG1).
         SizedGB(20).
-        BilledBy(aruba.BillingPeriodHour).
         WithVPC(vpc).
         WithSubnet(subnet).
         WithSecurityGroup(sg).
-        WithElasticIP(eip))
+        WithElasticIP(eip).
+        BilledBy(aruba.BillingPeriodHour))
 if err != nil {
     log.Fatalf("Create DBaaS: %v", err)
 }
@@ -428,9 +428,9 @@ arubaClient.FromDatabase().Databases()
 database, err := arubaClient.FromDatabase().Databases().Create(
     ctx,
     aruba.NewDatabase().
-        InDBaaS(db).
         Named("my-app-db").
-        Tagged("app-backend"))
+        Tagged("app-backend").
+        InDBaaS(db))
 if err != nil {
     log.Fatalf("Create Database: %v", err)
 }
@@ -468,10 +468,10 @@ arubaClient.FromDatabase().Users()
 user, err := arubaClient.FromDatabase().Users().Create(
     ctx,
     aruba.NewUser().
+        Tagged("app-backend").
         InDBaaS(db).
         WithUsername("app_user").
-        WithPassword("Str0ngP@ssword!").
-        Tagged("app-backend"))
+        WithPassword("Str0ngP@ssword!"))
 if err != nil {
     log.Fatalf("Create User: %v", err)
 }
@@ -510,9 +510,9 @@ arubaClient.FromDatabase().Grants()
 grant, err := arubaClient.FromDatabase().Grants().Create(
     ctx,
     aruba.NewGrant().
+        OfRole("liteadmin").
         InDatabase(database).
-        Named("app_user-grant").
-        WithPrivileges("ALL"))
+        ForUser("app_user"))
 if err != nil {
     log.Fatalf("Create Grant: %v", err)
 }
@@ -551,11 +551,11 @@ arubaClient.FromDatabase().DBaaSBackups()
 backup, err := arubaClient.FromDatabase().DBaaSBackups().Create(
     ctx,
     aruba.NewDBaaSBackup().
-        InProject(proj).
         Named("my-db-backup").
+        Tagged("backup").
+        InProject(proj).
         FromDBaaS(db).
-        BilledBy(aruba.BillingPeriodHour).
-        Tagged("backup"))
+        BilledBy(aruba.BillingPeriodHour))
 if err != nil {
     log.Fatalf("Create DBaaSBackup: %v", err)
 }
@@ -665,9 +665,9 @@ arubaClient.FromNetwork().VPCs()
 vpc, err := arubaClient.FromNetwork().VPCs().Create(
     ctx,
     aruba.NewVPC().
-        InProject(proj).
         Named("my-vpc").
         Tagged("network").
+        InProject(proj).
         InRegion(aruba.RegionITBGBergamo).
         NotDefault().
         WithoutPreset())
@@ -713,18 +713,18 @@ arubaClient.FromNetwork().Subnets()
 subnet, err := arubaClient.FromNetwork().Subnets().Create(
     ctx,
     aruba.NewSubnet().
-        InVPC(vpc).
+        OfType(aruba.SubnetTypeAdvanced).
         Named("my-subnet").
         Tagged("network").
+        InVPC(vpc).
         InRegion(aruba.RegionITBGBergamo).
-        OfType(aruba.SubnetTypeAdvanced).
-        NotDefault().
         WithCIDR("192.168.1.0/25").
         WithDHCP(aruba.NewSubnetDHCP().
             Enabled().
             WithRange("192.168.1.10", 50).
             WithRoutes(aruba.SubnetDHCPRoute{Address: "0.0.0.0/0", Gateway: "192.168.1.1"}).
-            WithDNSServers("8.8.8.8", "8.8.4.4")))
+            WithDNSServers("8.8.8.8", "8.8.4.4")).
+        NotDefault())
 if err != nil {
     log.Fatalf("Create Subnet: %v", err)
 }
@@ -766,9 +766,9 @@ arubaClient.FromNetwork().ElasticIPs()
 eip, err := arubaClient.FromNetwork().ElasticIPs().Create(
     ctx,
     aruba.NewElasticIP().
-        InProject(proj).
         Named("my-eip").
         Tagged("network").
+        InProject(proj).
         InRegion(aruba.RegionITBGBergamo).
         BilledBy(aruba.BillingPeriodHour))
 if err != nil {
@@ -810,9 +810,9 @@ arubaClient.FromNetwork().SecurityGroups()
 sg, err := arubaClient.FromNetwork().SecurityGroups().Create(
     ctx,
     aruba.NewSecurityGroup().
-        InVPC(vpc).
         Named("my-security-group").
         Tagged("security").
+        InVPC(vpc).
         NotDefault())
 if err != nil {
     log.Fatalf("Create SecurityGroup: %v", err)
@@ -855,9 +855,9 @@ arubaClient.FromNetwork().SecurityGroupRules()
 rule, err := arubaClient.FromNetwork().SecurityGroupRules().Create(
     ctx,
     aruba.NewSecurityRule().
-        InSecurityGroup(sg).
         Named("allow-ssh").
         Tagged("ssh-key").
+        InSecurityGroup(sg).
         InRegion(aruba.RegionITBGBergamo).
         WithDirection(aruba.RuleDirectionIngress).
         WithProtocol(aruba.RuleProtocolTCP).
@@ -936,9 +936,9 @@ arubaClient.FromNetwork().VPCPeerings()
 peering, err := arubaClient.FromNetwork().VPCPeerings().Create(
     ctx,
     aruba.NewVPCPeering().
-        InVPC(vpc).
         Named("my-peering").
         Tagged("network").
+        InVPC(vpc).
         InRegion(aruba.RegionITBGBergamo).
         WithPeerVPC(aruba.URI("/projects/"+peerProjectID+"/vpcs/"+peerVPCID)))
 if err != nil {
@@ -979,9 +979,9 @@ arubaClient.FromNetwork().VPCPeeringRoutes()
 route, err := arubaClient.FromNetwork().VPCPeeringRoutes().Create(
     ctx,
     aruba.NewVPCPeeringRoute().
-        InVPCPeering(peering).
         Named("my-peering-route").
         Tagged("network").
+        InVPCPeering(peering).
         InRegion(aruba.RegionITBGBergamo).
         WithCIDR("10.0.0.0/8").
         WithTarget(aruba.URI("/projects/"+projectID+"/vpcs/"+vpcID)))
@@ -1028,9 +1028,9 @@ VPN Tunnel sub-builders:
 tunnel, err := arubaClient.FromNetwork().VPNTunnels().Create(
     ctx,
     aruba.NewVPNTunnel().
-        InProject(proj).
         Named("my-vpn-tunnel").
         Tagged("vpn-net").
+        InProject(proj).
         InRegion(aruba.RegionITBGBergamo).
         WithPeerClientPublicIP("203.0.113.1").
         WithIKESettings(aruba.NewVPNIKE().
@@ -1082,9 +1082,9 @@ arubaClient.FromNetwork().VPNRoutes()
 vpnRoute, err := arubaClient.FromNetwork().VPNRoutes().Create(
     ctx,
     aruba.NewVPNRoute().
-        InVPNTunnel(tunnel).
         Named("my-vpn-route").
         Tagged("vpn-net").
+        InVPNTunnel(tunnel).
         InRegion(aruba.RegionITBGBergamo).
         WithCIDR("10.0.0.0/8").
         WithTarget(aruba.URI("/projects/"+projectID+"/vpcs/"+vpcID)))
@@ -1131,9 +1131,9 @@ Use `OneShotAt(t time.Time)` to schedule a one-shot job, or `WithCron(expr strin
 job, err := arubaClient.FromSchedule().Jobs().Create(
     ctx,
     aruba.NewJob().
-        InProject(proj).
         Named("my-one-shot-job").
         Tagged("automation").
+        InProject(proj).
         OneShotAt(time.Now().Add(10*time.Minute)))
 if err != nil {
     log.Fatalf("Create Job: %v", err)
@@ -1144,9 +1144,9 @@ fmt.Printf("✓ Job: %s (type: %s)\n", job.Name(), job.JobType())
 cronJob, err := arubaClient.FromSchedule().Jobs().Create(
     ctx,
     aruba.NewJob().
-        InProject(proj).
         Named("my-recurring-job").
         Tagged("automation").
+        InProject(proj).
         WithCron("0 * * * *"))
 if err != nil {
     log.Fatalf("Create recurring Job: %v", err)
@@ -1184,9 +1184,9 @@ arubaClient.FromSecurity().KMS()
 kms, err := arubaClient.FromSecurity().KMS().Create(
     ctx,
     aruba.NewKMS().
-        InProject(proj).
         Named("my-kms").
         Tagged("security").
+        InProject(proj).
         InRegion(aruba.RegionITBGBergamo).
         BilledBy(aruba.BillingPeriodHour))
 if err != nil {
@@ -1222,16 +1222,16 @@ arubaClient.FromSecurity().Keys()
 **Supported operations**: `Create`, `List`, `Get`, `Delete`
 **Async**: yes — `State()` and `FailureReason()` are available.
 
-`WithAlgorithm` accepts `aruba.KeyAlgorithmAes` or `aruba.KeyAlgorithmRsa` (typed constants — no string cast needed).
+`OfAlgorithm` accepts `aruba.KeyAlgorithmAes` or `aruba.KeyAlgorithmRsa` (typed constants — no string cast needed).
 
 ```go
 key, err := arubaClient.FromSecurity().Keys().Create(
     ctx,
     aruba.NewKey().
-        InKMS(kms).
+        OfAlgorithm(aruba.KeyAlgorithmAes).
         Named("my-encryption-key").
         Tagged("security").
-        WithAlgorithm(aruba.KeyAlgorithmAes))
+        InKMS(kms))
 if err != nil {
     log.Fatalf("Create Key: %v", err)
 }
@@ -1268,9 +1268,9 @@ arubaClient.FromSecurity().Kmips()
 km, err := arubaClient.FromSecurity().Kmips().Create(
     ctx,
     aruba.NewKmip().
-        InKMS(kms).
         Named("my-kmip").
-        Tagged("security"))
+        Tagged("security").
+        InKMS(kms))
 if err != nil {
     log.Fatalf("Create Kmip: %v", err)
 }
@@ -1323,16 +1323,16 @@ arubaClient.FromStorage().Volumes()
 bs, err := arubaClient.FromStorage().Volumes().Create(
     ctx,
     aruba.NewBlockStorage().
-        InProject(proj).
+        OfType(aruba.BlockStorageTypeStandard).
         Named("my-volume").
         Tagged("storage").
+        InProject(proj).
         InRegion(aruba.RegionITBGBergamo).
         InZone(aruba.ZoneITBG1).
         SizedGB(20).
-        OfType(aruba.BlockStorageTypeStandard).
-        BilledBy(aruba.BillingPeriodHour).
+        FromImage("LU22-001").
         AsBootable().
-        FromImage("LU22-001"))
+        BilledBy(aruba.BillingPeriodHour))
 if err != nil {
     log.Fatalf("Create BlockStorage: %v", err)
 }
@@ -1349,15 +1349,15 @@ To create a volume **from a snapshot**, use `FromSnapshot(snapshot)` instead of 
 bs, err := arubaClient.FromStorage().Volumes().Create(
     ctx,
     aruba.NewBlockStorage().
-        InProject(proj).
+        OfType(aruba.BlockStorageTypeStandard).
         Named("restored-volume").
+        InProject(proj).
         InRegion(aruba.RegionITBGBergamo).
         InZone(aruba.ZoneITBG1).
         SizedGB(20).
-        OfType(aruba.BlockStorageTypeStandard).
-        BilledBy(aruba.BillingPeriodHour).
+        FromSnapshot(snapshot).
         AsBootable().
-        FromSnapshot(snapshot))
+        BilledBy(aruba.BillingPeriodHour))
 ```
 
 **Response accessors**:
@@ -1393,12 +1393,12 @@ arubaClient.FromStorage().Snapshots()
 snap, err := arubaClient.FromStorage().Snapshots().Create(
     ctx,
     aruba.NewSnapshot().
-        InProject(proj).
         Named("my-snapshot").
         Tagged("backup").
+        InProject(proj).
         InRegion(aruba.RegionITBGBergamo).
-        BilledBy(aruba.BillingPeriodHour).
-        FromVolume(bs))
+        FromVolume(bs).
+        BilledBy(aruba.BillingPeriodHour))
 if err != nil {
     log.Fatalf("Create Snapshot: %v", err)
 }
@@ -1443,12 +1443,12 @@ arubaClient.FromStorage().Backups()
 backup, err := arubaClient.FromStorage().Backups().Create(
     ctx,
     aruba.NewStorageBackup().
-        InProject(proj).
+        OfType(aruba.StorageBackupTypeFull).
         Named("my-backup").
         Tagged("backup").
-        FromVolume(bs).
-        OfType(aruba.StorageBackupTypeFull).
+        InProject(proj).
         RetainedForDays(30).
+        FromVolume(bs).
         BilledBy(aruba.BillingPeriodHour))
 if err != nil {
     log.Fatalf("Create StorageBackup: %v", err)
@@ -1490,9 +1490,9 @@ arubaClient.FromStorage().Restores()
 restore, err := arubaClient.FromStorage().Restores().Create(
     ctx,
     aruba.NewStorageRestore().
-        FromBackup(backup).
         Named("my-restore").
         Tagged("restore").
+        FromBackup(backup).
         WithTarget(aruba.URI(backup.OriginURI())))
 if err != nil {
     log.Fatalf("Create StorageRestore: %v", err)

--- a/docs/website/docs/resources.md
+++ b/docs/website/docs/resources.md
@@ -27,7 +27,7 @@ result, err := client.Create(ctx,
     aruba.NewX().
         IntoParent(parentRef).   // scope to project / VPC / etc.
         Named("my-resource").
-        AddTag("env-prod").
+        Tagged("env-prod").
         WithFoo(...))
 
 // 3. Wait for async resources to become ready
@@ -64,8 +64,8 @@ proj, err := arubaClient.FromProject().Create(
     ctx,
     aruba.NewProject().
         Named("my-project").
-        WithDescription("Production project").
-        AddTag("env-prod").
+        DescribedAs("Production project").
+        Tagged("env-prod").
         NotDefault())
 if err != nil {
     log.Fatalf("Create project: %v", err)
@@ -142,18 +142,18 @@ A Cloud Server depends on network resources (VPC, Subnet, Security Group), an El
 cs, err := arubaClient.FromCompute().CloudServers().Create(
     ctx,
     aruba.NewCloudServer().
-        IntoProject(proj).
+        InProject(proj).
         Named("my-server").
-        AddTag("env-prod").
+        Tagged("env-prod").
         InRegion(aruba.RegionITBGBergamo).
         InZone(aruba.ZoneITBG1).
         OfFlavor(aruba.CloudServerFlavorCSO2A4).
         WithVPC(vpc).
-        AddSubnet(subnet).
-        AddSecurityGroup(sg).
+        OnSubnets(subnet).
+        WithSecurityGroups(sg).
         WithElasticIP(eip).
-        WithBootVolume(blockStorage).
-        WithKeyPair(keyPair))
+        BootingFrom(blockStorage).
+        UsingKeyPair(keyPair))
 if err != nil {
     log.Fatalf("Create Cloud Server: %v", err)
 }
@@ -206,7 +206,7 @@ arubaClient.FromCompute().KeyPairs()
 kp, err := arubaClient.FromCompute().KeyPairs().Create(
     ctx,
     aruba.NewKeyPair().
-        IntoProject(proj).
+        InProject(proj).
         Named("my-keypair").
         InRegion(aruba.RegionITBGBergamo).
         WithPublicKey("ssh-rsa AAAAB3NzaC1yc2E..."))
@@ -244,9 +244,9 @@ arubaClient.FromContainer().KaaS()
 k, err := arubaClient.FromContainer().KaaS().Create(
     ctx,
     aruba.NewKaaS().
-        IntoProject(proj).
+        InProject(proj).
         Named("my-cluster").
-        AddTag("env-prod").
+        Tagged("env-prod").
         InRegion(aruba.RegionITBGBergamo).
         WithVPC(vpc).
         WithSubnet(subnet).
@@ -254,9 +254,9 @@ k, err := arubaClient.FromContainer().KaaS().Create(
         WithNodeCIDR("10.100.0.0/16", "node-cidr").
         WithPodCIDR("10.200.0.0/16").
         WithKubernetesVersion(aruba.KubernetesVersion1323).
-        WithHA(true).
-        WithBillingPeriod(aruba.BillingPeriodHour).
-        AddNodePool(aruba.NewNodePool().
+        HighlyAvailable().
+        BilledHourly().
+        WithNodePools(aruba.NewNodePool().
             Named("default-pool").
             WithCount(3).
             OfInstance(aruba.NodePoolInstanceK4A8).
@@ -318,9 +318,9 @@ arubaClient.FromContainer().ContainerRegistry()
 reg, err := arubaClient.FromContainer().ContainerRegistry().Create(
     ctx,
     aruba.NewContainerRegistry().
-        IntoProject(proj).
+        InProject(proj).
         Named("my-registry").
-        AddTag("env-prod").
+        Tagged("env-prod").
         WithVPC(vpc).
         WithSubnet(subnet).
         WithSecurityGroup(sg).
@@ -328,7 +328,7 @@ reg, err := arubaClient.FromContainer().ContainerRegistry().Create(
         WithBlockStorage(blockStorage).
         WithAdminUsername("admin").
         OfSize(aruba.ContainerRegistrySizeFlavorSmall).
-        WithBillingPeriod(aruba.BillingPeriodHour))
+        BilledHourly())
 if err != nil {
     log.Fatalf("Create ContainerRegistry: %v", err)
 }
@@ -371,15 +371,15 @@ arubaClient.FromDatabase().DBaaS()
 db, err := arubaClient.FromDatabase().DBaaS().Create(
     ctx,
     aruba.NewDBaaS().
-        IntoProject(proj).
+        InProject(proj).
         Named("my-database").
-        AddTag("env-prod").
+        Tagged("env-prod").
         InRegion(aruba.RegionITBGBergamo).
         InZone(aruba.ZoneITBG1).
         OfEngine(aruba.DatabaseEngineMySQL80).
         OfFlavor(aruba.DBaaSFlavorDBO2A4).
-        WithSizeGB(20).
-        WithBillingPeriod(aruba.BillingPeriodHour).
+        SizedGB(20).
+        BilledHourly().
         WithVPC(vpc).
         WithSubnet(subnet).
         WithSecurityGroup(sg).
@@ -428,9 +428,9 @@ arubaClient.FromDatabase().Databases()
 database, err := arubaClient.FromDatabase().Databases().Create(
     ctx,
     aruba.NewDatabase().
-        IntoDBaaS(db).
+        InDBaaS(db).
         Named("my-app-db").
-        AddTag("app-backend"))
+        Tagged("app-backend"))
 if err != nil {
     log.Fatalf("Create Database: %v", err)
 }
@@ -468,10 +468,10 @@ arubaClient.FromDatabase().Users()
 user, err := arubaClient.FromDatabase().Users().Create(
     ctx,
     aruba.NewUser().
-        IntoDBaaS(db).
+        InDBaaS(db).
         WithUsername("app_user").
         WithPassword("Str0ngP@ssword!").
-        AddTag("app-backend"))
+        Tagged("app-backend"))
 if err != nil {
     log.Fatalf("Create User: %v", err)
 }
@@ -510,7 +510,7 @@ arubaClient.FromDatabase().Grants()
 grant, err := arubaClient.FromDatabase().Grants().Create(
     ctx,
     aruba.NewGrant().
-        IntoDatabase(database).
+        InDatabase(database).
         Named("app_user-grant").
         WithPrivileges("ALL"))
 if err != nil {
@@ -551,11 +551,11 @@ arubaClient.FromDatabase().DBaaSBackups()
 backup, err := arubaClient.FromDatabase().DBaaSBackups().Create(
     ctx,
     aruba.NewDBaaSBackup().
-        IntoProject(proj).
+        InProject(proj).
         Named("my-db-backup").
         FromDBaaS(db).
-        WithBillingPeriod(aruba.BillingPeriodHour).
-        AddTag("backup"))
+        BilledHourly().
+        Tagged("backup"))
 if err != nil {
     log.Fatalf("Create DBaaSBackup: %v", err)
 }
@@ -665,12 +665,12 @@ arubaClient.FromNetwork().VPCs()
 vpc, err := arubaClient.FromNetwork().VPCs().Create(
     ctx,
     aruba.NewVPC().
-        IntoProject(proj).
+        InProject(proj).
         Named("my-vpc").
-        AddTag("network").
+        Tagged("network").
         InRegion(aruba.RegionITBGBergamo).
         NotDefault().
-        WithPreset(false))
+        WithoutPreset())
 if err != nil {
     log.Fatalf("Create VPC: %v", err)
 }
@@ -713,9 +713,9 @@ arubaClient.FromNetwork().Subnets()
 subnet, err := arubaClient.FromNetwork().Subnets().Create(
     ctx,
     aruba.NewSubnet().
-        IntoVPC(vpc).
+        InVPC(vpc).
         Named("my-subnet").
-        AddTag("network").
+        Tagged("network").
         InRegion(aruba.RegionITBGBergamo).
         OfType(aruba.SubnetTypeAdvanced).
         NotDefault().
@@ -723,9 +723,8 @@ subnet, err := arubaClient.FromNetwork().Subnets().Create(
         WithDHCP(aruba.NewSubnetDHCP().
             Enabled().
             WithRange("192.168.1.10", 50).
-            AddRoute("0.0.0.0/0", "192.168.1.1").
-            AddDNS("8.8.8.8").
-            AddDNS("8.8.4.4")))
+            WithRoutes(aruba.SubnetDHCPRoute{Address: "0.0.0.0/0", Gateway: "192.168.1.1"}).
+            WithDNSServers("8.8.8.8", "8.8.4.4")))
 if err != nil {
     log.Fatalf("Create Subnet: %v", err)
 }
@@ -767,11 +766,11 @@ arubaClient.FromNetwork().ElasticIPs()
 eip, err := arubaClient.FromNetwork().ElasticIPs().Create(
     ctx,
     aruba.NewElasticIP().
-        IntoProject(proj).
+        InProject(proj).
         Named("my-eip").
-        AddTag("network").
+        Tagged("network").
         InRegion(aruba.RegionITBGBergamo).
-        WithBillingPeriod(aruba.BillingPeriodHour))
+        BilledHourly())
 if err != nil {
     log.Fatalf("Create ElasticIP: %v", err)
 }
@@ -811,9 +810,9 @@ arubaClient.FromNetwork().SecurityGroups()
 sg, err := arubaClient.FromNetwork().SecurityGroups().Create(
     ctx,
     aruba.NewSecurityGroup().
-        IntoVPC(vpc).
+        InVPC(vpc).
         Named("my-security-group").
-        AddTag("security").
+        Tagged("security").
         NotDefault())
 if err != nil {
     log.Fatalf("Create SecurityGroup: %v", err)
@@ -850,20 +849,20 @@ arubaClient.FromNetwork().SecurityGroupRules()
 
 `WithDirection` accepts `aruba.RuleDirectionIngress` or `aruba.RuleDirectionEgress`. `WithProtocol` accepts `aruba.RuleProtocolTCP`, `aruba.RuleProtocolUDP`, `aruba.RuleProtocolICMP`, or `aruba.RuleProtocolANY`.
 
-> **Caveat**: `WithTargetCIDR` and `WithTargetSecurityGroup` are mutually exclusive. Setting both records a setter-time error that surfaces on `Create`.
+> **Caveat**: `TargetingCIDR` and `TargetingSecurityGroup` are mutually exclusive. Setting both records a setter-time error that surfaces on `Create`.
 
 ```go
 rule, err := arubaClient.FromNetwork().SecurityGroupRules().Create(
     ctx,
     aruba.NewSecurityRule().
-        IntoSecurityGroup(sg).
+        InSecurityGroup(sg).
         Named("allow-ssh").
-        AddTag("ssh-key").
+        Tagged("ssh-key").
         InRegion(aruba.RegionITBGBergamo).
         WithDirection(aruba.RuleDirectionIngress).
         WithProtocol(aruba.RuleProtocolTCP).
         WithPort("22").
-        WithTargetCIDR("0.0.0.0/0"))
+        TargetingCIDR("0.0.0.0/0"))
 if err != nil {
     log.Fatalf("Create SecurityRule: %v", err)
 }
@@ -937,9 +936,9 @@ arubaClient.FromNetwork().VPCPeerings()
 peering, err := arubaClient.FromNetwork().VPCPeerings().Create(
     ctx,
     aruba.NewVPCPeering().
-        IntoVPC(vpc).
+        InVPC(vpc).
         Named("my-peering").
-        AddTag("network").
+        Tagged("network").
         InRegion(aruba.RegionITBGBergamo).
         WithPeerVPC(aruba.URI("/projects/"+peerProjectID+"/vpcs/"+peerVPCID)))
 if err != nil {
@@ -980,9 +979,9 @@ arubaClient.FromNetwork().VPCPeeringRoutes()
 route, err := arubaClient.FromNetwork().VPCPeeringRoutes().Create(
     ctx,
     aruba.NewVPCPeeringRoute().
-        IntoVPCPeering(peering).
+        InVPCPeering(peering).
         Named("my-peering-route").
-        AddTag("network").
+        Tagged("network").
         InRegion(aruba.RegionITBGBergamo).
         WithCIDR("10.0.0.0/8").
         WithTarget(aruba.URI("/projects/"+projectID+"/vpcs/"+vpcID)))
@@ -1029,9 +1028,9 @@ VPN Tunnel sub-builders:
 tunnel, err := arubaClient.FromNetwork().VPNTunnels().Create(
     ctx,
     aruba.NewVPNTunnel().
-        IntoProject(proj).
+        InProject(proj).
         Named("my-vpn-tunnel").
-        AddTag("vpn-net").
+        Tagged("vpn-net").
         InRegion(aruba.RegionITBGBergamo).
         WithPeerClientPublicIP("203.0.113.1").
         WithIKESettings(aruba.NewVPNIKE().
@@ -1083,9 +1082,9 @@ arubaClient.FromNetwork().VPNRoutes()
 vpnRoute, err := arubaClient.FromNetwork().VPNRoutes().Create(
     ctx,
     aruba.NewVPNRoute().
-        IntoVPNTunnel(tunnel).
+        InVPNTunnel(tunnel).
         Named("my-vpn-route").
-        AddTag("vpn-net").
+        Tagged("vpn-net").
         InRegion(aruba.RegionITBGBergamo).
         WithCIDR("10.0.0.0/8").
         WithTarget(aruba.URI("/projects/"+projectID+"/vpcs/"+vpcID)))
@@ -1132,9 +1131,9 @@ Use `OneShotAt(t time.Time)` to schedule a one-shot job, or `WithCron(expr strin
 job, err := arubaClient.FromSchedule().Jobs().Create(
     ctx,
     aruba.NewJob().
-        IntoProject(proj).
+        InProject(proj).
         Named("my-one-shot-job").
-        AddTag("automation").
+        Tagged("automation").
         OneShotAt(time.Now().Add(10*time.Minute)))
 if err != nil {
     log.Fatalf("Create Job: %v", err)
@@ -1145,9 +1144,9 @@ fmt.Printf("✓ Job: %s (type: %s)\n", job.Name(), job.JobType())
 cronJob, err := arubaClient.FromSchedule().Jobs().Create(
     ctx,
     aruba.NewJob().
-        IntoProject(proj).
+        InProject(proj).
         Named("my-recurring-job").
-        AddTag("automation").
+        Tagged("automation").
         WithCron("0 * * * *"))
 if err != nil {
     log.Fatalf("Create recurring Job: %v", err)
@@ -1160,7 +1159,7 @@ fmt.Printf("✓ Recurring Job: %s (cron: %s)\n", cronJob.Name(), cronJob.Cron())
 - `JobID()` — provider-assigned job ID
 - `JobType()` — job type (`types.JobTypeOneShot` or `types.JobTypeRecurring`)
 - `Cron()` — cron expression (recurring jobs)
-- `Enabled()` — bool
+- `IsEnabled()` — bool
 - `State()`, `FailureReason()`, `PreviousState()`, `IsDisabled()`, `DisableReasons()`
 - `Raw()` — underlying wire struct
 
@@ -1185,11 +1184,11 @@ arubaClient.FromSecurity().KMS()
 kms, err := arubaClient.FromSecurity().KMS().Create(
     ctx,
     aruba.NewKMS().
-        IntoProject(proj).
+        InProject(proj).
         Named("my-kms").
-        AddTag("security").
+        Tagged("security").
         InRegion(aruba.RegionITBGBergamo).
-        WithBillingPeriod(aruba.BillingPeriodHour))
+        BilledHourly())
 if err != nil {
     log.Fatalf("Create KMS: %v", err)
 }
@@ -1229,9 +1228,9 @@ arubaClient.FromSecurity().Keys()
 key, err := arubaClient.FromSecurity().Keys().Create(
     ctx,
     aruba.NewKey().
-        IntoKMS(kms).
+        InKMS(kms).
         Named("my-encryption-key").
-        AddTag("security").
+        Tagged("security").
         WithAlgorithm(aruba.KeyAlgorithmAes))
 if err != nil {
     log.Fatalf("Create Key: %v", err)
@@ -1269,9 +1268,9 @@ arubaClient.FromSecurity().Kmips()
 km, err := arubaClient.FromSecurity().Kmips().Create(
     ctx,
     aruba.NewKmip().
-        IntoKMS(kms).
+        InKMS(kms).
         Named("my-kmip").
-        AddTag("security"))
+        Tagged("security"))
 if err != nil {
     log.Fatalf("Create Kmip: %v", err)
 }
@@ -1318,21 +1317,21 @@ arubaClient.FromStorage().Volumes()
 **Supported operations**: `Create`, `List`, `Get`, `Update`, `Delete`
 **Async**: yes — call `WaitUntilReady(ctx)` after `Create`.
 
-`OfType` accepts `aruba.BlockStorageTypeStandard` or `aruba.BlockStorageTypePerformance`. Use `SetBootable()` to mark a volume as bootable; `UnsetBootable()` to unset. Use `FromImage(imageID)` to specify a base image.
+`OfType` accepts `aruba.BlockStorageTypeStandard` or `aruba.BlockStorageTypePerformance`. Use `AsBootable()` to mark a volume as bootable; `NotBootable()` to unset. Use `FromImage(imageID)` to specify a base image.
 
 ```go
 bs, err := arubaClient.FromStorage().Volumes().Create(
     ctx,
     aruba.NewBlockStorage().
-        IntoProject(proj).
+        InProject(proj).
         Named("my-volume").
-        AddTag("storage").
+        Tagged("storage").
         InRegion(aruba.RegionITBGBergamo).
         InZone(aruba.ZoneITBG1).
-        WithSizeGB(20).
+        SizedGB(20).
         OfType(aruba.BlockStorageTypeStandard).
-        WithBillingPeriod(aruba.BillingPeriodHour).
-        SetBootable().
+        BilledHourly().
+        AsBootable().
         FromImage("LU22-001"))
 if err != nil {
     log.Fatalf("Create BlockStorage: %v", err)
@@ -1350,14 +1349,14 @@ To create a volume **from a snapshot**, use `FromSnapshot(snapshot)` instead of 
 bs, err := arubaClient.FromStorage().Volumes().Create(
     ctx,
     aruba.NewBlockStorage().
-        IntoProject(proj).
+        InProject(proj).
         Named("restored-volume").
         InRegion(aruba.RegionITBGBergamo).
         InZone(aruba.ZoneITBG1).
-        WithSizeGB(20).
+        SizedGB(20).
         OfType(aruba.BlockStorageTypeStandard).
-        WithBillingPeriod(aruba.BillingPeriodHour).
-        SetBootable().
+        BilledHourly().
+        AsBootable().
         FromSnapshot(snapshot))
 ```
 
@@ -1368,7 +1367,7 @@ bs, err := arubaClient.FromStorage().Volumes().Create(
 - `Type()` — storage type
 - `Zone()` — availability zone
 - `BillingPeriod()` — billing cadence
-- `Bootable()` — bool
+- `IsBootable()` — bool
 - `Image()` — image reference
 - `SnapshotURI()` — source snapshot URI (if created from snapshot)
 - `State()`, `FailureReason()`, `PreviousState()`, `IsDisabled()`, `DisableReasons()`
@@ -1394,11 +1393,11 @@ arubaClient.FromStorage().Snapshots()
 snap, err := arubaClient.FromStorage().Snapshots().Create(
     ctx,
     aruba.NewSnapshot().
-        IntoProject(proj).
+        InProject(proj).
         Named("my-snapshot").
-        AddTag("backup").
+        Tagged("backup").
         InRegion(aruba.RegionITBGBergamo).
-        WithBillingPeriod(aruba.BillingPeriodHour).
+        BilledHourly().
         FromVolume(bs))
 if err != nil {
     log.Fatalf("Create Snapshot: %v", err)
@@ -1444,13 +1443,13 @@ arubaClient.FromStorage().Backups()
 backup, err := arubaClient.FromStorage().Backups().Create(
     ctx,
     aruba.NewStorageBackup().
-        IntoProject(proj).
+        InProject(proj).
         Named("my-backup").
-        AddTag("backup").
+        Tagged("backup").
         FromVolume(bs).
         OfType(aruba.StorageBackupTypeFull).
-        WithRetentionDays(30).
-        WithBillingPeriod(aruba.BillingPeriodHour))
+        RetainedForDays(30).
+        BilledHourly())
 if err != nil {
     log.Fatalf("Create StorageBackup: %v", err)
 }
@@ -1491,9 +1490,9 @@ arubaClient.FromStorage().Restores()
 restore, err := arubaClient.FromStorage().Restores().Create(
     ctx,
     aruba.NewStorageRestore().
-        IntoBackup(backup).
+        FromBackup(backup).
         Named("my-restore").
-        AddTag("restore").
+        Tagged("restore").
         WithTarget(aruba.URI(backup.OriginURI())))
 if err != nil {
     log.Fatalf("Create StorageRestore: %v", err)

--- a/docs/website/docs/resources.md
+++ b/docs/website/docs/resources.md
@@ -255,7 +255,7 @@ k, err := arubaClient.FromContainer().KaaS().Create(
         WithPodCIDR("10.200.0.0/16").
         WithKubernetesVersion(aruba.KubernetesVersion1323).
         HighlyAvailable().
-        BilledHourly().
+        BilledBy(aruba.BillingPeriodHour).
         WithNodePools(aruba.NewNodePool().
             Named("default-pool").
             WithCount(3).
@@ -328,7 +328,7 @@ reg, err := arubaClient.FromContainer().ContainerRegistry().Create(
         WithBlockStorage(blockStorage).
         WithAdminUsername("admin").
         OfSize(aruba.ContainerRegistrySizeFlavorSmall).
-        BilledHourly())
+        BilledBy(aruba.BillingPeriodHour))
 if err != nil {
     log.Fatalf("Create ContainerRegistry: %v", err)
 }
@@ -379,7 +379,7 @@ db, err := arubaClient.FromDatabase().DBaaS().Create(
         OfEngine(aruba.DatabaseEngineMySQL80).
         OfFlavor(aruba.DBaaSFlavorDBO2A4).
         SizedGB(20).
-        BilledHourly().
+        BilledBy(aruba.BillingPeriodHour).
         WithVPC(vpc).
         WithSubnet(subnet).
         WithSecurityGroup(sg).
@@ -554,7 +554,7 @@ backup, err := arubaClient.FromDatabase().DBaaSBackups().Create(
         InProject(proj).
         Named("my-db-backup").
         FromDBaaS(db).
-        BilledHourly().
+        BilledBy(aruba.BillingPeriodHour).
         Tagged("backup"))
 if err != nil {
     log.Fatalf("Create DBaaSBackup: %v", err)
@@ -770,7 +770,7 @@ eip, err := arubaClient.FromNetwork().ElasticIPs().Create(
         Named("my-eip").
         Tagged("network").
         InRegion(aruba.RegionITBGBergamo).
-        BilledHourly())
+        BilledBy(aruba.BillingPeriodHour))
 if err != nil {
     log.Fatalf("Create ElasticIP: %v", err)
 }
@@ -1188,7 +1188,7 @@ kms, err := arubaClient.FromSecurity().KMS().Create(
         Named("my-kms").
         Tagged("security").
         InRegion(aruba.RegionITBGBergamo).
-        BilledHourly())
+        BilledBy(aruba.BillingPeriodHour))
 if err != nil {
     log.Fatalf("Create KMS: %v", err)
 }
@@ -1330,7 +1330,7 @@ bs, err := arubaClient.FromStorage().Volumes().Create(
         InZone(aruba.ZoneITBG1).
         SizedGB(20).
         OfType(aruba.BlockStorageTypeStandard).
-        BilledHourly().
+        BilledBy(aruba.BillingPeriodHour).
         AsBootable().
         FromImage("LU22-001"))
 if err != nil {
@@ -1355,7 +1355,7 @@ bs, err := arubaClient.FromStorage().Volumes().Create(
         InZone(aruba.ZoneITBG1).
         SizedGB(20).
         OfType(aruba.BlockStorageTypeStandard).
-        BilledHourly().
+        BilledBy(aruba.BillingPeriodHour).
         AsBootable().
         FromSnapshot(snapshot))
 ```
@@ -1397,7 +1397,7 @@ snap, err := arubaClient.FromStorage().Snapshots().Create(
         Named("my-snapshot").
         Tagged("backup").
         InRegion(aruba.RegionITBGBergamo).
-        BilledHourly().
+        BilledBy(aruba.BillingPeriodHour).
         FromVolume(bs))
 if err != nil {
     log.Fatalf("Create Snapshot: %v", err)
@@ -1449,7 +1449,7 @@ backup, err := arubaClient.FromStorage().Backups().Create(
         FromVolume(bs).
         OfType(aruba.StorageBackupTypeFull).
         RetainedForDays(30).
-        BilledHourly())
+        BilledBy(aruba.BillingPeriodHour))
 if err != nil {
     log.Fatalf("Create StorageBackup: %v", err)
 }

--- a/docs/website/docs/response-handling.md
+++ b/docs/website/docs/response-handling.md
@@ -152,9 +152,9 @@ Fluent builder setters never return errors — instead they record them internal
 
 ```go
 rule := aruba.NewSecurityRule().
-    IntoSecurityGroup(sg).
-    WithTargetCIDR("0.0.0.0/0").
-    WithTargetSecurityGroup(otherSG) // conflicting setter — records an error
+    InSecurityGroup(sg).
+    TargetingCIDR("0.0.0.0/0").
+    TargetingSecurityGroup(otherSG) // conflicting setter — records an error
 
 if err := rule.Err(); err != nil {
     log.Fatalf("Bad rule configuration: %v", err)

--- a/docs/website/docs/walkthrough.md
+++ b/docs/website/docs/walkthrough.md
@@ -56,8 +56,8 @@ proj, err := arubaClient.FromProject().Create(
     ctx,
     aruba.NewProject().
         Named("my-project").
-        DescribedAs("Created via the Aruba Cloud Go SDK").
         Tagged("go-sdk").
+        DescribedAs("Created via the Aruba Cloud Go SDK").
         NotDefault())
 if err != nil {
     log.Fatalf("Create project: %v", err)
@@ -71,9 +71,9 @@ fmt.Printf("✓ Project created: %s (ID: %s)\n", proj.Name(), proj.ID())
 vpc, err := arubaClient.FromNetwork().VPCs().Create(
     ctx,
     aruba.NewVPC().
-        InProject(proj).
         Named("my-vpc").
         Tagged("network").
+        InProject(proj).
         InRegion(aruba.RegionITBGBergamo).
         NotDefault().
         WithoutPreset())
@@ -97,18 +97,18 @@ if err := vpc.WaitUntilReady(ctx); err != nil {
 subnet, err := arubaClient.FromNetwork().Subnets().Create(
     ctx,
     aruba.NewSubnet().
-        InVPC(vpc).
+        OfType(aruba.SubnetTypeAdvanced).
         Named("my-subnet").
         Tagged("network").
+        InVPC(vpc).
         InRegion(aruba.RegionITBGBergamo).
-        OfType(aruba.SubnetTypeAdvanced).
-        NotDefault().
         WithCIDR("192.168.1.0/25").
         WithDHCP(aruba.NewSubnetDHCP().
             Enabled().
             WithRange("192.168.1.10", 50).
             WithRoutes(aruba.SubnetDHCPRoute{Address: "10.0.0.0/8", Gateway: "192.168.1.1"}).
-            WithDNSServers("8.8.8.8", "8.8.4.4")))
+            WithDNSServers("8.8.8.8", "8.8.4.4")).
+        NotDefault())
 if err != nil {
     log.Fatalf("Create subnet: %v", err)
 }

--- a/docs/website/docs/walkthrough.md
+++ b/docs/website/docs/walkthrough.md
@@ -6,7 +6,7 @@ sidebar_position: 2
 
 The Aruba Cloud Go SDK gives you a single import — `github.com/Arubacloud/sdk-go/pkg/aruba` — that exposes a fluent builder API for every cloud resource. You construct a resource description with a `aruba.NewX()` builder chain, pass it to the appropriate client method (`Create`, `Get`, `Update`, `Delete`, or `List`), and work with the typed wrapper that comes back.
 
-Resources are scoped to a **Project**, and child resources reference their parents via the `aruba.Ref` interface. You never have to extract or thread raw ID strings by hand: pass the hydrated wrapper (returned by `Create` or `Get`) directly as a `Ref` parameter to builder methods like `IntoProject(proj)`, `IntoVPC(vpc)`, or `IntoSecurityGroup(sg)`.
+Resources are scoped to a **Project**, and child resources reference their parents via the `aruba.Ref` interface. You never have to extract or thread raw ID strings by hand: pass the hydrated wrapper (returned by `Create` or `Get`) directly as a `Ref` parameter to builder methods like `InProject(proj)`, `InVPC(vpc)`, or `InSecurityGroup(sg)`.
 
 This page walks through the core CRUD lifecycle on a minimal example — Project + VPC + Subnet. Every other resource follows the exact same shape. See [Resources](./resources) for copy-paste-ready snippets for all supported resources.
 
@@ -56,8 +56,8 @@ proj, err := arubaClient.FromProject().Create(
     ctx,
     aruba.NewProject().
         Named("my-project").
-        WithDescription("Created via the Aruba Cloud Go SDK").
-        AddTag("go-sdk").
+        DescribedAs("Created via the Aruba Cloud Go SDK").
+        Tagged("go-sdk").
         NotDefault())
 if err != nil {
     log.Fatalf("Create project: %v", err)
@@ -71,12 +71,12 @@ fmt.Printf("✓ Project created: %s (ID: %s)\n", proj.Name(), proj.ID())
 vpc, err := arubaClient.FromNetwork().VPCs().Create(
     ctx,
     aruba.NewVPC().
-        IntoProject(proj).
+        InProject(proj).
         Named("my-vpc").
-        AddTag("network").
+        Tagged("network").
         InRegion(aruba.RegionITBGBergamo).
         NotDefault().
-        WithPreset(false))
+        WithoutPreset())
 if err != nil {
     log.Fatalf("Create VPC: %v", err)
 }
@@ -89,7 +89,7 @@ if err := vpc.WaitUntilReady(ctx); err != nil {
 }
 ```
 
-`IntoProject(proj)` accepts any `aruba.Ref` — it binds the project scope without requiring you to extract a raw ID string.
+`InProject(proj)` accepts any `aruba.Ref` — it binds the project scope without requiring you to extract a raw ID string.
 
 ### Subnet
 
@@ -97,9 +97,9 @@ if err := vpc.WaitUntilReady(ctx); err != nil {
 subnet, err := arubaClient.FromNetwork().Subnets().Create(
     ctx,
     aruba.NewSubnet().
-        IntoVPC(vpc).
+        InVPC(vpc).
         Named("my-subnet").
-        AddTag("network").
+        Tagged("network").
         InRegion(aruba.RegionITBGBergamo).
         OfType(aruba.SubnetTypeAdvanced).
         NotDefault().
@@ -107,9 +107,8 @@ subnet, err := arubaClient.FromNetwork().Subnets().Create(
         WithDHCP(aruba.NewSubnetDHCP().
             Enabled().
             WithRange("192.168.1.10", 50).
-            AddRoute("10.0.0.0/8", "192.168.1.1").
-            AddDNS("8.8.8.8").
-            AddDNS("8.8.4.4")))
+            WithRoutes(aruba.SubnetDHCPRoute{Address: "10.0.0.0/8", Gateway: "192.168.1.1"}).
+            WithDNSServers("8.8.8.8", "8.8.4.4")))
 if err != nil {
     log.Fatalf("Create subnet: %v", err)
 }
@@ -141,7 +140,7 @@ if err != nil {
 
 // Mutate
 vpc.Named("my-vpc-updated").
-    ReplaceTags("network", "updated")
+    RetaggedAs("network", "updated")
 
 // Update
 updated, err := arubaClient.FromNetwork().VPCs().Update(ctx, vpc)
@@ -284,16 +283,16 @@ Builder setters never return an error — they record it in the wrapper. The err
 
 ```go
 rule := aruba.NewSecurityRule().
-    IntoSecurityGroup(sg).
-    WithTargetCIDR("0.0.0.0/0").
-    WithTargetSecurityGroup(otherSG) // conflicting — recorded as error
+    InSecurityGroup(sg).
+    TargetingCIDR("0.0.0.0/0").
+    TargetingSecurityGroup(otherSG) // conflicting — recorded as error
 
 if err := rule.Err(); err != nil {
     log.Fatalf("Bad rule config: %v", err)
 }
 ```
 
-> **Caveat**: `WithTargetCIDR` and `WithTargetSecurityGroup` are mutually exclusive. Setting both records a setter-time error that surfaces on `Create`.
+> **Caveat**: `TargetingCIDR` and `TargetingSecurityGroup` are mutually exclusive. Setting both records a setter-time error that surfaces on `Create`.
 
 ### `WaitUntilReady` requires a hydrated wrapper
 

--- a/docs/website/docs/working-at-low-level.md
+++ b/docs/website/docs/working-at-low-level.md
@@ -144,8 +144,8 @@ import (
 )
 
 vpc := aruba.NewVPC().
-    InProject(proj).
     Named("my-vpc").
+    InProject(proj).
     InRegion(aruba.RegionITBGBergamo).
     AsDefault()
 

--- a/docs/website/docs/working-at-low-level.md
+++ b/docs/website/docs/working-at-low-level.md
@@ -144,7 +144,7 @@ import (
 )
 
 vpc := aruba.NewVPC().
-    IntoProject(proj).
+    InProject(proj).
     Named("my-vpc").
     InRegion(aruba.RegionITBGBergamo).
     AsDefault()

--- a/docs/website/i18n/it/docusaurus-plugin-content-docs/current/intro.md
+++ b/docs/website/i18n/it/docusaurus-plugin-content-docs/current/intro.md
@@ -57,9 +57,8 @@ func main() {
 		ctx,
 		aruba.NewProject().
 			Named("my-first-project").
-			DescribedAs("Un progetto creato con l'SDK Go").
-			Tagged("go-sdk").
-			Tagged("quick-start"))
+			Tagged("go-sdk", "quick-start").
+			DescribedAs("Un progetto creato con l'SDK Go"))
 	if err != nil {
 		log.Fatalf("Error creating project: %v", err)
 	}

--- a/docs/website/i18n/it/docusaurus-plugin-content-docs/current/intro.md
+++ b/docs/website/i18n/it/docusaurus-plugin-content-docs/current/intro.md
@@ -57,9 +57,9 @@ func main() {
 		ctx,
 		aruba.NewProject().
 			Named("my-first-project").
-			WithDescription("Un progetto creato con l'SDK Go").
-			AddTag("go-sdk").
-			AddTag("quick-start"))
+			DescribedAs("Un progetto creato con l'SDK Go").
+			Tagged("go-sdk").
+			Tagged("quick-start"))
 	if err != nil {
 		log.Fatalf("Error creating project: %v", err)
 	}

--- a/docs/website/i18n/it/docusaurus-plugin-content-docs/current/resources.md
+++ b/docs/website/i18n/it/docusaurus-plugin-content-docs/current/resources.md
@@ -255,7 +255,7 @@ k, err := arubaClient.FromContainer().KaaS().Create(
         WithPodCIDR("10.200.0.0/16").
         WithKubernetesVersion("1.32.3").
         HighlyAvailable().
-        BilledHourly().
+        BilledBy(aruba.BillingPeriodHour).
         WithNodePools(aruba.NewNodePool().
             Named("default-pool").
             WithCount(3).
@@ -328,7 +328,7 @@ reg, err := arubaClient.FromContainer().ContainerRegistry().Create(
         WithBlockStorage(blockStorage).
         WithAdminUsername("admin").
         OfSize(aruba.ContainerRegistrySizeFlavorSmall).
-        BilledHourly())
+        BilledBy(aruba.BillingPeriodHour))
 if err != nil {
     log.Fatalf("Create ContainerRegistry: %v", err)
 }
@@ -380,7 +380,7 @@ db, err := arubaClient.FromDatabase().DBaaS().Create(
         WithEngine("mysql-8.0").
         WithFlavor("DBO2A4").
         WithStorage(20).
-        BilledHourly().
+        BilledBy(aruba.BillingPeriodHour).
         WithAutoscaling(true).
         WithNetworking(vpc, subnet, sg, eip))
 if err != nil {
@@ -552,7 +552,7 @@ backup, err := arubaClient.FromDatabase().DBaaSBackups().Create(
         InProject(proj).
         Named("my-db-backup").
         FromDBaaS(db).
-        BilledHourly().
+        BilledBy(aruba.BillingPeriodHour).
         Tagged("backup"))
 if err != nil {
     log.Fatalf("Create DBaaSBackup: %v", err)
@@ -766,7 +766,7 @@ eip, err := arubaClient.FromNetwork().ElasticIPs().Create(
         Named("my-eip").
         Tagged("network").
         InRegion("ITBG-Bergamo").
-        BilledHourly())
+        BilledBy(aruba.BillingPeriodHour))
 if err != nil {
     log.Fatalf("Create ElasticIP: %v", err)
 }
@@ -1182,7 +1182,7 @@ kms, err := arubaClient.FromSecurity().KMS().Create(
         Named("my-kms").
         Tagged("security").
         InRegion("ITBG-Bergamo").
-        BilledHourly())
+        BilledBy(aruba.BillingPeriodHour))
 if err != nil {
     log.Fatalf("Create KMS: %v", err)
 }
@@ -1326,7 +1326,7 @@ bs, err := arubaClient.FromStorage().Volumes().Create(
         InZone(aruba.ZoneITBG1).
         SizedGB(20).
         OfType(aruba.BlockStorageTypeStandard).
-        BilledHourly().
+        BilledBy(aruba.BillingPeriodHour).
         AsBootable().
         FromImage("LU22-001"))
 if err != nil {
@@ -1351,7 +1351,7 @@ bs, err := arubaClient.FromStorage().Volumes().Create(
         InZone(aruba.ZoneITBG1).
         SizedGB(20).
         OfType(aruba.BlockStorageTypeStandard).
-        BilledHourly().
+        BilledBy(aruba.BillingPeriodHour).
         AsBootable().
         FromSnapshot(snapshot))
 ```
@@ -1393,7 +1393,7 @@ snap, err := arubaClient.FromStorage().Snapshots().Create(
         Named("my-snapshot").
         Tagged("backup").
         InRegion("ITBG-Bergamo").
-        BilledHourly().
+        BilledBy(aruba.BillingPeriodHour).
         OfVolume(bs))
 if err != nil {
     log.Fatalf("Create Snapshot: %v", err)
@@ -1445,7 +1445,7 @@ backup, err := arubaClient.FromStorage().Backups().Create(
         FromVolume(bs).
         OfType(aruba.StorageBackupTypeFull).
         RetainedForDays(30).
-        BilledHourly())
+        BilledBy(aruba.BillingPeriodHour))
 if err != nil {
     log.Fatalf("Create StorageBackup: %v", err)
 }

--- a/docs/website/i18n/it/docusaurus-plugin-content-docs/current/resources.md
+++ b/docs/website/i18n/it/docusaurus-plugin-content-docs/current/resources.md
@@ -64,9 +64,9 @@ proj, err := arubaClient.FromProject().Create(
     ctx,
     aruba.NewProject().
         Named("my-project").
-        DescribedAs("Progetto di produzione").
         Tagged("env-prod").
-        WithDefault(false))
+        DescribedAs("Progetto di produzione").
+        NotDefault())
 if err != nil {
     log.Fatalf("Create project: %v", err)
 }
@@ -142,17 +142,17 @@ Un Cloud Server dipende da risorse di rete (VPC, Subnet, Security Group), un Ela
 cs, err := arubaClient.FromCompute().CloudServers().Create(
     ctx,
     aruba.NewCloudServer().
-        InProject(proj).
+        OfFlavor(aruba.CloudServerFlavorCSO2A4).
         Named("my-server").
         Tagged("env-prod").
-        InRegion("ITBG-Bergamo").
-        InZone("ITBG-1").
-        WithFlavor("CSO2A4").
+        InProject(proj).
+        InRegion(aruba.RegionITBGBergamo).
+        InZone(aruba.ZoneITBG1).
+        BootingFrom(blockStorage).
         WithVPC(vpc).
         OnSubnets(subnet).
         WithSecurityGroups(sg).
         WithElasticIP(eip).
-        BootingFrom(blockStorage).
         UsingKeyPair(keyPair))
 if err != nil {
     log.Fatalf("Create Cloud Server: %v", err)
@@ -206,9 +206,9 @@ arubaClient.FromCompute().KeyPairs()
 kp, err := arubaClient.FromCompute().KeyPairs().Create(
     ctx,
     aruba.NewKeyPair().
-        InProject(proj).
         Named("my-keypair").
-        InRegion("ITBG-Bergamo").
+        InProject(proj).
+        InRegion(aruba.RegionITBGBergamo).
         WithPublicKey("ssh-rsa AAAAB3NzaC1yc2E..."))
 if err != nil {
     log.Fatalf("Create KeyPair: %v", err)
@@ -244,23 +244,23 @@ arubaClient.FromContainer().KaaS()
 k, err := arubaClient.FromContainer().KaaS().Create(
     ctx,
     aruba.NewKaaS().
-        InProject(proj).
         Named("my-cluster").
         Tagged("env-prod").
-        WithLocation("ITBG-Bergamo").
+        InProject(proj).
+        InRegion(aruba.RegionITBGBergamo).
+        WithKubernetesVersion(aruba.KubernetesVersion1323).
+        WithPodCIDR("10.200.0.0/16").
+        WithNodeCIDR("10.100.0.0/16", "node-cidr").
         WithVPC(vpc).
         WithSubnet(subnet).
-        WithSecurityGroupName("my-security-group").
-        WithNodeCIDR("10.100.0.0/16", "node-cidr").
-        WithPodCIDR("10.200.0.0/16").
-        WithKubernetesVersion("1.32.3").
-        HighlyAvailable().
-        BilledBy(aruba.BillingPeriodHour).
+        WithSecurityGroup(sg).
         WithNodePools(aruba.NewNodePool().
+            OfInstance(aruba.NodePoolInstanceK4A8).
             Named("default-pool").
-            WithCount(3).
-            OfInstance("K4A8").
-            InZone("ITBG-1")))
+            InZone(aruba.ZoneITBG1).
+            WithCount(3)).
+        HighlyAvailable().
+        BilledBy(aruba.BillingPeriodHour))
 if err != nil {
     log.Fatalf("Create KaaS: %v", err)
 }
@@ -318,16 +318,16 @@ arubaClient.FromContainer().ContainerRegistry()
 reg, err := arubaClient.FromContainer().ContainerRegistry().Create(
     ctx,
     aruba.NewContainerRegistry().
-        InProject(proj).
+        OfSize(aruba.ContainerRegistrySizeFlavorSmall).
         Named("my-registry").
         Tagged("env-prod").
+        InProject(proj).
+        WithAdminUsername("admin").
         WithVPC(vpc).
         WithSubnet(subnet).
         WithSecurityGroup(sg).
         WithElasticIP(eip).
         WithBlockStorage(blockStorage).
-        WithAdminUsername("admin").
-        OfSize(aruba.ContainerRegistrySizeFlavorSmall).
         BilledBy(aruba.BillingPeriodHour))
 if err != nil {
     log.Fatalf("Create ContainerRegistry: %v", err)
@@ -372,17 +372,20 @@ arubaClient.FromDatabase().DBaaS()
 db, err := arubaClient.FromDatabase().DBaaS().Create(
     ctx,
     aruba.NewDBaaS().
-        InProject(proj).
+        OfEngine(aruba.DatabaseEngineMySQL80).
+        OfFlavor(aruba.DBaaSFlavorDBO2A4).
         Named("my-database").
         Tagged("env-prod").
-        InRegion("ITBG-Bergamo").
-        InZone("ITBG-1").
-        WithEngine("mysql-8.0").
-        WithFlavor("DBO2A4").
-        WithStorage(20).
-        BilledBy(aruba.BillingPeriodHour).
-        WithAutoscaling(true).
-        WithNetworking(vpc, subnet, sg, eip))
+        InProject(proj).
+        InRegion(aruba.RegionITBGBergamo).
+        InZone(aruba.ZoneITBG1).
+        SizedGB(20).
+        WithAutoscaling(2, 5).
+        WithVPC(vpc).
+        WithSubnet(subnet).
+        WithSecurityGroup(sg).
+        WithElasticIP(eip).
+        BilledBy(aruba.BillingPeriodHour))
 if err != nil {
     log.Fatalf("Create DBaaS: %v", err)
 }
@@ -427,9 +430,9 @@ arubaClient.FromDatabase().Databases()
 database, err := arubaClient.FromDatabase().Databases().Create(
     ctx,
     aruba.NewDatabase().
-        InDBaaS(db).
         Named("my-app-db").
-        Tagged("app-backend"))
+        Tagged("app-backend").
+        InDBaaS(db))
 if err != nil {
     log.Fatalf("Create Database: %v", err)
 }
@@ -468,9 +471,8 @@ user, err := arubaClient.FromDatabase().Users().Create(
     ctx,
     aruba.NewUser().
         InDBaaS(db).
-        Named("app_user").
-        WithPassword("Str0ngP@ssword!").
-        Tagged("app-backend"))
+        WithUsername("app_user").
+        WithPassword("Str0ngP@ssword!"))
 if err != nil {
     log.Fatalf("Create User: %v", err)
 }
@@ -508,9 +510,9 @@ arubaClient.FromDatabase().Grants()
 grant, err := arubaClient.FromDatabase().Grants().Create(
     ctx,
     aruba.NewGrant().
+        OfRole("liteadmin").
         InDatabase(database).
-        Named("app_user-grant").
-        WithPrivileges("ALL"))
+        ForUser("app_user"))
 if err != nil {
     log.Fatalf("Create Grant: %v", err)
 }
@@ -518,14 +520,14 @@ if err != nil {
 if err := grant.WaitUntilReady(ctx); err != nil {
     log.Fatalf("Grant did not become Active: %v", err)
 }
-fmt.Printf("✓ Grant: %s (privilegi: %s)\n", grant.Name(), grant.Privileges())
+fmt.Printf("✓ Grant: %s\n", grant.ID())
 ```
 
 **Accessor di risposta**:
-- `ID()`, `URI()`, `Name()`, `Tags()`
+- `ID()`, `URI()`
 - `GrantID()` — ID grant assegnato dal provider
 - `DatabaseID()` — ID Database genitore
-- `Privileges()` — stringa dei privilegi
+- `Role()` — ruolo assegnato (es. `"liteadmin"`)
 - `State()`, `FailureReason()`, `PreviousState()`, `IsDisabled()`, `DisableReasons()`
 - `WaitUntilReady(ctx, opts...)`, `WaitUntilActive(ctx, opts...)`, `WaitUntilStates(ctx, []types.State{...}, opts...)`, `WaitUntilGone(ctx, opts...)`
 - `Raw()` — struct wire sottostante
@@ -549,11 +551,11 @@ arubaClient.FromDatabase().DBaaSBackups()
 backup, err := arubaClient.FromDatabase().DBaaSBackups().Create(
     ctx,
     aruba.NewDBaaSBackup().
-        InProject(proj).
         Named("my-db-backup").
+        Tagged("backup").
+        InProject(proj).
         FromDBaaS(db).
-        BilledBy(aruba.BillingPeriodHour).
-        Tagged("backup"))
+        BilledBy(aruba.BillingPeriodHour))
 if err != nil {
     log.Fatalf("Create DBaaSBackup: %v", err)
 }
@@ -661,11 +663,11 @@ arubaClient.FromNetwork().VPCs()
 vpc, err := arubaClient.FromNetwork().VPCs().Create(
     ctx,
     aruba.NewVPC().
-        InProject(proj).
         Named("my-vpc").
         Tagged("network").
-        InRegion("ITBG-Bergamo").
-        WithDefault(false).
+        InProject(proj).
+        InRegion(aruba.RegionITBGBergamo).
+        NotDefault().
         WithoutPreset())
 if err != nil {
     log.Fatalf("Create VPC: %v", err)
@@ -709,18 +711,18 @@ arubaClient.FromNetwork().Subnets()
 subnet, err := arubaClient.FromNetwork().Subnets().Create(
     ctx,
     aruba.NewSubnet().
-        InVPC(vpc).
+        OfType(aruba.SubnetTypeAdvanced).
         Named("my-subnet").
         Tagged("network").
+        InVPC(vpc).
         InRegion(aruba.RegionITBGBergamo).
-        OfType(aruba.SubnetTypeAdvanced).
-        NotDefault().
         WithCIDR("192.168.1.0/25").
         WithDHCP(aruba.NewSubnetDHCP().
             Enabled().
             WithRange("192.168.1.10", 50).
             WithRoutes(aruba.SubnetDHCPRoute{Address: "0.0.0.0/0", Gateway: "192.168.1.1"}).
-            WithDNSServers("8.8.8.8", "8.8.4.4")))
+            WithDNSServers("8.8.8.8", "8.8.4.4")).
+        NotDefault())
 if err != nil {
     log.Fatalf("Create Subnet: %v", err)
 }
@@ -762,10 +764,10 @@ arubaClient.FromNetwork().ElasticIPs()
 eip, err := arubaClient.FromNetwork().ElasticIPs().Create(
     ctx,
     aruba.NewElasticIP().
-        InProject(proj).
         Named("my-eip").
         Tagged("network").
-        InRegion("ITBG-Bergamo").
+        InProject(proj).
+        InRegion(aruba.RegionITBGBergamo).
         BilledBy(aruba.BillingPeriodHour))
 if err != nil {
     log.Fatalf("Create ElasticIP: %v", err)
@@ -806,10 +808,10 @@ arubaClient.FromNetwork().SecurityGroups()
 sg, err := arubaClient.FromNetwork().SecurityGroups().Create(
     ctx,
     aruba.NewSecurityGroup().
-        InVPC(vpc).
         Named("my-security-group").
         Tagged("security").
-        WithDefault(false))
+        InVPC(vpc).
+        NotDefault())
 if err != nil {
     log.Fatalf("Create SecurityGroup: %v", err)
 }
@@ -843,7 +845,7 @@ arubaClient.FromNetwork().SecurityGroupRules()
 **Operazioni supportate**: `Create`, `List`, `Get`, `Delete`
 **Asincrono**: sì — `State()` e `FailureReason()` sono disponibili.
 
-`WithDirection` accetta `string(aruba.RuleDirectionIngress)` o `string(aruba.RuleDirectionEgress)`.
+`WithDirection` accetta `aruba.RuleDirectionIngress` o `aruba.RuleDirectionEgress`.
 
 > **Avvertenza**: `TargetingCIDR` e `TargetingSecurityGroup` si escludono a vicenda. Impostarli entrambi registra un errore al momento del setter che emerge su `Create`.
 
@@ -851,12 +853,12 @@ arubaClient.FromNetwork().SecurityGroupRules()
 rule, err := arubaClient.FromNetwork().SecurityGroupRules().Create(
     ctx,
     aruba.NewSecurityRule().
-        InSecurityGroup(sg).
         Named("allow-ssh").
         Tagged("ssh-key").
-        InRegion("ITBG-Bergamo").
-        WithDirection(string(aruba.RuleDirectionIngress)).
-        WithProtocol("TCP").
+        InSecurityGroup(sg).
+        InRegion(aruba.RegionITBGBergamo).
+        WithDirection(aruba.RuleDirectionIngress).
+        WithProtocol(aruba.RuleProtocolTCP).
         WithPort("22").
         TargetingCIDR("0.0.0.0/0"))
 if err != nil {
@@ -932,10 +934,10 @@ arubaClient.FromNetwork().VPCPeerings()
 peering, err := arubaClient.FromNetwork().VPCPeerings().Create(
     ctx,
     aruba.NewVPCPeering().
-        InVPC(vpc).
         Named("my-peering").
         Tagged("network").
-        InRegion("ITBG-Bergamo").
+        InVPC(vpc).
+        InRegion(aruba.RegionITBGBergamo).
         WithPeerVPC(aruba.URI("/projects/"+peerProjectID+"/vpcs/"+peerVPCID)))
 if err != nil {
     log.Fatalf("Create VPCPeering: %v", err)
@@ -975,10 +977,10 @@ arubaClient.FromNetwork().VPCPeeringRoutes()
 route, err := arubaClient.FromNetwork().VPCPeeringRoutes().Create(
     ctx,
     aruba.NewVPCPeeringRoute().
-        InVPCPeering(peering).
         Named("my-peering-route").
         Tagged("network").
-        InRegion("ITBG-Bergamo").
+        InVPCPeering(peering).
+        InRegion(aruba.RegionITBGBergamo).
         WithCIDR("10.0.0.0/8").
         WithTarget(aruba.URI("/projects/"+projectID+"/vpcs/"+vpcID)))
 if err != nil {
@@ -1016,29 +1018,28 @@ arubaClient.FromNetwork().VPNTunnels()
 **Asincrono**: sì — chiama `WaitUntilReady(ctx)` dopo `Create`.
 
 Sub-builder del VPN Tunnel:
-- `aruba.NewVPNIKE()` — parametri IKE fase 1
-- `aruba.NewVPNESP()` — parametri ESP fase 2
-- `aruba.NewVPNPSK()` — configurazione della pre-shared key
+- `aruba.NewVPNIKE()` — parametri IKE fase 1 (`WithEncryption(IKEEncryption)`, `WithHash(IKEHash)`, `WithDHGroup(IKEDHGroup)`, `WithDPDAction(IKEDPDAction)`)
+- `aruba.NewVPNESP()` — parametri ESP fase 2 (`WithEncryption(ESPEncryption)`, `WithHash(ESPHash)`, `WithPFS(ESPPFSGroup)`)
+- `aruba.NewVPNPSK()` — configurazione della pre-shared key (`WithKey(string)`, `WithCloudSite(string)`, `WithOnPremSite(string)`)
 
 ```go
 tunnel, err := arubaClient.FromNetwork().VPNTunnels().Create(
     ctx,
     aruba.NewVPNTunnel().
-        InProject(proj).
         Named("my-vpn-tunnel").
         Tagged("vpn-net").
-        InRegion("ITBG-Bergamo").
-        WithRemoteGateway("203.0.113.1").
-        WithIKE(aruba.NewVPNIKE().
-            WithEncryption(string(aruba.VPNEncryptionAES256)).
-            WithHash(string(aruba.VPNHashSHA256)).
-            WithDHGroup(string(aruba.VPNDHGroup14))).
-        WithESP(aruba.NewVPNESP().
-            WithEncryption(string(aruba.VPNEncryptionAES256)).
-            WithHash(string(aruba.VPNHashSHA256))).
-        WithPSK(aruba.NewVPNPSK().
-            WithKey("my-pre-shared-key").
-            WithID("tunnel-id")))
+        InProject(proj).
+        InRegion(aruba.RegionITBGBergamo).
+        WithPeerClientPublicIP("203.0.113.1").
+        WithIKESettings(aruba.NewVPNIKE().
+            WithEncryption(aruba.IKEEncryptionAES256).
+            WithHash(aruba.IKEHashSHA256).
+            WithDHGroup(aruba.IKEDHGroup14)).
+        WithESPSettings(aruba.NewVPNESP().
+            WithEncryption(aruba.ESPEncryptionAES256).
+            WithHash(aruba.ESPHashSHA256)).
+        WithPSKSettings(aruba.NewVPNPSK().
+            WithKey("my-pre-shared-key")))
 if err != nil {
     log.Fatalf("Create VPNTunnel: %v", err)
 }
@@ -1046,13 +1047,13 @@ if err != nil {
 if err := tunnel.WaitUntilReady(ctx); err != nil {
     log.Fatalf("VPNTunnel did not become Active: %v", err)
 }
-fmt.Printf("✓ VPN Tunnel: %s (gateway: %s)\n", tunnel.Name(), tunnel.RemoteGateway())
+fmt.Printf("✓ VPN Tunnel: %s (gateway: %s)\n", tunnel.Name(), tunnel.PeerClientPublicIP())
 ```
 
 **Accessor di risposta**:
 - `ID()`, `URI()`, `Name()`, `Tags()`
 - `VPNTunnelID()` — ID tunnel assegnato dal provider
-- `RemoteGateway()` — IP del gateway remoto
+- `PeerClientPublicIP()` — IP del gateway peer remoto
 - `State()`, `FailureReason()`, `PreviousState()`, `IsDisabled()`, `DisableReasons()`
 - `WaitUntilReady(ctx, opts...)`, `WaitUntilActive(ctx, opts...)`, `WaitUntilStates(ctx, []types.State{...}, opts...)`, `WaitUntilGone(ctx, opts...)`
 - `Raw()` — struct wire sottostante
@@ -1076,10 +1077,10 @@ arubaClient.FromNetwork().VPNRoutes()
 vpnRoute, err := arubaClient.FromNetwork().VPNRoutes().Create(
     ctx,
     aruba.NewVPNRoute().
-        InVPNTunnel(tunnel).
         Named("my-vpn-route").
         Tagged("vpn-net").
-        InRegion("ITBG-Bergamo").
+        InVPNTunnel(tunnel).
+        InRegion(aruba.RegionITBGBergamo).
         WithCIDR("10.0.0.0/8").
         WithTarget(aruba.URI("/projects/"+projectID+"/vpcs/"+vpcID)))
 if err != nil {
@@ -1125,9 +1126,9 @@ Usa `OneShotAt(t time.Time)` per pianificare un job una-tantum, o `WithCron(expr
 job, err := arubaClient.FromSchedule().Jobs().Create(
     ctx,
     aruba.NewJob().
-        InProject(proj).
         Named("my-one-shot-job").
         Tagged("automation").
+        InProject(proj).
         OneShotAt(time.Now().Add(10*time.Minute)))
 if err != nil {
     log.Fatalf("Create Job: %v", err)
@@ -1138,9 +1139,9 @@ fmt.Printf("✓ Job: %s (tipo: %s)\n", job.Name(), job.JobType())
 cronJob, err := arubaClient.FromSchedule().Jobs().Create(
     ctx,
     aruba.NewJob().
-        InProject(proj).
         Named("my-recurring-job").
         Tagged("automation").
+        InProject(proj).
         WithCron("0 * * * *"))
 if err != nil {
     log.Fatalf("Create recurring Job: %v", err)
@@ -1178,10 +1179,10 @@ arubaClient.FromSecurity().KMS()
 kms, err := arubaClient.FromSecurity().KMS().Create(
     ctx,
     aruba.NewKMS().
-        InProject(proj).
         Named("my-kms").
         Tagged("security").
-        InRegion("ITBG-Bergamo").
+        InProject(proj).
+        InRegion(aruba.RegionITBGBergamo).
         BilledBy(aruba.BillingPeriodHour))
 if err != nil {
     log.Fatalf("Create KMS: %v", err)
@@ -1217,16 +1218,16 @@ arubaClient.FromSecurity().Keys()
 **Operazioni supportate**: `Create`, `List`, `Get`, `Delete`
 **Asincrono**: sì — `State()` e `FailureReason()` sono disponibili.
 
-`WithAlgorithm` accetta `string(aruba.KeyAlgorithmAes)` o `string(aruba.KeyAlgorithmRsa)`.
+`OfAlgorithm` accetta `aruba.KeyAlgorithmAes` o `aruba.KeyAlgorithmRsa`.
 
 ```go
 key, err := arubaClient.FromSecurity().Keys().Create(
     ctx,
     aruba.NewKey().
-        InKMS(kms).
+        OfAlgorithm(aruba.KeyAlgorithmAes).
         Named("my-encryption-key").
         Tagged("security").
-        WithAlgorithm(string(aruba.KeyAlgorithmAes)))
+        InKMS(kms))
 if err != nil {
     log.Fatalf("Create Key: %v", err)
 }
@@ -1263,15 +1264,15 @@ arubaClient.FromSecurity().Kmips()
 km, err := arubaClient.FromSecurity().Kmips().Create(
     ctx,
     aruba.NewKmip().
-        InKMS(kms).
         Named("my-kmip").
-        Tagged("security"))
+        Tagged("security").
+        InKMS(kms))
 if err != nil {
     log.Fatalf("Create Kmip: %v", err)
 }
 
 // Attendi che il certificato sia disponibile
-if err := km.WaitUntilState(ctx, string(aruba.ServiceStatusCertificateAvailable)); err != nil {
+if err := km.WaitUntilCertificateAvailable(ctx); err != nil {
     log.Fatalf("Kmip certificate not available: %v", err)
 }
 fmt.Printf("✓ Kmip: %s\n", km.Name())
@@ -1319,16 +1320,16 @@ arubaClient.FromStorage().Volumes()
 bs, err := arubaClient.FromStorage().Volumes().Create(
     ctx,
     aruba.NewBlockStorage().
-        InProject(proj).
+        OfType(aruba.BlockStorageTypeStandard).
         Named("my-volume").
         Tagged("storage").
+        InProject(proj).
         InRegion(aruba.RegionITBGBergamo).
         InZone(aruba.ZoneITBG1).
         SizedGB(20).
-        OfType(aruba.BlockStorageTypeStandard).
-        BilledBy(aruba.BillingPeriodHour).
+        FromImage("LU22-001").
         AsBootable().
-        FromImage("LU22-001"))
+        BilledBy(aruba.BillingPeriodHour))
 if err != nil {
     log.Fatalf("Create BlockStorage: %v", err)
 }
@@ -1345,15 +1346,15 @@ Per creare un volume **da uno snapshot**, usa `FromSnapshot(snapshot)` al posto 
 bs, err := arubaClient.FromStorage().Volumes().Create(
     ctx,
     aruba.NewBlockStorage().
-        InProject(proj).
+        OfType(aruba.BlockStorageTypeStandard).
         Named("restored-volume").
+        InProject(proj).
         InRegion(aruba.RegionITBGBergamo).
         InZone(aruba.ZoneITBG1).
         SizedGB(20).
-        OfType(aruba.BlockStorageTypeStandard).
-        BilledBy(aruba.BillingPeriodHour).
+        FromSnapshot(snapshot).
         AsBootable().
-        FromSnapshot(snapshot))
+        BilledBy(aruba.BillingPeriodHour))
 ```
 
 **Accessor di risposta**:
@@ -1389,12 +1390,12 @@ arubaClient.FromStorage().Snapshots()
 snap, err := arubaClient.FromStorage().Snapshots().Create(
     ctx,
     aruba.NewSnapshot().
-        InProject(proj).
         Named("my-snapshot").
         Tagged("backup").
-        InRegion("ITBG-Bergamo").
-        BilledBy(aruba.BillingPeriodHour).
-        OfVolume(bs))
+        InProject(proj).
+        InRegion(aruba.RegionITBGBergamo).
+        FromVolume(bs).
+        BilledBy(aruba.BillingPeriodHour))
 if err != nil {
     log.Fatalf("Create Snapshot: %v", err)
 }
@@ -1439,12 +1440,12 @@ arubaClient.FromStorage().Backups()
 backup, err := arubaClient.FromStorage().Backups().Create(
     ctx,
     aruba.NewStorageBackup().
-        InProject(proj).
+        OfType(aruba.StorageBackupTypeFull).
         Named("my-backup").
         Tagged("backup").
-        FromVolume(bs).
-        OfType(aruba.StorageBackupTypeFull).
+        InProject(proj).
         RetainedForDays(30).
+        FromVolume(bs).
         BilledBy(aruba.BillingPeriodHour))
 if err != nil {
     log.Fatalf("Create StorageBackup: %v", err)
@@ -1485,10 +1486,10 @@ arubaClient.FromStorage().Restores()
 restore, err := arubaClient.FromStorage().Restores().Create(
     ctx,
     aruba.NewStorageRestore().
-        FromBackup(backup).
         Named("my-restore").
         Tagged("restore").
-        WithTarget(aruba.URI(backup.OriginURI())))
+        FromBackup(backup).
+        ToVolume(aruba.URI(backup.OriginURI())))
 if err != nil {
     log.Fatalf("Create StorageRestore: %v", err)
 }

--- a/docs/website/i18n/it/docusaurus-plugin-content-docs/current/resources.md
+++ b/docs/website/i18n/it/docusaurus-plugin-content-docs/current/resources.md
@@ -27,7 +27,7 @@ result, err := client.Create(ctx,
     aruba.NewX().
         IntoParent(parentRef).   // scope al progetto / VPC / ecc.
         Named("my-resource").
-        AddTag("env-prod").
+        Tagged("env-prod").
         WithFoo(...))
 
 // 3. Attendi che le risorse asincrone diventino pronte
@@ -64,8 +64,8 @@ proj, err := arubaClient.FromProject().Create(
     ctx,
     aruba.NewProject().
         Named("my-project").
-        WithDescription("Progetto di produzione").
-        AddTag("env-prod").
+        DescribedAs("Progetto di produzione").
+        Tagged("env-prod").
         WithDefault(false))
 if err != nil {
     log.Fatalf("Create project: %v", err)
@@ -142,18 +142,18 @@ Un Cloud Server dipende da risorse di rete (VPC, Subnet, Security Group), un Ela
 cs, err := arubaClient.FromCompute().CloudServers().Create(
     ctx,
     aruba.NewCloudServer().
-        IntoProject(proj).
+        InProject(proj).
         Named("my-server").
-        AddTag("env-prod").
+        Tagged("env-prod").
         InRegion("ITBG-Bergamo").
         InZone("ITBG-1").
         WithFlavor("CSO2A4").
         WithVPC(vpc).
-        AddSubnet(subnet).
-        AddSecurityGroup(sg).
+        OnSubnets(subnet).
+        WithSecurityGroups(sg).
         WithElasticIP(eip).
-        WithBootVolume(blockStorage).
-        WithKeyPair(keyPair))
+        BootingFrom(blockStorage).
+        UsingKeyPair(keyPair))
 if err != nil {
     log.Fatalf("Create Cloud Server: %v", err)
 }
@@ -206,7 +206,7 @@ arubaClient.FromCompute().KeyPairs()
 kp, err := arubaClient.FromCompute().KeyPairs().Create(
     ctx,
     aruba.NewKeyPair().
-        IntoProject(proj).
+        InProject(proj).
         Named("my-keypair").
         InRegion("ITBG-Bergamo").
         WithPublicKey("ssh-rsa AAAAB3NzaC1yc2E..."))
@@ -244,9 +244,9 @@ arubaClient.FromContainer().KaaS()
 k, err := arubaClient.FromContainer().KaaS().Create(
     ctx,
     aruba.NewKaaS().
-        IntoProject(proj).
+        InProject(proj).
         Named("my-cluster").
-        AddTag("env-prod").
+        Tagged("env-prod").
         WithLocation("ITBG-Bergamo").
         WithVPC(vpc).
         WithSubnet(subnet).
@@ -254,9 +254,9 @@ k, err := arubaClient.FromContainer().KaaS().Create(
         WithNodeCIDR("10.100.0.0/16", "node-cidr").
         WithPodCIDR("10.200.0.0/16").
         WithKubernetesVersion("1.32.3").
-        WithHA(true).
-        WithBillingPeriod("Hour").
-        AddNodePool(aruba.NewNodePool().
+        HighlyAvailable().
+        BilledHourly().
+        WithNodePools(aruba.NewNodePool().
             Named("default-pool").
             WithCount(3).
             OfInstance("K4A8").
@@ -318,17 +318,17 @@ arubaClient.FromContainer().ContainerRegistry()
 reg, err := arubaClient.FromContainer().ContainerRegistry().Create(
     ctx,
     aruba.NewContainerRegistry().
-        IntoProject(proj).
+        InProject(proj).
         Named("my-registry").
-        AddTag("env-prod").
+        Tagged("env-prod").
         WithVPC(vpc).
         WithSubnet(subnet).
         WithSecurityGroup(sg).
-        WithPublicIP(eip).
+        WithElasticIP(eip).
         WithBlockStorage(blockStorage).
         WithAdminUsername("admin").
-        WithSize(100).
-        WithBillingPeriod("Hour"))
+        OfSize(aruba.ContainerRegistrySizeFlavorSmall).
+        BilledHourly())
 if err != nil {
     log.Fatalf("Create ContainerRegistry: %v", err)
 }
@@ -372,15 +372,15 @@ arubaClient.FromDatabase().DBaaS()
 db, err := arubaClient.FromDatabase().DBaaS().Create(
     ctx,
     aruba.NewDBaaS().
-        IntoProject(proj).
+        InProject(proj).
         Named("my-database").
-        AddTag("env-prod").
+        Tagged("env-prod").
         InRegion("ITBG-Bergamo").
         InZone("ITBG-1").
         WithEngine("mysql-8.0").
         WithFlavor("DBO2A4").
         WithStorage(20).
-        WithBillingPeriod("Hour").
+        BilledHourly().
         WithAutoscaling(true).
         WithNetworking(vpc, subnet, sg, eip))
 if err != nil {
@@ -427,9 +427,9 @@ arubaClient.FromDatabase().Databases()
 database, err := arubaClient.FromDatabase().Databases().Create(
     ctx,
     aruba.NewDatabase().
-        IntoDBaaS(db).
+        InDBaaS(db).
         Named("my-app-db").
-        AddTag("app-backend"))
+        Tagged("app-backend"))
 if err != nil {
     log.Fatalf("Create Database: %v", err)
 }
@@ -467,10 +467,10 @@ arubaClient.FromDatabase().Users()
 user, err := arubaClient.FromDatabase().Users().Create(
     ctx,
     aruba.NewUser().
-        IntoDBaaS(db).
+        InDBaaS(db).
         Named("app_user").
         WithPassword("Str0ngP@ssword!").
-        AddTag("app-backend"))
+        Tagged("app-backend"))
 if err != nil {
     log.Fatalf("Create User: %v", err)
 }
@@ -508,7 +508,7 @@ arubaClient.FromDatabase().Grants()
 grant, err := arubaClient.FromDatabase().Grants().Create(
     ctx,
     aruba.NewGrant().
-        IntoDatabase(database).
+        InDatabase(database).
         Named("app_user-grant").
         WithPrivileges("ALL"))
 if err != nil {
@@ -549,12 +549,11 @@ arubaClient.FromDatabase().DBaaSBackups()
 backup, err := arubaClient.FromDatabase().DBaaSBackups().Create(
     ctx,
     aruba.NewDBaaSBackup().
-        IntoProject(proj).
+        InProject(proj).
         Named("my-db-backup").
-        WithDBaaS(db).
-        WithType("Full").
-        WithRetentionDays(30).
-        AddTag("backup"))
+        FromDBaaS(db).
+        BilledHourly().
+        Tagged("backup"))
 if err != nil {
     log.Fatalf("Create DBaaSBackup: %v", err)
 }
@@ -662,12 +661,12 @@ arubaClient.FromNetwork().VPCs()
 vpc, err := arubaClient.FromNetwork().VPCs().Create(
     ctx,
     aruba.NewVPC().
-        IntoProject(proj).
+        InProject(proj).
         Named("my-vpc").
-        AddTag("network").
+        Tagged("network").
         InRegion("ITBG-Bergamo").
         WithDefault(false).
-        WithPreset(false))
+        WithoutPreset())
 if err != nil {
     log.Fatalf("Create VPC: %v", err)
 }
@@ -702,7 +701,7 @@ arubaClient.FromNetwork().Subnets()
 **Operazioni supportate**: `Create`, `List`, `Get`, `Update`, `Delete`
 **Asincrono**: sì — chiama `WaitUntilReady(ctx)` dopo `Create`.
 
-`WithType` accetta `string(aruba.SubnetTypeBasic)` o `string(aruba.SubnetTypeAdvanced)`.
+`OfType` accetta `aruba.SubnetTypeBasic` o `aruba.SubnetTypeAdvanced` (costanti tipizzate — nessun cast a stringa necessario).
 
 `aruba.NewSubnetDHCP()` è un sub-builder per la configurazione DHCP. Si allega con `WithDHCP(...)`.
 
@@ -710,19 +709,18 @@ arubaClient.FromNetwork().Subnets()
 subnet, err := arubaClient.FromNetwork().Subnets().Create(
     ctx,
     aruba.NewSubnet().
-        IntoVPC(vpc).
+        InVPC(vpc).
         Named("my-subnet").
-        AddTag("network").
-        InRegion("ITBG-Bergamo").
-        WithType(string(aruba.SubnetTypeAdvanced)).
-        WithDefault(false).
+        Tagged("network").
+        InRegion(aruba.RegionITBGBergamo).
+        OfType(aruba.SubnetTypeAdvanced).
+        NotDefault().
         WithCIDR("192.168.1.0/25").
         WithDHCP(aruba.NewSubnetDHCP().
             Enabled().
             WithRange("192.168.1.10", 50).
-            AddRoute("0.0.0.0/0", "192.168.1.1").
-            AddDNS("8.8.8.8").
-            AddDNS("8.8.4.4")))
+            WithRoutes(aruba.SubnetDHCPRoute{Address: "0.0.0.0/0", Gateway: "192.168.1.1"}).
+            WithDNSServers("8.8.8.8", "8.8.4.4")))
 if err != nil {
     log.Fatalf("Create Subnet: %v", err)
 }
@@ -764,11 +762,11 @@ arubaClient.FromNetwork().ElasticIPs()
 eip, err := arubaClient.FromNetwork().ElasticIPs().Create(
     ctx,
     aruba.NewElasticIP().
-        IntoProject(proj).
+        InProject(proj).
         Named("my-eip").
-        AddTag("network").
+        Tagged("network").
         InRegion("ITBG-Bergamo").
-        WithBillingPeriod("Hour"))
+        BilledHourly())
 if err != nil {
     log.Fatalf("Create ElasticIP: %v", err)
 }
@@ -808,9 +806,9 @@ arubaClient.FromNetwork().SecurityGroups()
 sg, err := arubaClient.FromNetwork().SecurityGroups().Create(
     ctx,
     aruba.NewSecurityGroup().
-        IntoVPC(vpc).
+        InVPC(vpc).
         Named("my-security-group").
-        AddTag("security").
+        Tagged("security").
         WithDefault(false))
 if err != nil {
     log.Fatalf("Create SecurityGroup: %v", err)
@@ -847,20 +845,20 @@ arubaClient.FromNetwork().SecurityGroupRules()
 
 `WithDirection` accetta `string(aruba.RuleDirectionIngress)` o `string(aruba.RuleDirectionEgress)`.
 
-> **Avvertenza**: `WithTargetCIDR` e `WithTargetSecurityGroup` si escludono a vicenda. Impostarli entrambi registra un errore al momento del setter che emerge su `Create`.
+> **Avvertenza**: `TargetingCIDR` e `TargetingSecurityGroup` si escludono a vicenda. Impostarli entrambi registra un errore al momento del setter che emerge su `Create`.
 
 ```go
 rule, err := arubaClient.FromNetwork().SecurityGroupRules().Create(
     ctx,
     aruba.NewSecurityRule().
-        IntoSecurityGroup(sg).
+        InSecurityGroup(sg).
         Named("allow-ssh").
-        AddTag("ssh-key").
+        Tagged("ssh-key").
         InRegion("ITBG-Bergamo").
         WithDirection(string(aruba.RuleDirectionIngress)).
         WithProtocol("TCP").
         WithPort("22").
-        WithTargetCIDR("0.0.0.0/0"))
+        TargetingCIDR("0.0.0.0/0"))
 if err != nil {
     log.Fatalf("Create SecurityRule: %v", err)
 }
@@ -934,9 +932,9 @@ arubaClient.FromNetwork().VPCPeerings()
 peering, err := arubaClient.FromNetwork().VPCPeerings().Create(
     ctx,
     aruba.NewVPCPeering().
-        IntoVPC(vpc).
+        InVPC(vpc).
         Named("my-peering").
-        AddTag("network").
+        Tagged("network").
         InRegion("ITBG-Bergamo").
         WithPeerVPC(aruba.URI("/projects/"+peerProjectID+"/vpcs/"+peerVPCID)))
 if err != nil {
@@ -977,9 +975,9 @@ arubaClient.FromNetwork().VPCPeeringRoutes()
 route, err := arubaClient.FromNetwork().VPCPeeringRoutes().Create(
     ctx,
     aruba.NewVPCPeeringRoute().
-        IntoVPCPeering(peering).
+        InVPCPeering(peering).
         Named("my-peering-route").
-        AddTag("network").
+        Tagged("network").
         InRegion("ITBG-Bergamo").
         WithCIDR("10.0.0.0/8").
         WithTarget(aruba.URI("/projects/"+projectID+"/vpcs/"+vpcID)))
@@ -1026,9 +1024,9 @@ Sub-builder del VPN Tunnel:
 tunnel, err := arubaClient.FromNetwork().VPNTunnels().Create(
     ctx,
     aruba.NewVPNTunnel().
-        IntoProject(proj).
+        InProject(proj).
         Named("my-vpn-tunnel").
-        AddTag("vpn-net").
+        Tagged("vpn-net").
         InRegion("ITBG-Bergamo").
         WithRemoteGateway("203.0.113.1").
         WithIKE(aruba.NewVPNIKE().
@@ -1078,9 +1076,9 @@ arubaClient.FromNetwork().VPNRoutes()
 vpnRoute, err := arubaClient.FromNetwork().VPNRoutes().Create(
     ctx,
     aruba.NewVPNRoute().
-        IntoVPNTunnel(tunnel).
+        InVPNTunnel(tunnel).
         Named("my-vpn-route").
-        AddTag("vpn-net").
+        Tagged("vpn-net").
         InRegion("ITBG-Bergamo").
         WithCIDR("10.0.0.0/8").
         WithTarget(aruba.URI("/projects/"+projectID+"/vpcs/"+vpcID)))
@@ -1120,31 +1118,42 @@ arubaClient.FromSchedule().Jobs()
 **Operazioni supportate**: `Create`, `List`, `Get`, `Update`, `Delete`
 **Asincrono**: sì — `State()` e `FailureReason()` sono disponibili.
 
-`WithType` accetta `string(aruba.JobTypeOneShot)` o `string(aruba.JobTypeRecurring)`.
-
-Per i job ricorrenti, `WithRecurrence` accetta `aruba.RecurrenceTypeHourly`, `aruba.RecurrenceTypeDaily`, `aruba.RecurrenceTypeWeekly`, `aruba.RecurrenceTypeMonthly` o `aruba.RecurrenceTypeCustom`.
+Usa `OneShotAt(t time.Time)` per pianificare un job una-tantum, o `WithCron(expr string)` per un job ricorrente su pianificazione cron. Usa `RecurringUntil(t time.Time)` per impostare una data di fine per un job ricorrente.
 
 ```go
+// Job una-tantum — si attiva una volta a un'ora specifica
 job, err := arubaClient.FromSchedule().Jobs().Create(
     ctx,
     aruba.NewJob().
-        IntoProject(proj).
-        Named("my-job").
-        AddTag("automation").
-        WithType(string(aruba.JobTypeRecurring)).
-        WithRecurrence(string(aruba.RecurrenceTypeDaily)))
+        InProject(proj).
+        Named("my-one-shot-job").
+        Tagged("automation").
+        OneShotAt(time.Now().Add(10*time.Minute)))
 if err != nil {
     log.Fatalf("Create Job: %v", err)
 }
-fmt.Printf("✓ Job: %s (tipo: %s)\n", job.Name(), job.Type())
+fmt.Printf("✓ Job: %s (tipo: %s)\n", job.Name(), job.JobType())
+
+// Job ricorrente — si attiva secondo una pianificazione cron
+cronJob, err := arubaClient.FromSchedule().Jobs().Create(
+    ctx,
+    aruba.NewJob().
+        InProject(proj).
+        Named("my-recurring-job").
+        Tagged("automation").
+        WithCron("0 * * * *"))
+if err != nil {
+    log.Fatalf("Create recurring Job: %v", err)
+}
+fmt.Printf("✓ Job ricorrente: %s (cron: %s)\n", cronJob.Name(), cronJob.Cron())
 ```
 
 **Accessor di risposta**:
 - `ID()`, `URI()`, `Name()`, `Tags()`
 - `JobID()` — ID job assegnato dal provider
-- `Type()` — stringa del tipo di job
-- `Recurrence()` — stringa del tipo di ricorrenza
-- `Steps()` — step del job configurati
+- `JobType()` — tipo di job (`types.JobTypeOneShot` o `types.JobTypeRecurring`)
+- `Cron()` — espressione cron (job ricorrenti)
+- `IsEnabled()` — bool
 - `State()`, `FailureReason()`, `PreviousState()`, `IsDisabled()`, `DisableReasons()`
 - `Raw()` — struct wire sottostante
 
@@ -1169,11 +1178,11 @@ arubaClient.FromSecurity().KMS()
 kms, err := arubaClient.FromSecurity().KMS().Create(
     ctx,
     aruba.NewKMS().
-        IntoProject(proj).
+        InProject(proj).
         Named("my-kms").
-        AddTag("security").
+        Tagged("security").
         InRegion("ITBG-Bergamo").
-        WithBillingPeriod("Hour"))
+        BilledHourly())
 if err != nil {
     log.Fatalf("Create KMS: %v", err)
 }
@@ -1214,9 +1223,9 @@ arubaClient.FromSecurity().Keys()
 key, err := arubaClient.FromSecurity().Keys().Create(
     ctx,
     aruba.NewKey().
-        IntoKMS(kms).
+        InKMS(kms).
         Named("my-encryption-key").
-        AddTag("security").
+        Tagged("security").
         WithAlgorithm(string(aruba.KeyAlgorithmAes)))
 if err != nil {
     log.Fatalf("Create Key: %v", err)
@@ -1254,9 +1263,9 @@ arubaClient.FromSecurity().Kmips()
 km, err := arubaClient.FromSecurity().Kmips().Create(
     ctx,
     aruba.NewKmip().
-        IntoKMS(kms).
+        InKMS(kms).
         Named("my-kmip").
-        AddTag("security"))
+        Tagged("security"))
 if err != nil {
     log.Fatalf("Create Kmip: %v", err)
 }
@@ -1304,22 +1313,22 @@ arubaClient.FromStorage().Volumes()
 **Operazioni supportate**: `Create`, `List`, `Get`, `Update`, `Delete`
 **Asincrono**: sì — chiama `WaitUntilReady(ctx)` dopo `Create`.
 
-`WithType` accetta `aruba.BlockStorageTypeStandard` o `aruba.BlockStorageTypePerformance`.
+`OfType` accetta `aruba.BlockStorageTypeStandard` o `aruba.BlockStorageTypePerformance`. Usa `AsBootable()` per contrassegnare un volume come avviabile; `NotBootable()` per annullare. Usa `FromImage(imageID)` per specificare un'immagine base.
 
 ```go
 bs, err := arubaClient.FromStorage().Volumes().Create(
     ctx,
     aruba.NewBlockStorage().
-        IntoProject(proj).
+        InProject(proj).
         Named("my-volume").
-        AddTag("storage").
-        InRegion("ITBG-Bergamo").
-        InZone("ITBG-1").
-        WithSize(20).
-        WithType(aruba.BlockStorageTypeStandard).
-        WithBillingPeriod("Hour").
-        WithBootable(true).
-        WithImage("LU22-001"))
+        Tagged("storage").
+        InRegion(aruba.RegionITBGBergamo).
+        InZone(aruba.ZoneITBG1).
+        SizedGB(20).
+        OfType(aruba.BlockStorageTypeStandard).
+        BilledHourly().
+        AsBootable().
+        FromImage("LU22-001"))
 if err != nil {
     log.Fatalf("Create BlockStorage: %v", err)
 }
@@ -1327,34 +1336,34 @@ if err != nil {
 if err := bs.WaitUntilReady(ctx); err != nil {
     log.Fatalf("BlockStorage did not become Active: %v", err)
 }
-fmt.Printf("✓ Volume: %s (%d GB)\n", bs.Name(), bs.Size())
+fmt.Printf("✓ Volume: %s (%d GB)\n", bs.Name(), bs.SizeGB())
 ```
 
-Per creare un volume **da uno snapshot**, usa `FromSnapshot(snapshot)` al posto di `WithImage`:
+Per creare un volume **da uno snapshot**, usa `FromSnapshot(snapshot)` al posto di `FromImage`:
 
 ```go
 bs, err := arubaClient.FromStorage().Volumes().Create(
     ctx,
     aruba.NewBlockStorage().
-        IntoProject(proj).
+        InProject(proj).
         Named("restored-volume").
-        InRegion("ITBG-Bergamo").
-        InZone("ITBG-1").
-        WithSize(20).
-        WithType(aruba.BlockStorageTypeStandard).
-        WithBillingPeriod("Hour").
-        WithBootable(true).
+        InRegion(aruba.RegionITBGBergamo).
+        InZone(aruba.ZoneITBG1).
+        SizedGB(20).
+        OfType(aruba.BlockStorageTypeStandard).
+        BilledHourly().
+        AsBootable().
         FromSnapshot(snapshot))
 ```
 
 **Accessor di risposta**:
 - `ID()`, `URI()`, `Name()`, `Tags()`
 - `BlockStorageID()` — ID volume assegnato dal provider
-- `Size()` — dimensione in GB
+- `SizeGB()` — dimensione in GB
 - `Type()` — stringa del tipo di storage
 - `Zone()` — zona di disponibilità
 - `BillingPeriod()` — cadenza di fatturazione
-- `Bootable()` — bool
+- `IsBootable()` — bool
 - `Image()` — riferimento all'immagine
 - `SnapshotURI()` — URI dello snapshot sorgente (se creato da snapshot)
 - `State()`, `FailureReason()`, `PreviousState()`, `IsDisabled()`, `DisableReasons()`
@@ -1380,11 +1389,11 @@ arubaClient.FromStorage().Snapshots()
 snap, err := arubaClient.FromStorage().Snapshots().Create(
     ctx,
     aruba.NewSnapshot().
-        IntoProject(proj).
+        InProject(proj).
         Named("my-snapshot").
-        AddTag("backup").
+        Tagged("backup").
         InRegion("ITBG-Bergamo").
-        WithBillingPeriod("Hour").
+        BilledHourly().
         OfVolume(bs))
 if err != nil {
     log.Fatalf("Create Snapshot: %v", err)
@@ -1403,7 +1412,7 @@ fmt.Printf("✓ Snapshot: %s\n", snap.Name())
 - `Type()` — tipo di storage
 - `Zone()` — zona di disponibilità
 - `BillingPeriod()` — cadenza di fatturazione
-- `Bootable()` — bool
+- `IsBootable()` — bool
 - `VolumeURI()` — URI del volume sorgente
 - `State()`, `FailureReason()`, `PreviousState()`, `IsDisabled()`, `DisableReasons()`
 - `WaitUntilReady(ctx, opts...)`, `WaitUntilActive(ctx, opts...)`, `WaitUntilStates(ctx, []types.State{...}, opts...)`, `WaitUntilGone(ctx, opts...)`
@@ -1424,19 +1433,19 @@ arubaClient.FromStorage().Backups()
 **Operazioni supportate**: `Create`, `List`, `Get`, `Delete`
 **Asincrono**: sì — chiama `WaitUntilReady(ctx)` dopo `Create`.
 
-`WithType` accetta `aruba.StorageBackupTypeFull` o `aruba.StorageBackupTypeIncremental`.
+`OfType` accetta `aruba.StorageBackupTypeFull` o `aruba.StorageBackupTypeIncremental`.
 
 ```go
 backup, err := arubaClient.FromStorage().Backups().Create(
     ctx,
     aruba.NewStorageBackup().
-        IntoProject(proj).
+        InProject(proj).
         Named("my-backup").
-        AddTag("backup").
-        WithOrigin(bs).
-        WithType(aruba.StorageBackupTypeFull).
-        WithRetentionDays(30).
-        WithBillingPeriod("Hour"))
+        Tagged("backup").
+        FromVolume(bs).
+        OfType(aruba.StorageBackupTypeFull).
+        RetainedForDays(30).
+        BilledHourly())
 if err != nil {
     log.Fatalf("Create StorageBackup: %v", err)
 }
@@ -1476,9 +1485,9 @@ arubaClient.FromStorage().Restores()
 restore, err := arubaClient.FromStorage().Restores().Create(
     ctx,
     aruba.NewStorageRestore().
-        IntoBackup(backup).
+        FromBackup(backup).
         Named("my-restore").
-        AddTag("restore").
+        Tagged("restore").
         WithTarget(aruba.URI(backup.OriginURI())))
 if err != nil {
     log.Fatalf("Create StorageRestore: %v", err)

--- a/docs/website/i18n/it/docusaurus-plugin-content-docs/current/response-handling.md
+++ b/docs/website/i18n/it/docusaurus-plugin-content-docs/current/response-handling.md
@@ -147,9 +147,9 @@ I setter del builder fluente non restituiscono mai errori — li registrano inte
 
 ```go
 rule := aruba.NewSecurityRule().
-    IntoSecurityGroup(sg).
-    WithTargetCIDR("0.0.0.0/0").
-    WithTargetSecurityGroup(otherSG) // setter in conflitto — registra un errore
+    InSecurityGroup(sg).
+    TargetingCIDR("0.0.0.0/0").
+    TargetingSecurityGroup(otherSG) // setter in conflitto — registra un errore
 
 if err := rule.Err(); err != nil {
     log.Fatalf("Bad rule configuration: %v", err)

--- a/docs/website/i18n/it/docusaurus-plugin-content-docs/current/walkthrough.md
+++ b/docs/website/i18n/it/docusaurus-plugin-content-docs/current/walkthrough.md
@@ -56,9 +56,9 @@ proj, err := arubaClient.FromProject().Create(
     ctx,
     aruba.NewProject().
         Named("my-project").
-        DescribedAs("Creato tramite l'SDK Go di Aruba Cloud").
         Tagged("go-sdk").
-        WithDefault(false))
+        DescribedAs("Creato tramite l'SDK Go di Aruba Cloud").
+        NotDefault())
 if err != nil {
     log.Fatalf("Create project: %v", err)
 }
@@ -71,11 +71,11 @@ fmt.Printf("✓ Progetto creato: %s (ID: %s)\n", proj.Name(), proj.ID())
 vpc, err := arubaClient.FromNetwork().VPCs().Create(
     ctx,
     aruba.NewVPC().
-        InProject(proj).
         Named("my-vpc").
         Tagged("network").
-        InRegion("ITBG-Bergamo").
-        WithDefault(false).
+        InProject(proj).
+        InRegion(aruba.RegionITBGBergamo).
+        NotDefault().
         WithoutPreset())
 if err != nil {
     log.Fatalf("Create VPC: %v", err)
@@ -97,18 +97,18 @@ if err := vpc.WaitUntilReady(ctx); err != nil {
 subnet, err := arubaClient.FromNetwork().Subnets().Create(
     ctx,
     aruba.NewSubnet().
-        InVPC(vpc).
+        OfType(aruba.SubnetTypeAdvanced).
         Named("my-subnet").
         Tagged("network").
-        InRegion("ITBG-Bergamo").
-        WithType(string(aruba.SubnetTypeAdvanced)).
-        WithDefault(false).
+        InVPC(vpc).
+        InRegion(aruba.RegionITBGBergamo).
         WithCIDR("192.168.1.0/25").
         WithDHCP(aruba.NewSubnetDHCP().
             Enabled().
             WithRange("192.168.1.10", 50).
             WithRoutes(aruba.SubnetDHCPRoute{Address: "10.0.0.0/8", Gateway: "192.168.1.1"}).
-            WithDNSServers("8.8.8.8", "8.8.4.4")))
+            WithDNSServers("8.8.8.8", "8.8.4.4")).
+        NotDefault())
 if err != nil {
     log.Fatalf("Create subnet: %v", err)
 }
@@ -121,7 +121,7 @@ if err := subnet.WaitUntilReady(ctx); err != nil {
 
 `aruba.NewSubnetDHCP()` è un sub-builder per la configurazione DHCP. Si allega alla subnet con `WithDHCP(...)`.
 
-`WithType` accetta `string(aruba.SubnetTypeBasic)` o `string(aruba.SubnetTypeAdvanced)`.
+`OfType` accetta `aruba.SubnetTypeBasic` o `aruba.SubnetTypeAdvanced`.
 
 > Ogni altra risorsa — Security Group, Elastic IP, Block Storage, Cloud Server, cluster KaaS, istanze DBaaS e altro — segue esattamente la stessa struttura `NewX()` → `IntoParent(ref)` → `Create(ctx, ...)` → `WaitUntilReady(ctx)`. Vedi [Risorse](./resources) per l'elenco completo con snippet pronti all'uso.
 

--- a/docs/website/i18n/it/docusaurus-plugin-content-docs/current/walkthrough.md
+++ b/docs/website/i18n/it/docusaurus-plugin-content-docs/current/walkthrough.md
@@ -6,7 +6,7 @@ sidebar_position: 2
 
 L'SDK Go di Aruba Cloud fornisce un singolo import — `github.com/Arubacloud/sdk-go/pkg/aruba` — che espone un'API fluente con pattern builder per ogni risorsa cloud. Si costruisce la descrizione della risorsa con una catena `aruba.NewX()`, la si passa al metodo del client appropriato (`Create`, `Get`, `Update`, `Delete` o `List`), e si lavora con il wrapper tipizzato restituito.
 
-Le risorse sono organizzate in un **Progetto**, e le risorse figlio referenziano i propri genitori tramite l'interfaccia `aruba.Ref`. Non è mai necessario estrarre o passare manualmente stringhe di ID grezzi: si passa direttamente il wrapper idratato (restituito da `Create` o `Get`) come parametro `Ref` ai metodi builder come `IntoProject(proj)`, `IntoVPC(vpc)` o `IntoSecurityGroup(sg)`.
+Le risorse sono organizzate in un **Progetto**, e le risorse figlio referenziano i propri genitori tramite l'interfaccia `aruba.Ref`. Non è mai necessario estrarre o passare manualmente stringhe di ID grezzi: si passa direttamente il wrapper idratato (restituito da `Create` o `Get`) come parametro `Ref` ai metodi builder come `InProject(proj)`, `InVPC(vpc)` o `InSecurityGroup(sg)`.
 
 Questa pagina illustra il ciclo CRUD completo su un esempio minimale — Project + VPC + Subnet. Ogni altra risorsa segue esattamente la stessa struttura. Vedi [Risorse](./resources) per snippet pronti all'uso per tutte le risorse supportate.
 
@@ -56,8 +56,8 @@ proj, err := arubaClient.FromProject().Create(
     ctx,
     aruba.NewProject().
         Named("my-project").
-        WithDescription("Creato tramite l'SDK Go di Aruba Cloud").
-        AddTag("go-sdk").
+        DescribedAs("Creato tramite l'SDK Go di Aruba Cloud").
+        Tagged("go-sdk").
         WithDefault(false))
 if err != nil {
     log.Fatalf("Create project: %v", err)
@@ -71,12 +71,12 @@ fmt.Printf("✓ Progetto creato: %s (ID: %s)\n", proj.Name(), proj.ID())
 vpc, err := arubaClient.FromNetwork().VPCs().Create(
     ctx,
     aruba.NewVPC().
-        IntoProject(proj).
+        InProject(proj).
         Named("my-vpc").
-        AddTag("network").
+        Tagged("network").
         InRegion("ITBG-Bergamo").
         WithDefault(false).
-        WithPreset(false))
+        WithoutPreset())
 if err != nil {
     log.Fatalf("Create VPC: %v", err)
 }
@@ -89,7 +89,7 @@ if err := vpc.WaitUntilReady(ctx); err != nil {
 }
 ```
 
-`IntoProject(proj)` accetta qualsiasi `aruba.Ref` — lega lo scope del progetto senza richiedere l'estrazione di un ID stringa grezzo.
+`InProject(proj)` accetta qualsiasi `aruba.Ref` — lega lo scope del progetto senza richiedere l'estrazione di un ID stringa grezzo.
 
 ### Subnet
 
@@ -97,9 +97,9 @@ if err := vpc.WaitUntilReady(ctx); err != nil {
 subnet, err := arubaClient.FromNetwork().Subnets().Create(
     ctx,
     aruba.NewSubnet().
-        IntoVPC(vpc).
+        InVPC(vpc).
         Named("my-subnet").
-        AddTag("network").
+        Tagged("network").
         InRegion("ITBG-Bergamo").
         WithType(string(aruba.SubnetTypeAdvanced)).
         WithDefault(false).
@@ -107,9 +107,8 @@ subnet, err := arubaClient.FromNetwork().Subnets().Create(
         WithDHCP(aruba.NewSubnetDHCP().
             Enabled().
             WithRange("192.168.1.10", 50).
-            AddRoute("10.0.0.0/8", "192.168.1.1").
-            AddDNS("8.8.8.8").
-            AddDNS("8.8.4.4")))
+            WithRoutes(aruba.SubnetDHCPRoute{Address: "10.0.0.0/8", Gateway: "192.168.1.1"}).
+            WithDNSServers("8.8.8.8", "8.8.4.4")))
 if err != nil {
     log.Fatalf("Create subnet: %v", err)
 }
@@ -141,7 +140,7 @@ if err != nil {
 
 // Muta
 vpc.Named("my-vpc-updated").
-    ReplaceTags("network", "updated")
+    RetaggedAs("network", "updated")
 
 // Aggiorna
 updated, err := arubaClient.FromNetwork().VPCs().Update(ctx, vpc)
@@ -286,16 +285,16 @@ I setter del builder non restituiscono mai un errore — lo registrano nel wrapp
 
 ```go
 rule := aruba.NewSecurityRule().
-    IntoSecurityGroup(sg).
-    WithTargetCIDR("0.0.0.0/0").
-    WithTargetSecurityGroup(otherSG) // in conflitto — registrato come errore
+    InSecurityGroup(sg).
+    TargetingCIDR("0.0.0.0/0").
+    TargetingSecurityGroup(otherSG) // in conflitto — registrato come errore
 
 if err := rule.Err(); err != nil {
     log.Fatalf("Bad rule config: %v", err)
 }
 ```
 
-> **Avvertenza**: `WithTargetCIDR` e `WithTargetSecurityGroup` si escludono a vicenda. Impostarli entrambi registra un errore al momento del setter che emerge su `Create`.
+> **Avvertenza**: `TargetingCIDR` e `TargetingSecurityGroup` si escludono a vicenda. Impostarli entrambi registra un errore al momento del setter che emerge su `Create`.
 
 ### `WaitUntilReady` / `WaitUntilActive` richiedono un wrapper idratato
 

--- a/docs/website/i18n/it/docusaurus-plugin-content-docs/current/working-at-low-level.md
+++ b/docs/website/i18n/it/docusaurus-plugin-content-docs/current/working-at-low-level.md
@@ -144,8 +144,8 @@ import (
 )
 
 vpc := aruba.NewVPC().
-    InProject(proj).
     Named("my-vpc").
+    InProject(proj).
     InRegion(aruba.RegionITBGBergamo).
     AsDefault()
 

--- a/docs/website/i18n/it/docusaurus-plugin-content-docs/current/working-at-low-level.md
+++ b/docs/website/i18n/it/docusaurus-plugin-content-docs/current/working-at-low-level.md
@@ -144,7 +144,7 @@ import (
 )
 
 vpc := aruba.NewVPC().
-    IntoProject(proj).
+    InProject(proj).
     Named("my-vpc").
     InRegion(aruba.RegionITBGBergamo).
     AsDefault()

--- a/examples/all-resources/resource_block_storage.go
+++ b/examples/all-resources/resource_block_storage.go
@@ -12,16 +12,16 @@ func createBlockStorage(ctx context.Context, arubaClient aruba.Client, proj arub
 	fmt.Printf("--- Block Storage (%s) ---\n", name)
 
 	bs := aruba.NewBlockStorage().
-		IntoProject(proj).
+		InProject(proj).
 		Named(name).
-		AddTag("storage").
-		AddTag("data").
+		Tagged("storage").
+		Tagged("data").
 		InRegion(aruba.RegionITBGBergamo).
 		InZone(aruba.ZoneITBG1).
 		OfType(aruba.BlockStorageTypeStandard).
-		WithSizeGB(20).
-		SetBootable().
-		WithBillingPeriod(aruba.BillingPeriodHour).
+		SizedGB(20).
+		AsBootable().
+		BilledHourly().
 		FromImage(aruba.VolumeImageLU22001)
 
 	bs, err := arubaClient.FromStorage().Volumes().Create(ctx, bs)

--- a/examples/all-resources/resource_block_storage.go
+++ b/examples/all-resources/resource_block_storage.go
@@ -21,7 +21,7 @@ func createBlockStorage(ctx context.Context, arubaClient aruba.Client, proj arub
 		OfType(aruba.BlockStorageTypeStandard).
 		SizedGB(20).
 		AsBootable().
-		BilledHourly().
+		BilledBy(aruba.BillingPeriodHour).
 		FromImage(aruba.VolumeImageLU22001)
 
 	bs, err := arubaClient.FromStorage().Volumes().Create(ctx, bs)

--- a/examples/all-resources/resource_block_storage.go
+++ b/examples/all-resources/resource_block_storage.go
@@ -12,17 +12,16 @@ func createBlockStorage(ctx context.Context, arubaClient aruba.Client, proj arub
 	fmt.Printf("--- Block Storage (%s) ---\n", name)
 
 	bs := aruba.NewBlockStorage().
-		InProject(proj).
+		OfType(aruba.BlockStorageTypeStandard).
 		Named(name).
-		Tagged("storage").
-		Tagged("data").
+		Tagged("storage", "data").
+		InProject(proj).
 		InRegion(aruba.RegionITBGBergamo).
 		InZone(aruba.ZoneITBG1).
-		OfType(aruba.BlockStorageTypeStandard).
 		SizedGB(20).
+		FromImage(aruba.VolumeImageLU22001).
 		AsBootable().
-		BilledBy(aruba.BillingPeriodHour).
-		FromImage(aruba.VolumeImageLU22001)
+		BilledBy(aruba.BillingPeriodHour)
 
 	bs, err := arubaClient.FromStorage().Volumes().Create(ctx, bs)
 	if err != nil {

--- a/examples/all-resources/resource_cloud_server.go
+++ b/examples/all-resources/resource_cloud_server.go
@@ -40,21 +40,21 @@ write_files:
 	userData := base64.StdEncoding.EncodeToString([]byte(cloudInitContent))
 
 	cs := aruba.NewCloudServer().
-		IntoProject(resources.Project).
+		InProject(resources.Project).
 		Named(resourceName(NameCloudServer)).
-		AddTag("virtualmachine").
-		AddTag("container").
+		Tagged("virtualmachine").
+		Tagged("container").
 		InRegion(aruba.RegionITBGBergamo).
 		InZone(aruba.ZoneITBG1).
 		OfFlavor(aruba.CloudServerFlavorCSO4A8).
 		WithUserData(userData).
 		WithVPC(resources.VPC).
-		WithBootVolume(resources.CloudServerBlockStorage).
-		AddSubnet(resources.SubnetBasic).
-		AddSecurityGroup(resources.SecurityGroup).
+		BootingFrom(resources.CloudServerBlockStorage).
+		OnSubnets(resources.SubnetBasic).
+		WithSecurityGroups(resources.SecurityGroup).
 		WithElasticIP(resources.CloudServerEIP).
-		WithKeyPair(resources.KeyPair).
-		WithBillingPeriod(aruba.BillingPeriodHour)
+		UsingKeyPair(resources.KeyPair).
+		BilledHourly()
 
 	cs, err := arubaClient.FromCompute().CloudServers().Create(ctx, cs)
 	if err != nil {

--- a/examples/all-resources/resource_cloud_server.go
+++ b/examples/all-resources/resource_cloud_server.go
@@ -54,7 +54,7 @@ write_files:
 		WithSecurityGroups(resources.SecurityGroup).
 		WithElasticIP(resources.CloudServerEIP).
 		UsingKeyPair(resources.KeyPair).
-		BilledHourly()
+		BilledBy(aruba.BillingPeriodHour)
 
 	cs, err := arubaClient.FromCompute().CloudServers().Create(ctx, cs)
 	if err != nil {

--- a/examples/all-resources/resource_cloud_server.go
+++ b/examples/all-resources/resource_cloud_server.go
@@ -40,16 +40,15 @@ write_files:
 	userData := base64.StdEncoding.EncodeToString([]byte(cloudInitContent))
 
 	cs := aruba.NewCloudServer().
-		InProject(resources.Project).
+		OfFlavor(aruba.CloudServerFlavorCSO4A8).
 		Named(resourceName(NameCloudServer)).
-		Tagged("virtualmachine").
-		Tagged("container").
+		Tagged("virtualmachine", "container").
+		InProject(resources.Project).
 		InRegion(aruba.RegionITBGBergamo).
 		InZone(aruba.ZoneITBG1).
-		OfFlavor(aruba.CloudServerFlavorCSO4A8).
 		WithUserData(userData).
-		WithVPC(resources.VPC).
 		BootingFrom(resources.CloudServerBlockStorage).
+		WithVPC(resources.VPC).
 		OnSubnets(resources.SubnetBasic).
 		WithSecurityGroups(resources.SecurityGroup).
 		WithElasticIP(resources.CloudServerEIP).

--- a/examples/all-resources/resource_container_registry.go
+++ b/examples/all-resources/resource_container_registry.go
@@ -23,17 +23,17 @@ func createContainerRegistry(ctx context.Context, arubaClient aruba.Client, reso
 	}
 
 	r := aruba.NewContainerRegistry().
-		InProject(resources.Project).
-		Named(resourceName(NameContainerRegistry)).
-		InRegion(aruba.RegionITBGBergamo).
 		OfSize(aruba.ContainerRegistrySizeFlavorSmall).
+		Named(resourceName(NameContainerRegistry)).
+		InProject(resources.Project).
+		InRegion(aruba.RegionITBGBergamo).
 		WithAdminUsername("adminuser").
-		BilledBy(aruba.BillingPeriodHour).
 		WithVPC(resources.VPC).
 		WithSubnet(resources.SubnetBasic).
 		WithSecurityGroup(resources.SecurityGroup).
 		WithElasticIP(resources.ContainerRegistryEIP).
-		WithBlockStorage(resources.ContainerRegistryStorage)
+		WithBlockStorage(resources.ContainerRegistryStorage).
+		BilledBy(aruba.BillingPeriodHour)
 
 	resp, err := arubaClient.FromContainer().ContainerRegistry().Create(ctx, r)
 	if err != nil {

--- a/examples/all-resources/resource_container_registry.go
+++ b/examples/all-resources/resource_container_registry.go
@@ -23,12 +23,12 @@ func createContainerRegistry(ctx context.Context, arubaClient aruba.Client, reso
 	}
 
 	r := aruba.NewContainerRegistry().
-		IntoProject(resources.Project).
+		InProject(resources.Project).
 		Named(resourceName(NameContainerRegistry)).
 		InRegion(aruba.RegionITBGBergamo).
 		OfSize(aruba.ContainerRegistrySizeFlavorSmall).
 		WithAdminUsername("adminuser").
-		WithBillingPeriod(aruba.BillingPeriodHour).
+		BilledHourly().
 		WithVPC(resources.VPC).
 		WithSubnet(resources.SubnetBasic).
 		WithSecurityGroup(resources.SecurityGroup).

--- a/examples/all-resources/resource_container_registry.go
+++ b/examples/all-resources/resource_container_registry.go
@@ -28,7 +28,7 @@ func createContainerRegistry(ctx context.Context, arubaClient aruba.Client, reso
 		InRegion(aruba.RegionITBGBergamo).
 		OfSize(aruba.ContainerRegistrySizeFlavorSmall).
 		WithAdminUsername("adminuser").
-		BilledHourly().
+		BilledBy(aruba.BillingPeriodHour).
 		WithVPC(resources.VPC).
 		WithSubnet(resources.SubnetBasic).
 		WithSecurityGroup(resources.SecurityGroup).

--- a/examples/all-resources/resource_database.go
+++ b/examples/all-resources/resource_database.go
@@ -21,7 +21,7 @@ func createDatabase(ctx context.Context, arubaClient aruba.Client, dbaas *aruba.
 	// helper is bypassed here. A database name only needs to be unique within
 	// its DBaaS instance, and each example run creates a fresh DBaaS.
 	db := aruba.NewDatabase().
-		IntoDBaaS(dbaas).
+		InDBaaS(dbaas).
 		Named(NameDatabase)
 
 	res, err := arubaClient.FromDatabase().Databases().Create(ctx, db)

--- a/examples/all-resources/resource_dbaas.go
+++ b/examples/all-resources/resource_dbaas.go
@@ -33,7 +33,7 @@ func createDBaaS(ctx context.Context, arubaClient aruba.Client, proj aruba.Ref, 
 		OfFlavor(aruba.DBaaSFlavorDBO4A8).
 		SizedGB(10).
 		WithAutoscaling(2, 5).
-		BilledHourly().
+		BilledBy(aruba.BillingPeriodHour).
 		WithVPC(vpc).
 		WithSubnet(subnet).
 		WithSecurityGroup(sg).

--- a/examples/all-resources/resource_dbaas.go
+++ b/examples/all-resources/resource_dbaas.go
@@ -23,17 +23,17 @@ func createDBaaS(ctx context.Context, arubaClient aruba.Client, proj aruba.Ref, 
 	}
 
 	d := aruba.NewDBaaS().
-		IntoProject(proj).
+		InProject(proj).
 		Named(resourceName(NameDBaaS)).
-		AddTag("database").
-		AddTag("mysql").
+		Tagged("database").
+		Tagged("mysql").
 		InRegion(aruba.RegionITBGBergamo).
 		InZone(aruba.ZoneITBG1).
 		OfEngine(aruba.DatabaseEngineMySQL80).
 		OfFlavor(aruba.DBaaSFlavorDBO4A8).
-		WithSizeGB(10).
+		SizedGB(10).
 		WithAutoscaling(2, 5).
-		WithBillingPeriod(aruba.BillingPeriodHour).
+		BilledHourly().
 		WithVPC(vpc).
 		WithSubnet(subnet).
 		WithSecurityGroup(sg).
@@ -66,8 +66,8 @@ func updateDBaaS(ctx context.Context, arubaClient aruba.Client, d *aruba.DBaaS) 
 	// Mutate what needs updating; networking URIs are already hydrated from the
 	// prior Get call so they round-trip automatically into the Update request.
 	d.Named(updatedName(d.Name())).
-		ReplaceTags("database", "mysql", "updated").
-		WithSizeGB(25) // Increased from 20 to 25 GB
+		RetaggedAs("database", "mysql", "updated").
+		SizedGB(25) // Increased from 20 to 25 GB
 
 	result, err := arubaClient.FromDatabase().DBaaS().Update(ctx, d)
 	if err != nil {

--- a/examples/all-resources/resource_dbaas.go
+++ b/examples/all-resources/resource_dbaas.go
@@ -23,21 +23,20 @@ func createDBaaS(ctx context.Context, arubaClient aruba.Client, proj aruba.Ref, 
 	}
 
 	d := aruba.NewDBaaS().
-		InProject(proj).
-		Named(resourceName(NameDBaaS)).
-		Tagged("database").
-		Tagged("mysql").
-		InRegion(aruba.RegionITBGBergamo).
-		InZone(aruba.ZoneITBG1).
 		OfEngine(aruba.DatabaseEngineMySQL80).
 		OfFlavor(aruba.DBaaSFlavorDBO4A8).
+		Named(resourceName(NameDBaaS)).
+		Tagged("database", "mysql").
+		InProject(proj).
+		InRegion(aruba.RegionITBGBergamo).
+		InZone(aruba.ZoneITBG1).
 		SizedGB(10).
 		WithAutoscaling(2, 5).
-		BilledBy(aruba.BillingPeriodHour).
 		WithVPC(vpc).
 		WithSubnet(subnet).
 		WithSecurityGroup(sg).
-		WithElasticIP(eip)
+		WithElasticIP(eip).
+		BilledBy(aruba.BillingPeriodHour)
 	if err := d.Err(); err != nil {
 		log.Printf("✗ Invalid DBaaS request: %v", err)
 		return nil

--- a/examples/all-resources/resource_dbaas_user.go
+++ b/examples/all-resources/resource_dbaas_user.go
@@ -18,7 +18,7 @@ func createDBaaSUser(ctx context.Context, arubaClient aruba.Client, dbaas *aruba
 	}
 
 	u := aruba.NewUser().
-		IntoDBaaS(dbaas).
+		InDBaaS(dbaas).
 		WithUsername(NameDBaaSUser).
 		WithPassword("Prova123456789AC@")
 

--- a/examples/all-resources/resource_elastic_ip.go
+++ b/examples/all-resources/resource_elastic_ip.go
@@ -17,7 +17,7 @@ func createElasticIP(ctx context.Context, arubaClient aruba.Client, proj aruba.R
 		Tagged("network").
 		Tagged("public").
 		InRegion(aruba.RegionITBGBergamo).
-		BilledHourly()
+		BilledBy(aruba.BillingPeriodHour)
 
 	created, err := arubaClient.FromNetwork().ElasticIPs().Create(ctx, eip)
 	if err != nil {

--- a/examples/all-resources/resource_elastic_ip.go
+++ b/examples/all-resources/resource_elastic_ip.go
@@ -12,12 +12,12 @@ func createElasticIP(ctx context.Context, arubaClient aruba.Client, proj aruba.R
 	fmt.Printf("--- Elastic IP (%s) ---\n", name)
 
 	eip := aruba.NewElasticIP().
-		IntoProject(proj).
+		InProject(proj).
 		Named(name).
-		AddTag("network").
-		AddTag("public").
+		Tagged("network").
+		Tagged("public").
 		InRegion(aruba.RegionITBGBergamo).
-		WithBillingPeriod(aruba.BillingPeriodHour)
+		BilledHourly()
 
 	created, err := arubaClient.FromNetwork().ElasticIPs().Create(ctx, eip)
 	if err != nil {

--- a/examples/all-resources/resource_elastic_ip.go
+++ b/examples/all-resources/resource_elastic_ip.go
@@ -12,10 +12,9 @@ func createElasticIP(ctx context.Context, arubaClient aruba.Client, proj aruba.R
 	fmt.Printf("--- Elastic IP (%s) ---\n", name)
 
 	eip := aruba.NewElasticIP().
-		InProject(proj).
 		Named(name).
-		Tagged("network").
-		Tagged("public").
+		Tagged("network", "public").
+		InProject(proj).
 		InRegion(aruba.RegionITBGBergamo).
 		BilledBy(aruba.BillingPeriodHour)
 

--- a/examples/all-resources/resource_grant.go
+++ b/examples/all-resources/resource_grant.go
@@ -11,9 +11,9 @@ func createGrant(ctx context.Context, arubaClient aruba.Client, db *aruba.Databa
 	printBanner("DBaaS Grant", "")
 
 	g := aruba.NewGrant().
-		IntoDatabase(db).
-		WithUsername(user.Username()).
-		WithRoleName("liteadmin")
+		InDatabase(db).
+		ForUser(user.Username()).
+		OfRole("liteadmin")
 
 	res, err := arubaClient.FromDatabase().Grants().Create(ctx, g)
 	if err != nil {

--- a/examples/all-resources/resource_grant.go
+++ b/examples/all-resources/resource_grant.go
@@ -11,9 +11,9 @@ func createGrant(ctx context.Context, arubaClient aruba.Client, db *aruba.Databa
 	printBanner("DBaaS Grant", "")
 
 	g := aruba.NewGrant().
+		OfRole("liteadmin").
 		InDatabase(db).
-		ForUser(user.Username()).
-		OfRole("liteadmin")
+		ForUser(user.Username())
 
 	res, err := arubaClient.FromDatabase().Grants().Create(ctx, g)
 	if err != nil {

--- a/examples/all-resources/resource_job.go
+++ b/examples/all-resources/resource_job.go
@@ -12,19 +12,18 @@ func createRecurringJob(ctx context.Context, arubaClient aruba.Client, proj arub
 	printBanner("Recurring Job", "")
 
 	j := aruba.NewJob().
-		InProject(proj).
 		Named(resourceName(NameJobRecurring)).
-		Tagged("schedule").
-		Tagged("recurring").
+		Tagged("schedule", "recurring").
+		InProject(proj).
 		InRegion(aruba.RegionITBGBergamo).
-		Enabled().
 		WithCron("0 10 * * *").
 		RecurringUntil(time.Now().AddDate(0, 2, 0)).
 		WithSteps(aruba.NewJobStep().
 			Named("poweroff-step").
 			Targeting(target).
 			WithAction("poweroff").
-			WithVerb(aruba.HTTPVerbPOST))
+			WithVerb(aruba.HTTPVerbPOST)).
+		Enabled()
 
 	res, err := arubaClient.FromSchedule().Jobs().Create(ctx, j)
 	if err != nil {
@@ -40,18 +39,17 @@ func createOneShotJob(ctx context.Context, arubaClient aruba.Client, proj aruba.
 	printBanner("One-Shot Job", "")
 
 	j := aruba.NewJob().
-		InProject(proj).
 		Named(resourceName(NameJobOneShot)).
-		Tagged("schedule").
-		Tagged("oneshot").
+		Tagged("schedule", "oneshot").
+		InProject(proj).
 		InRegion(aruba.RegionITBGBergamo).
-		Enabled().
 		OneShotAt(time.Now().Add(24 * time.Hour)).
 		WithSteps(aruba.NewJobStep().
 			Named("poweroff-step").
 			Targeting(target).
 			WithAction("poweroff").
-			WithVerb(aruba.HTTPVerbPOST))
+			WithVerb(aruba.HTTPVerbPOST)).
+		Enabled()
 
 	res, err := arubaClient.FromSchedule().Jobs().Create(ctx, j)
 	if err != nil {

--- a/examples/all-resources/resource_job.go
+++ b/examples/all-resources/resource_job.go
@@ -12,17 +12,17 @@ func createRecurringJob(ctx context.Context, arubaClient aruba.Client, proj arub
 	printBanner("Recurring Job", "")
 
 	j := aruba.NewJob().
-		IntoProject(proj).
+		InProject(proj).
 		Named(resourceName(NameJobRecurring)).
-		AddTag("schedule").
-		AddTag("recurring").
+		Tagged("schedule").
+		Tagged("recurring").
 		InRegion(aruba.RegionITBGBergamo).
-		WithEnabled(true).
+		Enabled().
 		WithCron("0 10 * * *").
 		RecurringUntil(time.Now().AddDate(0, 2, 0)).
-		AddStep(aruba.NewJobStep().
+		WithSteps(aruba.NewJobStep().
 			Named("poweroff-step").
-			OfResource(target).
+			Targeting(target).
 			WithAction("poweroff").
 			WithVerb(aruba.HTTPVerbPOST))
 
@@ -40,16 +40,16 @@ func createOneShotJob(ctx context.Context, arubaClient aruba.Client, proj aruba.
 	printBanner("One-Shot Job", "")
 
 	j := aruba.NewJob().
-		IntoProject(proj).
+		InProject(proj).
 		Named(resourceName(NameJobOneShot)).
-		AddTag("schedule").
-		AddTag("oneshot").
+		Tagged("schedule").
+		Tagged("oneshot").
 		InRegion(aruba.RegionITBGBergamo).
-		WithEnabled(true).
+		Enabled().
 		OneShotAt(time.Now().Add(24 * time.Hour)).
-		AddStep(aruba.NewJobStep().
+		WithSteps(aruba.NewJobStep().
 			Named("poweroff-step").
-			OfResource(target).
+			Targeting(target).
 			WithAction("poweroff").
 			WithVerb(aruba.HTTPVerbPOST))
 

--- a/examples/all-resources/resource_kaas.go
+++ b/examples/all-resources/resource_kaas.go
@@ -33,7 +33,7 @@ func createKaaS(ctx context.Context, arubaClient aruba.Client, proj aruba.Ref, v
 		WithPodCIDR("10.0.3.0/24").
 		WithNodeCIDR("172.16.0.0/16", resourceName(NameKaaSNodeCIDR)).
 		HighlyAvailable().
-		BilledHourly().
+		BilledBy(aruba.BillingPeriodHour).
 		WithVPC(vpc).
 		WithSubnet(subnet).
 		WithSecurityGroup(kaasSG).
@@ -65,7 +65,7 @@ func updateKaaS(ctx context.Context, arubaClient aruba.Client, k *aruba.KaaS) {
 	k.Named(updatedName(k.Name())).
 		RetaggedAs("kubernetes", "container", "updated").
 		WithMaxStorageQuotaGB(100).
-		BilledHourly().
+		BilledBy(aruba.BillingPeriodHour).
 		HighlyAvailable().
 		WithNodePools(aruba.NewNodePool().
 			Named(resourceName(NameNodePool)).

--- a/examples/all-resources/resource_kaas.go
+++ b/examples/all-resources/resource_kaas.go
@@ -24,25 +24,24 @@ func createKaaS(ctx context.Context, arubaClient aruba.Client, proj aruba.Ref, v
 		Named(resourceName(NameKaaSSecurityGroup))
 
 	k := aruba.NewKaaS().
-		InProject(proj).
 		Named(resourceName(NameKaaS)).
-		Tagged("kubernetes").
-		Tagged("container").
+		Tagged("kubernetes", "container").
+		InProject(proj).
 		InRegion(aruba.RegionITBGBergamo).
 		WithKubernetesVersion(aruba.KubernetesVersion1341).
 		WithPodCIDR("10.0.3.0/24").
 		WithNodeCIDR("172.16.0.0/16", resourceName(NameKaaSNodeCIDR)).
-		HighlyAvailable().
-		BilledBy(aruba.BillingPeriodHour).
 		WithVPC(vpc).
 		WithSubnet(subnet).
 		WithSecurityGroup(kaasSG).
 		WithNodePools(aruba.NewNodePool().
-			Named(resourceName(NameNodePool)).
-			WithCount(2).
-			WithAutoscaling(1, 5).
 			OfInstance(aruba.NodePoolInstanceK2A4).
-			InZone(aruba.ZoneITBG1))
+			Named(resourceName(NameNodePool)).
+			InZone(aruba.ZoneITBG1).
+			WithCount(2).
+			WithAutoscaling(1, 5)).
+		HighlyAvailable().
+		BilledBy(aruba.BillingPeriodHour)
 
 	result, err := arubaClient.FromContainer().KaaS().Create(ctx, k)
 	if err != nil {
@@ -65,14 +64,14 @@ func updateKaaS(ctx context.Context, arubaClient aruba.Client, k *aruba.KaaS) {
 	k.Named(updatedName(k.Name())).
 		RetaggedAs("kubernetes", "container", "updated").
 		WithMaxStorageQuotaGB(100).
-		BilledBy(aruba.BillingPeriodHour).
-		HighlyAvailable().
 		WithNodePools(aruba.NewNodePool().
-			Named(resourceName(NameNodePool)).
-			WithCount(5).
-			WithAutoscaling(1, 5).
 			OfInstance(aruba.NodePoolInstanceK2A4).
-			InZone(aruba.ZoneITBG1))
+			Named(resourceName(NameNodePool)).
+			InZone(aruba.ZoneITBG1).
+			WithCount(5).
+			WithAutoscaling(1, 5)).
+		HighlyAvailable().
+		BilledBy(aruba.BillingPeriodHour)
 
 	result, err := arubaClient.FromContainer().KaaS().Update(ctx, k)
 	if err != nil {

--- a/examples/all-resources/resource_kaas.go
+++ b/examples/all-resources/resource_kaas.go
@@ -24,20 +24,20 @@ func createKaaS(ctx context.Context, arubaClient aruba.Client, proj aruba.Ref, v
 		Named(resourceName(NameKaaSSecurityGroup))
 
 	k := aruba.NewKaaS().
-		IntoProject(proj).
+		InProject(proj).
 		Named(resourceName(NameKaaS)).
-		AddTag("kubernetes").
-		AddTag("container").
+		Tagged("kubernetes").
+		Tagged("container").
 		InRegion(aruba.RegionITBGBergamo).
 		WithKubernetesVersion(aruba.KubernetesVersion1341).
 		WithPodCIDR("10.0.3.0/24").
 		WithNodeCIDR("172.16.0.0/16", resourceName(NameKaaSNodeCIDR)).
-		WithHA(true).
-		WithBillingPeriod(aruba.BillingPeriodHour).
+		HighlyAvailable().
+		BilledHourly().
 		WithVPC(vpc).
 		WithSubnet(subnet).
 		WithSecurityGroup(kaasSG).
-		AddNodePool(aruba.NewNodePool().
+		WithNodePools(aruba.NewNodePool().
 			Named(resourceName(NameNodePool)).
 			WithCount(2).
 			WithAutoscaling(1, 5).
@@ -63,11 +63,11 @@ func updateKaaS(ctx context.Context, arubaClient aruba.Client, k *aruba.KaaS) {
 	// Mutate only the fields exposed by KaaSUpdateRequest.
 	// Networking URIs and CIDRs are immutable after creation.
 	k.Named(updatedName(k.Name())).
-		ReplaceTags("kubernetes", "container", "updated").
+		RetaggedAs("kubernetes", "container", "updated").
 		WithMaxStorageQuotaGB(100).
-		WithBillingPeriod(aruba.BillingPeriodHour).
-		WithHA(true).
-		AddNodePool(aruba.NewNodePool().
+		BilledHourly().
+		HighlyAvailable().
+		WithNodePools(aruba.NewNodePool().
 			Named(resourceName(NameNodePool)).
 			WithCount(5).
 			WithAutoscaling(1, 5).

--- a/examples/all-resources/resource_key_pair.go
+++ b/examples/all-resources/resource_key_pair.go
@@ -14,10 +14,10 @@ func createKeyPair(ctx context.Context, arubaClient aruba.Client, proj aruba.Ref
 	sshPublicKey := "ssh-rsa AAAAB3NzaC1yc2EAAAABJQAAAQEA2No7At0tgHrcZTL0kGWyLLUqPKfOhD9hGdNV9PbJxhjOGNFxcwdQ9wCXsJ3RQaRHBuGIgVodDurrlqzxFK86yCHMgXT2YLHF0j9P4m9GDiCfOK6msbFb89p5xZExjwD2zK+w68r7iOKZeRB2yrznW5TD3KDemSPIQQIVcyLF+yxft49HWBTI3PVQ4rBVOBJ2PdC9SAOf7CYnptW24CRrC0h85szIDwMA+Kmasfl3YGzk4MxheHrTO8C40aXXpieJ9S2VQA4VJAMRyAboptIK0cKjBYrbt5YkEL0AlyBGPIu6MPYr5K/MHyDunDi9yc7VYRYRR0f46MBOSqMUiGPnMw=="
 
 	kp := aruba.NewKeyPair().
-		IntoProject(proj).
+		InProject(proj).
 		Named(resourceName(NameKeyPair)).
-		AddTag("ssh-access").
-		AddTag("ingress").
+		Tagged("ssh-access").
+		Tagged("ingress").
 		InRegion(aruba.RegionITBGBergamo).
 		WithPublicKey(sshPublicKey)
 

--- a/examples/all-resources/resource_key_pair.go
+++ b/examples/all-resources/resource_key_pair.go
@@ -14,10 +14,9 @@ func createKeyPair(ctx context.Context, arubaClient aruba.Client, proj aruba.Ref
 	sshPublicKey := "ssh-rsa AAAAB3NzaC1yc2EAAAABJQAAAQEA2No7At0tgHrcZTL0kGWyLLUqPKfOhD9hGdNV9PbJxhjOGNFxcwdQ9wCXsJ3RQaRHBuGIgVodDurrlqzxFK86yCHMgXT2YLHF0j9P4m9GDiCfOK6msbFb89p5xZExjwD2zK+w68r7iOKZeRB2yrznW5TD3KDemSPIQQIVcyLF+yxft49HWBTI3PVQ4rBVOBJ2PdC9SAOf7CYnptW24CRrC0h85szIDwMA+Kmasfl3YGzk4MxheHrTO8C40aXXpieJ9S2VQA4VJAMRyAboptIK0cKjBYrbt5YkEL0AlyBGPIu6MPYr5K/MHyDunDi9yc7VYRYRR0f46MBOSqMUiGPnMw=="
 
 	kp := aruba.NewKeyPair().
-		InProject(proj).
 		Named(resourceName(NameKeyPair)).
-		Tagged("ssh-access").
-		Tagged("ingress").
+		Tagged("ssh-access", "ingress").
+		InProject(proj).
 		InRegion(aruba.RegionITBGBergamo).
 		WithPublicKey(sshPublicKey)
 

--- a/examples/all-resources/resource_kms.go
+++ b/examples/all-resources/resource_kms.go
@@ -18,7 +18,7 @@ func createKMS(ctx context.Context, arubaClient aruba.Client, proj aruba.Ref) *a
 		Tagged("security").
 		Tagged("encryption").
 		InRegion(aruba.RegionITBGBergamo).
-		BilledHourly()
+		BilledBy(aruba.BillingPeriodHour)
 
 	result, err := arubaClient.FromSecurity().KMS().Create(ctx, k)
 	if err != nil {

--- a/examples/all-resources/resource_kms.go
+++ b/examples/all-resources/resource_kms.go
@@ -13,12 +13,12 @@ func createKMS(ctx context.Context, arubaClient aruba.Client, proj aruba.Ref) *a
 	fmt.Println("--- KMS Instance ---")
 
 	k := aruba.NewKMS().
-		IntoProject(proj).
+		InProject(proj).
 		Named(resourceName(NameKMS)).
-		AddTag("security").
-		AddTag("encryption").
+		Tagged("security").
+		Tagged("encryption").
 		InRegion(aruba.RegionITBGBergamo).
-		WithBillingPeriod(aruba.BillingPeriodHour)
+		BilledHourly()
 
 	result, err := arubaClient.FromSecurity().KMS().Create(ctx, k)
 	if err != nil {
@@ -44,7 +44,7 @@ func createKMSKey(ctx context.Context, arubaClient aruba.Client, kmsParent *arub
 	}
 
 	key := aruba.NewKey().
-		IntoKMS(kmsParent).
+		InKMS(kmsParent).
 		Named(resourceName(NameKMSKey)).
 		OfAlgorithm(aruba.KeyAlgorithmAes)
 
@@ -69,7 +69,7 @@ func createKmip(ctx context.Context, arubaClient aruba.Client, kmsParent *aruba.
 		return nil
 	}
 
-	km := aruba.NewKmip().IntoKMS(kmsParent).
+	km := aruba.NewKmip().InKMS(kmsParent).
 		Named(resourceName(NameKmip))
 
 	created, err := arubaClient.FromSecurity().Kmips().Create(ctx, km)

--- a/examples/all-resources/resource_kms.go
+++ b/examples/all-resources/resource_kms.go
@@ -13,10 +13,9 @@ func createKMS(ctx context.Context, arubaClient aruba.Client, proj aruba.Ref) *a
 	fmt.Println("--- KMS Instance ---")
 
 	k := aruba.NewKMS().
-		InProject(proj).
 		Named(resourceName(NameKMS)).
-		Tagged("security").
-		Tagged("encryption").
+		Tagged("security", "encryption").
+		InProject(proj).
 		InRegion(aruba.RegionITBGBergamo).
 		BilledBy(aruba.BillingPeriodHour)
 
@@ -44,9 +43,9 @@ func createKMSKey(ctx context.Context, arubaClient aruba.Client, kmsParent *arub
 	}
 
 	key := aruba.NewKey().
-		InKMS(kmsParent).
+		OfAlgorithm(aruba.KeyAlgorithmAes).
 		Named(resourceName(NameKMSKey)).
-		OfAlgorithm(aruba.KeyAlgorithmAes)
+		InKMS(kmsParent)
 
 	result, err := arubaClient.FromSecurity().Keys().Create(ctx, key)
 	if err != nil {
@@ -69,8 +68,9 @@ func createKmip(ctx context.Context, arubaClient aruba.Client, kmsParent *aruba.
 		return nil
 	}
 
-	km := aruba.NewKmip().InKMS(kmsParent).
-		Named(resourceName(NameKmip))
+	km := aruba.NewKmip().
+		Named(resourceName(NameKmip)).
+		InKMS(kmsParent)
 
 	created, err := arubaClient.FromSecurity().Kmips().Create(ctx, km)
 	if err != nil {

--- a/examples/all-resources/resource_project.go
+++ b/examples/all-resources/resource_project.go
@@ -15,8 +15,7 @@ func createProject(ctx context.Context, arubaClient aruba.Client) *aruba.Project
 
 	proj := aruba.NewProject().
 		Named(resourceName(NameProject)).
-		Tagged("production").
-		Tagged("arubacloud-sdk").
+		Tagged("production", "arubacloud-sdk").
 		DescribedAs("My production project")
 
 	created, err := arubaClient.FromProject().Create(ctx, proj)

--- a/examples/all-resources/resource_project.go
+++ b/examples/all-resources/resource_project.go
@@ -15,9 +15,9 @@ func createProject(ctx context.Context, arubaClient aruba.Client) *aruba.Project
 
 	proj := aruba.NewProject().
 		Named(resourceName(NameProject)).
-		AddTag("production").
-		AddTag("arubacloud-sdk").
-		WithDescription("My production project")
+		Tagged("production").
+		Tagged("arubacloud-sdk").
+		DescribedAs("My production project")
 
 	created, err := arubaClient.FromProject().Create(ctx, proj)
 	if err != nil {
@@ -34,8 +34,8 @@ func updateProject(ctx context.Context, arubaClient aruba.Client, proj *aruba.Pr
 
 	proj.Named(
 		updatedName(proj.Name())).
-		ReplaceTags("production", "arubacloud-sdk", "updated").
-		WithDescription("My production project - UPDATED")
+		RetaggedAs("production", "arubacloud-sdk", "updated").
+		DescribedAs("My production project - UPDATED")
 
 	updated, err := arubaClient.FromProject().Update(ctx, proj)
 	if err != nil {

--- a/examples/all-resources/resource_security_group.go
+++ b/examples/all-resources/resource_security_group.go
@@ -19,10 +19,10 @@ func createSecurityGroup(ctx context.Context, arubaClient aruba.Client, vpc *aru
 	}
 
 	sg := aruba.NewSecurityGroup().
-		IntoVPC(vpc).
+		InVPC(vpc).
 		Named(resourceName(NameSecurityGroup)).
-		AddTag("security").
-		AddTag("network")
+		Tagged("security").
+		Tagged("network")
 
 	created, err := arubaClient.FromNetwork().SecurityGroups().Create(ctx, sg)
 	if err != nil {
@@ -48,15 +48,15 @@ func createSecurityGroupIngressRule(ctx context.Context, arubaClient aruba.Clien
 	}
 
 	rule := aruba.NewSecurityRule().
-		IntoSecurityGroup(sg).
+		InSecurityGroup(sg).
 		Named(name).
-		AddTag(tag).
-		AddTag("ingress").
+		Tagged(tag).
+		Tagged("ingress").
 		InRegion(aruba.RegionITBGBergamo).
 		WithDirection(aruba.RuleDirectionIngress).
 		WithProtocol(protocol).
 		WithPort(port).
-		WithTargetCIDR("0.0.0.0/0")
+		TargetingCIDR("0.0.0.0/0")
 
 	created, err := arubaClient.FromNetwork().SecurityGroupRules().Create(ctx, rule)
 	if err != nil {
@@ -83,13 +83,13 @@ func createSecurityGroupEgressRule(ctx context.Context, arubaClient aruba.Client
 	}
 
 	rule := aruba.NewSecurityRule().
-		IntoSecurityGroup(sg).
+		InSecurityGroup(sg).
 		Named(resourceName(NameSGRuleEgress)).
-		AddTag("egress").
+		Tagged("egress").
 		InRegion(aruba.RegionITBGBergamo).
 		WithDirection(aruba.RuleDirectionEgress).
 		WithProtocol(aruba.RuleProtocolANY).
-		WithTargetCIDR("0.0.0.0/0")
+		TargetingCIDR("0.0.0.0/0")
 
 	created, err := arubaClient.FromNetwork().SecurityGroupRules().Create(ctx, rule)
 	if err != nil {

--- a/examples/all-resources/resource_security_group.go
+++ b/examples/all-resources/resource_security_group.go
@@ -19,10 +19,9 @@ func createSecurityGroup(ctx context.Context, arubaClient aruba.Client, vpc *aru
 	}
 
 	sg := aruba.NewSecurityGroup().
-		InVPC(vpc).
 		Named(resourceName(NameSecurityGroup)).
-		Tagged("security").
-		Tagged("network")
+		Tagged("security", "network").
+		InVPC(vpc)
 
 	created, err := arubaClient.FromNetwork().SecurityGroups().Create(ctx, sg)
 	if err != nil {
@@ -48,10 +47,9 @@ func createSecurityGroupIngressRule(ctx context.Context, arubaClient aruba.Clien
 	}
 
 	rule := aruba.NewSecurityRule().
-		InSecurityGroup(sg).
 		Named(name).
-		Tagged(tag).
-		Tagged("ingress").
+		Tagged(tag, "ingress").
+		InSecurityGroup(sg).
 		InRegion(aruba.RegionITBGBergamo).
 		WithDirection(aruba.RuleDirectionIngress).
 		WithProtocol(protocol).
@@ -83,9 +81,9 @@ func createSecurityGroupEgressRule(ctx context.Context, arubaClient aruba.Client
 	}
 
 	rule := aruba.NewSecurityRule().
-		InSecurityGroup(sg).
 		Named(resourceName(NameSGRuleEgress)).
 		Tagged("egress").
+		InSecurityGroup(sg).
 		InRegion(aruba.RegionITBGBergamo).
 		WithDirection(aruba.RuleDirectionEgress).
 		WithProtocol(aruba.RuleProtocolANY).

--- a/examples/all-resources/resource_snapshot.go
+++ b/examples/all-resources/resource_snapshot.go
@@ -24,7 +24,7 @@ func createSnapshot(ctx context.Context, arubaClient aruba.Client, proj aruba.Re
 		Tagged("backup").
 		Tagged("snapshot").
 		InRegion(aruba.RegionITBGBergamo).
-		BilledHourly().
+		BilledBy(aruba.BillingPeriodHour).
 		FromVolume(bs)
 
 	snap, err := arubaClient.FromStorage().Snapshots().Create(ctx, snap)

--- a/examples/all-resources/resource_snapshot.go
+++ b/examples/all-resources/resource_snapshot.go
@@ -19,13 +19,12 @@ func createSnapshot(ctx context.Context, arubaClient aruba.Client, proj aruba.Re
 	}
 
 	snap := aruba.NewSnapshot().
-		InProject(proj).
 		Named(resourceName(NameSnapshot)).
-		Tagged("backup").
-		Tagged("snapshot").
+		Tagged("backup", "snapshot").
+		InProject(proj).
 		InRegion(aruba.RegionITBGBergamo).
-		BilledBy(aruba.BillingPeriodHour).
-		FromVolume(bs)
+		FromVolume(bs).
+		BilledBy(aruba.BillingPeriodHour)
 
 	snap, err := arubaClient.FromStorage().Snapshots().Create(ctx, snap)
 	if err != nil {

--- a/examples/all-resources/resource_snapshot.go
+++ b/examples/all-resources/resource_snapshot.go
@@ -19,12 +19,12 @@ func createSnapshot(ctx context.Context, arubaClient aruba.Client, proj aruba.Re
 	}
 
 	snap := aruba.NewSnapshot().
-		IntoProject(proj).
+		InProject(proj).
 		Named(resourceName(NameSnapshot)).
-		AddTag("backup").
-		AddTag("snapshot").
+		Tagged("backup").
+		Tagged("snapshot").
 		InRegion(aruba.RegionITBGBergamo).
-		WithBillingPeriod(aruba.BillingPeriodHour).
+		BilledHourly().
 		FromVolume(bs)
 
 	snap, err := arubaClient.FromStorage().Snapshots().Create(ctx, snap)

--- a/examples/all-resources/resource_storage_backup.go
+++ b/examples/all-resources/resource_storage_backup.go
@@ -19,12 +19,12 @@ func createStorageBackup(ctx context.Context, arubaClient aruba.Client, proj aru
 	}
 
 	b := aruba.NewStorageBackup().
-		IntoProject(proj).
+		InProject(proj).
 		Named(resourceName(NameStorageBackup)).
 		InRegion(aruba.RegionITBGBergamo).
 		OfType(aruba.StorageBackupTypeFull).
-		WithRetentionDays(10).
-		WithBillingPeriod(aruba.BillingPeriodHour).
+		RetainedForDays(10).
+		BilledHourly().
 		FromVolume(bs)
 
 	result, err := arubaClient.FromStorage().Backups().Create(ctx, b)

--- a/examples/all-resources/resource_storage_backup.go
+++ b/examples/all-resources/resource_storage_backup.go
@@ -24,7 +24,7 @@ func createStorageBackup(ctx context.Context, arubaClient aruba.Client, proj aru
 		InRegion(aruba.RegionITBGBergamo).
 		OfType(aruba.StorageBackupTypeFull).
 		RetainedForDays(10).
-		BilledHourly().
+		BilledBy(aruba.BillingPeriodHour).
 		FromVolume(bs)
 
 	result, err := arubaClient.FromStorage().Backups().Create(ctx, b)

--- a/examples/all-resources/resource_storage_backup.go
+++ b/examples/all-resources/resource_storage_backup.go
@@ -19,13 +19,13 @@ func createStorageBackup(ctx context.Context, arubaClient aruba.Client, proj aru
 	}
 
 	b := aruba.NewStorageBackup().
-		InProject(proj).
-		Named(resourceName(NameStorageBackup)).
-		InRegion(aruba.RegionITBGBergamo).
 		OfType(aruba.StorageBackupTypeFull).
+		Named(resourceName(NameStorageBackup)).
+		InProject(proj).
+		InRegion(aruba.RegionITBGBergamo).
 		RetainedForDays(10).
-		BilledBy(aruba.BillingPeriodHour).
-		FromVolume(bs)
+		FromVolume(bs).
+		BilledBy(aruba.BillingPeriodHour)
 
 	result, err := arubaClient.FromStorage().Backups().Create(ctx, b)
 	if err != nil {

--- a/examples/all-resources/resource_storage_restore.go
+++ b/examples/all-resources/resource_storage_restore.go
@@ -20,9 +20,9 @@ func createRestore(ctx context.Context, arubaClient aruba.Client, b *aruba.Stora
 	}
 
 	r := aruba.NewStorageRestore().
-		FromBackup(b).
 		Named(resourceName(NameStorageRestore)).
 		InRegion(aruba.RegionITBGBergamo).
+		FromBackup(b).
 		ToVolume(target)
 
 	r, err := arubaClient.FromStorage().Restores().Create(ctx, r)

--- a/examples/all-resources/resource_storage_restore.go
+++ b/examples/all-resources/resource_storage_restore.go
@@ -20,7 +20,7 @@ func createRestore(ctx context.Context, arubaClient aruba.Client, b *aruba.Stora
 	}
 
 	r := aruba.NewStorageRestore().
-		IntoBackup(b).
+		FromBackup(b).
 		Named(resourceName(NameStorageRestore)).
 		InRegion(aruba.RegionITBGBergamo).
 		ToVolume(target)

--- a/examples/all-resources/resource_subnet.go
+++ b/examples/all-resources/resource_subnet.go
@@ -18,18 +18,16 @@ func createAdvancedSubnet(ctx context.Context, arubaClient aruba.Client, vpc *ar
 	}
 
 	subnet := aruba.NewSubnet().
-		InVPC(vpc).
-		Named(resourceName(NameSubnetAdvanced)).
-		Tagged("network").
-		Tagged("subnet").
-		InRegion(aruba.RegionITBGBergamo).
 		OfType(aruba.SubnetTypeAdvanced).
+		Named(resourceName(NameSubnetAdvanced)).
+		Tagged("network", "subnet").
+		InVPC(vpc).
+		InRegion(aruba.RegionITBGBergamo).
 		WithCIDR("10.0.1.0/24").
 		WithDHCP(aruba.NewSubnetDHCP().
 			Enabled().
 			WithRange("10.0.1.10", 100).
-			WithDNSServers("8.8.8.8").
-			WithDNSServers("8.8.4.4"))
+			WithDNSServers("8.8.8.8", "8.8.4.4"))
 
 	result, err := arubaClient.FromNetwork().Subnets().Create(ctx, subnet)
 	if err != nil {
@@ -55,12 +53,11 @@ func createBasicSubnet(ctx context.Context, arubaClient aruba.Client, vpc *aruba
 	}
 
 	subnet := aruba.NewSubnet().
-		InVPC(vpc).
+		OfType(aruba.SubnetTypeBasic).
 		Named(resourceName(NameSubnetBasic)).
-		Tagged("network").
-		Tagged("subnet").
-		InRegion(aruba.RegionITBGBergamo).
-		OfType(aruba.SubnetTypeBasic)
+		Tagged("network", "subnet").
+		InVPC(vpc).
+		InRegion(aruba.RegionITBGBergamo)
 
 	result, err := arubaClient.FromNetwork().Subnets().Create(ctx, subnet)
 	if err != nil {

--- a/examples/all-resources/resource_subnet.go
+++ b/examples/all-resources/resource_subnet.go
@@ -18,18 +18,18 @@ func createAdvancedSubnet(ctx context.Context, arubaClient aruba.Client, vpc *ar
 	}
 
 	subnet := aruba.NewSubnet().
-		IntoVPC(vpc).
+		InVPC(vpc).
 		Named(resourceName(NameSubnetAdvanced)).
-		AddTag("network").
-		AddTag("subnet").
+		Tagged("network").
+		Tagged("subnet").
 		InRegion(aruba.RegionITBGBergamo).
 		OfType(aruba.SubnetTypeAdvanced).
 		WithCIDR("10.0.1.0/24").
 		WithDHCP(aruba.NewSubnetDHCP().
 			Enabled().
 			WithRange("10.0.1.10", 100).
-			AddDNS("8.8.8.8").
-			AddDNS("8.8.4.4"))
+			WithDNSServers("8.8.8.8").
+			WithDNSServers("8.8.4.4"))
 
 	result, err := arubaClient.FromNetwork().Subnets().Create(ctx, subnet)
 	if err != nil {
@@ -55,10 +55,10 @@ func createBasicSubnet(ctx context.Context, arubaClient aruba.Client, vpc *aruba
 	}
 
 	subnet := aruba.NewSubnet().
-		IntoVPC(vpc).
+		InVPC(vpc).
 		Named(resourceName(NameSubnetBasic)).
-		AddTag("network").
-		AddTag("subnet").
+		Tagged("network").
+		Tagged("subnet").
 		InRegion(aruba.RegionITBGBergamo).
 		OfType(aruba.SubnetTypeBasic)
 

--- a/examples/all-resources/resource_vpc.go
+++ b/examples/all-resources/resource_vpc.go
@@ -12,11 +12,11 @@ func createVPC(ctx context.Context, arubaClient aruba.Client, proj aruba.Ref) *a
 	fmt.Println("--- VPC ---")
 
 	vpc := aruba.NewVPC().
-		IntoProject(proj).
+		InProject(proj).
 		Named(resourceName(NameVPC)).
-		AddTag("network").AddTag("infrastructure").
+		Tagged("network").Tagged("infrastructure").
 		InRegion(aruba.RegionITBGBergamo).
-		WithPreset(false)
+		WithoutPreset()
 
 	created, err := arubaClient.FromNetwork().VPCs().Create(ctx, vpc)
 	if err != nil {

--- a/examples/all-resources/resource_vpc.go
+++ b/examples/all-resources/resource_vpc.go
@@ -12,9 +12,9 @@ func createVPC(ctx context.Context, arubaClient aruba.Client, proj aruba.Ref) *a
 	fmt.Println("--- VPC ---")
 
 	vpc := aruba.NewVPC().
-		InProject(proj).
 		Named(resourceName(NameVPC)).
-		Tagged("network").Tagged("infrastructure").
+		Tagged("network", "infrastructure").
+		InProject(proj).
 		InRegion(aruba.RegionITBGBergamo).
 		WithoutPreset()
 

--- a/pkg/aruba/mixin_common_test.go
+++ b/pkg/aruba/mixin_common_test.go
@@ -73,7 +73,7 @@ func TestMetadataMixin(t *testing.T) {
 	m.removeTag("a")
 	tags := m.Tags()
 	if len(tags) != 1 || tags[0] != "b" {
-		t.Errorf("after RemoveTag(a): %v", tags)
+		t.Errorf("after Untagged(a): %v", tags)
 	}
 
 	m.removeTag("nonexistent") // no-op

--- a/pkg/aruba/resource_block_storage.go
+++ b/pkg/aruba/resource_block_storage.go
@@ -13,7 +13,7 @@ import (
 
 // BlockStorage is the wrapper for an Aruba Cloud BlockStorage volume
 // (a direct child of a Project). Construct with aruba.NewBlockStorage()
-// and bind it via IntoProject(project).
+// and bind it via InProject(project).
 type BlockStorage struct {
 	errMixin
 	metadataMixin
@@ -44,20 +44,30 @@ func NewBlockStorage() *BlockStorage {
 
 // Setters — chainable, general → specific
 
-// IntoProject binds this BlockStorage to its parent project. Required before Create.
-func (b *BlockStorage) IntoProject(p Ref) *BlockStorage { b.intoProject(p); return b }
+// InProject binds this BlockStorage to its parent project. Required before Create.
+func (b *BlockStorage) InProject(p Ref) *BlockStorage { b.intoProject(p); return b }
 
 // Named sets the resource name. Required by the API.
 func (b *BlockStorage) Named(n string) *BlockStorage { b.named(n); return b }
 
-// AddTag appends a tag for filtering and accounting.
-func (b *BlockStorage) AddTag(t string) *BlockStorage { b.addTag(t); return b }
+// Tagged appends tags for filtering and accounting. Repeated calls append.
+func (b *BlockStorage) Tagged(ts ...string) *BlockStorage {
+	for _, t := range ts {
+		b.addTag(t)
+	}
+	return b
+}
 
-// RemoveTag removes a previously-added tag. No-op if absent.
-func (b *BlockStorage) RemoveTag(t string) *BlockStorage { b.removeTag(t); return b }
+// Untagged removes each listed tag. No-op for tags not present.
+func (b *BlockStorage) Untagged(ts ...string) *BlockStorage {
+	for _, t := range ts {
+		b.removeTag(t)
+	}
+	return b
+}
 
-// ReplaceTags replaces the entire tag set with the given values.
-func (b *BlockStorage) ReplaceTags(ts ...string) *BlockStorage { b.replaceTags(ts...); return b }
+// RetaggedAs replaces the entire tag set with the given values.
+func (b *BlockStorage) RetaggedAs(ts ...string) *BlockStorage { b.replaceTags(ts...); return b }
 
 // InRegion sets the region for this resource.
 func (b *BlockStorage) InRegion(region Region) *BlockStorage { b.inRegion(region); return b }
@@ -65,8 +75,8 @@ func (b *BlockStorage) InRegion(region Region) *BlockStorage { b.inRegion(region
 // InZone sets the availability zone. More specific than InRegion.
 func (b *BlockStorage) InZone(zone Zone) *BlockStorage { b.inZone(zone); return b }
 
-// WithSizeGB sets the volume size in GiB.
-func (b *BlockStorage) WithSizeGB(gb int) *BlockStorage { v := int32(gb); b.sizeGB = &v; return b }
+// SizedGB sets the volume size in GiB.
+func (b *BlockStorage) SizedGB(gb int) *BlockStorage { v := int32(gb); b.sizeGB = &v; return b }
 
 // OfType sets the storage type (e.g. SSD, HDD).
 func (b *BlockStorage) OfType(t types.BlockStorageType) *BlockStorage {
@@ -74,20 +84,35 @@ func (b *BlockStorage) OfType(t types.BlockStorageType) *BlockStorage {
 	return b
 }
 
-// WithBillingPeriod sets the billing period. Defaults to hourly when unset.
-func (b *BlockStorage) WithBillingPeriod(p BillingPeriod) *BlockStorage {
-	b.billingPeriod = &p
+// BilledHourly sets hourly billing.
+func (b *BlockStorage) BilledHourly() *BlockStorage {
+	v := BillingPeriodHour
+	b.billingPeriod = &v
+	return b
+}
+
+// BilledMonthly sets monthly billing.
+func (b *BlockStorage) BilledMonthly() *BlockStorage {
+	v := BillingPeriodMonth
+	b.billingPeriod = &v
+	return b
+}
+
+// BilledYearly sets yearly billing.
+func (b *BlockStorage) BilledYearly() *BlockStorage {
+	v := BillingPeriodYear
+	b.billingPeriod = &v
 	return b
 }
 
 // FromImage sets the source image name for bootable volumes.
 func (b *BlockStorage) FromImage(img string) *BlockStorage { b.image = &img; return b }
 
-// SetBootable marks the volume as bootable.
-func (b *BlockStorage) SetBootable() *BlockStorage { v := true; b.bootable = &v; return b }
+// AsBootable marks the volume as bootable.
+func (b *BlockStorage) AsBootable() *BlockStorage { v := true; b.bootable = &v; return b }
 
-// UnsetBootable explicitly marks the volume as non-bootable.
-func (b *BlockStorage) UnsetBootable() *BlockStorage { v := false; b.bootable = &v; return b }
+// NotBootable explicitly marks the volume as non-bootable.
+func (b *BlockStorage) NotBootable() *BlockStorage { v := false; b.bootable = &v; return b }
 
 // FromSnapshot binds the source snapshot via its URI. Pass any Ref (typed or
 // aruba.URI(...)). Empty URIs are recorded on the error sink and the field
@@ -145,8 +170,8 @@ func (b *BlockStorage) BillingPeriod() BillingPeriod {
 // Image returns the source image name, or "" if unset.
 func (b *BlockStorage) Image() string { return blockStorageDerefString(b.image) }
 
-// Bootable returns whether the volume is bootable, or false if unset.
-func (b *BlockStorage) Bootable() bool {
+// IsBootable returns whether the volume is bootable, or false if unset.
+func (b *BlockStorage) IsBootable() bool {
 	if b.bootable == nil {
 		return false
 	}
@@ -346,7 +371,7 @@ func (a *volumesClientAdapter) Create(ctx context.Context, vol *BlockStorage, op
 		return vol, err
 	}
 	if vol.ProjectID() == "" {
-		return vol, fmt.Errorf("Create: BlockStorage has no project — call IntoProject first")
+		return vol, fmt.Errorf("Create: BlockStorage has no project — call InProject first")
 	}
 	co := applyCallOptions(opts)
 	rp := co.toRequestParameters()
@@ -419,7 +444,7 @@ func (a *volumesClientAdapter) Update(ctx context.Context, vol *BlockStorage, op
 		return vol, fmt.Errorf("Update: BlockStorage has no ID — call Get first or seed from response metadata")
 	}
 	if vol.ProjectID() == "" {
-		return vol, fmt.Errorf("Update: BlockStorage has no project — call IntoProject first")
+		return vol, fmt.Errorf("Update: BlockStorage has no project — call InProject first")
 	}
 	co := applyCallOptions(opts)
 	rp := co.toRequestParameters()

--- a/pkg/aruba/resource_block_storage.go
+++ b/pkg/aruba/resource_block_storage.go
@@ -84,24 +84,9 @@ func (b *BlockStorage) OfType(t types.BlockStorageType) *BlockStorage {
 	return b
 }
 
-// BilledHourly sets hourly billing.
-func (b *BlockStorage) BilledHourly() *BlockStorage {
-	v := BillingPeriodHour
-	b.billingPeriod = &v
-	return b
-}
-
-// BilledMonthly sets monthly billing.
-func (b *BlockStorage) BilledMonthly() *BlockStorage {
-	v := BillingPeriodMonth
-	b.billingPeriod = &v
-	return b
-}
-
-// BilledYearly sets yearly billing.
-func (b *BlockStorage) BilledYearly() *BlockStorage {
-	v := BillingPeriodYear
-	b.billingPeriod = &v
+// BilledBy sets the billing cadence. Accepted periods are resource-specific; check the API reference.
+func (b *BlockStorage) BilledBy(period BillingPeriod) *BlockStorage {
+	b.billingPeriod = &period
 	return b
 }
 

--- a/pkg/aruba/resource_block_storage_test.go
+++ b/pkg/aruba/resource_block_storage_test.go
@@ -35,7 +35,7 @@ func TestBlockStorage_FluentSetters(t *testing.T) {
 		InRegion(RegionITBGBergamo).
 		SizedGB(50).
 		OfType(BlockStorageTypeStandard).
-		BilledHourly().
+		BilledBy(BillingPeriodHour).
 		FromImage(VolumeImageLU22001).
 		AsBootable()
 
@@ -164,7 +164,7 @@ func TestBlockStorage_ToRequestRoundTrip(t *testing.T) {
 		SizedGB(30).
 		OfType(BlockStorageTypePerformance).
 		InZone(ZoneITBG1).
-		BilledHourly().
+		BilledBy(BillingPeriodHour).
 		AsBootable().
 		FromImage(VolumeImageLU22001).
 		FromSnapshot(URI(snapURI))
@@ -496,7 +496,7 @@ func TestVolumesClientAdapter_Create_Success(t *testing.T) {
 		InRegion(RegionITBGBergamo).
 		SizedGB(20).
 		OfType(BlockStorageTypeStandard).
-		BilledHourly()
+		BilledBy(BillingPeriodHour)
 
 	result, err := adapter.Create(context.Background(), bs)
 	if err != nil {

--- a/pkg/aruba/resource_block_storage_test.go
+++ b/pkg/aruba/resource_block_storage_test.go
@@ -27,17 +27,17 @@ func TestBlockStorage_FluentSetters(t *testing.T) {
 	proj.fromResponse(projectTestResponse("p-1", "my-proj", "/projects/p-1"))
 
 	bs := NewBlockStorage().
-		IntoProject(proj).
+		InProject(proj).
 		Named("my-bs").
-		AddTag("storage").
-		AddTag("data").
-		AddTag("storage"). // dedupe
+		Tagged("storage").
+		Tagged("data").
+		Tagged("storage"). // dedupe
 		InRegion(RegionITBGBergamo).
-		WithSizeGB(50).
+		SizedGB(50).
 		OfType(BlockStorageTypeStandard).
-		WithBillingPeriod(BillingPeriodHour).
+		BilledHourly().
 		FromImage(VolumeImageLU22001).
-		SetBootable()
+		AsBootable()
 
 	if bs.Name() != "my-bs" {
 		t.Errorf("Name() = %q", bs.Name())
@@ -60,8 +60,8 @@ func TestBlockStorage_FluentSetters(t *testing.T) {
 	if bs.Image() != VolumeImageLU22001 {
 		t.Errorf("Image() = %q", bs.Image())
 	}
-	if !bs.Bootable() {
-		t.Error("Bootable() should be true")
+	if !bs.IsBootable() {
+		t.Error("IsBootable() should be true")
 	}
 	if bs.ProjectID() != "p-1" {
 		t.Errorf("ProjectID() = %q", bs.ProjectID())
@@ -70,12 +70,12 @@ func TestBlockStorage_FluentSetters(t *testing.T) {
 		t.Errorf("Err() = %v", bs.Err())
 	}
 
-	bs.RemoveTag("storage")
+	bs.Untagged("storage")
 	if tags := bs.Tags(); len(tags) != 1 || tags[0] != "data" {
 		t.Errorf("after RemoveTag Tags() = %v", tags)
 	}
 
-	bs.ReplaceTags("x", "y")
+	bs.RetaggedAs("x", "y")
 	if tags := bs.Tags(); len(tags) != 2 || tags[0] != "x" || tags[1] != "y" {
 		t.Errorf("after ReplaceTags Tags() = %v", tags)
 	}
@@ -88,7 +88,7 @@ func TestBlockStorage_FluentSetters(t *testing.T) {
 func TestBlockStorage_IntoProject_TypedRef(t *testing.T) {
 	proj := &Project{}
 	proj.fromResponse(projectTestResponse("p-42", "n", "/projects/p-42"))
-	bs := NewBlockStorage().IntoProject(proj)
+	bs := NewBlockStorage().InProject(proj)
 	if bs.ProjectID() != "p-42" {
 		t.Errorf("ProjectID() = %q", bs.ProjectID())
 	}
@@ -98,7 +98,7 @@ func TestBlockStorage_IntoProject_TypedRef(t *testing.T) {
 }
 
 func TestBlockStorage_IntoProject_URIRef(t *testing.T) {
-	bs := NewBlockStorage().IntoProject(URI("/projects/p-uri"))
+	bs := NewBlockStorage().InProject(URI("/projects/p-uri"))
 	if bs.ProjectID() != "p-uri" {
 		t.Errorf("ProjectID() = %q", bs.ProjectID())
 	}
@@ -108,7 +108,7 @@ func TestBlockStorage_IntoProject_URIRef(t *testing.T) {
 }
 
 func TestBlockStorage_IntoProject_BadRef(t *testing.T) {
-	bs := NewBlockStorage().IntoProject(URI("/garbage"))
+	bs := NewBlockStorage().InProject(URI("/garbage"))
 	if bs.Err() == nil {
 		t.Error("expected Err() != nil for unresolvable Ref")
 	}
@@ -159,13 +159,13 @@ func TestBlockStorage_ToRequestRoundTrip(t *testing.T) {
 	snapURI := "/projects/p/providers/Aruba.Storage/snapshots/s1"
 	bs := NewBlockStorage().Named(
 		"bs-rt").
-		AddTag("t1").AddTag("t2").
+		Tagged("t1").Tagged("t2").
 		InRegion(RegionITBGBergamo).
-		WithSizeGB(30).
+		SizedGB(30).
 		OfType(BlockStorageTypePerformance).
 		InZone(ZoneITBG1).
-		WithBillingPeriod(BillingPeriodHour).
-		SetBootable().
+		BilledHourly().
+		AsBootable().
 		FromImage(VolumeImageLU22001).
 		FromSnapshot(URI(snapURI))
 
@@ -205,7 +205,7 @@ func TestBlockStorage_ToRequestRoundTrip(t *testing.T) {
 
 func TestBlockStorage_ToRequest_UnsetOptionals_AreNilOrZero(t *testing.T) {
 	bs := NewBlockStorage().
-		Named("bare").WithSizeGB(10).OfType(BlockStorageTypeStandard)
+		Named("bare").SizedGB(10).OfType(BlockStorageTypeStandard)
 	req := bs.RawRequest()
 
 	// RawRequest delegates to toCreateRequest where bootable defaults to false.
@@ -338,8 +338,8 @@ func TestBlockStorage_FromResponseHydration(t *testing.T) {
 	if bs.Image() != VolumeImageLU22001 {
 		t.Errorf("Image() = %q", bs.Image())
 	}
-	if !bs.Bootable() {
-		t.Error("Bootable() should be true")
+	if !bs.IsBootable() {
+		t.Error("IsBootable() should be true")
 	}
 	if bs.SnapshotURI() != "/projects/p/providers/Aruba.Storage/snapshots/s1" {
 		t.Errorf("SnapshotURI() = %q", bs.SnapshotURI())
@@ -491,12 +491,12 @@ func TestVolumesClientAdapter_Create_Success(t *testing.T) {
 	})
 
 	bs := NewBlockStorage().
-		IntoProject(URI("/projects/p")).
+		InProject(URI("/projects/p")).
 		Named("my-bs").
 		InRegion(RegionITBGBergamo).
-		WithSizeGB(20).
+		SizedGB(20).
 		OfType(BlockStorageTypeStandard).
-		WithBillingPeriod(BillingPeriodHour)
+		BilledHourly()
 
 	result, err := adapter.Create(context.Background(), bs)
 	if err != nil {
@@ -544,7 +544,7 @@ func TestVolumesClientAdapter_Create_MetadataValidationError(t *testing.T) {
 		fmt.Fprint(w, `{"metadata":{"name":"bs","uri":"/projects/p/providers/Aruba.Storage/blockStorages/x"},"properties":{},"status":{}}`)
 	})
 
-	bs := NewBlockStorage().IntoProject(URI("/projects/p")).
+	bs := NewBlockStorage().InProject(URI("/projects/p")).
 		Named("bs")
 	result, err := adapter.Create(context.Background(), bs)
 	if err == nil {
@@ -566,7 +566,7 @@ func TestVolumesClientAdapter_Create_NonTwoXX(t *testing.T) {
 		fmt.Fprint(w, testutil.ErrorBodyJSON("Validation Failed", "name is required", 422))
 	})
 
-	bs := NewBlockStorage().IntoProject(URI("/projects/p"))
+	bs := NewBlockStorage().InProject(URI("/projects/p"))
 	result, err := adapter.Create(context.Background(), bs)
 	if err == nil {
 		t.Fatal("expected error on 422")
@@ -638,7 +638,7 @@ func TestVolumesClientAdapter_Update_Success(t *testing.T) {
 
 	bs := &BlockStorage{}
 	bs.fromResponse(blockStorageTestResponse("bs-1", "my-bs", "/projects/p/providers/Aruba.Storage/blockStorages/bs-1", "p"))
-	bs.WithSizeGB(40)
+	bs.SizedGB(40)
 
 	result, err := adapter.Update(context.Background(), bs)
 	if err != nil {
@@ -659,7 +659,7 @@ func TestVolumesClientAdapter_Update_NoID(t *testing.T) {
 		w.WriteHeader(http.StatusOK)
 	})
 
-	bs := NewBlockStorage().IntoProject(URI("/projects/p")).
+	bs := NewBlockStorage().InProject(URI("/projects/p")).
 		Named("x")
 	_, err := adapter.Update(context.Background(), bs)
 	if err == nil {
@@ -772,8 +772,8 @@ func TestBlockStorage_Accessors_ZeroValue(t *testing.T) {
 	if bs.Type() != "" {
 		t.Errorf("Type() zero value = %q, want \"\"", bs.Type())
 	}
-	if bs.Bootable() != false {
-		t.Error("Bootable() zero value should be false")
+	if bs.IsBootable() != false {
+		t.Error("IsBootable() zero value should be false")
 	}
 }
 
@@ -844,7 +844,7 @@ func TestVolumesClientAdapter_Update_NonTwoXX(t *testing.T) {
 
 	bs := &BlockStorage{}
 	bs.fromResponse(blockStorageTestResponse("bs-1", "my-bs", "/projects/p/providers/Aruba.Storage/blockStorages/bs-1", "p"))
-	bs.WithSizeGB(99999)
+	bs.SizedGB(99999)
 
 	_, err := adapter.Update(context.Background(), bs)
 	if err == nil {
@@ -1007,7 +1007,7 @@ func TestBlockStorage_UpdateRequest_OmitsUnsetBootable(t *testing.T) {
 }
 
 func TestBlockStorage_UpdateRequest_ExplicitBootable(t *testing.T) {
-	bs := NewBlockStorage().Named("vol").WithSizeGB(10).UnsetBootable()
+	bs := NewBlockStorage().Named("vol").SizedGB(10).NotBootable()
 	req := bs.toUpdateRequest()
 	if req.Properties.Bootable == nil || *req.Properties.Bootable != false {
 		t.Errorf("Update request bootable should be false when UnsetBootable was called, got %v", req.Properties.Bootable)

--- a/pkg/aruba/resource_cloud_server.go
+++ b/pkg/aruba/resource_cloud_server.go
@@ -172,14 +172,13 @@ func (cs *CloudServer) setSingleRef(label string, r Ref, dst **string) *CloudSer
 	return cs
 }
 
-func (cs *CloudServer) appendRef(label string, r Ref, dst *[]string) *CloudServer {
+func (cs *CloudServer) appendRef(label string, r Ref, dst *[]string) {
 	uri := r.URI()
 	if uri == "" {
 		cs.addErr(fmt.Errorf("%s: empty URI", label))
-		return cs
+		return
 	}
 	*dst = append(*dst, uri)
-	return cs
 }
 
 // Getters — general → specific

--- a/pkg/aruba/resource_cloud_server.go
+++ b/pkg/aruba/resource_cloud_server.go
@@ -116,24 +116,9 @@ func (cs *CloudServer) WithVPCPreset() *CloudServer { v := true; cs.vpcPreset = 
 // WithoutVPCPreset disables VPC preset networking.
 func (cs *CloudServer) WithoutVPCPreset() *CloudServer { v := false; cs.vpcPreset = &v; return cs }
 
-// BilledHourly sets hourly billing.
-func (cs *CloudServer) BilledHourly() *CloudServer {
-	v := BillingPeriodHour
-	cs.billingPeriod = &v
-	return cs
-}
-
-// BilledMonthly sets monthly billing.
-func (cs *CloudServer) BilledMonthly() *CloudServer {
-	v := BillingPeriodMonth
-	cs.billingPeriod = &v
-	return cs
-}
-
-// BilledYearly sets yearly billing.
-func (cs *CloudServer) BilledYearly() *CloudServer {
-	v := BillingPeriodYear
-	cs.billingPeriod = &v
+// BilledBy sets the billing cadence. Accepted periods are resource-specific; check the API reference.
+func (cs *CloudServer) BilledBy(period BillingPeriod) *CloudServer {
+	cs.billingPeriod = &period
 	return cs
 }
 

--- a/pkg/aruba/resource_cloud_server.go
+++ b/pkg/aruba/resource_cloud_server.go
@@ -12,8 +12,8 @@ import (
 // ---- Wrapper ----
 
 // CloudServer is the wrapper for an Aruba Cloud Compute server (a direct child of a Project).
-// Construct with aruba.NewCloudServer() and bind it via IntoProject(project), WithVPC(vpc),
-// WithBootVolume(volume), etc.
+// Construct with aruba.NewCloudServer() and bind it via InProject(project), WithVPC(vpc),
+// BootingFrom(volume), etc.
 //
 // Schema asymmetry: the request side uses FlavorName *string under the "flavorName" wire
 // field; the response side returns a full Flavor struct under the "flavor" wire field.
@@ -70,20 +70,30 @@ func NewCloudServer() *CloudServer {
 
 // Setters — chainable, general → specific
 
-// IntoProject binds this CloudServer to its parent project. Required before Create.
-func (cs *CloudServer) IntoProject(p Ref) *CloudServer { cs.intoProject(p); return cs }
+// InProject binds this CloudServer to its parent project. Required before Create.
+func (cs *CloudServer) InProject(p Ref) *CloudServer { cs.intoProject(p); return cs }
 
 // Named sets the resource name. Required by the API.
 func (cs *CloudServer) Named(n string) *CloudServer { cs.named(n); return cs }
 
-// AddTag appends a tag for filtering and accounting.
-func (cs *CloudServer) AddTag(t string) *CloudServer { cs.addTag(t); return cs }
+// Tagged appends tags for filtering and accounting. Repeated calls append.
+func (cs *CloudServer) Tagged(ts ...string) *CloudServer {
+	for _, t := range ts {
+		cs.addTag(t)
+	}
+	return cs
+}
 
-// RemoveTag removes a previously-added tag. No-op if absent.
-func (cs *CloudServer) RemoveTag(t string) *CloudServer { cs.removeTag(t); return cs }
+// Untagged removes each listed tag. No-op for tags not present.
+func (cs *CloudServer) Untagged(ts ...string) *CloudServer {
+	for _, t := range ts {
+		cs.removeTag(t)
+	}
+	return cs
+}
 
-// ReplaceTags replaces the entire tag set with the given values.
-func (cs *CloudServer) ReplaceTags(ts ...string) *CloudServer { cs.replaceTags(ts...); return cs }
+// RetaggedAs replaces the entire tag set with the given values.
+func (cs *CloudServer) RetaggedAs(ts ...string) *CloudServer { cs.replaceTags(ts...); return cs }
 
 // InRegion sets the region for this resource.
 func (cs *CloudServer) InRegion(region Region) *CloudServer { cs.inRegion(region); return cs }
@@ -101,11 +111,29 @@ func (cs *CloudServer) OfFlavor(flavor CloudServerFlavor) *CloudServer {
 func (cs *CloudServer) WithUserData(b64 string) *CloudServer { cs.userData = &b64; return cs }
 
 // WithVPCPreset marks the server to use VPC preset networking.
-func (cs *CloudServer) WithVPCPreset(b bool) *CloudServer { cs.vpcPreset = &b; return cs }
+func (cs *CloudServer) WithVPCPreset() *CloudServer { v := true; cs.vpcPreset = &v; return cs }
 
-// WithBillingPeriod sets the billing period. Defaults to hourly when unset.
-func (cs *CloudServer) WithBillingPeriod(period BillingPeriod) *CloudServer {
-	cs.billingPeriod = &period
+// WithoutVPCPreset disables VPC preset networking.
+func (cs *CloudServer) WithoutVPCPreset() *CloudServer { v := false; cs.vpcPreset = &v; return cs }
+
+// BilledHourly sets hourly billing.
+func (cs *CloudServer) BilledHourly() *CloudServer {
+	v := BillingPeriodHour
+	cs.billingPeriod = &v
+	return cs
+}
+
+// BilledMonthly sets monthly billing.
+func (cs *CloudServer) BilledMonthly() *CloudServer {
+	v := BillingPeriodMonth
+	cs.billingPeriod = &v
+	return cs
+}
+
+// BilledYearly sets yearly billing.
+func (cs *CloudServer) BilledYearly() *CloudServer {
+	v := BillingPeriodYear
+	cs.billingPeriod = &v
 	return cs
 }
 
@@ -114,14 +142,14 @@ func (cs *CloudServer) WithBillingPeriod(period BillingPeriod) *CloudServer {
 // WithVPC attaches the server to the given VPC by URI reference.
 func (cs *CloudServer) WithVPC(v Ref) *CloudServer { return cs.setSingleRef("WithVPC", v, &cs.vpcRef) }
 
-// WithBootVolume sets the boot volume by URI reference.
-func (cs *CloudServer) WithBootVolume(vol Ref) *CloudServer {
-	return cs.setSingleRef("WithBootVolume", vol, &cs.bootVolumeRef)
+// BootingFrom sets the boot volume by URI reference.
+func (cs *CloudServer) BootingFrom(vol Ref) *CloudServer {
+	return cs.setSingleRef("BootingFrom", vol, &cs.bootVolumeRef)
 }
 
-// WithKeyPair attaches an SSH key pair by URI reference.
-func (cs *CloudServer) WithKeyPair(kp Ref) *CloudServer {
-	return cs.setSingleRef("WithKeyPair", kp, &cs.keyPairRef)
+// UsingKeyPair attaches an SSH key pair by URI reference.
+func (cs *CloudServer) UsingKeyPair(kp Ref) *CloudServer {
+	return cs.setSingleRef("UsingKeyPair", kp, &cs.keyPairRef)
 }
 
 // WithElasticIP attaches an elastic IP by URI reference.
@@ -131,14 +159,20 @@ func (cs *CloudServer) WithElasticIP(eip Ref) *CloudServer {
 
 // Multi-ref slice setters.
 
-// AddSubnet appends a subnet by URI reference.
-func (cs *CloudServer) AddSubnet(s Ref) *CloudServer {
-	return cs.appendRef("AddSubnet", s, &cs.subnetRefs)
+// OnSubnets appends subnets by URI reference. Repeated calls append.
+func (cs *CloudServer) OnSubnets(s ...Ref) *CloudServer {
+	for _, ref := range s {
+		cs.appendRef("OnSubnets", ref, &cs.subnetRefs)
+	}
+	return cs
 }
 
-// AddSecurityGroup appends a security group by URI reference.
-func (cs *CloudServer) AddSecurityGroup(sg Ref) *CloudServer {
-	return cs.appendRef("AddSecurityGroup", sg, &cs.securityGroupRefs)
+// WithSecurityGroups appends security groups by URI reference. Repeated calls append.
+func (cs *CloudServer) WithSecurityGroups(sg ...Ref) *CloudServer {
+	for _, ref := range sg {
+		cs.appendRef("WithSecurityGroups", ref, &cs.securityGroupRefs)
+	}
+	return cs
 }
 
 // Internal ref helpers.
@@ -494,7 +528,7 @@ func (a *cloudServersClientAdapter) Create(ctx context.Context, cs *CloudServer,
 		return cs, err
 	}
 	if cs.ProjectID() == "" {
-		return cs, fmt.Errorf("Create: CloudServer has no parent project — call IntoProject first")
+		return cs, fmt.Errorf("Create: CloudServer has no parent project — call InProject first")
 	}
 	co := applyCallOptions(opts)
 	rp := co.toRequestParameters()
@@ -532,7 +566,7 @@ func (a *cloudServersClientAdapter) Update(ctx context.Context, cs *CloudServer,
 		return cs, fmt.Errorf("Update: CloudServer has no ID")
 	}
 	if cs.ProjectID() == "" {
-		return cs, fmt.Errorf("Update: CloudServer has no parent project — call IntoProject first")
+		return cs, fmt.Errorf("Update: CloudServer has no parent project — call InProject first")
 	}
 	co := applyCallOptions(opts)
 	rp := co.toRequestParameters()

--- a/pkg/aruba/resource_cloud_server_test.go
+++ b/pkg/aruba/resource_cloud_server_test.go
@@ -1350,14 +1350,14 @@ func TestCloudServersClientAdapter_Get_InjectsRefresh(t *testing.T) {
 // --------------------------------------------------------------------------
 
 func TestCloudServer_WithBillingPeriod_SetsField(t *testing.T) {
-	cs := NewCloudServer().BilledHourly()
+	cs := NewCloudServer().BilledBy(BillingPeriodHour)
 	if cs.BillingPeriod() != BillingPeriodHour {
 		t.Errorf("BillingPeriod() = %q, want %q", cs.BillingPeriod(), BillingPeriodHour)
 	}
 }
 
 func TestCloudServer_WithBillingPeriod_InRequest(t *testing.T) {
-	cs := NewCloudServer().BilledMonthly()
+	cs := NewCloudServer().BilledBy(BillingPeriodMonth)
 	req := cs.RawRequest()
 	if req.Properties.BillingPlan == nil || req.Properties.BillingPlan.BillingPeriod == nil || *req.Properties.BillingPlan.BillingPeriod != BillingPeriodMonth {
 		t.Errorf("request BillingPlan.BillingPeriod = %v, want %q", req.Properties.BillingPlan, BillingPeriodMonth)

--- a/pkg/aruba/resource_cloud_server_test.go
+++ b/pkg/aruba/resource_cloud_server_test.go
@@ -27,15 +27,15 @@ func TestCloudServer_FluentSetters(t *testing.T) {
 	proj.fromResponse(projectTestResponse("p-1", "my-project", "/projects/p-1"))
 
 	cs := NewCloudServer().
-		IntoProject(proj).
+		InProject(proj).
 		Named("my-server").
-		AddTag("compute").
-		AddTag("prod").
+		Tagged("compute").
+		Tagged("prod").
 		InRegion(RegionITBGBergamo).
 		InZone(ZoneITBG1).
 		OfFlavor(CloudServerFlavorCSO2A4).
 		WithUserData("dGVzdA==").
-		WithVPCPreset(true)
+		WithVPCPreset()
 
 	if cs.Name() != "my-server" {
 		t.Errorf("Name() = %q", cs.Name())
@@ -59,12 +59,12 @@ func TestCloudServer_FluentSetters(t *testing.T) {
 		t.Errorf("Err() = %v", cs.Err())
 	}
 
-	cs.RemoveTag("compute")
+	cs.Untagged("compute")
 	if tags := cs.Tags(); len(tags) != 1 || tags[0] != "prod" {
 		t.Errorf("after RemoveTag Tags() = %v", tags)
 	}
 
-	cs.ReplaceTags("x", "y")
+	cs.RetaggedAs("x", "y")
 	if tags := cs.Tags(); len(tags) != 2 || tags[0] != "x" || tags[1] != "y" {
 		t.Errorf("after ReplaceTags Tags() = %v", tags)
 	}
@@ -78,7 +78,7 @@ func TestCloudServer_IntoProject_TypedRef(t *testing.T) {
 	proj := &Project{}
 	proj.fromResponse(projectTestResponse("p-42", "n", "/projects/p-42"))
 
-	cs := NewCloudServer().IntoProject(proj)
+	cs := NewCloudServer().InProject(proj)
 	if cs.ProjectID() != "p-42" {
 		t.Errorf("ProjectID() = %q", cs.ProjectID())
 	}
@@ -88,7 +88,7 @@ func TestCloudServer_IntoProject_TypedRef(t *testing.T) {
 }
 
 func TestCloudServer_IntoProject_URIRef(t *testing.T) {
-	cs := NewCloudServer().IntoProject(URI("/projects/p-uri"))
+	cs := NewCloudServer().InProject(URI("/projects/p-uri"))
 	if cs.ProjectID() != "p-uri" {
 		t.Errorf("ProjectID() = %q", cs.ProjectID())
 	}
@@ -98,7 +98,7 @@ func TestCloudServer_IntoProject_URIRef(t *testing.T) {
 }
 
 func TestCloudServer_IntoProject_BadRef(t *testing.T) {
-	cs := NewCloudServer().IntoProject(URI("/something/else"))
+	cs := NewCloudServer().InProject(URI("/something/else"))
 	if cs.Err() == nil {
 		t.Error("expected Err() to be set for unresolvable parent")
 	}
@@ -129,7 +129,7 @@ func TestCloudServer_WithVPC_EmptyURI(t *testing.T) {
 }
 
 func TestCloudServer_WithBootVolume_URIRef(t *testing.T) {
-	cs := NewCloudServer().WithBootVolume(URI("/projects/p/storage/volumes/vol-1"))
+	cs := NewCloudServer().BootingFrom(URI("/projects/p/storage/volumes/vol-1"))
 	if cs.BootVolume() != "/projects/p/storage/volumes/vol-1" {
 		t.Errorf("BootVolume() = %q", cs.BootVolume())
 	}
@@ -139,14 +139,14 @@ func TestCloudServer_WithBootVolume_URIRef(t *testing.T) {
 }
 
 func TestCloudServer_WithBootVolume_EmptyURI(t *testing.T) {
-	cs := NewCloudServer().WithBootVolume(URI(""))
+	cs := NewCloudServer().BootingFrom(URI(""))
 	if cs.Err() == nil {
 		t.Error("expected Err() for empty BootVolume URI")
 	}
 }
 
 func TestCloudServer_WithKeyPair_URIRef(t *testing.T) {
-	cs := NewCloudServer().WithKeyPair(URI("/projects/p/providers/Aruba.Compute/keyPairs/kp-1"))
+	cs := NewCloudServer().UsingKeyPair(URI("/projects/p/providers/Aruba.Compute/keyPairs/kp-1"))
 	if cs.KeyPair() != "/projects/p/providers/Aruba.Compute/keyPairs/kp-1" {
 		t.Errorf("KeyPair() = %q", cs.KeyPair())
 	}
@@ -156,7 +156,7 @@ func TestCloudServer_WithKeyPair_URIRef(t *testing.T) {
 }
 
 func TestCloudServer_WithKeyPair_EmptyURI(t *testing.T) {
-	cs := NewCloudServer().WithKeyPair(URI(""))
+	cs := NewCloudServer().UsingKeyPair(URI(""))
 	if cs.Err() == nil {
 		t.Error("expected Err() for empty KeyPair URI")
 	}
@@ -182,8 +182,8 @@ func TestCloudServer_WithElasticIP_EmptyURI(t *testing.T) {
 
 func TestCloudServer_AddSubnet_AppendsTwo(t *testing.T) {
 	cs := NewCloudServer().
-		AddSubnet(URI("/subnets/s-1")).
-		AddSubnet(URI("/subnets/s-2"))
+		OnSubnets(URI("/subnets/s-1")).
+		OnSubnets(URI("/subnets/s-2"))
 	if cs.Err() != nil {
 		t.Errorf("Err() = %v", cs.Err())
 	}
@@ -200,7 +200,7 @@ func TestCloudServer_AddSubnet_AppendsTwo(t *testing.T) {
 }
 
 func TestCloudServer_AddSubnet_EmptyURI(t *testing.T) {
-	cs := NewCloudServer().AddSubnet(URI(""))
+	cs := NewCloudServer().OnSubnets(URI(""))
 	if cs.Err() == nil {
 		t.Error("expected Err() for empty Subnet URI")
 	}
@@ -211,8 +211,8 @@ func TestCloudServer_AddSubnet_EmptyURI(t *testing.T) {
 
 func TestCloudServer_AddSecurityGroup_AppendsTwo(t *testing.T) {
 	cs := NewCloudServer().
-		AddSecurityGroup(URI("/sgs/sg-1")).
-		AddSecurityGroup(URI("/sgs/sg-2"))
+		WithSecurityGroups(URI("/sgs/sg-1")).
+		WithSecurityGroups(URI("/sgs/sg-2"))
 	if cs.Err() != nil {
 		t.Errorf("Err() = %v", cs.Err())
 	}
@@ -223,7 +223,7 @@ func TestCloudServer_AddSecurityGroup_AppendsTwo(t *testing.T) {
 }
 
 func TestCloudServer_AddSecurityGroup_EmptyURI(t *testing.T) {
-	cs := NewCloudServer().AddSecurityGroup(URI(""))
+	cs := NewCloudServer().WithSecurityGroups(URI(""))
 	if cs.Err() == nil {
 		t.Error("expected Err() for empty SecurityGroup URI")
 	}
@@ -252,7 +252,7 @@ func TestCloudServer_WithUserData(t *testing.T) {
 }
 
 func TestCloudServer_WithVPCPreset(t *testing.T) {
-	cs := NewCloudServer().WithVPCPreset(true)
+	cs := NewCloudServer().WithVPCPreset()
 	req := cs.toRequest()
 	if !req.Properties.VPCPreset {
 		t.Error("VPCPreset not emitted correctly")
@@ -276,18 +276,18 @@ func TestCloudServer_InZone(t *testing.T) {
 
 func TestCloudServer_ToRequestRoundTrip(t *testing.T) {
 	cs := NewCloudServer().
-		IntoProject(URI("/projects/p")).
+		InProject(URI("/projects/p")).
 		Named("srv").
-		AddTag("tag1").
+		Tagged("tag1").
 		InRegion(RegionITBGBergamo).
 		InZone(ZoneITBG1).
 		OfFlavor(CloudServerFlavorCSO2A4).
 		WithVPC(URI("/vpcs/v")).
-		WithBootVolume(URI("/vols/bv")).
-		WithKeyPair(URI("/kps/kp")).
+		BootingFrom(URI("/vols/bv")).
+		UsingKeyPair(URI("/kps/kp")).
 		WithElasticIP(URI("/eips/eip")).
-		AddSubnet(URI("/subnets/s")).
-		AddSecurityGroup(URI("/sgs/sg")).
+		OnSubnets(URI("/subnets/s")).
+		WithSecurityGroups(URI("/sgs/sg")).
 		WithUserData("dA==")
 
 	req := cs.RawRequest()
@@ -583,14 +583,14 @@ func TestCloudServersClientAdapter_Create_Success(t *testing.T) {
 	})
 
 	cs := NewCloudServer().
-		IntoProject(URI("/projects/p")).
+		InProject(URI("/projects/p")).
 		Named("my-server").
 		InZone(ZoneITBG1).
 		OfFlavor(CloudServerFlavorCSO2A4).
 		WithVPC(URI("/vpcs/v")).
-		WithBootVolume(URI("/vols/bv")).
-		WithKeyPair(URI("/kps/kp")).
-		AddSubnet(URI("/subnets/s"))
+		BootingFrom(URI("/vols/bv")).
+		UsingKeyPair(URI("/kps/kp")).
+		OnSubnets(URI("/subnets/s"))
 
 	result, err := adapter.Create(context.Background(), cs)
 	if err != nil {
@@ -651,7 +651,7 @@ func TestCloudServersClientAdapter_Create_MetadataValidationError(t *testing.T) 
 		fmt.Fprint(w, `{"metadata":{"name":"srv","uri":"/projects/p/providers/Aruba.Compute/cloudServers/x"},"properties":{}}`)
 	})
 
-	cs := NewCloudServer().IntoProject(URI("/projects/p")).
+	cs := NewCloudServer().InProject(URI("/projects/p")).
 		Named("srv").OfFlavor(CloudServerFlavorCSO2A4)
 	result, err := adapter.Create(context.Background(), cs)
 	if err == nil {
@@ -673,7 +673,7 @@ func TestCloudServersClientAdapter_Create_NonTwoXX(t *testing.T) {
 		fmt.Fprint(w, testutil.ErrorBodyJSON("Validation Failed", "zone is required", 422))
 	})
 
-	cs := NewCloudServer().IntoProject(URI("/projects/p")).
+	cs := NewCloudServer().InProject(URI("/projects/p")).
 		Named("srv")
 	result, err := adapter.Create(context.Background(), cs)
 	if err == nil {
@@ -729,7 +729,7 @@ func TestCloudServersClientAdapter_Update_NoID(t *testing.T) {
 		w.WriteHeader(http.StatusOK)
 	})
 
-	cs := NewCloudServer().IntoProject(URI("/projects/p")).
+	cs := NewCloudServer().InProject(URI("/projects/p")).
 		Named("x")
 	_, err := adapter.Update(context.Background(), cs)
 	if err == nil {
@@ -1350,14 +1350,14 @@ func TestCloudServersClientAdapter_Get_InjectsRefresh(t *testing.T) {
 // --------------------------------------------------------------------------
 
 func TestCloudServer_WithBillingPeriod_SetsField(t *testing.T) {
-	cs := NewCloudServer().WithBillingPeriod(BillingPeriodHour)
+	cs := NewCloudServer().BilledHourly()
 	if cs.BillingPeriod() != BillingPeriodHour {
 		t.Errorf("BillingPeriod() = %q, want %q", cs.BillingPeriod(), BillingPeriodHour)
 	}
 }
 
 func TestCloudServer_WithBillingPeriod_InRequest(t *testing.T) {
-	cs := NewCloudServer().WithBillingPeriod(BillingPeriodMonth)
+	cs := NewCloudServer().BilledMonthly()
 	req := cs.RawRequest()
 	if req.Properties.BillingPlan == nil || req.Properties.BillingPlan.BillingPeriod == nil || *req.Properties.BillingPlan.BillingPeriod != BillingPeriodMonth {
 		t.Errorf("request BillingPlan.BillingPeriod = %v, want %q", req.Properties.BillingPlan, BillingPeriodMonth)

--- a/pkg/aruba/resource_container_registry.go
+++ b/pkg/aruba/resource_container_registry.go
@@ -13,7 +13,7 @@ import (
 
 // ContainerRegistry is the wrapper for an Aruba Cloud Container Registry
 // (a direct child of a Project). Construct with aruba.NewContainerRegistry()
-// and bind it via IntoProject(project), WithVPC(vpc), etc.
+// and bind it via InProject(project), WithVPC(vpc), etc.
 //
 // Family A: regional, Metadata/Properties envelope, location-aware.
 // Supports full CRUD including Update (same request shape as Create).
@@ -45,7 +45,7 @@ type ContainerRegistry struct {
 }
 
 // NewContainerRegistry returns a fresh *ContainerRegistry ready for fluent setters and a Create call.
-// Binds projectScopedMixin's error sink so IntoProject failures surface via Err().
+// Binds projectScopedMixin's error sink so InProject failures surface via Err().
 func NewContainerRegistry() *ContainerRegistry {
 	r := &ContainerRegistry{}
 	r.projectScopedMixin = bindProjectScoped(&r.errMixin)
@@ -56,20 +56,30 @@ func NewContainerRegistry() *ContainerRegistry {
 
 // Standard setters.
 
-// IntoProject binds this ContainerRegistry to its parent project. Required before Create.
-func (r *ContainerRegistry) IntoProject(p Ref) *ContainerRegistry { r.intoProject(p); return r }
+// InProject binds this ContainerRegistry to its parent project. Required before Create.
+func (r *ContainerRegistry) InProject(p Ref) *ContainerRegistry { r.intoProject(p); return r }
 
 // Named sets the resource name. Required by the API.
 func (r *ContainerRegistry) Named(n string) *ContainerRegistry { r.named(n); return r }
 
-// AddTag appends a tag for filtering and accounting.
-func (r *ContainerRegistry) AddTag(t string) *ContainerRegistry { r.addTag(t); return r }
+// Tagged appends tags for filtering and accounting. Repeated calls append.
+func (r *ContainerRegistry) Tagged(ts ...string) *ContainerRegistry {
+	for _, t := range ts {
+		r.addTag(t)
+	}
+	return r
+}
 
-// RemoveTag removes a previously-added tag. No-op if absent.
-func (r *ContainerRegistry) RemoveTag(t string) *ContainerRegistry { r.removeTag(t); return r }
+// Untagged removes each listed tag. No-op for tags not present.
+func (r *ContainerRegistry) Untagged(ts ...string) *ContainerRegistry {
+	for _, t := range ts {
+		r.removeTag(t)
+	}
+	return r
+}
 
-// ReplaceTags replaces the entire tag set with the given values.
-func (r *ContainerRegistry) ReplaceTags(ts ...string) *ContainerRegistry {
+// RetaggedAs replaces the entire tag set with the given values.
+func (r *ContainerRegistry) RetaggedAs(ts ...string) *ContainerRegistry {
 	r.replaceTags(ts...)
 	return r
 }
@@ -135,9 +145,24 @@ func (r *ContainerRegistry) OfSize(flavor types.ContainerRegistrySizeFlavor) *Co
 	return r
 }
 
-// WithBillingPeriod sets the billing period. Defaults to hourly when unset.
-func (r *ContainerRegistry) WithBillingPeriod(p BillingPeriod) *ContainerRegistry {
-	r.billingPeriod = &p
+// BilledHourly sets hourly billing.
+func (r *ContainerRegistry) BilledHourly() *ContainerRegistry {
+	v := BillingPeriodHour
+	r.billingPeriod = &v
+	return r
+}
+
+// BilledMonthly sets monthly billing.
+func (r *ContainerRegistry) BilledMonthly() *ContainerRegistry {
+	v := BillingPeriodMonth
+	r.billingPeriod = &v
+	return r
+}
+
+// BilledYearly sets yearly billing.
+func (r *ContainerRegistry) BilledYearly() *ContainerRegistry {
+	v := BillingPeriodYear
+	r.billingPeriod = &v
 	return r
 }
 
@@ -387,7 +412,7 @@ func (a *containerRegistriesClientAdapter) Create(ctx context.Context, r *Contai
 		return r, err
 	}
 	if r.ProjectID() == "" {
-		return r, fmt.Errorf("Create: ContainerRegistry has no parent project — call IntoProject first")
+		return r, fmt.Errorf("Create: ContainerRegistry has no parent project — call InProject first")
 	}
 	co := applyCallOptions(opts)
 	rp := co.toRequestParameters()
@@ -424,7 +449,7 @@ func (a *containerRegistriesClientAdapter) Update(ctx context.Context, r *Contai
 		return r, fmt.Errorf("Update: ContainerRegistry has no ID")
 	}
 	if r.ProjectID() == "" {
-		return r, fmt.Errorf("Update: ContainerRegistry has no parent project — call IntoProject first")
+		return r, fmt.Errorf("Update: ContainerRegistry has no parent project — call InProject first")
 	}
 	co := applyCallOptions(opts)
 	rp := co.toRequestParameters()

--- a/pkg/aruba/resource_container_registry.go
+++ b/pkg/aruba/resource_container_registry.go
@@ -145,24 +145,9 @@ func (r *ContainerRegistry) OfSize(flavor types.ContainerRegistrySizeFlavor) *Co
 	return r
 }
 
-// BilledHourly sets hourly billing.
-func (r *ContainerRegistry) BilledHourly() *ContainerRegistry {
-	v := BillingPeriodHour
-	r.billingPeriod = &v
-	return r
-}
-
-// BilledMonthly sets monthly billing.
-func (r *ContainerRegistry) BilledMonthly() *ContainerRegistry {
-	v := BillingPeriodMonth
-	r.billingPeriod = &v
-	return r
-}
-
-// BilledYearly sets yearly billing.
-func (r *ContainerRegistry) BilledYearly() *ContainerRegistry {
-	v := BillingPeriodYear
-	r.billingPeriod = &v
+// BilledBy sets the billing cadence. Accepted periods are resource-specific; check the API reference.
+func (r *ContainerRegistry) BilledBy(period BillingPeriod) *ContainerRegistry {
+	r.billingPeriod = &period
 	return r
 }
 

--- a/pkg/aruba/resource_container_registry_test.go
+++ b/pkg/aruba/resource_container_registry_test.go
@@ -37,11 +37,11 @@ func TestContainerRegistry_FluentSetters(t *testing.T) {
 	bsURI := URI("/projects/p-1/providers/Aruba.Storage/blockStorages/bs-1")
 
 	cr := NewContainerRegistry().
-		IntoProject(proj).
+		InProject(proj).
 		Named("my-registry").
-		AddTag("env:prod").
-		AddTag("registry").
-		AddTag("env:prod"). // dedupe
+		Tagged("env:prod").
+		Tagged("registry").
+		Tagged("env:prod"). // dedupe
 		InRegion(RegionITBGBergamo).
 		WithVPC(vpcURI).
 		WithSubnet(subnetURI).
@@ -50,7 +50,7 @@ func TestContainerRegistry_FluentSetters(t *testing.T) {
 		WithBlockStorage(bsURI).
 		WithAdminUsername("admin").
 		OfSize(ContainerRegistrySizeFlavorSmall).
-		WithBillingPeriod(BillingPeriodHour)
+		BilledHourly()
 
 	if cr.Name() != "my-registry" {
 		t.Errorf("Name() = %q", cr.Name())
@@ -92,12 +92,12 @@ func TestContainerRegistry_FluentSetters(t *testing.T) {
 		t.Errorf("Err() = %v", cr.Err())
 	}
 
-	cr.RemoveTag("env:prod")
+	cr.Untagged("env:prod")
 	if tags := cr.Tags(); len(tags) != 1 || tags[0] != "registry" {
 		t.Errorf("after RemoveTag Tags() = %v", tags)
 	}
 
-	cr.ReplaceTags("x", "y")
+	cr.RetaggedAs("x", "y")
 	if tags := cr.Tags(); len(tags) != 2 || tags[0] != "x" || tags[1] != "y" {
 		t.Errorf("after ReplaceTags Tags() = %v", tags)
 	}
@@ -110,7 +110,7 @@ func TestContainerRegistry_FluentSetters(t *testing.T) {
 func TestContainerRegistry_IntoProject_TypedRef(t *testing.T) {
 	proj := &Project{}
 	proj.fromResponse(projectTestResponse("p-42", "n", "/projects/p-42"))
-	cr := NewContainerRegistry().IntoProject(proj)
+	cr := NewContainerRegistry().InProject(proj)
 	if cr.ProjectID() != "p-42" {
 		t.Errorf("ProjectID() = %q", cr.ProjectID())
 	}
@@ -120,7 +120,7 @@ func TestContainerRegistry_IntoProject_TypedRef(t *testing.T) {
 }
 
 func TestContainerRegistry_IntoProject_URIRef(t *testing.T) {
-	cr := NewContainerRegistry().IntoProject(URI("/projects/p-uri"))
+	cr := NewContainerRegistry().InProject(URI("/projects/p-uri"))
 	if cr.ProjectID() != "p-uri" {
 		t.Errorf("ProjectID() = %q", cr.ProjectID())
 	}
@@ -130,7 +130,7 @@ func TestContainerRegistry_IntoProject_URIRef(t *testing.T) {
 }
 
 func TestContainerRegistry_IntoProject_BadRef(t *testing.T) {
-	cr := NewContainerRegistry().IntoProject(URI("/garbage"))
+	cr := NewContainerRegistry().InProject(URI("/garbage"))
 	if cr.Err() == nil {
 		t.Error("expected Err() != nil for unresolvable Ref")
 	}
@@ -330,7 +330,7 @@ func TestContainerRegistry_OfSize(t *testing.T) {
 }
 
 func TestContainerRegistry_WithBillingPeriod(t *testing.T) {
-	cr := NewContainerRegistry().WithBillingPeriod(BillingPeriodHour)
+	cr := NewContainerRegistry().BilledHourly()
 	if cr.BillingPeriod() != BillingPeriodHour {
 		t.Errorf("BillingPeriod() = %q", cr.BillingPeriod())
 	}
@@ -349,7 +349,7 @@ func TestContainerRegistry_ToRequest(t *testing.T) {
 
 	cr := NewContainerRegistry().Named(
 		"reg-rt").
-		AddTag("t1").AddTag("t2").
+		Tagged("t1").Tagged("t2").
 		InRegion(RegionITBGBergamo).
 		WithVPC(URI(vpcURI)).
 		WithSubnet(URI(subnetURI)).
@@ -358,7 +358,7 @@ func TestContainerRegistry_ToRequest(t *testing.T) {
 		WithBlockStorage(URI(bsURI)).
 		WithAdminUsername("admin").
 		OfSize(ContainerRegistrySizeFlavorHighPerf).
-		WithBillingPeriod(BillingPeriodHour)
+		BilledHourly()
 
 	req := cr.RawRequest()
 
@@ -652,7 +652,7 @@ func TestContainerRegistriesClientAdapter_Create_Success(t *testing.T) {
 	})
 
 	cr := NewContainerRegistry().
-		IntoProject(URI("/projects/p")).
+		InProject(URI("/projects/p")).
 		Named("my-registry").
 		InRegion(RegionITBGBergamo).
 		WithVPC(URI("/projects/p/providers/Aruba.Network/vpcs/vpc-1")).
@@ -662,7 +662,7 @@ func TestContainerRegistriesClientAdapter_Create_Success(t *testing.T) {
 		WithBlockStorage(URI("/projects/p/providers/Aruba.Storage/blockStorages/bs-1")).
 		WithAdminUsername("admin").
 		OfSize(ContainerRegistrySizeFlavorSmall).
-		WithBillingPeriod(BillingPeriodHour)
+		BilledHourly()
 
 	result, err := adapter.Create(context.Background(), cr)
 	if err != nil {
@@ -714,7 +714,7 @@ func TestContainerRegistriesClientAdapter_Create_MetadataValidationError(t *test
 		fmt.Fprint(w, `{"metadata":{"name":"reg","uri":"/projects/p/providers/Aruba.Container/registries/x"},"properties":{},"status":{}}`)
 	})
 
-	cr := NewContainerRegistry().IntoProject(URI("/projects/p")).
+	cr := NewContainerRegistry().InProject(URI("/projects/p")).
 		Named("reg")
 	result, err := adapter.Create(context.Background(), cr)
 	if err == nil {
@@ -736,7 +736,7 @@ func TestContainerRegistriesClientAdapter_Create_NonTwoXX(t *testing.T) {
 		fmt.Fprint(w, testutil.ErrorBodyJSON("Validation Failed", "name is required", 422))
 	})
 
-	cr := NewContainerRegistry().IntoProject(URI("/projects/p"))
+	cr := NewContainerRegistry().InProject(URI("/projects/p"))
 	result, err := adapter.Create(context.Background(), cr)
 	if err == nil {
 		t.Fatal("expected error on 422")
@@ -774,7 +774,7 @@ func TestContainerRegistriesClientAdapter_Create_WithBodyRefs_ViaFake(t *testing
 	adapter := &containerRegistriesClientAdapter{low: fake}
 
 	cr := NewContainerRegistry().
-		IntoProject(URI("/projects/p")).
+		InProject(URI("/projects/p")).
 		InRegion(RegionITBGBergamo).
 		WithVPC(URI(vpcURI)).
 		WithSubnet(URI(subnetURI)).
@@ -829,7 +829,7 @@ func TestContainerRegistriesClientAdapter_Update_Success(t *testing.T) {
 	})
 
 	cr := NewContainerRegistry().
-		IntoProject(URI("/projects/p")).
+		InProject(URI("/projects/p")).
 		Named("my-registry").
 		InRegion(RegionITBGBergamo).
 		WithVPC(URI("/projects/p/providers/Aruba.Network/vpcs/vpc-1"))
@@ -856,7 +856,7 @@ func TestContainerRegistriesClientAdapter_Update_NoID(t *testing.T) {
 		w.WriteHeader(http.StatusOK)
 	})
 
-	cr := NewContainerRegistry().IntoProject(URI("/projects/p")).
+	cr := NewContainerRegistry().InProject(URI("/projects/p")).
 		Named("x")
 	_, err := adapter.Update(context.Background(), cr)
 	if err == nil {

--- a/pkg/aruba/resource_container_registry_test.go
+++ b/pkg/aruba/resource_container_registry_test.go
@@ -50,7 +50,7 @@ func TestContainerRegistry_FluentSetters(t *testing.T) {
 		WithBlockStorage(bsURI).
 		WithAdminUsername("admin").
 		OfSize(ContainerRegistrySizeFlavorSmall).
-		BilledHourly()
+		BilledBy(BillingPeriodHour)
 
 	if cr.Name() != "my-registry" {
 		t.Errorf("Name() = %q", cr.Name())
@@ -330,7 +330,7 @@ func TestContainerRegistry_OfSize(t *testing.T) {
 }
 
 func TestContainerRegistry_WithBillingPeriod(t *testing.T) {
-	cr := NewContainerRegistry().BilledHourly()
+	cr := NewContainerRegistry().BilledBy(BillingPeriodHour)
 	if cr.BillingPeriod() != BillingPeriodHour {
 		t.Errorf("BillingPeriod() = %q", cr.BillingPeriod())
 	}
@@ -358,7 +358,7 @@ func TestContainerRegistry_ToRequest(t *testing.T) {
 		WithBlockStorage(URI(bsURI)).
 		WithAdminUsername("admin").
 		OfSize(ContainerRegistrySizeFlavorHighPerf).
-		BilledHourly()
+		BilledBy(BillingPeriodHour)
 
 	req := cr.RawRequest()
 
@@ -662,7 +662,7 @@ func TestContainerRegistriesClientAdapter_Create_Success(t *testing.T) {
 		WithBlockStorage(URI("/projects/p/providers/Aruba.Storage/blockStorages/bs-1")).
 		WithAdminUsername("admin").
 		OfSize(ContainerRegistrySizeFlavorSmall).
-		BilledHourly()
+		BilledBy(BillingPeriodHour)
 
 	result, err := adapter.Create(context.Background(), cr)
 	if err != nil {

--- a/pkg/aruba/resource_database.go
+++ b/pkg/aruba/resource_database.go
@@ -13,7 +13,7 @@ import (
 // ---- Wrapper ----
 
 // Database is the wrapper for an Aruba Cloud database (a child of a DBaaS
-// instance). Construct with aruba.NewDatabase() and bind via IntoDBaaS(parent).
+// instance). Construct with aruba.NewDatabase() and bind via InDBaaS(parent).
 //
 // Family B: flat request (no Metadata/Properties boxing, no metadataMixin,
 // no tags, no location).
@@ -33,7 +33,7 @@ type Database struct {
 }
 
 // NewDatabase returns a fresh *Database ready for fluent setters and a Create call.
-// Binds dbaasScopedMixin's error sink so IntoDBaaS failures surface via Err().
+// Binds dbaasScopedMixin's error sink so InDBaaS failures surface via Err().
 func NewDatabase() *Database {
 	d := &Database{}
 	d.dbaasScopedMixin = bindDBaaSScoped(&d.errMixin)
@@ -42,8 +42,8 @@ func NewDatabase() *Database {
 
 // Setters — chainable, general → specific
 
-// IntoDBaaS binds this Database to its parent DBaaS instance. Required before Create.
-func (d *Database) IntoDBaaS(parent Ref) *Database { d.intoDBaaS(parent); return d }
+// InDBaaS binds this Database to its parent DBaaS instance. Required before Create.
+func (d *Database) InDBaaS(parent Ref) *Database { d.intoDBaaS(parent); return d }
 
 // Named sets the resource name. Required by the API.
 func (d *Database) Named(name string) *Database { d.name = &name; return d }
@@ -167,10 +167,10 @@ func (a *databasesClientAdapter) Create(ctx context.Context, db *Database, opts 
 		return db, err
 	}
 	if db.ProjectID() == "" {
-		return db, fmt.Errorf("Create: Database has no parent project — call IntoDBaaS first")
+		return db, fmt.Errorf("Create: Database has no parent project — call InDBaaS first")
 	}
 	if db.DBaaSID() == "" {
-		return db, fmt.Errorf("Create: Database has no parent DBaaS — call IntoDBaaS first")
+		return db, fmt.Errorf("Create: Database has no parent DBaaS — call InDBaaS first")
 	}
 	if db.Name() == "" {
 		return db, fmt.Errorf("Create: Database has no name — call Named first")
@@ -210,10 +210,10 @@ func (a *databasesClientAdapter) Update(ctx context.Context, db *Database, opts 
 		return db, fmt.Errorf("Update: Database has no ID — call Named first")
 	}
 	if db.DBaaSID() == "" {
-		return db, fmt.Errorf("Update: Database has no parent DBaaS — call IntoDBaaS first")
+		return db, fmt.Errorf("Update: Database has no parent DBaaS — call InDBaaS first")
 	}
 	if db.ProjectID() == "" {
-		return db, fmt.Errorf("Update: Database has no parent project — call IntoDBaaS first")
+		return db, fmt.Errorf("Update: Database has no parent project — call InDBaaS first")
 	}
 	co := applyCallOptions(opts)
 	rp := co.toRequestParameters()

--- a/pkg/aruba/resource_database_test.go
+++ b/pkg/aruba/resource_database_test.go
@@ -29,7 +29,7 @@ var (
 
 func TestDatabase_FluentSetters(t *testing.T) {
 	db := NewDatabase().
-		IntoDBaaS(URI("/projects/p-1/providers/Aruba.Database/dbaas/d-1")).
+		InDBaaS(URI("/projects/p-1/providers/Aruba.Database/dbaas/d-1")).
 		Named("mydb")
 
 	if db.Name() != "mydb" {
@@ -60,7 +60,7 @@ func TestDatabase_IntoDBaaS_TypedRef(t *testing.T) {
 	dbaas := &DBaaS{}
 	dbaas.fromResponse(dbaasTestResponse("d-1", "my-dbaas", "/projects/p-1/providers/Aruba.Database/dbaas/d-1"))
 
-	db := NewDatabase().IntoDBaaS(dbaas)
+	db := NewDatabase().InDBaaS(dbaas)
 	if db.DBaaSID() != "d-1" {
 		t.Errorf("DBaaSID() = %q", db.DBaaSID())
 	}
@@ -73,7 +73,7 @@ func TestDatabase_IntoDBaaS_TypedRef(t *testing.T) {
 }
 
 func TestDatabase_IntoDBaaS_URIRef(t *testing.T) {
-	db := NewDatabase().IntoDBaaS(URI("/projects/p-uri/providers/Aruba.Database/dbaas/d-uri"))
+	db := NewDatabase().InDBaaS(URI("/projects/p-uri/providers/Aruba.Database/dbaas/d-uri"))
 	if db.DBaaSID() != "d-uri" {
 		t.Errorf("DBaaSID() = %q", db.DBaaSID())
 	}
@@ -86,7 +86,7 @@ func TestDatabase_IntoDBaaS_URIRef(t *testing.T) {
 }
 
 func TestDatabase_IntoDBaaS_BadRef(t *testing.T) {
-	db := NewDatabase().IntoDBaaS(URI("/something/garbage"))
+	db := NewDatabase().InDBaaS(URI("/something/garbage"))
 	if db.Err() == nil {
 		t.Error("expected Err() to be set for unresolvable parent")
 	}
@@ -98,7 +98,7 @@ func TestDatabase_IntoDBaaS_BadRef(t *testing.T) {
 
 func TestDatabase_URI_Constructed(t *testing.T) {
 	db := NewDatabase().
-		IntoDBaaS(URI("/projects/p-1/providers/Aruba.Database/dbaas/d-1")).
+		InDBaaS(URI("/projects/p-1/providers/Aruba.Database/dbaas/d-1")).
 		Named("mydb")
 
 	want := "/projects/p-1/providers/Aruba.Database/dbaas/d-1/databases/mydb"
@@ -216,7 +216,7 @@ func TestDatabase_FromResponse_NilSafe(t *testing.T) {
 
 func TestDatabaseIDsFromRef_TypedRef(t *testing.T) {
 	db := NewDatabase().
-		IntoDBaaS(URI("/projects/p/providers/Aruba.Database/dbaas/d-1")).
+		InDBaaS(URI("/projects/p/providers/Aruba.Database/dbaas/d-1")).
 		Named("mydb")
 
 	pid, did, name, err := databaseIDsFromRef(db)
@@ -292,7 +292,7 @@ func TestDatabasesClientAdapter_Create_Success(t *testing.T) {
 	})
 
 	db := NewDatabase().
-		IntoDBaaS(URI("/projects/p/providers/Aruba.Database/dbaas/d-1")).
+		InDBaaS(URI("/projects/p/providers/Aruba.Database/dbaas/d-1")).
 		Named("my-db")
 
 	result, err := adapter.Create(context.Background(), db)
@@ -333,7 +333,7 @@ func TestDatabasesClientAdapter_Create_NoName(t *testing.T) {
 	adapter := buildDatabaseTestAdapter(t, func(w http.ResponseWriter, r *http.Request) {
 		callCount++
 	})
-	db := NewDatabase().IntoDBaaS(URI("/projects/p/providers/Aruba.Database/dbaas/d-1")) // no Named
+	db := NewDatabase().InDBaaS(URI("/projects/p/providers/Aruba.Database/dbaas/d-1")) // no Named
 	_, err := adapter.Create(context.Background(), db)
 	if err == nil {
 		t.Error("expected error when name is missing")
@@ -351,7 +351,7 @@ func TestDatabasesClientAdapter_Create_NonTwoXX(t *testing.T) {
 	})
 
 	db := NewDatabase().
-		IntoDBaaS(URI("/projects/p/providers/Aruba.Database/dbaas/d-1")).
+		InDBaaS(URI("/projects/p/providers/Aruba.Database/dbaas/d-1")).
 		Named("my-db")
 
 	_, err := adapter.Create(context.Background(), db)
@@ -379,7 +379,7 @@ func TestDatabasesClientAdapter_Update_Success(t *testing.T) {
 	})
 
 	db := NewDatabase().
-		IntoDBaaS(URI("/projects/p/providers/Aruba.Database/dbaas/d-1")).
+		InDBaaS(URI("/projects/p/providers/Aruba.Database/dbaas/d-1")).
 		Named("my-db")
 
 	result, err := adapter.Update(context.Background(), db)
@@ -443,7 +443,7 @@ func TestDatabasesClientAdapter_Get_TypedRef(t *testing.T) {
 	})
 
 	db := NewDatabase().
-		IntoDBaaS(URI("/projects/p/providers/Aruba.Database/dbaas/d-1")).
+		InDBaaS(URI("/projects/p/providers/Aruba.Database/dbaas/d-1")).
 		Named("my-db")
 
 	result, err := adapter.Get(context.Background(), db)
@@ -568,7 +568,7 @@ func TestDatabasesClientAdapter_Update_NonTwoXX(t *testing.T) {
 		fmt.Fprint(w, `{"title":"Conflict","detail":"concurrent update"}`)
 	})
 	db := NewDatabase().
-		IntoDBaaS(URI("/projects/p/providers/Aruba.Database/dbaas/d-1")).
+		InDBaaS(URI("/projects/p/providers/Aruba.Database/dbaas/d-1")).
 		Named("my-db")
 
 	_, err := adapter.Update(context.Background(), db)
@@ -663,7 +663,7 @@ func TestDatabasesClientAdapter_Create_ErrMixin(t *testing.T) {
 		callCount++
 	})
 	// IntoDBaaS with bad URI sets errMixin
-	db := NewDatabase().IntoDBaaS(URI("/garbage")).
+	db := NewDatabase().InDBaaS(URI("/garbage")).
 		Named("mydb")
 	_, err := adapter.Create(context.Background(), db)
 	if err == nil {
@@ -681,7 +681,7 @@ func TestDatabasesClientAdapter_Create_ErrMixin(t *testing.T) {
 func TestDatabasesClientAdapter_Update_BrokenClient(t *testing.T) {
 	adapter := &databasesClientAdapter{low: database.NewDatabasesClientImpl(testutil.NewBrokenClient(t, "http://localhost:9"))}
 	db := NewDatabase().
-		IntoDBaaS(URI("/projects/p/providers/Aruba.Database/dbaas/d-1")).
+		InDBaaS(URI("/projects/p/providers/Aruba.Database/dbaas/d-1")).
 		Named("my-db")
 
 	_, err := adapter.Update(context.Background(), db)

--- a/pkg/aruba/resource_dbaas.go
+++ b/pkg/aruba/resource_dbaas.go
@@ -136,14 +136,8 @@ func (d *DBaaS) WithoutAutoscaling() *DBaaS {
 	return d
 }
 
-// BilledHourly sets hourly billing.
-func (d *DBaaS) BilledHourly() *DBaaS { v := BillingPeriodHour; d.billingPeriod = &v; return d }
-
-// BilledMonthly sets monthly billing.
-func (d *DBaaS) BilledMonthly() *DBaaS { v := BillingPeriodMonth; d.billingPeriod = &v; return d }
-
-// BilledYearly sets yearly billing.
-func (d *DBaaS) BilledYearly() *DBaaS { v := BillingPeriodYear; d.billingPeriod = &v; return d }
+// BilledBy sets the billing cadence. Accepted periods are resource-specific; check the API reference.
+func (d *DBaaS) BilledBy(period BillingPeriod) *DBaaS { d.billingPeriod = &period; return d }
 
 // WithVPC sets the VPC for this DBaaS via its URI. Wire field: VPCURI.
 func (d *DBaaS) WithVPC(v Ref) *DBaaS { return d.setSingleRef("WithVPC", v, &d.vpcRef) }

--- a/pkg/aruba/resource_dbaas.go
+++ b/pkg/aruba/resource_dbaas.go
@@ -75,20 +75,30 @@ func NewDBaaS() *DBaaS {
 
 // Setters — chainable, general → specific
 
-// IntoProject binds this DBaaS to its parent project. Required before Create.
-func (d *DBaaS) IntoProject(p Ref) *DBaaS { d.intoProject(p); return d }
+// InProject binds this DBaaS to its parent project. Required before Create.
+func (d *DBaaS) InProject(p Ref) *DBaaS { d.intoProject(p); return d }
 
 // Named sets the resource name. Required by the API.
 func (d *DBaaS) Named(n string) *DBaaS { d.named(n); return d }
 
-// AddTag appends a tag for filtering and accounting.
-func (d *DBaaS) AddTag(t string) *DBaaS { d.addTag(t); return d }
+// Tagged appends tags for filtering and accounting. Repeated calls append.
+func (d *DBaaS) Tagged(ts ...string) *DBaaS {
+	for _, t := range ts {
+		d.addTag(t)
+	}
+	return d
+}
 
-// RemoveTag removes a previously-added tag. No-op if absent.
-func (d *DBaaS) RemoveTag(t string) *DBaaS { d.removeTag(t); return d }
+// Untagged removes each listed tag. No-op for tags not present.
+func (d *DBaaS) Untagged(ts ...string) *DBaaS {
+	for _, t := range ts {
+		d.removeTag(t)
+	}
+	return d
+}
 
-// ReplaceTags replaces the entire tag set with the given values.
-func (d *DBaaS) ReplaceTags(ts ...string) *DBaaS { d.replaceTags(ts...); return d }
+// RetaggedAs replaces the entire tag set with the given values.
+func (d *DBaaS) RetaggedAs(ts ...string) *DBaaS { d.replaceTags(ts...); return d }
 
 // InRegion sets the region for this resource.
 func (d *DBaaS) InRegion(region Region) *DBaaS { d.inRegion(region); return d }
@@ -102,8 +112,8 @@ func (d *DBaaS) OfEngine(engine DatabaseEngine) *DBaaS { d.engine = &engine; ret
 // OfFlavor sets the database flavor (size/performance tier). The wire request emits Flavor.Name.
 func (d *DBaaS) OfFlavor(flavor DBaaSFlavor) *DBaaS { d.flavor = &flavor; return d }
 
-// WithSizeGB sets the storage size in GB. The wire request emits Storage.SizeGB.
-func (d *DBaaS) WithSizeGB(gb int) *DBaaS { v := int32(gb); d.sizeGB = &v; return d }
+// SizedGB sets the storage size in GB. The wire request emits Storage.SizeGB.
+func (d *DBaaS) SizedGB(gb int) *DBaaS { v := int32(gb); d.sizeGB = &v; return d }
 
 // WithAutoscaling enables autoscaling and pins the available-space threshold and
 // step size in GB. Mirrors NodePool.WithAutoscaling(min, max) from resource_kaas_nodepool.go.
@@ -126,8 +136,14 @@ func (d *DBaaS) WithoutAutoscaling() *DBaaS {
 	return d
 }
 
-// WithBillingPeriod sets the billing period. Defaults to hourly when unset.
-func (d *DBaaS) WithBillingPeriod(period BillingPeriod) *DBaaS { d.billingPeriod = &period; return d }
+// BilledHourly sets hourly billing.
+func (d *DBaaS) BilledHourly() *DBaaS { v := BillingPeriodHour; d.billingPeriod = &v; return d }
+
+// BilledMonthly sets monthly billing.
+func (d *DBaaS) BilledMonthly() *DBaaS { v := BillingPeriodMonth; d.billingPeriod = &v; return d }
+
+// BilledYearly sets yearly billing.
+func (d *DBaaS) BilledYearly() *DBaaS { v := BillingPeriodYear; d.billingPeriod = &v; return d }
 
 // WithVPC sets the VPC for this DBaaS via its URI. Wire field: VPCURI.
 func (d *DBaaS) WithVPC(v Ref) *DBaaS { return d.setSingleRef("WithVPC", v, &d.vpcRef) }
@@ -525,7 +541,7 @@ func (a *dbaasClientAdapter) Create(ctx context.Context, d *DBaaS, opts ...CallO
 		return d, err
 	}
 	if d.ProjectID() == "" {
-		return d, fmt.Errorf("Create: DBaaS has no parent project — call IntoProject first")
+		return d, fmt.Errorf("Create: DBaaS has no parent project — call InProject first")
 	}
 	co := applyCallOptions(opts)
 	rp := co.toRequestParameters()
@@ -562,7 +578,7 @@ func (a *dbaasClientAdapter) Update(ctx context.Context, d *DBaaS, opts ...CallO
 		return d, fmt.Errorf("Update: DBaaS has no ID")
 	}
 	if d.ProjectID() == "" {
-		return d, fmt.Errorf("Update: DBaaS has no parent project — call IntoProject first")
+		return d, fmt.Errorf("Update: DBaaS has no parent project — call InProject first")
 	}
 	co := applyCallOptions(opts)
 	rp := co.toRequestParameters()

--- a/pkg/aruba/resource_dbaas_backup.go
+++ b/pkg/aruba/resource_dbaas_backup.go
@@ -13,7 +13,7 @@ import (
 
 // DBaaSBackup is the wrapper for an Aruba Cloud DBaaS Backup (a direct child
 // of a Project; the source DBaaS and Database are body-refs, not path-parents).
-// Construct with aruba.NewDBaaSBackup() and bind it via IntoProject(project),
+// Construct with aruba.NewDBaaSBackup() and bind it via InProject(project),
 // FromDBaaS(d), and FromDatabase(db).
 //
 // Family A: regional, Metadata/Properties envelope, location-aware. No Update
@@ -48,20 +48,30 @@ func NewDBaaSBackup() *DBaaSBackup {
 
 // Setters — chainable, general → specific
 
-// IntoProject binds this DBaaSBackup to its parent project. Required before Create.
-func (b *DBaaSBackup) IntoProject(p Ref) *DBaaSBackup { b.intoProject(p); return b }
+// InProject binds this DBaaSBackup to its parent project. Required before Create.
+func (b *DBaaSBackup) InProject(p Ref) *DBaaSBackup { b.intoProject(p); return b }
 
 // Named sets the resource name. Required by the API.
 func (b *DBaaSBackup) Named(n string) *DBaaSBackup { b.named(n); return b }
 
-// AddTag appends a tag for filtering and accounting.
-func (b *DBaaSBackup) AddTag(t string) *DBaaSBackup { b.addTag(t); return b }
+// Tagged appends tags for filtering and accounting. Repeated calls append.
+func (b *DBaaSBackup) Tagged(ts ...string) *DBaaSBackup {
+	for _, t := range ts {
+		b.addTag(t)
+	}
+	return b
+}
 
-// RemoveTag removes a previously-added tag. No-op if absent.
-func (b *DBaaSBackup) RemoveTag(t string) *DBaaSBackup { b.removeTag(t); return b }
+// Untagged removes each listed tag. No-op for tags not present.
+func (b *DBaaSBackup) Untagged(ts ...string) *DBaaSBackup {
+	for _, t := range ts {
+		b.removeTag(t)
+	}
+	return b
+}
 
-// ReplaceTags replaces the entire tag set with the given values.
-func (b *DBaaSBackup) ReplaceTags(ts ...string) *DBaaSBackup { b.replaceTags(ts...); return b }
+// RetaggedAs replaces the entire tag set with the given values.
+func (b *DBaaSBackup) RetaggedAs(ts ...string) *DBaaSBackup { b.replaceTags(ts...); return b }
 
 // InRegion sets the region for this resource.
 func (b *DBaaSBackup) InRegion(region Region) *DBaaSBackup { b.inRegion(region); return b }
@@ -94,9 +104,24 @@ func (b *DBaaSBackup) FromDatabase(db Ref) *DBaaSBackup {
 	return b
 }
 
-// WithBillingPeriod sets the billing period. Defaults to hourly when unset.
-func (b *DBaaSBackup) WithBillingPeriod(p BillingPeriod) *DBaaSBackup {
-	b.billingPeriod = &p
+// BilledHourly sets hourly billing.
+func (b *DBaaSBackup) BilledHourly() *DBaaSBackup {
+	v := BillingPeriodHour
+	b.billingPeriod = &v
+	return b
+}
+
+// BilledMonthly sets monthly billing.
+func (b *DBaaSBackup) BilledMonthly() *DBaaSBackup {
+	v := BillingPeriodMonth
+	b.billingPeriod = &v
+	return b
+}
+
+// BilledYearly sets yearly billing.
+func (b *DBaaSBackup) BilledYearly() *DBaaSBackup {
+	v := BillingPeriodYear
+	b.billingPeriod = &v
 	return b
 }
 
@@ -283,7 +308,7 @@ func (a *dbaasBackupsClientAdapter) Create(ctx context.Context, b *DBaaSBackup, 
 		return b, err
 	}
 	if b.ProjectID() == "" {
-		return b, fmt.Errorf("Create: DBaaSBackup has no parent project — call IntoProject first")
+		return b, fmt.Errorf("Create: DBaaSBackup has no parent project — call InProject first")
 	}
 	co := applyCallOptions(opts)
 	rp := co.toRequestParameters()

--- a/pkg/aruba/resource_dbaas_backup.go
+++ b/pkg/aruba/resource_dbaas_backup.go
@@ -104,24 +104,9 @@ func (b *DBaaSBackup) FromDatabase(db Ref) *DBaaSBackup {
 	return b
 }
 
-// BilledHourly sets hourly billing.
-func (b *DBaaSBackup) BilledHourly() *DBaaSBackup {
-	v := BillingPeriodHour
-	b.billingPeriod = &v
-	return b
-}
-
-// BilledMonthly sets monthly billing.
-func (b *DBaaSBackup) BilledMonthly() *DBaaSBackup {
-	v := BillingPeriodMonth
-	b.billingPeriod = &v
-	return b
-}
-
-// BilledYearly sets yearly billing.
-func (b *DBaaSBackup) BilledYearly() *DBaaSBackup {
-	v := BillingPeriodYear
-	b.billingPeriod = &v
+// BilledBy sets the billing cadence. Accepted periods are resource-specific; check the API reference.
+func (b *DBaaSBackup) BilledBy(period BillingPeriod) *DBaaSBackup {
+	b.billingPeriod = &period
 	return b
 }
 

--- a/pkg/aruba/resource_dbaas_backup_test.go
+++ b/pkg/aruba/resource_dbaas_backup_test.go
@@ -36,15 +36,15 @@ func TestDBaaSBackup_FluentSetters(t *testing.T) {
 	dbURI := URI("/projects/p-1/providers/Aruba.Database/dbaas/d-1/databases/mydb")
 
 	bkp := NewDBaaSBackup().
-		IntoProject(proj).
+		InProject(proj).
 		Named("my-dbaas-backup").
-		AddTag("backup").
-		AddTag("dbaas").
-		AddTag("backup"). // dedupe
+		Tagged("backup").
+		Tagged("dbaas").
+		Tagged("backup"). // dedupe
 		InRegion(RegionITBGBergamo).
 		FromDBaaS(dbaasURI).
 		FromDatabase(dbURI).
-		WithBillingPeriod(BillingPeriodHour)
+		BilledHourly()
 
 	if bkp.Name() != "my-dbaas-backup" {
 		t.Errorf("Name() = %q", bkp.Name())
@@ -71,12 +71,12 @@ func TestDBaaSBackup_FluentSetters(t *testing.T) {
 		t.Errorf("Err() = %v", bkp.Err())
 	}
 
-	bkp.RemoveTag("backup")
+	bkp.Untagged("backup")
 	if tags := bkp.Tags(); len(tags) != 1 || tags[0] != "dbaas" {
 		t.Errorf("after RemoveTag Tags() = %v", tags)
 	}
 
-	bkp.ReplaceTags("x", "y")
+	bkp.RetaggedAs("x", "y")
 	if tags := bkp.Tags(); len(tags) != 2 || tags[0] != "x" || tags[1] != "y" {
 		t.Errorf("after ReplaceTags Tags() = %v", tags)
 	}
@@ -89,7 +89,7 @@ func TestDBaaSBackup_FluentSetters(t *testing.T) {
 func TestDBaaSBackup_IntoProject_TypedRef(t *testing.T) {
 	proj := &Project{}
 	proj.fromResponse(projectTestResponse("p-42", "n", "/projects/p-42"))
-	bkp := NewDBaaSBackup().IntoProject(proj)
+	bkp := NewDBaaSBackup().InProject(proj)
 	if bkp.ProjectID() != "p-42" {
 		t.Errorf("ProjectID() = %q", bkp.ProjectID())
 	}
@@ -99,7 +99,7 @@ func TestDBaaSBackup_IntoProject_TypedRef(t *testing.T) {
 }
 
 func TestDBaaSBackup_IntoProject_URIRef(t *testing.T) {
-	bkp := NewDBaaSBackup().IntoProject(URI("/projects/p-uri"))
+	bkp := NewDBaaSBackup().InProject(URI("/projects/p-uri"))
 	if bkp.ProjectID() != "p-uri" {
 		t.Errorf("ProjectID() = %q", bkp.ProjectID())
 	}
@@ -109,7 +109,7 @@ func TestDBaaSBackup_IntoProject_URIRef(t *testing.T) {
 }
 
 func TestDBaaSBackup_IntoProject_BadRef(t *testing.T) {
-	bkp := NewDBaaSBackup().IntoProject(URI("/garbage"))
+	bkp := NewDBaaSBackup().InProject(URI("/garbage"))
 	if bkp.Err() == nil {
 		t.Error("expected Err() != nil for unresolvable Ref")
 	}
@@ -201,11 +201,11 @@ func TestDBaaSBackup_ToRequest(t *testing.T) {
 
 	bkp := NewDBaaSBackup().Named(
 		"bkp-rt").
-		AddTag("t1").AddTag("t2").
+		Tagged("t1").Tagged("t2").
 		InRegion(RegionITBGBergamo).
 		FromDBaaS(URI(dbaasURI)).
 		FromDatabase(URI(dbURI)).
-		WithBillingPeriod(BillingPeriodHour)
+		BilledHourly()
 
 	req := bkp.RawRequest()
 
@@ -471,12 +471,12 @@ func TestDBaaSBackupsClientAdapter_Create_Success(t *testing.T) {
 	})
 
 	bkp := NewDBaaSBackup().
-		IntoProject(URI("/projects/p")).
+		InProject(URI("/projects/p")).
 		Named("my-backup").
 		InRegion(RegionITBGBergamo).
 		FromDBaaS(URI("/projects/p/providers/Aruba.Database/dbaas/d-1")).
 		FromDatabase(URI("/projects/p/providers/Aruba.Database/dbaas/d-1/databases/mydb")).
-		WithBillingPeriod(BillingPeriodHour)
+		BilledHourly()
 
 	result, err := adapter.Create(context.Background(), bkp)
 	if err != nil {
@@ -537,7 +537,7 @@ func TestDBaaSBackupsClientAdapter_Create_MetadataValidationError(t *testing.T) 
 		fmt.Fprint(w, `{"metadata":{"name":"bkp","uri":"/projects/p/providers/Aruba.Database/backups/x"},"properties":{},"status":{}}`)
 	})
 
-	bkp := NewDBaaSBackup().IntoProject(URI("/projects/p")).
+	bkp := NewDBaaSBackup().InProject(URI("/projects/p")).
 		Named("bkp")
 	result, err := adapter.Create(context.Background(), bkp)
 	if err == nil {
@@ -559,7 +559,7 @@ func TestDBaaSBackupsClientAdapter_Create_NonTwoXX(t *testing.T) {
 		fmt.Fprint(w, testutil.ErrorBodyJSON("Validation Failed", "name is required", 422))
 	})
 
-	bkp := NewDBaaSBackup().IntoProject(URI("/projects/p"))
+	bkp := NewDBaaSBackup().InProject(URI("/projects/p"))
 	result, err := adapter.Create(context.Background(), bkp)
 	if err == nil {
 		t.Fatal("expected error on 422")
@@ -594,11 +594,11 @@ func TestDBaaSBackupsClientAdapter_Create_WithBodyRefs_ViaFake(t *testing.T) {
 	adapter := &dbaasBackupsClientAdapter{low: fake}
 
 	bkp := NewDBaaSBackup().
-		IntoProject(URI("/projects/p")).
+		InProject(URI("/projects/p")).
 		InRegion(RegionITBGBergamo).
 		FromDBaaS(URI(dbaasURI)).
 		FromDatabase(URI(dbURI)).
-		WithBillingPeriod(BillingPeriodHour)
+		BilledHourly()
 
 	_, err := adapter.Create(context.Background(), bkp)
 	if err != nil {

--- a/pkg/aruba/resource_dbaas_backup_test.go
+++ b/pkg/aruba/resource_dbaas_backup_test.go
@@ -44,7 +44,7 @@ func TestDBaaSBackup_FluentSetters(t *testing.T) {
 		InRegion(RegionITBGBergamo).
 		FromDBaaS(dbaasURI).
 		FromDatabase(dbURI).
-		BilledHourly()
+		BilledBy(BillingPeriodHour)
 
 	if bkp.Name() != "my-dbaas-backup" {
 		t.Errorf("Name() = %q", bkp.Name())
@@ -205,7 +205,7 @@ func TestDBaaSBackup_ToRequest(t *testing.T) {
 		InRegion(RegionITBGBergamo).
 		FromDBaaS(URI(dbaasURI)).
 		FromDatabase(URI(dbURI)).
-		BilledHourly()
+		BilledBy(BillingPeriodHour)
 
 	req := bkp.RawRequest()
 
@@ -476,7 +476,7 @@ func TestDBaaSBackupsClientAdapter_Create_Success(t *testing.T) {
 		InRegion(RegionITBGBergamo).
 		FromDBaaS(URI("/projects/p/providers/Aruba.Database/dbaas/d-1")).
 		FromDatabase(URI("/projects/p/providers/Aruba.Database/dbaas/d-1/databases/mydb")).
-		BilledHourly()
+		BilledBy(BillingPeriodHour)
 
 	result, err := adapter.Create(context.Background(), bkp)
 	if err != nil {
@@ -598,7 +598,7 @@ func TestDBaaSBackupsClientAdapter_Create_WithBodyRefs_ViaFake(t *testing.T) {
 		InRegion(RegionITBGBergamo).
 		FromDBaaS(URI(dbaasURI)).
 		FromDatabase(URI(dbURI)).
-		BilledHourly()
+		BilledBy(BillingPeriodHour)
 
 	_, err := adapter.Create(context.Background(), bkp)
 	if err != nil {

--- a/pkg/aruba/resource_dbaas_test.go
+++ b/pkg/aruba/resource_dbaas_test.go
@@ -37,7 +37,7 @@ func TestDBaaS_FluentSetters(t *testing.T) {
 		OfEngine(DatabaseEngineMySQL80).
 		OfFlavor(DBaaSFlavorDBO2A4).
 		SizedGB(20).
-		BilledHourly().
+		BilledBy(BillingPeriodHour).
 		WithAutoscaling(50, 10)
 
 	if d.Name() != "my-dbaas" {
@@ -259,7 +259,7 @@ func TestDBaaS_WithoutAutoscaling(t *testing.T) {
 }
 
 func TestDBaaS_BilledMonthly(t *testing.T) {
-	d := NewDBaaS().BilledMonthly()
+	d := NewDBaaS().BilledBy(BillingPeriodMonth)
 	if d.BillingPeriod() != BillingPeriodMonth {
 		t.Errorf("BillingPeriod() = %q", d.BillingPeriod())
 	}
@@ -279,7 +279,7 @@ func TestDBaaS_ToRequestRoundTrip(t *testing.T) {
 		OfEngine(DatabaseEngineMySQL80).
 		OfFlavor(DBaaSFlavorDBO2A4).
 		SizedGB(20).
-		BilledHourly().
+		BilledBy(BillingPeriodHour).
 		WithAutoscaling(50, 10).
 		WithVPC(URI("/vpcs/v")).
 		WithSubnet(URI("/subnets/s")).
@@ -668,7 +668,7 @@ func TestDBaaSClientAdapter_Create_Success(t *testing.T) {
 		OfEngine(DatabaseEngineMySQL80).
 		OfFlavor(DBaaSFlavorDBO2A4).
 		SizedGB(20).
-		BilledHourly().
+		BilledBy(BillingPeriodHour).
 		WithAutoscaling(50, 10).
 		WithVPC(URI("/vpcs/v")).
 		WithSubnet(URI("/subnets/s")).

--- a/pkg/aruba/resource_dbaas_test.go
+++ b/pkg/aruba/resource_dbaas_test.go
@@ -28,16 +28,16 @@ func TestDBaaS_FluentSetters(t *testing.T) {
 	proj.fromResponse(projectTestResponse("p-1", "my-project", "/projects/p-1"))
 
 	d := NewDBaaS().
-		IntoProject(proj).
+		InProject(proj).
 		Named("my-dbaas").
-		AddTag("db").
-		AddTag("prod").
+		Tagged("db").
+		Tagged("prod").
 		InRegion(RegionITBGBergamo).
 		InZone(ZoneITBG1).
 		OfEngine(DatabaseEngineMySQL80).
 		OfFlavor(DBaaSFlavorDBO2A4).
-		WithSizeGB(20).
-		WithBillingPeriod(BillingPeriodHour).
+		SizedGB(20).
+		BilledHourly().
 		WithAutoscaling(50, 10)
 
 	if d.Name() != "my-dbaas" {
@@ -80,12 +80,12 @@ func TestDBaaS_FluentSetters(t *testing.T) {
 		t.Errorf("Err() = %v", d.Err())
 	}
 
-	d.RemoveTag("db")
+	d.Untagged("db")
 	if tags := d.Tags(); len(tags) != 1 || tags[0] != "prod" {
 		t.Errorf("after RemoveTag Tags() = %v", tags)
 	}
 
-	d.ReplaceTags("x", "y")
+	d.RetaggedAs("x", "y")
 	if tags := d.Tags(); len(tags) != 2 || tags[0] != "x" || tags[1] != "y" {
 		t.Errorf("after ReplaceTags Tags() = %v", tags)
 	}
@@ -98,7 +98,7 @@ func TestDBaaS_FluentSetters(t *testing.T) {
 func TestDBaaS_IntoProject_TypedRef(t *testing.T) {
 	proj := &Project{}
 	proj.fromResponse(projectTestResponse("p-42", "n", "/projects/p-42"))
-	d := NewDBaaS().IntoProject(proj)
+	d := NewDBaaS().InProject(proj)
 	if d.ProjectID() != "p-42" {
 		t.Errorf("ProjectID() = %q", d.ProjectID())
 	}
@@ -108,7 +108,7 @@ func TestDBaaS_IntoProject_TypedRef(t *testing.T) {
 }
 
 func TestDBaaS_IntoProject_URIRef(t *testing.T) {
-	d := NewDBaaS().IntoProject(URI("/projects/p-uri"))
+	d := NewDBaaS().InProject(URI("/projects/p-uri"))
 	if d.ProjectID() != "p-uri" {
 		t.Errorf("ProjectID() = %q", d.ProjectID())
 	}
@@ -118,7 +118,7 @@ func TestDBaaS_IntoProject_URIRef(t *testing.T) {
 }
 
 func TestDBaaS_IntoProject_BadRef(t *testing.T) {
-	d := NewDBaaS().IntoProject(URI("/something/else"))
+	d := NewDBaaS().InProject(URI("/something/else"))
 	if d.Err() == nil {
 		t.Error("expected Err() to be set for unresolvable parent")
 	}
@@ -206,7 +206,7 @@ func TestDBaaS_OfFlavor(t *testing.T) {
 }
 
 func TestDBaaS_WithSizeGB(t *testing.T) {
-	d := NewDBaaS().WithSizeGB(50)
+	d := NewDBaaS().SizedGB(50)
 	if d.SizeGB() != 50 {
 		t.Errorf("Storage() = %d", d.SizeGB())
 	}
@@ -258,9 +258,9 @@ func TestDBaaS_WithoutAutoscaling(t *testing.T) {
 	}
 }
 
-func TestDBaaS_WithBillingPeriod(t *testing.T) {
-	d := NewDBaaS().WithBillingPeriod("Month")
-	if d.BillingPeriod() != "Month" {
+func TestDBaaS_BilledMonthly(t *testing.T) {
+	d := NewDBaaS().BilledMonthly()
+	if d.BillingPeriod() != BillingPeriodMonth {
 		t.Errorf("BillingPeriod() = %q", d.BillingPeriod())
 	}
 }
@@ -271,15 +271,15 @@ func TestDBaaS_WithBillingPeriod(t *testing.T) {
 
 func TestDBaaS_ToRequestRoundTrip(t *testing.T) {
 	d := NewDBaaS().
-		IntoProject(URI("/projects/p")).
+		InProject(URI("/projects/p")).
 		Named("my-dbaas").
-		AddTag("tag1").
+		Tagged("tag1").
 		InRegion(RegionITBGBergamo).
 		InZone(ZoneITBG1).
 		OfEngine(DatabaseEngineMySQL80).
 		OfFlavor(DBaaSFlavorDBO2A4).
-		WithSizeGB(20).
-		WithBillingPeriod(BillingPeriodHour).
+		SizedGB(20).
+		BilledHourly().
 		WithAutoscaling(50, 10).
 		WithVPC(URI("/vpcs/v")).
 		WithSubnet(URI("/subnets/s")).
@@ -542,7 +542,7 @@ func TestDBaaS_RoundTripUpdateFlow(t *testing.T) {
 	d.fromResponse(resp)
 
 	// Mutate storage; networking URIs should still come from the hydrated response.
-	d.WithSizeGB(40)
+	d.SizedGB(40)
 
 	req := d.RawRequest()
 	if req.Properties.Storage == nil || req.Properties.Storage.SizeGB == nil || *req.Properties.Storage.SizeGB != 40 {
@@ -662,13 +662,13 @@ func TestDBaaSClientAdapter_Create_Success(t *testing.T) {
 	})
 
 	d := NewDBaaS().
-		IntoProject(URI("/projects/p")).
+		InProject(URI("/projects/p")).
 		Named("my-dbaas").
 		InZone(ZoneITBG1).
 		OfEngine(DatabaseEngineMySQL80).
 		OfFlavor(DBaaSFlavorDBO2A4).
-		WithSizeGB(20).
-		WithBillingPeriod(BillingPeriodHour).
+		SizedGB(20).
+		BilledHourly().
 		WithAutoscaling(50, 10).
 		WithVPC(URI("/vpcs/v")).
 		WithSubnet(URI("/subnets/s")).
@@ -728,7 +728,7 @@ func TestDBaaSClientAdapter_Create_MetadataValidationError(t *testing.T) {
 		fmt.Fprint(w, `{"metadata":{"name":"db","uri":"/projects/p/providers/Aruba.Database/dbaas/x"},"properties":{}}`)
 	})
 
-	d := NewDBaaS().IntoProject(URI("/projects/p")).
+	d := NewDBaaS().InProject(URI("/projects/p")).
 		Named("db").OfEngine(DatabaseEngineMySQL80)
 	result, err := adapter.Create(context.Background(), d)
 	if err == nil {
@@ -750,7 +750,7 @@ func TestDBaaSClientAdapter_Create_NonTwoXX(t *testing.T) {
 		fmt.Fprint(w, testutil.ErrorBodyJSON("Validation Failed", "engine is required", 422))
 	})
 
-	d := NewDBaaS().IntoProject(URI("/projects/p")).
+	d := NewDBaaS().InProject(URI("/projects/p")).
 		Named("db")
 	result, err := adapter.Create(context.Background(), d)
 	if err == nil {
@@ -803,7 +803,7 @@ func TestDBaaSClientAdapter_Update_NoID(t *testing.T) {
 		w.WriteHeader(http.StatusOK)
 	})
 
-	d := NewDBaaS().IntoProject(URI("/projects/p")).
+	d := NewDBaaS().InProject(URI("/projects/p")).
 		Named("x")
 	_, err := adapter.Update(context.Background(), d)
 	if err == nil {
@@ -1094,7 +1094,7 @@ func TestDBaaSClientAdapter_Update_ErrMixin(t *testing.T) {
 		callCount++
 		w.WriteHeader(http.StatusOK)
 	})
-	d := NewDBaaS().IntoProject(URI("/garbage/project")) // triggers errMixin on intoProject
+	d := NewDBaaS().InProject(URI("/garbage/project")) // triggers errMixin on intoProject
 	_, err := adapter.Update(context.Background(), d)
 	if err == nil {
 		t.Fatal("expected error from errMixin")

--- a/pkg/aruba/resource_elastic_ip.go
+++ b/pkg/aruba/resource_elastic_ip.go
@@ -47,26 +47,46 @@ func NewElasticIP() *ElasticIP {
 
 // Setters — chainable, general → specific
 
-// IntoProject binds this ElasticIP to its parent project. Required before Create.
-func (e *ElasticIP) IntoProject(p Ref) *ElasticIP { e.intoProject(p); return e }
+// InProject binds this ElasticIP to its parent project. Required before Create.
+func (e *ElasticIP) InProject(p Ref) *ElasticIP { e.intoProject(p); return e }
 
 // Named sets the resource name. Required by the API.
 func (e *ElasticIP) Named(n string) *ElasticIP { e.named(n); return e }
 
-// AddTag appends a tag for filtering and accounting.
-func (e *ElasticIP) AddTag(t string) *ElasticIP { e.addTag(t); return e }
+// Tagged appends tags for filtering and accounting. Repeated calls append.
+func (e *ElasticIP) Tagged(ts ...string) *ElasticIP {
+	for _, t := range ts {
+		e.addTag(t)
+	}
+	return e
+}
 
-// RemoveTag removes a previously-added tag. No-op if absent.
-func (e *ElasticIP) RemoveTag(t string) *ElasticIP { e.removeTag(t); return e }
+// Untagged removes each listed tag. No-op for tags not present.
+func (e *ElasticIP) Untagged(ts ...string) *ElasticIP {
+	for _, t := range ts {
+		e.removeTag(t)
+	}
+	return e
+}
 
-// ReplaceTags replaces the entire tag set with the given values.
-func (e *ElasticIP) ReplaceTags(ts ...string) *ElasticIP { e.replaceTags(ts...); return e }
+// RetaggedAs replaces the entire tag set with the given values.
+func (e *ElasticIP) RetaggedAs(ts ...string) *ElasticIP { e.replaceTags(ts...); return e }
 
 // InRegion sets the region for this resource.
 func (e *ElasticIP) InRegion(region Region) *ElasticIP { e.inRegion(region); return e }
 
-// WithBillingPeriod sets the billing period. Defaults to hourly when unset.
-func (e *ElasticIP) WithBillingPeriod(p BillingPeriod) *ElasticIP { e.billingPeriod = &p; return e }
+// BilledHourly sets hourly billing.
+func (e *ElasticIP) BilledHourly() *ElasticIP { v := BillingPeriodHour; e.billingPeriod = &v; return e }
+
+// BilledMonthly sets monthly billing.
+func (e *ElasticIP) BilledMonthly() *ElasticIP {
+	v := BillingPeriodMonth
+	e.billingPeriod = &v
+	return e
+}
+
+// BilledYearly sets yearly billing.
+func (e *ElasticIP) BilledYearly() *ElasticIP { v := BillingPeriodYear; e.billingPeriod = &v; return e }
 
 // Getters — general → specific
 
@@ -211,7 +231,7 @@ func (a *elasticIPsClientAdapter) Create(ctx context.Context, e *ElasticIP, opts
 		return e, err
 	}
 	if e.ProjectID() == "" {
-		return e, fmt.Errorf("Create: elastic IP has no project — call IntoProject first")
+		return e, fmt.Errorf("Create: elastic IP has no project — call InProject first")
 	}
 	co := applyCallOptions(opts)
 	rp := co.toRequestParameters()
@@ -282,7 +302,7 @@ func (a *elasticIPsClientAdapter) Update(ctx context.Context, e *ElasticIP, opts
 		return e, fmt.Errorf("Update: elastic IP has no ID — call Get first or seed from response metadata")
 	}
 	if e.ProjectID() == "" {
-		return e, fmt.Errorf("Update: elastic IP has no project — call IntoProject first")
+		return e, fmt.Errorf("Update: elastic IP has no project — call InProject first")
 	}
 	co := applyCallOptions(opts)
 	rp := co.toRequestParameters()

--- a/pkg/aruba/resource_elastic_ip.go
+++ b/pkg/aruba/resource_elastic_ip.go
@@ -75,18 +75,8 @@ func (e *ElasticIP) RetaggedAs(ts ...string) *ElasticIP { e.replaceTags(ts...); 
 // InRegion sets the region for this resource.
 func (e *ElasticIP) InRegion(region Region) *ElasticIP { e.inRegion(region); return e }
 
-// BilledHourly sets hourly billing.
-func (e *ElasticIP) BilledHourly() *ElasticIP { v := BillingPeriodHour; e.billingPeriod = &v; return e }
-
-// BilledMonthly sets monthly billing.
-func (e *ElasticIP) BilledMonthly() *ElasticIP {
-	v := BillingPeriodMonth
-	e.billingPeriod = &v
-	return e
-}
-
-// BilledYearly sets yearly billing.
-func (e *ElasticIP) BilledYearly() *ElasticIP { v := BillingPeriodYear; e.billingPeriod = &v; return e }
+// BilledBy sets the billing cadence. Accepted periods are resource-specific; check the API reference.
+func (e *ElasticIP) BilledBy(period BillingPeriod) *ElasticIP { e.billingPeriod = &period; return e }
 
 // Getters — general → specific
 

--- a/pkg/aruba/resource_elastic_ip_test.go
+++ b/pkg/aruba/resource_elastic_ip_test.go
@@ -33,7 +33,7 @@ func TestElasticIP_FluentSetters(t *testing.T) {
 		Tagged("public").
 		Tagged("net"). // dedupe
 		InRegion(RegionITBGBergamo).
-		BilledHourly()
+		BilledBy(BillingPeriodHour)
 
 	if e.Name() != "my-eip" {
 		t.Errorf("Name() = %q", e.Name())
@@ -86,7 +86,7 @@ func TestElasticIP_ToRequestRoundTrip(t *testing.T) {
 		Tagged("t1").
 		Tagged("t2").
 		InRegion(RegionITBGBergamo).
-		BilledHourly()
+		BilledBy(BillingPeriodHour)
 
 	req := e.RawRequest()
 
@@ -117,32 +117,25 @@ func TestElasticIP_ToRequestRoundTrip(t *testing.T) {
 // --------------------------------------------------------------------------
 
 func TestElasticIP_BillingPeriod_WireBillingPlan(t *testing.T) {
-	cases := []struct {
-		period BillingPeriod
-		set    func(*ElasticIP) *ElasticIP
-	}{
-		{BillingPeriodHour, (*ElasticIP).BilledHourly},
-		{BillingPeriodMonth, (*ElasticIP).BilledMonthly},
-		{BillingPeriodYear, (*ElasticIP).BilledYearly},
-	}
-	for _, tc := range cases {
-		t.Run(string(tc.period), func(t *testing.T) {
-			req := tc.set(NewElasticIP().Named("x").InRegion(RegionITBGBergamo)).RawRequest()
+	for _, period := range []BillingPeriod{BillingPeriodHour, BillingPeriodMonth, BillingPeriodYear} {
+		tc := period
+		t.Run(string(tc), func(t *testing.T) {
+			req := NewElasticIP().Named("x").InRegion(RegionITBGBergamo).BilledBy(tc).RawRequest()
 			if req.Properties.BillingPlan == nil || req.Properties.BillingPlan.BillingPeriod == nil {
 				t.Fatal("BillingPlan or BillingPlan.BillingPeriod is nil")
 			}
-			if got := *req.Properties.BillingPlan.BillingPeriod; got != tc.period {
-				t.Errorf("toRequest wire = %q, want %q", got, tc.period)
+			if got := *req.Properties.BillingPlan.BillingPeriod; got != tc {
+				t.Errorf("toRequest wire = %q, want %q", got, tc)
 			}
-			std := tc.period
+			std := tc
 			e := &ElasticIP{}
 			e.fromResponse(&types.ElasticIPResponse{
 				Properties: types.ElasticIPPropertiesResponse{
 					BillingPlan: &types.BillingPlan{BillingPeriod: &std},
 				},
 			})
-			if e.BillingPeriod() != tc.period {
-				t.Errorf("fromResponse getter = %q, want %q", e.BillingPeriod(), tc.period)
+			if e.BillingPeriod() != tc {
+				t.Errorf("fromResponse getter = %q, want %q", e.BillingPeriod(), tc)
 			}
 		})
 	}
@@ -334,7 +327,7 @@ func TestElasticIPsClientAdapter_Create_Success(t *testing.T) {
 		InProject(URI("/projects/p")).
 		Named("my-eip").
 		InRegion(RegionITBGBergamo).
-		BilledHourly()
+		BilledBy(BillingPeriodHour)
 
 	result, err := adapter.Create(context.Background(), eip)
 	if err != nil {
@@ -477,7 +470,7 @@ func TestElasticIPsClientAdapter_Update_Success(t *testing.T) {
 
 	e := &ElasticIP{}
 	e.fromResponse(elasticIPTestResponse("eid", "orig", "/projects/p/providers/Aruba.Network/elasticIps/eid", "p"))
-	e.Named("renamed").BilledHourly()
+	e.Named("renamed").BilledBy(BillingPeriodHour)
 
 	result, err := adapter.Update(context.Background(), e)
 	if err != nil {

--- a/pkg/aruba/resource_elastic_ip_test.go
+++ b/pkg/aruba/resource_elastic_ip_test.go
@@ -27,13 +27,13 @@ func TestElasticIP_FluentSetters(t *testing.T) {
 	parent.fromResponse(projectTestResponse("proj-1", "my-proj", "/projects/proj-1"))
 
 	e := NewElasticIP().
-		IntoProject(parent).
+		InProject(parent).
 		Named("my-eip").
-		AddTag("net").
-		AddTag("public").
-		AddTag("net"). // dedupe
+		Tagged("net").
+		Tagged("public").
+		Tagged("net"). // dedupe
 		InRegion(RegionITBGBergamo).
-		WithBillingPeriod(BillingPeriodHour)
+		BilledHourly()
 
 	if e.Name() != "my-eip" {
 		t.Errorf("Name() = %q", e.Name())
@@ -54,12 +54,12 @@ func TestElasticIP_FluentSetters(t *testing.T) {
 		t.Errorf("Err() = %v", e.Err())
 	}
 
-	e.RemoveTag("net")
+	e.Untagged("net")
 	if tags := e.Tags(); len(tags) != 1 || tags[0] != "public" {
 		t.Errorf("after RemoveTag Tags() = %v", tags)
 	}
 
-	e.ReplaceTags("x", "y")
+	e.RetaggedAs("x", "y")
 	if tags := e.Tags(); len(tags) != 2 || tags[0] != "x" || tags[1] != "y" {
 		t.Errorf("after ReplaceTags Tags() = %v", tags)
 	}
@@ -70,7 +70,7 @@ func TestElasticIP_FluentSetters(t *testing.T) {
 // --------------------------------------------------------------------------
 
 func TestElasticIP_IntoProject_BadRef(t *testing.T) {
-	e := NewElasticIP().IntoProject(URI("/garbage"))
+	e := NewElasticIP().InProject(URI("/garbage"))
 	if e.Err() == nil {
 		t.Error("expected Err() != nil for unresolvable Ref, got nil")
 	}
@@ -83,10 +83,10 @@ func TestElasticIP_IntoProject_BadRef(t *testing.T) {
 func TestElasticIP_ToRequestRoundTrip(t *testing.T) {
 	e := NewElasticIP().Named(
 		"eip-1").
-		AddTag("t1").
-		AddTag("t2").
+		Tagged("t1").
+		Tagged("t2").
 		InRegion(RegionITBGBergamo).
-		WithBillingPeriod(BillingPeriodHour)
+		BilledHourly()
 
 	req := e.RawRequest()
 
@@ -117,26 +117,32 @@ func TestElasticIP_ToRequestRoundTrip(t *testing.T) {
 // --------------------------------------------------------------------------
 
 func TestElasticIP_BillingPeriod_WireBillingPlan(t *testing.T) {
-	cases := []BillingPeriod{BillingPeriodHour, BillingPeriodMonth, BillingPeriodYear}
-	for _, std := range cases {
-		t.Run(string(std), func(t *testing.T) {
-			req := NewElasticIP().
-				Named("x").InRegion(RegionITBGBergamo).
-				WithBillingPeriod(std).RawRequest()
+	cases := []struct {
+		period BillingPeriod
+		set    func(*ElasticIP) *ElasticIP
+	}{
+		{BillingPeriodHour, (*ElasticIP).BilledHourly},
+		{BillingPeriodMonth, (*ElasticIP).BilledMonthly},
+		{BillingPeriodYear, (*ElasticIP).BilledYearly},
+	}
+	for _, tc := range cases {
+		t.Run(string(tc.period), func(t *testing.T) {
+			req := tc.set(NewElasticIP().Named("x").InRegion(RegionITBGBergamo)).RawRequest()
 			if req.Properties.BillingPlan == nil || req.Properties.BillingPlan.BillingPeriod == nil {
 				t.Fatal("BillingPlan or BillingPlan.BillingPeriod is nil")
 			}
-			if got := *req.Properties.BillingPlan.BillingPeriod; got != std {
-				t.Errorf("toRequest wire = %q, want %q", got, std)
+			if got := *req.Properties.BillingPlan.BillingPeriod; got != tc.period {
+				t.Errorf("toRequest wire = %q, want %q", got, tc.period)
 			}
+			std := tc.period
 			e := &ElasticIP{}
 			e.fromResponse(&types.ElasticIPResponse{
 				Properties: types.ElasticIPPropertiesResponse{
 					BillingPlan: &types.BillingPlan{BillingPeriod: &std},
 				},
 			})
-			if e.BillingPeriod() != std {
-				t.Errorf("fromResponse getter = %q, want %q", e.BillingPeriod(), std)
+			if e.BillingPeriod() != tc.period {
+				t.Errorf("fromResponse getter = %q, want %q", e.BillingPeriod(), tc.period)
 			}
 		})
 	}
@@ -325,10 +331,10 @@ func TestElasticIPsClientAdapter_Create_Success(t *testing.T) {
 	})
 
 	eip := NewElasticIP().
-		IntoProject(URI("/projects/p")).
+		InProject(URI("/projects/p")).
 		Named("my-eip").
 		InRegion(RegionITBGBergamo).
-		WithBillingPeriod(BillingPeriodHour)
+		BilledHourly()
 
 	result, err := adapter.Create(context.Background(), eip)
 	if err != nil {
@@ -376,7 +382,7 @@ func TestElasticIPsClientAdapter_Create_MetadataValidationError(t *testing.T) {
 		fmt.Fprint(w, `{"metadata":{"name":"eip","uri":"/projects/p/providers/Aruba.Network/elasticIps/x"},"properties":{},"status":{}}`)
 	})
 
-	eip := NewElasticIP().IntoProject(URI("/projects/p")).
+	eip := NewElasticIP().InProject(URI("/projects/p")).
 		Named("eip")
 	result, err := adapter.Create(context.Background(), eip)
 	if err == nil {
@@ -398,7 +404,7 @@ func TestElasticIPsClientAdapter_Create_NonTwoXX(t *testing.T) {
 		fmt.Fprint(w, testutil.ErrorBodyJSON("Validation Failed", "name is required", 422))
 	})
 
-	eip := NewElasticIP().IntoProject(URI("/projects/p"))
+	eip := NewElasticIP().InProject(URI("/projects/p"))
 	result, err := adapter.Create(context.Background(), eip)
 	if err == nil {
 		t.Fatal("expected error on 422")
@@ -471,7 +477,7 @@ func TestElasticIPsClientAdapter_Update_Success(t *testing.T) {
 
 	e := &ElasticIP{}
 	e.fromResponse(elasticIPTestResponse("eid", "orig", "/projects/p/providers/Aruba.Network/elasticIps/eid", "p"))
-	e.Named("renamed").WithBillingPeriod(BillingPeriodHour)
+	e.Named("renamed").BilledHourly()
 
 	result, err := adapter.Update(context.Background(), e)
 	if err != nil {
@@ -492,7 +498,7 @@ func TestElasticIPsClientAdapter_Update_NoID(t *testing.T) {
 		w.WriteHeader(http.StatusOK)
 	})
 
-	e := NewElasticIP().IntoProject(URI("/projects/p")).
+	e := NewElasticIP().InProject(URI("/projects/p")).
 		Named("x")
 	_, err := adapter.Update(context.Background(), e)
 	if err == nil {
@@ -691,7 +697,7 @@ func TestElasticIPsClientAdapter_Create_WithBuilderError(t *testing.T) {
 		callCount++
 		w.WriteHeader(http.StatusCreated)
 	})
-	e := NewElasticIP().IntoProject(URI("/garbage"))
+	e := NewElasticIP().InProject(URI("/garbage"))
 	_, err := adapter.Create(context.Background(), e)
 	if err == nil {
 		t.Fatal("expected error for builder error")
@@ -725,7 +731,7 @@ func TestElasticIPsClientAdapter_Update_WithBuilderError(t *testing.T) {
 		callCount++
 		w.WriteHeader(http.StatusOK)
 	})
-	e := NewElasticIP().IntoProject(URI("/garbage"))
+	e := NewElasticIP().InProject(URI("/garbage"))
 	_, err := adapter.Update(context.Background(), e)
 	if err == nil {
 		t.Fatal("expected error for builder error")

--- a/pkg/aruba/resource_grant.go
+++ b/pkg/aruba/resource_grant.go
@@ -51,14 +51,14 @@ func NewGrant() *Grant {
 
 // Setters — chainable, general → specific
 
-// IntoDatabase binds this Grant to its parent Database. Required before Create.
-func (g *Grant) IntoDatabase(parent Ref) *Grant { g.intoDatabase(parent); return g }
+// InDatabase binds this Grant to its parent Database. Required before Create.
+func (g *Grant) InDatabase(parent Ref) *Grant { g.intoDatabase(parent); return g }
 
-// WithUsername sets the database username this grant applies to. Wire field: User.Username.
-func (g *Grant) WithUsername(name string) *Grant { g.username = &name; return g }
+// ForUser sets the database username this grant applies to. Wire field: User.Username.
+func (g *Grant) ForUser(name string) *Grant { g.username = &name; return g }
 
-// WithRoleName sets the role to grant to the user. Wire field: Role.Name.
-func (g *Grant) WithRoleName(name string) *Grant { g.roleName = &name; return g }
+// OfRole sets the role to grant to the user. Wire field: Role.Name.
+func (g *Grant) OfRole(name string) *Grant { g.roleName = &name; return g }
 
 // Getters — general → specific
 
@@ -244,19 +244,19 @@ func (a *grantsClientAdapter) Create(ctx context.Context, g *Grant, opts ...Call
 		return g, err
 	}
 	if g.ProjectID() == "" {
-		return g, fmt.Errorf("Create: Grant has no parent project — call IntoDatabase first")
+		return g, fmt.Errorf("Create: Grant has no parent project — call InDatabase first")
 	}
 	if g.DBaaSID() == "" {
-		return g, fmt.Errorf("Create: Grant has no parent DBaaS — call IntoDatabase first")
+		return g, fmt.Errorf("Create: Grant has no parent DBaaS — call InDatabase first")
 	}
 	if g.DatabaseID() == "" {
-		return g, fmt.Errorf("Create: Grant has no parent database — call IntoDatabase first")
+		return g, fmt.Errorf("Create: Grant has no parent database — call InDatabase first")
 	}
 	if g.username == nil {
-		return g, fmt.Errorf("Create: Grant has no username — call WithUsername first")
+		return g, fmt.Errorf("Create: Grant has no username — call ForUser first")
 	}
 	if g.roleName == nil {
-		return g, fmt.Errorf("Create: Grant has no role — call WithRoleName first")
+		return g, fmt.Errorf("Create: Grant has no role — call OfRole first")
 	}
 	co := applyCallOptions(opts)
 	rp := co.toRequestParameters()
@@ -293,19 +293,19 @@ func (a *grantsClientAdapter) Update(ctx context.Context, g *Grant, opts ...Call
 		return g, fmt.Errorf("Update: Grant has no ID — get the grant via Get first to obtain the opaque ID")
 	}
 	if g.DatabaseID() == "" {
-		return g, fmt.Errorf("Update: Grant has no parent database — call IntoDatabase first")
+		return g, fmt.Errorf("Update: Grant has no parent database — call InDatabase first")
 	}
 	if g.DBaaSID() == "" {
-		return g, fmt.Errorf("Update: Grant has no parent DBaaS — call IntoDatabase first")
+		return g, fmt.Errorf("Update: Grant has no parent DBaaS — call InDatabase first")
 	}
 	if g.ProjectID() == "" {
-		return g, fmt.Errorf("Update: Grant has no parent project — call IntoDatabase first")
+		return g, fmt.Errorf("Update: Grant has no parent project — call InDatabase first")
 	}
 	if g.username == nil {
-		return g, fmt.Errorf("Update: Grant has no username — call WithUsername first")
+		return g, fmt.Errorf("Update: Grant has no username — call ForUser first")
 	}
 	if g.roleName == nil {
-		return g, fmt.Errorf("Update: Grant has no role — call WithRoleName first")
+		return g, fmt.Errorf("Update: Grant has no role — call OfRole first")
 	}
 	co := applyCallOptions(opts)
 	rp := co.toRequestParameters()

--- a/pkg/aruba/resource_grant_test.go
+++ b/pkg/aruba/resource_grant_test.go
@@ -29,9 +29,9 @@ var (
 
 func TestGrant_FluentSetters(t *testing.T) {
 	g := NewGrant().
-		IntoDatabase(URI("/projects/p-1/providers/Aruba.Database/dbaas/d-1/databases/db-1")).
-		WithUsername("alice").
-		WithRoleName("READ_WRITE")
+		InDatabase(URI("/projects/p-1/providers/Aruba.Database/dbaas/d-1/databases/db-1")).
+		ForUser("alice").
+		OfRole("READ_WRITE")
 
 	if g.Username() != "alice" {
 		t.Errorf("UserName() = %q", g.Username())
@@ -62,10 +62,10 @@ func TestGrant_FluentSetters(t *testing.T) {
 
 func TestGrant_IntoDatabase_TypedRef(t *testing.T) {
 	db := NewDatabase().
-		IntoDBaaS(URI("/projects/p-1/providers/Aruba.Database/dbaas/d-1")).
+		InDBaaS(URI("/projects/p-1/providers/Aruba.Database/dbaas/d-1")).
 		Named("db-1")
 
-	g := NewGrant().IntoDatabase(db)
+	g := NewGrant().InDatabase(db)
 	if g.DatabaseID() != "db-1" {
 		t.Errorf("DatabaseID() = %q", g.DatabaseID())
 	}
@@ -81,7 +81,7 @@ func TestGrant_IntoDatabase_TypedRef(t *testing.T) {
 }
 
 func TestGrant_IntoDatabase_URIRef(t *testing.T) {
-	g := NewGrant().IntoDatabase(URI("/projects/p-uri/providers/Aruba.Database/dbaas/d-uri/databases/db-uri"))
+	g := NewGrant().InDatabase(URI("/projects/p-uri/providers/Aruba.Database/dbaas/d-uri/databases/db-uri"))
 	if g.DatabaseID() != "db-uri" {
 		t.Errorf("DatabaseID() = %q", g.DatabaseID())
 	}
@@ -97,7 +97,7 @@ func TestGrant_IntoDatabase_URIRef(t *testing.T) {
 }
 
 func TestGrant_IntoDatabase_BadRef(t *testing.T) {
-	g := NewGrant().IntoDatabase(URI("/something/garbage"))
+	g := NewGrant().InDatabase(URI("/something/garbage"))
 	if g.Err() == nil {
 		t.Error("expected Err() to be set for unresolvable parent")
 	}
@@ -109,7 +109,7 @@ func TestGrant_IntoDatabase_BadRef(t *testing.T) {
 
 func TestGrant_URI_Constructed(t *testing.T) {
 	g := NewGrant().
-		IntoDatabase(URI("/projects/p-1/providers/Aruba.Database/dbaas/d-1/databases/db-1"))
+		InDatabase(URI("/projects/p-1/providers/Aruba.Database/dbaas/d-1/databases/db-1"))
 	gid := "g-1"
 	g.id = &gid
 
@@ -167,7 +167,7 @@ func TestGrant_URI_MissingGrantID(t *testing.T) {
 // --------------------------------------------------------------------------
 
 func TestGrant_ToRequest(t *testing.T) {
-	g := NewGrant().WithUsername("alice").WithRoleName("READ_WRITE")
+	g := NewGrant().ForUser("alice").OfRole("READ_WRITE")
 	req := g.toRequest()
 	if req.User.Username != "alice" {
 		t.Errorf("toRequest().User.Username = %q", req.User.Username)
@@ -260,7 +260,7 @@ func TestGrant_FromResponse_DoesNotTouchID(t *testing.T) {
 
 func TestGrantIDsFromRef_TypedRef(t *testing.T) {
 	g := NewGrant().
-		IntoDatabase(URI("/projects/p/providers/Aruba.Database/dbaas/d-1/databases/db-1"))
+		InDatabase(URI("/projects/p/providers/Aruba.Database/dbaas/d-1/databases/db-1"))
 	gid := "g-1"
 	g.id = &gid
 
@@ -372,9 +372,9 @@ func TestGrantsClientAdapter_Create_Success(t *testing.T) {
 	})
 
 	g := NewGrant().
-		IntoDatabase(URI("/projects/p/providers/Aruba.Database/dbaas/d-1/databases/db-1")).
-		WithUsername("alice").
-		WithRoleName("READ_WRITE")
+		InDatabase(URI("/projects/p/providers/Aruba.Database/dbaas/d-1/databases/db-1")).
+		ForUser("alice").
+		OfRole("READ_WRITE")
 
 	result, err := adapter.Create(context.Background(), g)
 	if err != nil {
@@ -406,7 +406,7 @@ func TestGrantsClientAdapter_Create_NoParent(t *testing.T) {
 	adapter := buildGrantTestAdapter(t, func(w http.ResponseWriter, r *http.Request) {
 		callCount++
 	})
-	g := NewGrant().WithUsername("alice").WithRoleName("READ_WRITE") // no IntoDatabase
+	g := NewGrant().ForUser("alice").OfRole("READ_WRITE") // no IntoDatabase
 	_, err := adapter.Create(context.Background(), g)
 	if err == nil {
 		t.Error("expected error when parent database is missing")
@@ -422,8 +422,8 @@ func TestGrantsClientAdapter_Create_NoUsername(t *testing.T) {
 		callCount++
 	})
 	g := NewGrant().
-		IntoDatabase(URI("/projects/p/providers/Aruba.Database/dbaas/d-1/databases/db-1")).
-		WithRoleName("READ_WRITE") // no WithUserName
+		InDatabase(URI("/projects/p/providers/Aruba.Database/dbaas/d-1/databases/db-1")).
+		OfRole("READ_WRITE") // no WithUserName
 	_, err := adapter.Create(context.Background(), g)
 	if err == nil {
 		t.Error("expected error when username is missing")
@@ -439,8 +439,8 @@ func TestGrantsClientAdapter_Create_NoRoleName(t *testing.T) {
 		callCount++
 	})
 	g := NewGrant().
-		IntoDatabase(URI("/projects/p/providers/Aruba.Database/dbaas/d-1/databases/db-1")).
-		WithUsername("alice") // no WithRoleName
+		InDatabase(URI("/projects/p/providers/Aruba.Database/dbaas/d-1/databases/db-1")).
+		ForUser("alice") // no WithRoleName
 	_, err := adapter.Create(context.Background(), g)
 	if err == nil {
 		t.Error("expected error when role is missing")
@@ -458,9 +458,9 @@ func TestGrantsClientAdapter_Create_NonTwoXX(t *testing.T) {
 	})
 
 	g := NewGrant().
-		IntoDatabase(URI("/projects/p/providers/Aruba.Database/dbaas/d-1/databases/db-1")).
-		WithUsername("alice").
-		WithRoleName("READ_WRITE")
+		InDatabase(URI("/projects/p/providers/Aruba.Database/dbaas/d-1/databases/db-1")).
+		ForUser("alice").
+		OfRole("READ_WRITE")
 	_, err := adapter.Create(context.Background(), g)
 	var httpErr *HTTPError
 	if !errors.As(err, &httpErr) {
@@ -486,9 +486,9 @@ func TestGrantsClientAdapter_Update_Success(t *testing.T) {
 	})
 
 	g := NewGrant().
-		IntoDatabase(URI("/projects/p/providers/Aruba.Database/dbaas/d-1/databases/db-1")).
-		WithUsername("alice").
-		WithRoleName("READ_WRITE")
+		InDatabase(URI("/projects/p/providers/Aruba.Database/dbaas/d-1/databases/db-1")).
+		ForUser("alice").
+		OfRole("READ_WRITE")
 	gid := "g-789"
 	g.id = &gid // white-box: simulate prior Get populating the opaque ID
 
@@ -514,9 +514,9 @@ func TestGrantsClientAdapter_Update_NoID(t *testing.T) {
 		callCount++
 	})
 	g := NewGrant().
-		IntoDatabase(URI("/projects/p/providers/Aruba.Database/dbaas/d-1/databases/db-1")).
-		WithUsername("alice").
-		WithRoleName("READ_WRITE") // all ancestor IDs set, but no g.id
+		InDatabase(URI("/projects/p/providers/Aruba.Database/dbaas/d-1/databases/db-1")).
+		ForUser("alice").
+		OfRole("READ_WRITE") // all ancestor IDs set, but no g.id
 	_, err := adapter.Update(context.Background(), g)
 	if err == nil {
 		t.Error("expected error when grant ID is missing")
@@ -581,7 +581,7 @@ func TestGrantsClientAdapter_Get_TypedRef(t *testing.T) {
 	})
 
 	g := NewGrant().
-		IntoDatabase(URI("/projects/p/providers/Aruba.Database/dbaas/d-1/databases/db-1"))
+		InDatabase(URI("/projects/p/providers/Aruba.Database/dbaas/d-1/databases/db-1"))
 	gid := "g-1"
 	g.id = &gid // white-box: typed Ref with populated ID
 
@@ -629,7 +629,7 @@ func TestGrantsClientAdapter_Delete_NonTwoXX(t *testing.T) {
 // --------------------------------------------------------------------------
 
 func TestGrant_RawRequest(t *testing.T) {
-	g := NewGrant().WithUsername("alice").WithRoleName("READ_WRITE")
+	g := NewGrant().ForUser("alice").OfRole("READ_WRITE")
 	req := g.RawRequest()
 	if req.User.Username != "alice" {
 		t.Errorf("RawRequest().User.Username = %q", req.User.Username)
@@ -669,9 +669,9 @@ func TestGrantsClientAdapter_Create_NoDBaaS(t *testing.T) {
 	})
 	// Has database in path but no DBaaS — bad URI produces no dbaasID
 	g := NewGrant().
-		IntoDatabase(URI("/projects/p/providers/Aruba.Database/databases/db-1")).
-		WithUsername("alice").
-		WithRoleName("READ_WRITE")
+		InDatabase(URI("/projects/p/providers/Aruba.Database/databases/db-1")).
+		ForUser("alice").
+		OfRole("READ_WRITE")
 	_, err := adapter.Create(context.Background(), g)
 	if err == nil {
 		t.Fatal("expected error when DBaaS is missing")
@@ -808,9 +808,9 @@ func TestGrantsClientAdapter_Update_NonTwoXX(t *testing.T) {
 		fmt.Fprint(w, `{"title":"Conflict","detail":"concurrent update"}`)
 	})
 	g := NewGrant().
-		IntoDatabase(URI("/projects/p/providers/Aruba.Database/dbaas/d-1/databases/db-1")).
-		WithUsername("alice").
-		WithRoleName("READ_WRITE")
+		InDatabase(URI("/projects/p/providers/Aruba.Database/dbaas/d-1/databases/db-1")).
+		ForUser("alice").
+		OfRole("READ_WRITE")
 	gid := "g-1"
 	g.id = &gid
 	_, err := adapter.Update(context.Background(), g)
@@ -861,9 +861,9 @@ func TestGrantsClientAdapter_Get_NonTwoXX(t *testing.T) {
 func TestGrantsClientAdapter_Create_BrokenClient(t *testing.T) {
 	adapter := &grantsClientAdapter{low: database.NewGrantsClientImpl(testutil.NewBrokenClient(t, "http://localhost:9"))}
 	g := NewGrant().
-		IntoDatabase(URI("/projects/p/providers/Aruba.Database/dbaas/d-1/databases/db-1")).
-		WithUsername("alice").
-		WithRoleName("READ_WRITE")
+		InDatabase(URI("/projects/p/providers/Aruba.Database/dbaas/d-1/databases/db-1")).
+		ForUser("alice").
+		OfRole("READ_WRITE")
 	_, err := adapter.Create(context.Background(), g)
 	if err == nil {
 		t.Fatal("expected network error from broken client")
@@ -880,7 +880,7 @@ func TestGrantsClientAdapter_Create_ErrMixin(t *testing.T) {
 		callCount++
 	})
 	// IntoDatabase with bad URI sets errMixin
-	g := NewGrant().IntoDatabase(URI("/garbage")).WithUsername("alice").WithRoleName("READ_WRITE")
+	g := NewGrant().InDatabase(URI("/garbage")).ForUser("alice").OfRole("READ_WRITE")
 	_, err := adapter.Create(context.Background(), g)
 	if err == nil {
 		t.Fatal("expected error from errMixin")

--- a/pkg/aruba/resource_job.go
+++ b/pkg/aruba/resource_job.go
@@ -13,7 +13,7 @@ import (
 // ---- Wrapper ----
 
 // Job is the wrapper for an Aruba Cloud scheduled job (a direct child of a Project).
-// Construct with aruba.NewJob() and bind via IntoProject(project).
+// Construct with aruba.NewJob() and bind via InProject(project).
 //
 // Family A: regional, Metadata/Properties envelope, location-aware.
 // Supports full CRUD. Create and Update share the same request type (JobRequest) —
@@ -58,26 +58,39 @@ func NewJob() *Job {
 
 // Setters — chainable, general → specific
 
-// IntoProject binds this Job to its parent project. Required before Create.
-func (j *Job) IntoProject(p Ref) *Job { j.intoProject(p); return j }
+// InProject binds this Job to its parent project. Required before Create.
+func (j *Job) InProject(p Ref) *Job { j.intoProject(p); return j }
 
 // Named sets the resource name. Required by the API.
 func (j *Job) Named(n string) *Job { j.named(n); return j }
 
-// AddTag appends a tag for filtering and accounting.
-func (j *Job) AddTag(t string) *Job { j.addTag(t); return j }
+// Tagged appends tags for filtering and accounting. Repeated calls append.
+func (j *Job) Tagged(ts ...string) *Job {
+	for _, t := range ts {
+		j.addTag(t)
+	}
+	return j
+}
 
-// RemoveTag removes a previously-added tag. No-op if absent.
-func (j *Job) RemoveTag(t string) *Job { j.removeTag(t); return j }
+// Untagged removes each listed tag. No-op for tags not present.
+func (j *Job) Untagged(ts ...string) *Job {
+	for _, t := range ts {
+		j.removeTag(t)
+	}
+	return j
+}
 
-// ReplaceTags replaces the entire tag set with the given values.
-func (j *Job) ReplaceTags(ts ...string) *Job { j.replaceTags(ts...); return j }
+// RetaggedAs replaces the entire tag set with the given values.
+func (j *Job) RetaggedAs(ts ...string) *Job { j.replaceTags(ts...); return j }
 
 // InRegion sets the region for this resource.
 func (j *Job) InRegion(region Region) *Job { j.inRegion(region); return j }
 
-// WithEnabled sets whether the job is active. Pass false to disable the job via Update.
-func (j *Job) WithEnabled(enabled bool) *Job { j.enabled = &enabled; return j }
+// Enabled marks the job as active.
+func (j *Job) Enabled() *Job { v := true; j.enabled = &v; return j }
+
+// Disabled deactivates the job.
+func (j *Job) Disabled() *Job { v := false; j.enabled = &v; return j }
 
 // OneShotAt schedules a one-time execution at t (UTC, RFC3339).
 // Returns an error if a Recurring schedule has already been configured.
@@ -120,16 +133,18 @@ func (j *Job) requireMode(want types.JobType, label string) bool {
 	return true
 }
 
-// AddStep appends step to the job's step list.
-// Errors accumulated on step are drained into j at attachment time.
-func (j *Job) AddStep(step *JobStep) *Job {
-	if step == nil {
-		return j
+// WithSteps appends steps to the job's step list.
+// Errors accumulated on each step are drained into j at attachment time.
+func (j *Job) WithSteps(steps ...*JobStep) *Job {
+	for _, step := range steps {
+		if step == nil {
+			continue
+		}
+		for _, e := range step.errs {
+			j.addErr(e)
+		}
+		j.steps = append(j.steps, step)
 	}
-	for _, e := range step.errs {
-		j.addErr(e)
-	}
-	j.steps = append(j.steps, step)
 	return j
 }
 
@@ -149,8 +164,8 @@ func (j *Job) RawYAML() []byte         { return marshalRawYAML(j.response) }
 // RawRequest returns what toRequest() would emit right now.
 func (j *Job) RawRequest() types.JobRequest { return j.toRequest() }
 
-// Enabled returns whether the job is active.
-func (j *Job) Enabled() bool {
+// IsEnabled returns whether the job is active.
+func (j *Job) IsEnabled() bool {
 	if j.response != nil {
 		return j.response.Properties.Enabled
 	}
@@ -359,7 +374,7 @@ func (a *jobsClientAdapter) Create(ctx context.Context, j *Job, opts ...CallOpti
 		return j, err
 	}
 	if j.ProjectID() == "" {
-		return j, fmt.Errorf("Create: Job has no parent project — call IntoProject first")
+		return j, fmt.Errorf("Create: Job has no parent project — call InProject first")
 	}
 	co := applyCallOptions(opts)
 	rp := co.toRequestParameters()
@@ -396,7 +411,7 @@ func (a *jobsClientAdapter) Update(ctx context.Context, j *Job, opts ...CallOpti
 		return j, fmt.Errorf("Update: Job has no ID")
 	}
 	if j.ProjectID() == "" {
-		return j, fmt.Errorf("Update: Job has no parent project — call IntoProject first")
+		return j, fmt.Errorf("Update: Job has no parent project — call InProject first")
 	}
 	co := applyCallOptions(opts)
 	rp := co.toRequestParameters()

--- a/pkg/aruba/resource_job_step.go
+++ b/pkg/aruba/resource_job_step.go
@@ -39,11 +39,11 @@ func (s *JobStep) WithVerb(verb HTTPVerb) *JobStep { s.httpVerb = &verb; return 
 // WithBody sets the JSON request body for this step.
 func (s *JobStep) WithBody(body string) *JobStep { s.body = &body; return s }
 
-// OfResource sets the resource URI for this step. Errors if the ref's URI is empty.
-func (s *JobStep) OfResource(res Ref) *JobStep {
+// Targeting sets the resource URI for this step. Errors if the ref's URI is empty.
+func (s *JobStep) Targeting(res Ref) *JobStep {
 	uri := res.URI()
 	if uri == "" {
-		s.addErr(fmt.Errorf("OfResource: empty URI"))
+		s.addErr(fmt.Errorf("Targeting: empty URI"))
 		return s
 	}
 	s.resourceURI = &uri

--- a/pkg/aruba/resource_job_test.go
+++ b/pkg/aruba/resource_job_test.go
@@ -33,13 +33,13 @@ func TestJob_FluentSetters(t *testing.T) {
 	proj.fromResponse(projectTestResponse("p-1", "my-proj", "/projects/p-1"))
 
 	j := NewJob().
-		IntoProject(proj).
+		InProject(proj).
 		Named("my-job").
-		AddTag("env:prod").
-		AddTag("schedule").
-		AddTag("env:prod"). // dedupe
+		Tagged("env:prod").
+		Tagged("schedule").
+		Tagged("env:prod"). // dedupe
 		InRegion(RegionITBGBergamo).
-		WithEnabled(true)
+		Enabled()
 
 	if j.Name() != "my-job" {
 		t.Errorf("Name() = %q", j.Name())
@@ -50,7 +50,7 @@ func TestJob_FluentSetters(t *testing.T) {
 	if j.Region() != RegionITBGBergamo {
 		t.Errorf("Region() = %q", j.Region())
 	}
-	if !j.Enabled() {
+	if !j.IsEnabled() {
 		t.Error("Enabled() should be true")
 	}
 	if j.ProjectID() != "p-1" {
@@ -68,7 +68,7 @@ func TestJob_FluentSetters(t *testing.T) {
 func TestJob_IntoProject_TypedRef(t *testing.T) {
 	proj := &Project{}
 	proj.fromResponse(projectTestResponse("p-42", "proj", "/projects/p-42"))
-	j := NewJob().IntoProject(proj)
+	j := NewJob().InProject(proj)
 	if j.ProjectID() != "p-42" {
 		t.Errorf("ProjectID() = %q", j.ProjectID())
 	}
@@ -78,14 +78,14 @@ func TestJob_IntoProject_TypedRef(t *testing.T) {
 }
 
 func TestJob_IntoProject_URIRef(t *testing.T) {
-	j := NewJob().IntoProject(URI("/projects/p-uri"))
+	j := NewJob().InProject(URI("/projects/p-uri"))
 	if j.ProjectID() != "p-uri" {
 		t.Errorf("ProjectID() = %q", j.ProjectID())
 	}
 }
 
 func TestJob_IntoProject_BadRef(t *testing.T) {
-	j := NewJob().IntoProject(URI("not-a-project-uri"))
+	j := NewJob().InProject(URI("not-a-project-uri"))
 	if j.Err() == nil {
 		t.Error("expected Err() != nil for non-project URI")
 	}
@@ -96,7 +96,7 @@ func TestJob_IntoProject_BadRef(t *testing.T) {
 // --------------------------------------------------------------------------
 
 func TestJob_WithEnabled_True(t *testing.T) {
-	j := NewJob().WithEnabled(true)
+	j := NewJob().Enabled()
 	req := j.RawRequest()
 	if req.Properties.Enabled == nil || !*req.Properties.Enabled {
 		t.Error("Enabled should be true")
@@ -104,7 +104,7 @@ func TestJob_WithEnabled_True(t *testing.T) {
 }
 
 func TestJob_WithEnabled_False(t *testing.T) {
-	j := NewJob().WithEnabled(false)
+	j := NewJob().Disabled()
 	if j.enabled == nil || *j.enabled != false {
 		t.Error("enabled *bool should be set to false")
 	}
@@ -207,7 +207,7 @@ func TestJob_WithCron_Then_OneShotAt_Errors(t *testing.T) {
 func TestJobStep_Build_Basic(t *testing.T) {
 	s := NewJobStep().
 		Named("restart").
-		OfResource(URI("/projects/p/providers/Aruba.Compute/cloudServers/srv-1")).
+		Targeting(URI("/projects/p/providers/Aruba.Compute/cloudServers/srv-1")).
 		WithAction("/projects/p/providers/Aruba.Compute/cloudServers/srv-1/providers/Aruba.Compute/actions/reboot").
 		WithVerb(HTTPVerbPOST).
 		WithBody(`{"force":true}`)
@@ -228,24 +228,24 @@ func TestJobStep_Build_Basic(t *testing.T) {
 }
 
 func TestJobStep_OfResource_EmptyURI_Errors(t *testing.T) {
-	s := NewJobStep().OfResource(URI(""))
+	s := NewJobStep().Targeting(URI(""))
 	if s.Err() == nil {
 		t.Error("expected Err() != nil for empty resource URI")
 	}
 }
 
 func TestJob_AddStep_DrainErrors(t *testing.T) {
-	step := NewJobStep().OfResource(URI("")) // adds error to step
-	j := NewJob().AddStep(step)
+	step := NewJobStep().Targeting(URI("")) // adds error to step
+	j := NewJob().WithSteps(step)
 	if j.Err() == nil {
 		t.Error("expected step errors to be drained into job")
 	}
 }
 
 func TestJob_AddStep_Nil(t *testing.T) {
-	j := NewJob().AddStep(nil)
+	j := NewJob().WithSteps(nil)
 	if j.Err() != nil {
-		t.Errorf("AddStep(nil) should not error: %v", j.Err())
+		t.Errorf("WithSteps(nil) should not error: %v", j.Err())
 	}
 }
 
@@ -256,14 +256,14 @@ func TestJob_AddStep_Nil(t *testing.T) {
 func TestJob_ToRequest_OneShot(t *testing.T) {
 	ts := time.Date(2026, 5, 1, 12, 0, 0, 0, time.UTC)
 	j := NewJob().
-		IntoProject(URI("/projects/p")).
+		InProject(URI("/projects/p")).
 		Named("one-shot-job").
 		InRegion(RegionITBGBergamo).
-		WithEnabled(true).
+		Enabled().
 		OneShotAt(ts).
-		AddStep(NewJobStep().
+		WithSteps(NewJobStep().
 			Named("step-1").
-			OfResource(URI("/projects/p/providers/Aruba.Compute/cloudServers/s-1")).
+			Targeting(URI("/projects/p/providers/Aruba.Compute/cloudServers/s-1")).
 			WithAction("/projects/p/providers/Aruba.Compute/cloudServers/s-1/actions/start").
 			WithVerb(HTTPVerbPOST))
 
@@ -291,7 +291,7 @@ func TestJob_ToRequest_OneShot(t *testing.T) {
 func TestJob_ToRequest_Recurring(t *testing.T) {
 	until := time.Date(2026, 12, 31, 0, 0, 0, 0, time.UTC)
 	j := NewJob().
-		IntoProject(URI("/projects/p")).
+		InProject(URI("/projects/p")).
 		Named("cron-job").
 		WithCron("0 8 * * 1-5").
 		RecurringUntil(until)
@@ -370,7 +370,7 @@ func TestJob_FromResponseHydration(t *testing.T) {
 	if j.Region() != RegionITBGBergamo {
 		t.Errorf("Region() = %q", j.Region())
 	}
-	if !j.Enabled() {
+	if !j.IsEnabled() {
 		t.Error("Enabled() should be true")
 	}
 	if j.JobType() != JobTypeOneShot {
@@ -504,10 +504,10 @@ func TestJobsClientAdapter_Create_Success(t *testing.T) {
 
 	ts := time.Date(2026, 5, 1, 12, 0, 0, 0, time.UTC)
 	j := NewJob().
-		IntoProject(URI("/projects/p")).
+		InProject(URI("/projects/p")).
 		Named("my-job").
 		InRegion(RegionITBGBergamo).
-		WithEnabled(true).
+		Enabled().
 		OneShotAt(ts)
 
 	result, err := adapter.Create(context.Background(), j)
@@ -555,7 +555,7 @@ func TestJobsClientAdapter_Create_MetadataValidationError(t *testing.T) {
 		fmt.Fprint(w, `{"metadata":{"name":"j","uri":"/projects/p/providers/Aruba.Schedule/jobs/x"},"properties":{},"status":{}}`)
 	})
 
-	j := NewJob().IntoProject(URI("/projects/p")).
+	j := NewJob().InProject(URI("/projects/p")).
 		Named("j")
 	result, err := adapter.Create(context.Background(), j)
 	if err == nil {
@@ -576,7 +576,7 @@ func TestJobsClientAdapter_Create_NonTwoXX(t *testing.T) {
 		w.WriteHeader(http.StatusBadRequest)
 		fmt.Fprint(w, `{"message":"bad request"}`)
 	})
-	_, err := adapter.Create(context.Background(), NewJob().IntoProject(URI("/projects/p")).
+	_, err := adapter.Create(context.Background(), NewJob().InProject(URI("/projects/p")).
 		Named("j"))
 	var httpErr *HTTPError
 	if !errors.As(err, &httpErr) {
@@ -601,7 +601,7 @@ func TestJobsClientAdapter_Update_Success(t *testing.T) {
 	// Load from response, then only update non-schedule fields to avoid mode conflict.
 	j := &Job{}
 	j.fromResponse(jobTestResponse("my-job"))
-	j.Named("my-job-updated").WithEnabled(false)
+	j.Named("my-job-updated").Disabled()
 
 	result, err := adapter.Update(context.Background(), j)
 	if err != nil {
@@ -616,7 +616,7 @@ func TestJobsClientAdapter_Update_NoID(t *testing.T) {
 	adapter := buildJobsTestAdapter(t, func(w http.ResponseWriter, _ *http.Request) {
 		w.WriteHeader(http.StatusOK)
 	})
-	j := NewJob().IntoProject(URI("/projects/p")).
+	j := NewJob().InProject(URI("/projects/p")).
 		Named("x")
 	_, err := adapter.Update(context.Background(), j)
 	if err == nil {
@@ -760,11 +760,11 @@ func TestJobsClientAdapter_List_TwoItems(t *testing.T) {
 
 func TestJob_SetterDelegation(t *testing.T) {
 	j := NewJob().
-		AddTag("a").
-		AddTag("b").
-		AddTag("c").
-		RemoveTag("b").
-		ReplaceTags("x", "y").
+		Tagged("a").
+		Tagged("b").
+		Tagged("c").
+		Untagged("b").
+		RetaggedAs("x", "y").
 		InRegion(RegionITBGBergamo)
 
 	tags := j.Tags()
@@ -807,7 +807,7 @@ func TestJob_Accessors_ZeroValue(t *testing.T) {
 	if j.Raw() != nil {
 		t.Errorf("Raw() zero = %v", j.Raw())
 	}
-	if j.Enabled() != false {
+	if j.IsEnabled() != false {
 		t.Error("Enabled() zero should be false")
 	}
 	if j.JobType() != "" {
@@ -823,8 +823,8 @@ func TestJob_Accessors_ZeroValue(t *testing.T) {
 // --------------------------------------------------------------------------
 
 func TestJob_Enabled_RequestFallback(t *testing.T) {
-	j := NewJob().WithEnabled(true)
-	if !j.Enabled() {
+	j := NewJob().Enabled()
+	if !j.IsEnabled() {
 		t.Error("Enabled() request fallback should be true")
 	}
 }
@@ -975,7 +975,7 @@ func TestJobsClientAdapter_Update_ErrSet(t *testing.T) {
 	adapter := buildJobsTestAdapter(t, func(w http.ResponseWriter, _ *http.Request) {
 		w.WriteHeader(http.StatusOK)
 	})
-	j := NewJob().IntoProject(URI("not-a-project-uri")) // sets Err()
+	j := NewJob().InProject(URI("not-a-project-uri")) // sets Err()
 	_, err := adapter.Update(context.Background(), j)
 	if err == nil {
 		t.Fatal("expected error when Job has Err() set")

--- a/pkg/aruba/resource_kaas.go
+++ b/pkg/aruba/resource_kaas.go
@@ -13,7 +13,7 @@ import (
 
 // KaaS is the wrapper for an Aruba Cloud Kubernetes-as-a-Service cluster
 // (a direct child of a Project). Construct with aruba.NewKaaS() and bind it
-// via IntoProject(project), WithVPC(vpc), WithSubnet(subnet), etc.
+// via InProject(project), WithVPC(vpc), WithSubnet(subnet), etc.
 //
 // Family A: regional, Metadata/Properties envelope, location-aware.
 // Supports full CRUD. Update emits KaaSUpdateRequest (narrower than KaaSRequest):
@@ -73,20 +73,30 @@ func NewKaaS() *KaaS {
 
 // Setters — chainable, general → specific
 
-// IntoProject binds this KaaS to its parent project. Required before Create.
-func (k *KaaS) IntoProject(p Ref) *KaaS { k.intoProject(p); return k }
+// InProject binds this KaaS to its parent project. Required before Create.
+func (k *KaaS) InProject(p Ref) *KaaS { k.intoProject(p); return k }
 
 // Named sets the resource name. Required by the API.
 func (k *KaaS) Named(n string) *KaaS { k.named(n); return k }
 
-// AddTag appends a tag for filtering and accounting.
-func (k *KaaS) AddTag(t string) *KaaS { k.addTag(t); return k }
+// Tagged appends tags for filtering and accounting. Repeated calls append.
+func (k *KaaS) Tagged(ts ...string) *KaaS {
+	for _, t := range ts {
+		k.addTag(t)
+	}
+	return k
+}
 
-// RemoveTag removes a previously-added tag. No-op if absent.
-func (k *KaaS) RemoveTag(t string) *KaaS { k.removeTag(t); return k }
+// Untagged removes each listed tag. No-op for tags not present.
+func (k *KaaS) Untagged(ts ...string) *KaaS {
+	for _, t := range ts {
+		k.removeTag(t)
+	}
+	return k
+}
 
-// ReplaceTags replaces the entire tag set with the given values.
-func (k *KaaS) ReplaceTags(ts ...string) *KaaS { k.replaceTags(ts...); return k }
+// RetaggedAs replaces the entire tag set with the given values.
+func (k *KaaS) RetaggedAs(ts ...string) *KaaS { k.replaceTags(ts...); return k }
 
 // InRegion sets the region for this resource.
 func (k *KaaS) InRegion(region Region) *KaaS { k.inRegion(region); return k }
@@ -100,14 +110,17 @@ func (k *KaaS) WithKubernetesVersion(v KubernetesVersion) *KaaS {
 // WithPodCIDR sets the pod CIDR block for the cluster network.
 func (k *KaaS) WithPodCIDR(cidr string) *KaaS { k.podCIDR = &cidr; return k }
 
-// WithHA enables or disables high-availability mode for the control plane.
-func (k *KaaS) WithHA(enabled bool) *KaaS { k.ha = &enabled; return k }
+// HighlyAvailable enables high-availability mode for the control plane.
+func (k *KaaS) HighlyAvailable() *KaaS { v := true; k.ha = &v; return k }
 
-// WithBillingPeriod sets the billing period. Defaults to hourly when unset.
-func (k *KaaS) WithBillingPeriod(period BillingPeriod) *KaaS {
-	k.billingPeriod = &period
-	return k
-}
+// BilledHourly sets hourly billing.
+func (k *KaaS) BilledHourly() *KaaS { v := BillingPeriodHour; k.billingPeriod = &v; return k }
+
+// BilledMonthly sets monthly billing.
+func (k *KaaS) BilledMonthly() *KaaS { v := BillingPeriodMonth; k.billingPeriod = &v; return k }
+
+// BilledYearly sets yearly billing.
+func (k *KaaS) BilledYearly() *KaaS { v := BillingPeriodYear; k.billingPeriod = &v; return k }
 
 // WithSecurityGroup attaches a SecurityGroup to the cluster. The KaaS API
 // stores only the SG's name (not its URI), so the supplied Ref must be a
@@ -191,38 +204,35 @@ func (k *KaaS) setSingleRef(label string, ref Ref, dst **string) *KaaS {
 	return k
 }
 
-// AddNodePool appends np to the cluster's node pool list.
-// Errors accumulated on np are drained into k at attachment time.
-func (k *KaaS) AddNodePool(np *NodePool) *KaaS {
-	if np == nil {
-		return k
+// WithNodePools appends node pools to the cluster's pool list.
+// Errors accumulated on each pool are drained into k at attachment time.
+func (k *KaaS) WithNodePools(nps ...*NodePool) *KaaS {
+	for _, np := range nps {
+		if np == nil {
+			continue
+		}
+		for _, e := range np.errs {
+			k.addErr(e)
+		}
+		k.nodePools = append(k.nodePools, np)
 	}
-	for _, e := range np.errs {
-		k.addErr(e)
-	}
-	k.nodePools = append(k.nodePools, np)
 	return k
 }
 
-// ClearNodePools removes all previously-added node pools from the cluster.
-func (k *KaaS) ClearNodePools() *KaaS {
+// WithoutNodePools removes all previously-added node pools from the cluster.
+func (k *KaaS) WithoutNodePools() *KaaS {
 	k.nodePools = nil
 	return k
 }
 
 // ReplaceNodePools replaces the entire node pool list with the given pools.
-// Equivalent to ClearNodePools followed by AddNodePool for each entry.
+// Equivalent to WithoutNodePools followed by WithNodePools for each entry.
 func (k *KaaS) ReplaceNodePools(pools ...*NodePool) *KaaS {
 	k.nodePools = nil
 	for _, np := range pools {
-		k.AddNodePool(np)
+		k.WithNodePools(np)
 	}
 	return k
-}
-
-// SetNodePools is an alias for ReplaceNodePools for naming-convention parity.
-func (k *KaaS) SetNodePools(pools ...*NodePool) *KaaS {
-	return k.ReplaceNodePools(pools...)
 }
 
 // DownloadKubeconfig downloads the kubeconfig for this cluster and returns it
@@ -610,7 +620,7 @@ func (a *kaasClientAdapter) Create(ctx context.Context, k *KaaS, opts ...CallOpt
 		return k, err
 	}
 	if k.ProjectID() == "" {
-		return k, fmt.Errorf("Create: KaaS has no parent project — call IntoProject first")
+		return k, fmt.Errorf("Create: KaaS has no parent project — call InProject first")
 	}
 	co := applyCallOptions(opts)
 	rp := co.toRequestParameters()
@@ -648,7 +658,7 @@ func (a *kaasClientAdapter) Update(ctx context.Context, k *KaaS, opts ...CallOpt
 		return k, fmt.Errorf("Update: KaaS has no ID")
 	}
 	if k.ProjectID() == "" {
-		return k, fmt.Errorf("Update: KaaS has no parent project — call IntoProject first")
+		return k, fmt.Errorf("Update: KaaS has no parent project — call InProject first")
 	}
 	co := applyCallOptions(opts)
 	rp := co.toRequestParameters()

--- a/pkg/aruba/resource_kaas.go
+++ b/pkg/aruba/resource_kaas.go
@@ -113,14 +113,8 @@ func (k *KaaS) WithPodCIDR(cidr string) *KaaS { k.podCIDR = &cidr; return k }
 // HighlyAvailable enables high-availability mode for the control plane.
 func (k *KaaS) HighlyAvailable() *KaaS { v := true; k.ha = &v; return k }
 
-// BilledHourly sets hourly billing.
-func (k *KaaS) BilledHourly() *KaaS { v := BillingPeriodHour; k.billingPeriod = &v; return k }
-
-// BilledMonthly sets monthly billing.
-func (k *KaaS) BilledMonthly() *KaaS { v := BillingPeriodMonth; k.billingPeriod = &v; return k }
-
-// BilledYearly sets yearly billing.
-func (k *KaaS) BilledYearly() *KaaS { v := BillingPeriodYear; k.billingPeriod = &v; return k }
+// BilledBy sets the billing cadence. Accepted periods are resource-specific; check the API reference.
+func (k *KaaS) BilledBy(period BillingPeriod) *KaaS { k.billingPeriod = &period; return k }
 
 // WithSecurityGroup attaches a SecurityGroup to the cluster. The KaaS API
 // stores only the SG's name (not its URI), so the supplied Ref must be a

--- a/pkg/aruba/resource_kaas_test.go
+++ b/pkg/aruba/resource_kaas_test.go
@@ -50,7 +50,7 @@ func TestKaaS_FluentSetters(t *testing.T) {
 		WithKubernetesVersion("1.32.3").
 		HighlyAvailable().
 		WithMaxStorageQuotaGB(100).
-		BilledHourly().
+		BilledBy(BillingPeriodHour).
 		WithIdentity("cid", "csecret")
 
 	if k.Name() != "my-cluster" {
@@ -252,7 +252,7 @@ func TestKaaS_WithKubernetesVersion(t *testing.T) {
 }
 
 func TestKaaS_WithBillingPeriod(t *testing.T) {
-	k := NewKaaS().BilledHourly()
+	k := NewKaaS().BilledBy(BillingPeriodHour)
 	if k.BillingPeriod() != BillingPeriodHour {
 		t.Errorf("BillingPeriod() = %q", k.BillingPeriod())
 	}
@@ -352,7 +352,7 @@ func TestKaaS_ToRequest(t *testing.T) {
 		WithKubernetesVersion("1.32.3").
 		HighlyAvailable().
 		WithMaxStorageQuotaGB(100).
-		BilledHourly().
+		BilledBy(BillingPeriodHour).
 		WithIdentity("cid", "csecret").
 		WithNodePools(NewNodePool().
 			Named("pool-1").OfInstance(NodePoolInstanceK4A8).InZone(ZoneITBG1).WithCount(3))
@@ -425,7 +425,7 @@ func TestKaaS_ToUpdateRequest_MutableOnly(t *testing.T) {
 		WithKubernetesVersion("1.33.0").
 		HighlyAvailable().
 		WithMaxStorageQuotaGB(200).
-		BilledHourly().
+		BilledBy(BillingPeriodHour).
 		WithNodePools(NewNodePool().
 			Named("pool-1").WithCount(5).OfInstance(NodePoolInstanceK4A8).InZone(ZoneITBG1))
 
@@ -743,7 +743,7 @@ func TestKaaSClientAdapter_Create_Success(t *testing.T) {
 		WithSecurityGroup(sgFixture).
 		WithNodeCIDR("10.100.0.0/16", "node-cidr").
 		WithKubernetesVersion("1.32.3").
-		BilledHourly().
+		BilledBy(BillingPeriodHour).
 		HighlyAvailable().
 		WithNodePools(NewNodePool().
 			Named("pool-1").WithCount(3).OfInstance(NodePoolInstanceK4A8).InZone(ZoneITBG1))

--- a/pkg/aruba/resource_kaas_test.go
+++ b/pkg/aruba/resource_kaas_test.go
@@ -36,11 +36,11 @@ func TestKaaS_FluentSetters(t *testing.T) {
 		Named("sg-name")
 
 	k := NewKaaS().
-		IntoProject(proj).
+		InProject(proj).
 		Named("my-cluster").
-		AddTag("env:prod").
-		AddTag("k8s").
-		AddTag("env:prod"). // dedupe
+		Tagged("env:prod").
+		Tagged("k8s").
+		Tagged("env:prod"). // dedupe
 		InRegion(RegionITBGBergamo).
 		WithVPC(vpcURI).
 		WithSubnet(subnetURI).
@@ -48,9 +48,9 @@ func TestKaaS_FluentSetters(t *testing.T) {
 		WithNodeCIDR("10.100.0.0/16", "node-cidr").
 		WithPodCIDR("10.200.0.0/16").
 		WithKubernetesVersion("1.32.3").
-		WithHA(true).
+		HighlyAvailable().
 		WithMaxStorageQuotaGB(100).
-		WithBillingPeriod(BillingPeriodHour).
+		BilledHourly().
 		WithIdentity("cid", "csecret")
 
 	if k.Name() != "my-cluster" {
@@ -92,7 +92,7 @@ func TestKaaS_FluentSetters(t *testing.T) {
 func TestKaaS_IntoProject_TypedRef(t *testing.T) {
 	proj := &Project{}
 	proj.fromResponse(projectTestResponse("p-42", "proj", "/projects/p-42"))
-	k := NewKaaS().IntoProject(proj)
+	k := NewKaaS().InProject(proj)
 	if k.ProjectID() != "p-42" {
 		t.Errorf("ProjectID() = %q", k.ProjectID())
 	}
@@ -102,14 +102,14 @@ func TestKaaS_IntoProject_TypedRef(t *testing.T) {
 }
 
 func TestKaaS_IntoProject_URIRef(t *testing.T) {
-	k := NewKaaS().IntoProject(URI("/projects/p-uri"))
+	k := NewKaaS().InProject(URI("/projects/p-uri"))
 	if k.ProjectID() != "p-uri" {
 		t.Errorf("ProjectID() = %q", k.ProjectID())
 	}
 }
 
 func TestKaaS_IntoProject_BadRef(t *testing.T) {
-	k := NewKaaS().IntoProject(URI("not-a-project-uri"))
+	k := NewKaaS().InProject(URI("not-a-project-uri"))
 	if k.Err() == nil {
 		t.Error("expected Err() != nil for non-project URI")
 	}
@@ -229,7 +229,7 @@ func TestKaaS_WithPodCIDR(t *testing.T) {
 }
 
 func TestKaaS_WithHA(t *testing.T) {
-	k := NewKaaS().WithHA(true)
+	k := NewKaaS().HighlyAvailable()
 	req := k.RawRequest()
 	if req.Properties.HA == nil || !*req.Properties.HA {
 		t.Errorf("HA = %v", req.Properties.HA)
@@ -252,7 +252,7 @@ func TestKaaS_WithKubernetesVersion(t *testing.T) {
 }
 
 func TestKaaS_WithBillingPeriod(t *testing.T) {
-	k := NewKaaS().WithBillingPeriod(BillingPeriodHour)
+	k := NewKaaS().BilledHourly()
 	if k.BillingPeriod() != BillingPeriodHour {
 		t.Errorf("BillingPeriod() = %q", k.BillingPeriod())
 	}
@@ -317,16 +317,16 @@ func TestKaaS_AddNodePool_DrainErrors(t *testing.T) {
 	k := NewKaaS()
 	np := NewNodePool()
 	np.addErr(fmt.Errorf("test sub-builder error"))
-	k.AddNodePool(np)
+	k.WithNodePools(np)
 	if k.Err() == nil {
 		t.Error("expected Err() != nil after AddNodePool with errored sub-builder")
 	}
 }
 
 func TestKaaS_AddNodePool_Nil(t *testing.T) {
-	k := NewKaaS().AddNodePool(nil)
+	k := NewKaaS().WithNodePools(nil)
 	if k.Err() != nil {
-		t.Errorf("AddNodePool(nil) should not error: %v", k.Err())
+		t.Errorf("WithNodePools(nil) should not error: %v", k.Err())
 	}
 }
 
@@ -342,7 +342,7 @@ func TestKaaS_ToRequest(t *testing.T) {
 
 	k := NewKaaS().Named(
 		"my-cluster").
-		AddTag("t1").AddTag("t2").
+		Tagged("t1").Tagged("t2").
 		InRegion(RegionITBGBergamo).
 		WithVPC(URI(vpcURI)).
 		WithSubnet(URI(subnetURI)).
@@ -350,11 +350,11 @@ func TestKaaS_ToRequest(t *testing.T) {
 		WithNodeCIDR("10.100.0.0/16", "node-cidr").
 		WithPodCIDR("10.200.0.0/16").
 		WithKubernetesVersion("1.32.3").
-		WithHA(true).
+		HighlyAvailable().
 		WithMaxStorageQuotaGB(100).
-		WithBillingPeriod(BillingPeriodHour).
+		BilledHourly().
 		WithIdentity("cid", "csecret").
-		AddNodePool(NewNodePool().
+		WithNodePools(NewNodePool().
 			Named("pool-1").OfInstance(NodePoolInstanceK4A8).InZone(ZoneITBG1).WithCount(3))
 
 	req := k.RawRequest()
@@ -423,10 +423,10 @@ func TestKaaS_ToUpdateRequest_MutableOnly(t *testing.T) {
 		InRegion(RegionITBGBergamo).
 		WithVPC(URI(vpcURI)). // set but must NOT appear in update request
 		WithKubernetesVersion("1.33.0").
-		WithHA(true).
+		HighlyAvailable().
 		WithMaxStorageQuotaGB(200).
-		WithBillingPeriod(BillingPeriodHour).
-		AddNodePool(NewNodePool().
+		BilledHourly().
+		WithNodePools(NewNodePool().
 			Named("pool-1").WithCount(5).OfInstance(NodePoolInstanceK4A8).InZone(ZoneITBG1))
 
 	upd := k.toUpdateRequest()
@@ -735,7 +735,7 @@ func TestKaaSClientAdapter_Create_Success(t *testing.T) {
 	sgFixture := NewSecurityGroup().
 		Named("sg-name")
 	k := NewKaaS().
-		IntoProject(URI("/projects/p")).
+		InProject(URI("/projects/p")).
 		Named("my-cluster").
 		InRegion(RegionITBGBergamo).
 		WithVPC(URI("/projects/p/providers/Aruba.Network/vpcs/vpc-1")).
@@ -743,9 +743,9 @@ func TestKaaSClientAdapter_Create_Success(t *testing.T) {
 		WithSecurityGroup(sgFixture).
 		WithNodeCIDR("10.100.0.0/16", "node-cidr").
 		WithKubernetesVersion("1.32.3").
-		WithBillingPeriod(BillingPeriodHour).
-		WithHA(true).
-		AddNodePool(NewNodePool().
+		BilledHourly().
+		HighlyAvailable().
+		WithNodePools(NewNodePool().
 			Named("pool-1").WithCount(3).OfInstance(NodePoolInstanceK4A8).InZone(ZoneITBG1))
 
 	result, err := adapter.Create(context.Background(), k)
@@ -801,7 +801,7 @@ func TestKaaSClientAdapter_Create_MetadataValidationError(t *testing.T) {
 		fmt.Fprint(w, `{"metadata":{"name":"cluster","uri":"/projects/p/providers/Aruba.Container/kaas/x"},"properties":{},"status":{}}`)
 	})
 
-	k := NewKaaS().IntoProject(URI("/projects/p")).
+	k := NewKaaS().InProject(URI("/projects/p")).
 		Named("cluster")
 	result, err := adapter.Create(context.Background(), k)
 	if err == nil {
@@ -823,7 +823,7 @@ func TestKaaSClientAdapter_Create_NonTwoXX(t *testing.T) {
 		fmt.Fprint(w, testutil.ErrorBodyJSON("Validation Failed", "name is required", 422))
 	})
 
-	k := NewKaaS().IntoProject(URI("/projects/p"))
+	k := NewKaaS().InProject(URI("/projects/p"))
 	result, err := adapter.Create(context.Background(), k)
 	if err == nil {
 		t.Fatal("expected error on 422")
@@ -862,7 +862,7 @@ func TestKaaSClientAdapter_Create_WithBodyRefs_ViaFake(t *testing.T) {
 	adapter := &kaasClientAdapter{low: fake}
 
 	k := NewKaaS().
-		IntoProject(URI("/projects/p")).
+		InProject(URI("/projects/p")).
 		WithVPC(URI("/projects/p/providers/Aruba.Network/vpcs/vpc-1")).
 		WithSubnet(URI("/projects/p/providers/Aruba.Network/vpcs/vpc-1/subnets/sn-1"))
 
@@ -910,7 +910,7 @@ func TestKaaSClientAdapter_Update_Success(t *testing.T) {
 		},
 	})
 	k.WithKubernetesVersion("1.33.0").
-		AddNodePool(NewNodePool().
+		WithNodePools(NewNodePool().
 			Named("pool-1").WithCount(5).OfInstance(NodePoolInstanceK4A8).InZone(ZoneITBG1))
 
 	result, err := adapter.Update(context.Background(), k)
@@ -930,7 +930,7 @@ func TestKaaSClientAdapter_Update_NoID(t *testing.T) {
 	adapter := buildKaaSTestAdapter(t, func(w http.ResponseWriter, _ *http.Request) {
 		w.WriteHeader(http.StatusOK)
 	})
-	_, err := adapter.Update(context.Background(), NewKaaS().IntoProject(URI("/projects/p")))
+	_, err := adapter.Update(context.Background(), NewKaaS().InProject(URI("/projects/p")))
 	if err == nil {
 		t.Fatal("expected error when KaaS has no ID")
 	}
@@ -1228,10 +1228,10 @@ func TestKaaSClient_HasUpdateMethod(t *testing.T) {
 
 func TestKaaS_RemoveTag_ReplaceTags_InRegion(t *testing.T) {
 	k := NewKaaS().
-		AddTag("a").
-		AddTag("b").
-		RemoveTag("a").
-		ReplaceTags("x", "y").
+		Tagged("a").
+		Tagged("b").
+		Untagged("a").
+		RetaggedAs("x", "y").
 		InRegion("ITMI-Milano-1")
 
 	tags := k.Tags()
@@ -1683,7 +1683,7 @@ func TestKaaS_ReplaceNodePools_ReplacesExisting(t *testing.T) {
 
 	k := NewKaaS().Named("c").InRegion(RegionITBGBergamo).
 		WithVPC(URI("/v")).WithSubnet(URI("/s")).
-		AddNodePool(np1).AddNodePool(np2)
+		WithNodePools(np1).WithNodePools(np2)
 
 	k.ReplaceNodePools(np3)
 
@@ -1700,9 +1700,9 @@ func TestKaaS_ClearNodePools_RemovesAll(t *testing.T) {
 	np := NewNodePool().Named("pool-1").OfInstance("inst-1").WithAutoscaling(1, 2)
 	k := NewKaaS().Named("c").InRegion(RegionITBGBergamo).
 		WithVPC(URI("/v")).WithSubnet(URI("/s")).
-		AddNodePool(np)
+		WithNodePools(np)
 
-	k.ClearNodePools()
+	k.WithoutNodePools()
 
 	req := k.toRequest()
 	if len(req.Properties.NodePools) != 0 {
@@ -1716,9 +1716,9 @@ func TestKaaS_SetNodePools_AliasForReplace(t *testing.T) {
 
 	k := NewKaaS().Named("c").InRegion(RegionITBGBergamo).
 		WithVPC(URI("/v")).WithSubnet(URI("/s")).
-		AddNodePool(np1)
+		WithNodePools(np1)
 
-	k.SetNodePools(np2)
+	k.ReplaceNodePools(np2)
 
 	req := k.toRequest()
 	if len(req.Properties.NodePools) != 1 {

--- a/pkg/aruba/resource_key.go
+++ b/pkg/aruba/resource_key.go
@@ -12,7 +12,7 @@ import (
 // ---- Wrapper ----
 
 // Key is the wrapper for a cryptographic key nested inside a KMS instance.
-// Construct with aruba.NewKey() and bind via IntoKMS(parent).
+// Construct with aruba.NewKey() and bind via InKMS(parent).
 //
 // Family B: flat request (no Metadata/Properties boxing, no metadataMixin,
 // no tags, no location).
@@ -34,7 +34,7 @@ type Key struct {
 }
 
 // NewKey returns a fresh *Key ready for fluent setters and a Create call.
-// Binds kmsScopedMixin's error sink so IntoKMS failures surface via Err().
+// Binds kmsScopedMixin's error sink so InKMS failures surface via Err().
 func NewKey() *Key {
 	k := &Key{}
 	k.kmsScopedMixin = bindKMSScoped(&k.errMixin)
@@ -43,8 +43,8 @@ func NewKey() *Key {
 
 // Setters — chainable, general → specific
 
-// IntoKMS binds this Key to its parent KMS instance. Required before Create.
-func (k *Key) IntoKMS(parent Ref) *Key { k.intoKMS(parent); return k }
+// InKMS binds this Key to its parent KMS instance. Required before Create.
+func (k *Key) InKMS(parent Ref) *Key { k.intoKMS(parent); return k }
 
 // Named sets the key name. Required by the API.
 func (k *Key) Named(n string) *Key { k.name = &n; return k }
@@ -240,10 +240,10 @@ func (a *keysClientAdapter) Create(ctx context.Context, k *Key, opts ...CallOpti
 		return k, err
 	}
 	if k.ProjectID() == "" {
-		return k, fmt.Errorf("Create: Key has no parent project — call IntoKMS first")
+		return k, fmt.Errorf("Create: Key has no parent project — call InKMS first")
 	}
 	if k.KMSID() == "" {
-		return k, fmt.Errorf("Create: Key has no parent KMS — call IntoKMS first")
+		return k, fmt.Errorf("Create: Key has no parent KMS — call InKMS first")
 	}
 	co := applyCallOptions(opts)
 	rp := co.toRequestParameters()

--- a/pkg/aruba/resource_key_pair.go
+++ b/pkg/aruba/resource_key_pair.go
@@ -39,20 +39,30 @@ func NewKeyPair() *KeyPair {
 
 // Setters — chainable, general → specific
 
-// IntoProject binds this KeyPair to its parent project. Required before Create.
-func (k *KeyPair) IntoProject(p Ref) *KeyPair { k.intoProject(p); return k }
+// InProject binds this KeyPair to its parent project. Required before Create.
+func (k *KeyPair) InProject(p Ref) *KeyPair { k.intoProject(p); return k }
 
 // Named sets the resource name. Required by the API.
 func (k *KeyPair) Named(n string) *KeyPair { k.named(n); return k }
 
-// AddTag appends a tag for filtering and accounting.
-func (k *KeyPair) AddTag(t string) *KeyPair { k.addTag(t); return k }
+// Tagged appends tags for filtering and accounting. Repeated calls append.
+func (k *KeyPair) Tagged(ts ...string) *KeyPair {
+	for _, t := range ts {
+		k.addTag(t)
+	}
+	return k
+}
 
-// RemoveTag removes a previously-added tag. No-op if absent.
-func (k *KeyPair) RemoveTag(t string) *KeyPair { k.removeTag(t); return k }
+// Untagged removes each listed tag. No-op for tags not present.
+func (k *KeyPair) Untagged(ts ...string) *KeyPair {
+	for _, t := range ts {
+		k.removeTag(t)
+	}
+	return k
+}
 
-// ReplaceTags replaces the entire tag set with the given values.
-func (k *KeyPair) ReplaceTags(ts ...string) *KeyPair { k.replaceTags(ts...); return k }
+// RetaggedAs replaces the entire tag set with the given values.
+func (k *KeyPair) RetaggedAs(ts ...string) *KeyPair { k.replaceTags(ts...); return k }
 
 // InRegion sets the region for this resource.
 func (k *KeyPair) InRegion(region Region) *KeyPair { k.inRegion(region); return k }
@@ -176,7 +186,7 @@ func (a *keyPairsClientAdapter) Create(ctx context.Context, kp *KeyPair, opts ..
 		return kp, err
 	}
 	if kp.ProjectID() == "" {
-		return kp, fmt.Errorf("Create: KeyPair has no parent project — call IntoProject first")
+		return kp, fmt.Errorf("Create: KeyPair has no parent project — call InProject first")
 	}
 	co := applyCallOptions(opts)
 	rp := co.toRequestParameters()

--- a/pkg/aruba/resource_key_pair_test.go
+++ b/pkg/aruba/resource_key_pair_test.go
@@ -27,11 +27,11 @@ func TestKeyPair_FluentSetters(t *testing.T) {
 	proj.fromResponse(projectTestResponse("p-1", "my-project", "/projects/p-1"))
 
 	kp := NewKeyPair().
-		IntoProject(proj).
+		InProject(proj).
 		Named("allow-ssh").
-		AddTag("ssh-access").
-		AddTag("ingress").
-		AddTag("ssh-access"). // dedupe
+		Tagged("ssh-access").
+		Tagged("ingress").
+		Tagged("ssh-access"). // dedupe
 		InRegion(RegionITBGBergamo).
 		WithPublicKey("ssh-rsa AAAA...")
 
@@ -54,12 +54,12 @@ func TestKeyPair_FluentSetters(t *testing.T) {
 		t.Errorf("Err() = %v", kp.Err())
 	}
 
-	kp.RemoveTag("ssh-access")
+	kp.Untagged("ssh-access")
 	if tags := kp.Tags(); len(tags) != 1 || tags[0] != "ingress" {
 		t.Errorf("after RemoveTag Tags() = %v", tags)
 	}
 
-	kp.ReplaceTags("x", "y")
+	kp.RetaggedAs("x", "y")
 	if tags := kp.Tags(); len(tags) != 2 || tags[0] != "x" || tags[1] != "y" {
 		t.Errorf("after ReplaceTags Tags() = %v", tags)
 	}
@@ -73,7 +73,7 @@ func TestKeyPair_IntoProject_TypedRef(t *testing.T) {
 	proj := &Project{}
 	proj.fromResponse(projectTestResponse("p-42", "n", "/projects/p-42"))
 
-	kp := NewKeyPair().IntoProject(proj)
+	kp := NewKeyPair().InProject(proj)
 	if kp.ProjectID() != "p-42" {
 		t.Errorf("ProjectID() = %q", kp.ProjectID())
 	}
@@ -83,7 +83,7 @@ func TestKeyPair_IntoProject_TypedRef(t *testing.T) {
 }
 
 func TestKeyPair_IntoProject_URIRef(t *testing.T) {
-	kp := NewKeyPair().IntoProject(URI("/projects/p-uri"))
+	kp := NewKeyPair().InProject(URI("/projects/p-uri"))
 	if kp.ProjectID() != "p-uri" {
 		t.Errorf("ProjectID() = %q", kp.ProjectID())
 	}
@@ -93,7 +93,7 @@ func TestKeyPair_IntoProject_URIRef(t *testing.T) {
 }
 
 func TestKeyPair_IntoProject_BadRef(t *testing.T) {
-	kp := NewKeyPair().IntoProject(URI("/something/else"))
+	kp := NewKeyPair().InProject(URI("/something/else"))
 	if kp.Err() == nil {
 		t.Error("expected Err() != nil for unresolvable Ref")
 	}
@@ -120,7 +120,7 @@ func TestKeyPair_WithPublicKey(t *testing.T) {
 func TestKeyPair_ToRequestRoundTrip(t *testing.T) {
 	kp := NewKeyPair().Named(
 		"my-keypair").
-		AddTag("t1").AddTag("t2").
+		Tagged("t1").Tagged("t2").
 		InRegion(RegionITBGBergamo).
 		WithPublicKey("ssh-rsa AAAA...")
 
@@ -337,7 +337,7 @@ func TestKeyPairsClientAdapter_Create_Success(t *testing.T) {
 	})
 
 	kp := NewKeyPair().
-		IntoProject(URI("/projects/p")).
+		InProject(URI("/projects/p")).
 		Named("allow-ssh").
 		InRegion(RegionITBGBergamo).
 		WithPublicKey("ssh-rsa AAAA...")
@@ -388,7 +388,7 @@ func TestKeyPairsClientAdapter_Create_MetadataValidationError(t *testing.T) {
 		fmt.Fprint(w, `{"metadata":{"name":"kp","uri":"/projects/p/providers/Aruba.Compute/keyPairs/x"},"properties":{}}`)
 	})
 
-	kp := NewKeyPair().IntoProject(URI("/projects/p")).
+	kp := NewKeyPair().InProject(URI("/projects/p")).
 		Named("kp").WithPublicKey("ssh-rsa AAAA...")
 	result, err := adapter.Create(context.Background(), kp)
 	if err == nil {
@@ -410,7 +410,7 @@ func TestKeyPairsClientAdapter_Create_NonTwoXX(t *testing.T) {
 		fmt.Fprint(w, testutil.ErrorBodyJSON("Validation Failed", "value is required", 422))
 	})
 
-	kp := NewKeyPair().IntoProject(URI("/projects/p")).WithPublicKey("ssh-rsa")
+	kp := NewKeyPair().InProject(URI("/projects/p")).WithPublicKey("ssh-rsa")
 	result, err := adapter.Create(context.Background(), kp)
 	if err == nil {
 		t.Fatal("expected error on 422")

--- a/pkg/aruba/resource_key_test.go
+++ b/pkg/aruba/resource_key_test.go
@@ -44,7 +44,7 @@ func keyMakeKMSParent(projectID, kmsID string) *KMS {
 func TestKey_FluentSetters(t *testing.T) {
 	parent := keyMakeKMSParent("p-1", "kms-1")
 	k := NewKey().
-		IntoKMS(parent).
+		InKMS(parent).
 		Named("my-key").
 		OfAlgorithm(KeyAlgorithmAes)
 
@@ -71,7 +71,7 @@ func TestKey_FluentSetters(t *testing.T) {
 
 func TestKey_IntoKMS_TypedRef(t *testing.T) {
 	parent := keyMakeKMSParent("p-42", "kms-42")
-	k := NewKey().IntoKMS(parent)
+	k := NewKey().InKMS(parent)
 	if k.KMSID() != "kms-42" {
 		t.Errorf("KMSID() = %q", k.KMSID())
 	}
@@ -84,7 +84,7 @@ func TestKey_IntoKMS_TypedRef(t *testing.T) {
 }
 
 func TestKey_IntoKMS_URIRef(t *testing.T) {
-	k := NewKey().IntoKMS(URI("/projects/p-uri/providers/Aruba.Security/kms/kms-uri"))
+	k := NewKey().InKMS(URI("/projects/p-uri/providers/Aruba.Security/kms/kms-uri"))
 	if k.KMSID() != "kms-uri" {
 		t.Errorf("KMSID() = %q", k.KMSID())
 	}
@@ -97,14 +97,14 @@ func TestKey_IntoKMS_URIRef(t *testing.T) {
 }
 
 func TestKey_IntoKMS_BadRef_NoKMS(t *testing.T) {
-	k := NewKey().IntoKMS(URI("/projects/p-1"))
+	k := NewKey().InKMS(URI("/projects/p-1"))
 	if k.Err() == nil {
 		t.Error("expected Err() != nil for URI missing kms segment")
 	}
 }
 
 func TestKey_IntoKMS_BadRef_NoProject(t *testing.T) {
-	k := NewKey().IntoKMS(URI("/providers/Aruba.Security/kms/kms-1"))
+	k := NewKey().InKMS(URI("/providers/Aruba.Security/kms/kms-1"))
 	if k.Err() == nil {
 		t.Error("expected Err() != nil for URI missing project segment")
 	}
@@ -390,7 +390,7 @@ func TestKeysClientAdapter_Create_Success(t *testing.T) {
 	})
 
 	parent := keyMakeKMSParent("p-1", "kms-1")
-	k := NewKey().IntoKMS(parent).
+	k := NewKey().InKMS(parent).
 		Named("my-key").OfAlgorithm(KeyAlgorithmAes)
 
 	result, err := adapter.Create(context.Background(), k)
@@ -453,7 +453,7 @@ func TestKeysClientAdapter_Create_ErrMixin(t *testing.T) {
 	adapter := buildKeyTestAdapter(t, func(w http.ResponseWriter, _ *http.Request) {
 		w.WriteHeader(http.StatusCreated)
 	})
-	k := NewKey().IntoKMS(URI("not-a-valid-kms-uri"))
+	k := NewKey().InKMS(URI("not-a-valid-kms-uri"))
 	_, err := adapter.Create(context.Background(), k)
 	if err == nil {
 		t.Fatal("expected error from errMixin when IntoKMS failed")
@@ -467,7 +467,7 @@ func TestKeysClientAdapter_Create_NonTwoXX(t *testing.T) {
 		fmt.Fprint(w, `{"message":"bad request"}`)
 	})
 	parent := keyMakeKMSParent("p-1", "kms-1")
-	_, err := adapter.Create(context.Background(), NewKey().IntoKMS(parent).
+	_, err := adapter.Create(context.Background(), NewKey().InKMS(parent).
 		Named("k").OfAlgorithm(KeyAlgorithmAes))
 	var httpErr *HTTPError
 	if !errors.As(err, &httpErr) {

--- a/pkg/aruba/resource_kmip.go
+++ b/pkg/aruba/resource_kmip.go
@@ -14,7 +14,7 @@ import (
 // ---- Wrapper ----
 
 // Kmip is the wrapper for a KMIP service nested inside a KMS instance.
-// Construct with aruba.NewKmip() and bind via IntoKMS(parent).
+// Construct with aruba.NewKmip() and bind via InKMS(parent).
 //
 // Family B: flat request (no Metadata/Properties boxing, no metadataMixin,
 // no tags, no location).
@@ -37,7 +37,7 @@ type Kmip struct {
 }
 
 // NewKmip returns a fresh *Kmip ready for fluent setters and a Create call.
-// Binds kmsScopedMixin's error sink so IntoKMS failures surface via Err().
+// Binds kmsScopedMixin's error sink so InKMS failures surface via Err().
 func NewKmip() *Kmip {
 	km := &Kmip{}
 	km.kmsScopedMixin = bindKMSScoped(&km.errMixin)
@@ -104,8 +104,8 @@ func (km *Kmip) WaitUntilCertificateAvailable(ctx context.Context, opts ...WaitO
 
 // Setters — chainable, general → specific
 
-// IntoKMS binds this Kmip to its parent KMS instance. Required before Create.
-func (km *Kmip) IntoKMS(parent Ref) *Kmip { km.intoKMS(parent); return km }
+// InKMS binds this Kmip to its parent KMS instance. Required before Create.
+func (km *Kmip) InKMS(parent Ref) *Kmip { km.intoKMS(parent); return km }
 
 // Named sets the resource name. Required by the API.
 func (km *Kmip) Named(n string) *Kmip { km.name = &n; return km }
@@ -279,10 +279,10 @@ func (a *kmipsClientAdapter) Create(ctx context.Context, km *Kmip, opts ...CallO
 		return km, err
 	}
 	if km.ProjectID() == "" {
-		return km, fmt.Errorf("Create: Kmip has no parent project — call IntoKMS first")
+		return km, fmt.Errorf("Create: Kmip has no parent project — call InKMS first")
 	}
 	if km.KMSID() == "" {
-		return km, fmt.Errorf("Create: Kmip has no parent KMS — call IntoKMS first")
+		return km, fmt.Errorf("Create: Kmip has no parent KMS — call InKMS first")
 	}
 	co := applyCallOptions(opts)
 	rp := co.toRequestParameters()

--- a/pkg/aruba/resource_kmip_test.go
+++ b/pkg/aruba/resource_kmip_test.go
@@ -44,7 +44,7 @@ func kmipMakeKMSParent(projectID, kmsID string) *KMS {
 func TestKmip_FluentSetters(t *testing.T) {
 	parent := kmipMakeKMSParent("p-1", "kms-1")
 	km := NewKmip().
-		IntoKMS(parent).
+		InKMS(parent).
 		Named("my-kmip")
 
 	if km.Name() != "my-kmip" {
@@ -67,7 +67,7 @@ func TestKmip_FluentSetters(t *testing.T) {
 
 func TestKmip_IntoKMS_TypedRef(t *testing.T) {
 	parent := kmipMakeKMSParent("p-42", "kms-42")
-	km := NewKmip().IntoKMS(parent)
+	km := NewKmip().InKMS(parent)
 	if km.KMSID() != "kms-42" {
 		t.Errorf("KMSID() = %q", km.KMSID())
 	}
@@ -80,7 +80,7 @@ func TestKmip_IntoKMS_TypedRef(t *testing.T) {
 }
 
 func TestKmip_IntoKMS_URIRef(t *testing.T) {
-	km := NewKmip().IntoKMS(URI("/projects/p-uri/providers/Aruba.Security/kms/kms-uri"))
+	km := NewKmip().InKMS(URI("/projects/p-uri/providers/Aruba.Security/kms/kms-uri"))
 	if km.KMSID() != "kms-uri" {
 		t.Errorf("KMSID() = %q", km.KMSID())
 	}
@@ -93,14 +93,14 @@ func TestKmip_IntoKMS_URIRef(t *testing.T) {
 }
 
 func TestKmip_IntoKMS_BadRef_NoKMS(t *testing.T) {
-	km := NewKmip().IntoKMS(URI("/projects/p-1"))
+	km := NewKmip().InKMS(URI("/projects/p-1"))
 	if km.Err() == nil {
 		t.Error("expected Err() != nil for URI missing kms segment")
 	}
 }
 
 func TestKmip_IntoKMS_BadRef_NoProject(t *testing.T) {
-	km := NewKmip().IntoKMS(URI("/providers/Aruba.Security/kms/kms-1"))
+	km := NewKmip().InKMS(URI("/providers/Aruba.Security/kms/kms-1"))
 	if km.Err() == nil {
 		t.Error("expected Err() != nil for URI missing project segment")
 	}
@@ -364,7 +364,7 @@ func TestKmipsClientAdapter_Create_Success(t *testing.T) {
 	})
 
 	parent := kmipMakeKMSParent("p-1", "kms-1")
-	km := NewKmip().IntoKMS(parent).
+	km := NewKmip().InKMS(parent).
 		Named("my-kmip")
 
 	result, err := adapter.Create(context.Background(), km)
@@ -424,7 +424,7 @@ func TestKmipsClientAdapter_Create_ErrMixin(t *testing.T) {
 	adapter := buildKmipTestAdapter(t, func(w http.ResponseWriter, _ *http.Request) {
 		w.WriteHeader(http.StatusCreated)
 	})
-	km := NewKmip().IntoKMS(URI("not-a-valid-kms-uri"))
+	km := NewKmip().InKMS(URI("not-a-valid-kms-uri"))
 	_, err := adapter.Create(context.Background(), km)
 	if err == nil {
 		t.Fatal("expected error from errMixin when IntoKMS failed")
@@ -438,7 +438,7 @@ func TestKmipsClientAdapter_Create_NonTwoXX(t *testing.T) {
 		fmt.Fprint(w, `{"message":"bad request"}`)
 	})
 	parent := kmipMakeKMSParent("p-1", "kms-1")
-	_, err := adapter.Create(context.Background(), NewKmip().IntoKMS(parent).
+	_, err := adapter.Create(context.Background(), NewKmip().InKMS(parent).
 		Named("km"))
 	var httpErr *HTTPError
 	if !errors.As(err, &httpErr) {
@@ -820,7 +820,7 @@ func TestKmipsClientAdapter_Create_InjectsRefresh(t *testing.T) {
 		fmt.Fprint(w, kmipSuccessBody)
 	})
 	parent := kmipMakeKMSParent("p-1", "kms-1")
-	km, err := adapter.Create(context.Background(), NewKmip().IntoKMS(parent).
+	km, err := adapter.Create(context.Background(), NewKmip().InKMS(parent).
 		Named("my-kmip"))
 	if err != nil {
 		t.Fatalf("Create error: %v", err)

--- a/pkg/aruba/resource_kms.go
+++ b/pkg/aruba/resource_kms.go
@@ -46,26 +46,42 @@ func NewKMS() *KMS {
 
 // Setters — chainable, general → specific
 
-// IntoProject binds this KMS to its parent project. Required before Create.
-func (k *KMS) IntoProject(p Ref) *KMS { k.intoProject(p); return k }
+// InProject binds this KMS to its parent project. Required before Create.
+func (k *KMS) InProject(p Ref) *KMS { k.intoProject(p); return k }
 
 // Named sets the resource name. Required by the API.
 func (k *KMS) Named(n string) *KMS { k.named(n); return k }
 
-// AddTag appends a tag for filtering and accounting.
-func (k *KMS) AddTag(t string) *KMS { k.addTag(t); return k }
+// Tagged appends tags for filtering and accounting. Repeated calls append.
+func (k *KMS) Tagged(ts ...string) *KMS {
+	for _, t := range ts {
+		k.addTag(t)
+	}
+	return k
+}
 
-// RemoveTag removes a previously-added tag. No-op if absent.
-func (k *KMS) RemoveTag(t string) *KMS { k.removeTag(t); return k }
+// Untagged removes each listed tag. No-op for tags not present.
+func (k *KMS) Untagged(ts ...string) *KMS {
+	for _, t := range ts {
+		k.removeTag(t)
+	}
+	return k
+}
 
-// ReplaceTags replaces the entire tag set with the given values.
-func (k *KMS) ReplaceTags(ts ...string) *KMS { k.replaceTags(ts...); return k }
+// RetaggedAs replaces the entire tag set with the given values.
+func (k *KMS) RetaggedAs(ts ...string) *KMS { k.replaceTags(ts...); return k }
 
 // InRegion sets the region for this resource.
 func (k *KMS) InRegion(region Region) *KMS { k.inRegion(region); return k }
 
-// WithBillingPeriod sets the billing period. Defaults to hourly when unset.
-func (k *KMS) WithBillingPeriod(p BillingPeriod) *KMS { k.billingPeriod = &p; return k }
+// BilledHourly sets hourly billing.
+func (k *KMS) BilledHourly() *KMS { v := BillingPeriodHour; k.billingPeriod = &v; return k }
+
+// BilledMonthly sets monthly billing.
+func (k *KMS) BilledMonthly() *KMS { v := BillingPeriodMonth; k.billingPeriod = &v; return k }
+
+// BilledYearly sets yearly billing.
+func (k *KMS) BilledYearly() *KMS { v := BillingPeriodYear; k.billingPeriod = &v; return k }
 
 // Getters — general → specific
 
@@ -209,7 +225,7 @@ func (a *kmsClientAdapter) Create(ctx context.Context, k *KMS, opts ...CallOptio
 		return k, err
 	}
 	if k.ProjectID() == "" {
-		return k, fmt.Errorf("Create: KMS has no parent project — call IntoProject first")
+		return k, fmt.Errorf("Create: KMS has no parent project — call InProject first")
 	}
 	co := applyCallOptions(opts)
 	rp := co.toRequestParameters()
@@ -246,7 +262,7 @@ func (a *kmsClientAdapter) Update(ctx context.Context, k *KMS, opts ...CallOptio
 		return k, fmt.Errorf("Update: KMS has no ID")
 	}
 	if k.ProjectID() == "" {
-		return k, fmt.Errorf("Update: KMS has no parent project — call IntoProject first")
+		return k, fmt.Errorf("Update: KMS has no parent project — call InProject first")
 	}
 	co := applyCallOptions(opts)
 	rp := co.toRequestParameters()

--- a/pkg/aruba/resource_kms.go
+++ b/pkg/aruba/resource_kms.go
@@ -74,14 +74,8 @@ func (k *KMS) RetaggedAs(ts ...string) *KMS { k.replaceTags(ts...); return k }
 // InRegion sets the region for this resource.
 func (k *KMS) InRegion(region Region) *KMS { k.inRegion(region); return k }
 
-// BilledHourly sets hourly billing.
-func (k *KMS) BilledHourly() *KMS { v := BillingPeriodHour; k.billingPeriod = &v; return k }
-
-// BilledMonthly sets monthly billing.
-func (k *KMS) BilledMonthly() *KMS { v := BillingPeriodMonth; k.billingPeriod = &v; return k }
-
-// BilledYearly sets yearly billing.
-func (k *KMS) BilledYearly() *KMS { v := BillingPeriodYear; k.billingPeriod = &v; return k }
+// BilledBy sets the billing cadence. Accepted periods are resource-specific; check the API reference.
+func (k *KMS) BilledBy(period BillingPeriod) *KMS { k.billingPeriod = &period; return k }
 
 // Getters — general → specific
 

--- a/pkg/aruba/resource_kms_test.go
+++ b/pkg/aruba/resource_kms_test.go
@@ -32,13 +32,13 @@ func TestKMS_FluentSetters(t *testing.T) {
 	proj.fromResponse(projectTestResponse("p-1", "my-proj", "/projects/p-1"))
 
 	k := NewKMS().
-		IntoProject(proj).
+		InProject(proj).
 		Named("my-kms").
-		AddTag("security").
-		AddTag("encryption").
-		AddTag("security"). // dedupe
+		Tagged("security").
+		Tagged("encryption").
+		Tagged("security"). // dedupe
 		InRegion(RegionITBGBergamo).
-		WithBillingPeriod(BillingPeriodHour)
+		BilledHourly()
 
 	if k.Name() != "my-kms" {
 		t.Errorf("Name() = %q", k.Name())
@@ -67,7 +67,7 @@ func TestKMS_FluentSetters(t *testing.T) {
 func TestKMS_IntoProject_TypedRef(t *testing.T) {
 	proj := &Project{}
 	proj.fromResponse(projectTestResponse("p-42", "proj", "/projects/p-42"))
-	k := NewKMS().IntoProject(proj)
+	k := NewKMS().InProject(proj)
 	if k.ProjectID() != "p-42" {
 		t.Errorf("ProjectID() = %q", k.ProjectID())
 	}
@@ -77,14 +77,14 @@ func TestKMS_IntoProject_TypedRef(t *testing.T) {
 }
 
 func TestKMS_IntoProject_URIRef(t *testing.T) {
-	k := NewKMS().IntoProject(URI("/projects/p-uri"))
+	k := NewKMS().InProject(URI("/projects/p-uri"))
 	if k.ProjectID() != "p-uri" {
 		t.Errorf("ProjectID() = %q", k.ProjectID())
 	}
 }
 
 func TestKMS_IntoProject_BadRef(t *testing.T) {
-	k := NewKMS().IntoProject(URI("not-a-project-uri"))
+	k := NewKMS().InProject(URI("not-a-project-uri"))
 	if k.Err() == nil {
 		t.Error("expected Err() != nil for non-project URI")
 	}
@@ -95,7 +95,7 @@ func TestKMS_IntoProject_BadRef(t *testing.T) {
 // --------------------------------------------------------------------------
 
 func TestKMS_WithBillingPeriod_RoundTrip(t *testing.T) {
-	k := NewKMS().WithBillingPeriod(BillingPeriodHour)
+	k := NewKMS().BilledHourly()
 	req := k.RawRequest()
 	if req.Properties.BillingPeriod == nil || *req.Properties.BillingPeriod != BillingPeriodHour {
 		t.Errorf("Properties.BillingPeriod = %v", req.Properties.BillingPeriod)
@@ -108,11 +108,11 @@ func TestKMS_WithBillingPeriod_RoundTrip(t *testing.T) {
 
 func TestKMS_ToRequest_FullyPopulated(t *testing.T) {
 	k := NewKMS().
-		IntoProject(URI("/projects/p")).
+		InProject(URI("/projects/p")).
 		Named("kms-name").
-		AddTag("tag1").
+		Tagged("tag1").
 		InRegion(RegionITBGBergamo).
-		WithBillingPeriod(BillingPeriodHour)
+		BilledHourly()
 
 	req := k.RawRequest()
 	if req.Metadata.Name != "kms-name" {
@@ -278,10 +278,10 @@ func TestKMSClientAdapter_Create_Success(t *testing.T) {
 	})
 
 	k := NewKMS().
-		IntoProject(URI("/projects/p")).
+		InProject(URI("/projects/p")).
 		Named("my-kms").
 		InRegion(RegionITBGBergamo).
-		WithBillingPeriod(BillingPeriodHour)
+		BilledHourly()
 
 	result, err := adapter.Create(context.Background(), k)
 	if err != nil {
@@ -328,7 +328,7 @@ func TestKMSClientAdapter_Create_MetadataValidationError(t *testing.T) {
 		fmt.Fprint(w, `{"metadata":{"name":"k","uri":"/projects/p/providers/Aruba.Security/kms/x"},"properties":{},"status":{}}`)
 	})
 
-	k := NewKMS().IntoProject(URI("/projects/p")).
+	k := NewKMS().InProject(URI("/projects/p")).
 		Named("k")
 	result, err := adapter.Create(context.Background(), k)
 	if err == nil {
@@ -349,7 +349,7 @@ func TestKMSClientAdapter_Create_NonTwoXX(t *testing.T) {
 		w.WriteHeader(http.StatusBadRequest)
 		fmt.Fprint(w, `{"message":"bad request"}`)
 	})
-	_, err := adapter.Create(context.Background(), NewKMS().IntoProject(URI("/projects/p")).
+	_, err := adapter.Create(context.Background(), NewKMS().InProject(URI("/projects/p")).
 		Named("k"))
 	var httpErr *HTTPError
 	if !errors.As(err, &httpErr) {
@@ -373,7 +373,7 @@ func TestKMSClientAdapter_Update_Success(t *testing.T) {
 
 	k := &KMS{}
 	k.fromResponse(kmsTestResponse("my-kms"))
-	k.WithBillingPeriod(BillingPeriodHour)
+	k.BilledHourly()
 
 	result, err := adapter.Update(context.Background(), k)
 	if err != nil {
@@ -388,7 +388,7 @@ func TestKMSClientAdapter_Update_NoID(t *testing.T) {
 	adapter := buildKMSTestAdapter(t, func(w http.ResponseWriter, _ *http.Request) {
 		w.WriteHeader(http.StatusOK)
 	})
-	k := NewKMS().IntoProject(URI("/projects/p")).
+	k := NewKMS().InProject(URI("/projects/p")).
 		Named("x")
 	_, err := adapter.Update(context.Background(), k)
 	if err == nil {
@@ -532,11 +532,11 @@ func TestKMSClientAdapter_List_TwoItems(t *testing.T) {
 
 func TestKMS_SetterDelegation(t *testing.T) {
 	k := NewKMS().
-		AddTag("a").
-		AddTag("b").
-		AddTag("c").
-		RemoveTag("b").
-		ReplaceTags("x", "y").
+		Tagged("a").
+		Tagged("b").
+		Tagged("c").
+		Untagged("b").
+		RetaggedAs("x", "y").
 		InRegion(RegionITBGBergamo)
 
 	tags := k.Tags()
@@ -589,7 +589,7 @@ func TestKMS_Accessors_ZeroValue(t *testing.T) {
 // --------------------------------------------------------------------------
 
 func TestKMS_BillingPeriod_RequestFallback(t *testing.T) {
-	k := NewKMS().WithBillingPeriod(BillingPeriodHour)
+	k := NewKMS().BilledHourly()
 	// response is nil, so it falls through to the request-side value
 	if k.BillingPeriod() != BillingPeriodHour {
 		t.Errorf("BillingPeriod() request fallback = %q", k.BillingPeriod())
@@ -732,7 +732,7 @@ func TestKMSClientAdapter_Update_ErrSet(t *testing.T) {
 	adapter := buildKMSTestAdapter(t, func(w http.ResponseWriter, _ *http.Request) {
 		w.WriteHeader(http.StatusOK)
 	})
-	k := NewKMS().IntoProject(URI("not-a-project-uri")) // sets Err()
+	k := NewKMS().InProject(URI("not-a-project-uri")) // sets Err()
 	_, err := adapter.Update(context.Background(), k)
 	if err == nil {
 		t.Fatal("expected error when KMS has Err() set")

--- a/pkg/aruba/resource_kms_test.go
+++ b/pkg/aruba/resource_kms_test.go
@@ -38,7 +38,7 @@ func TestKMS_FluentSetters(t *testing.T) {
 		Tagged("encryption").
 		Tagged("security"). // dedupe
 		InRegion(RegionITBGBergamo).
-		BilledHourly()
+		BilledBy(BillingPeriodHour)
 
 	if k.Name() != "my-kms" {
 		t.Errorf("Name() = %q", k.Name())
@@ -95,7 +95,7 @@ func TestKMS_IntoProject_BadRef(t *testing.T) {
 // --------------------------------------------------------------------------
 
 func TestKMS_WithBillingPeriod_RoundTrip(t *testing.T) {
-	k := NewKMS().BilledHourly()
+	k := NewKMS().BilledBy(BillingPeriodHour)
 	req := k.RawRequest()
 	if req.Properties.BillingPeriod == nil || *req.Properties.BillingPeriod != BillingPeriodHour {
 		t.Errorf("Properties.BillingPeriod = %v", req.Properties.BillingPeriod)
@@ -112,7 +112,7 @@ func TestKMS_ToRequest_FullyPopulated(t *testing.T) {
 		Named("kms-name").
 		Tagged("tag1").
 		InRegion(RegionITBGBergamo).
-		BilledHourly()
+		BilledBy(BillingPeriodHour)
 
 	req := k.RawRequest()
 	if req.Metadata.Name != "kms-name" {
@@ -281,7 +281,7 @@ func TestKMSClientAdapter_Create_Success(t *testing.T) {
 		InProject(URI("/projects/p")).
 		Named("my-kms").
 		InRegion(RegionITBGBergamo).
-		BilledHourly()
+		BilledBy(BillingPeriodHour)
 
 	result, err := adapter.Create(context.Background(), k)
 	if err != nil {
@@ -373,7 +373,7 @@ func TestKMSClientAdapter_Update_Success(t *testing.T) {
 
 	k := &KMS{}
 	k.fromResponse(kmsTestResponse("my-kms"))
-	k.BilledHourly()
+	k.BilledBy(BillingPeriodHour)
 
 	result, err := adapter.Update(context.Background(), k)
 	if err != nil {
@@ -589,7 +589,7 @@ func TestKMS_Accessors_ZeroValue(t *testing.T) {
 // --------------------------------------------------------------------------
 
 func TestKMS_BillingPeriod_RequestFallback(t *testing.T) {
-	k := NewKMS().BilledHourly()
+	k := NewKMS().BilledBy(BillingPeriodHour)
 	// response is nil, so it falls through to the request-side value
 	if k.BillingPeriod() != BillingPeriodHour {
 		t.Errorf("BillingPeriod() request fallback = %q", k.BillingPeriod())

--- a/pkg/aruba/resource_project.go
+++ b/pkg/aruba/resource_project.go
@@ -33,17 +33,27 @@ func NewProject() *Project { return &Project{} }
 // Named sets the project name.
 func (p *Project) Named(n string) *Project { p.named(n); return p }
 
-// AddTag adds a tag (deduped).
-func (p *Project) AddTag(t string) *Project { p.addTag(t); return p }
+// Tagged appends tags for filtering and accounting. Repeated calls append.
+func (p *Project) Tagged(ts ...string) *Project {
+	for _, t := range ts {
+		p.addTag(t)
+	}
+	return p
+}
 
-// RemoveTag removes a tag.
-func (p *Project) RemoveTag(t string) *Project { p.removeTag(t); return p }
+// Untagged removes each listed tag. No-op for tags not present.
+func (p *Project) Untagged(ts ...string) *Project {
+	for _, t := range ts {
+		p.removeTag(t)
+	}
+	return p
+}
 
-// ReplaceTags overwrites the tag list.
-func (p *Project) ReplaceTags(ts ...string) *Project { p.replaceTags(ts...); return p }
+// RetaggedAs overwrites the tag list.
+func (p *Project) RetaggedAs(ts ...string) *Project { p.replaceTags(ts...); return p }
 
-// WithDescription sets the project description.
-func (p *Project) WithDescription(d string) *Project { p.description = &d; return p }
+// DescribedAs sets the project description.
+func (p *Project) DescribedAs(d string) *Project { p.description = &d; return p }
 
 // AsDefault marks the project as the account default.
 func (p *Project) AsDefault() *Project { p.defaultProj = true; return p }

--- a/pkg/aruba/resource_project_test.go
+++ b/pkg/aruba/resource_project_test.go
@@ -25,10 +25,10 @@ var _ Ref = (*Project)(nil)
 func TestProject_FluentSetters(t *testing.T) {
 	p := NewProject().Named(
 		"my-project").
-		AddTag("a").
-		AddTag("b").
-		AddTag("a"). // dedupe
-		WithDescription("desc").
+		Tagged("a").
+		Tagged("b").
+		Tagged("a"). // dedupe
+		DescribedAs("desc").
 		AsDefault()
 
 	if p.Name() != "my-project" {
@@ -44,12 +44,12 @@ func TestProject_FluentSetters(t *testing.T) {
 		t.Error("IsDefault() should be true")
 	}
 
-	p.RemoveTag("a")
+	p.Untagged("a")
 	if tags := p.Tags(); len(tags) != 1 || tags[0] != "b" {
 		t.Errorf("after RemoveTag Tags() = %v", tags)
 	}
 
-	p.ReplaceTags("x", "y")
+	p.RetaggedAs("x", "y")
 	if tags := p.Tags(); len(tags) != 2 || tags[0] != "x" || tags[1] != "y" {
 		t.Errorf("after ReplaceTags Tags() = %v", tags)
 	}
@@ -69,9 +69,9 @@ func TestProject_Description_Unset(t *testing.T) {
 func TestProject_ToRequestRoundTrip(t *testing.T) {
 	p := NewProject().Named(
 		"proj").
-		AddTag("t1").
-		AddTag("t2").
-		WithDescription("d").
+		Tagged("t1").
+		Tagged("t2").
+		DescribedAs("d").
 		AsDefault()
 
 	req := p.toRequest()

--- a/pkg/aruba/resource_security_group.go
+++ b/pkg/aruba/resource_security_group.go
@@ -46,20 +46,30 @@ func NewSecurityGroup() *SecurityGroup {
 
 // Setters — chainable, general → specific
 
-// IntoVPC binds this SecurityGroup to its parent VPC. Required before Create.
-func (sg *SecurityGroup) IntoVPC(v Ref) *SecurityGroup { sg.intoVPC(v); return sg }
+// InVPC binds this SecurityGroup to its parent VPC. Required before Create.
+func (sg *SecurityGroup) InVPC(v Ref) *SecurityGroup { sg.intoVPC(v); return sg }
 
 // Named sets the resource name. Required by the API.
 func (sg *SecurityGroup) Named(n string) *SecurityGroup { sg.named(n); return sg }
 
-// AddTag appends a tag for filtering and accounting.
-func (sg *SecurityGroup) AddTag(t string) *SecurityGroup { sg.addTag(t); return sg }
+// Tagged appends tags for filtering and accounting. Repeated calls append.
+func (sg *SecurityGroup) Tagged(ts ...string) *SecurityGroup {
+	for _, t := range ts {
+		sg.addTag(t)
+	}
+	return sg
+}
 
-// RemoveTag removes a previously-added tag. No-op if absent.
-func (sg *SecurityGroup) RemoveTag(t string) *SecurityGroup { sg.removeTag(t); return sg }
+// Untagged removes each listed tag. No-op for tags not present.
+func (sg *SecurityGroup) Untagged(ts ...string) *SecurityGroup {
+	for _, t := range ts {
+		sg.removeTag(t)
+	}
+	return sg
+}
 
-// ReplaceTags replaces the entire tag set with the given values.
-func (sg *SecurityGroup) ReplaceTags(ts ...string) *SecurityGroup { sg.replaceTags(ts...); return sg }
+// RetaggedAs replaces the entire tag set with the given values.
+func (sg *SecurityGroup) RetaggedAs(ts ...string) *SecurityGroup { sg.replaceTags(ts...); return sg }
 
 // AsDefault marks this security group as the VPC default.
 func (sg *SecurityGroup) AsDefault() *SecurityGroup { t := true; sg.defaultSG = &t; return sg }
@@ -187,7 +197,7 @@ func (a *securityGroupsClientAdapter) Create(ctx context.Context, sg *SecurityGr
 		return sg, err
 	}
 	if sg.VPCID() == "" || sg.ProjectID() == "" {
-		return sg, fmt.Errorf("Create: security group has no VPC — call IntoVPC first")
+		return sg, fmt.Errorf("Create: security group has no VPC — call InVPC first")
 	}
 	co := applyCallOptions(opts)
 	rp := co.toRequestParameters()
@@ -259,7 +269,7 @@ func (a *securityGroupsClientAdapter) Update(ctx context.Context, sg *SecurityGr
 		return sg, fmt.Errorf("Update: security group has no ID — call Get first or seed from response metadata")
 	}
 	if sg.VPCID() == "" || sg.ProjectID() == "" {
-		return sg, fmt.Errorf("Update: security group has no VPC — call IntoVPC first")
+		return sg, fmt.Errorf("Update: security group has no VPC — call InVPC first")
 	}
 	co := applyCallOptions(opts)
 	rp := co.toRequestParameters()

--- a/pkg/aruba/resource_security_group_test.go
+++ b/pkg/aruba/resource_security_group_test.go
@@ -28,11 +28,11 @@ func TestSecurityGroup_FluentSetters(t *testing.T) {
 	parent.fromResponse(vpcTestResponse("v1", "my-vpc", "/projects/p1/providers/Aruba.Network/vpcs/v1", "p1"))
 
 	sg := NewSecurityGroup().
-		IntoVPC(parent).
+		InVPC(parent).
 		Named("my-sg").
-		AddTag("security").
-		AddTag("network").
-		AddTag("security"). // dedupe
+		Tagged("security").
+		Tagged("network").
+		Tagged("security"). // dedupe
 		AsDefault()
 
 	if sg.Name() != "my-sg" {
@@ -54,12 +54,12 @@ func TestSecurityGroup_FluentSetters(t *testing.T) {
 		t.Errorf("Err() = %v", sg.Err())
 	}
 
-	sg.RemoveTag("security")
+	sg.Untagged("security")
 	if tags := sg.Tags(); len(tags) != 1 || tags[0] != "network" {
 		t.Errorf("after RemoveTag Tags() = %v", tags)
 	}
 
-	sg.ReplaceTags("x", "y")
+	sg.RetaggedAs("x", "y")
 	if tags := sg.Tags(); len(tags) != 2 || tags[0] != "x" || tags[1] != "y" {
 		t.Errorf("after ReplaceTags Tags() = %v", tags)
 	}
@@ -70,7 +70,7 @@ func TestSecurityGroup_FluentSetters(t *testing.T) {
 // --------------------------------------------------------------------------
 
 func TestSecurityGroup_IntoVPC_BadRef(t *testing.T) {
-	sg := NewSecurityGroup().IntoVPC(URI("/garbage"))
+	sg := NewSecurityGroup().InVPC(URI("/garbage"))
 	if sg.Err() == nil {
 		t.Error("expected Err() != nil for unresolvable Ref, got nil")
 	}
@@ -83,8 +83,8 @@ func TestSecurityGroup_IntoVPC_BadRef(t *testing.T) {
 func TestSecurityGroup_ToRequestRoundTrip(t *testing.T) {
 	sg := NewSecurityGroup().Named(
 		"sg-1").
-		AddTag("t1").
-		AddTag("t2").
+		Tagged("t1").
+		Tagged("t2").
 		NotDefault()
 
 	req := sg.RawRequest()
@@ -343,7 +343,7 @@ func TestSecurityGroupsClientAdapter_Create_Success(t *testing.T) {
 	vpc.fromResponse(vpcTestResponse("v", "my-vpc", "/projects/p/providers/Aruba.Network/vpcs/v", "p"))
 
 	sg := NewSecurityGroup().
-		IntoVPC(vpc).
+		InVPC(vpc).
 		Named("my-sg").
 		NotDefault()
 
@@ -396,7 +396,7 @@ func TestSecurityGroupsClientAdapter_Create_MetadataValidationError(t *testing.T
 	vpc := &VPC{}
 	vpc.fromResponse(vpcTestResponse("v", "my-vpc", "/projects/p/providers/Aruba.Network/vpcs/v", "p"))
 
-	sg := NewSecurityGroup().IntoVPC(vpc).
+	sg := NewSecurityGroup().InVPC(vpc).
 		Named("sg")
 	result, err := adapter.Create(context.Background(), sg)
 	if err == nil {
@@ -421,7 +421,7 @@ func TestSecurityGroupsClientAdapter_Create_NonTwoXX(t *testing.T) {
 	vpc := &VPC{}
 	vpc.fromResponse(vpcTestResponse("v", "my-vpc", "/projects/p/providers/Aruba.Network/vpcs/v", "p"))
 
-	sg := NewSecurityGroup().IntoVPC(vpc)
+	sg := NewSecurityGroup().InVPC(vpc)
 	result, err := adapter.Create(context.Background(), sg)
 	if err == nil {
 		t.Fatal("expected error on 422")
@@ -538,7 +538,7 @@ func TestSecurityGroupsClientAdapter_Update_NoID(t *testing.T) {
 		w.WriteHeader(http.StatusOK)
 	})
 
-	sg := NewSecurityGroup().IntoVPC(URI("/projects/p/providers/Aruba.Network/vpcs/v")).
+	sg := NewSecurityGroup().InVPC(URI("/projects/p/providers/Aruba.Network/vpcs/v")).
 		Named("x")
 	_, err := adapter.Update(context.Background(), sg)
 	if err == nil {
@@ -706,7 +706,7 @@ func TestSecurityGroupsClientAdapter_Create_WithBuilderError(t *testing.T) {
 		callCount++
 		w.WriteHeader(http.StatusCreated)
 	})
-	sg := NewSecurityGroup().IntoVPC(URI("/garbage"))
+	sg := NewSecurityGroup().InVPC(URI("/garbage"))
 	_, err := adapter.Create(context.Background(), sg)
 	if err == nil {
 		t.Fatal("expected error for builder error")
@@ -740,7 +740,7 @@ func TestSecurityGroupsClientAdapter_Update_WithBuilderError(t *testing.T) {
 		callCount++
 		w.WriteHeader(http.StatusOK)
 	})
-	sg := NewSecurityGroup().IntoVPC(URI("/garbage"))
+	sg := NewSecurityGroup().InVPC(URI("/garbage"))
 	_, err := adapter.Update(context.Background(), sg)
 	if err == nil {
 		t.Fatal("expected error for builder error")

--- a/pkg/aruba/resource_security_rule.go
+++ b/pkg/aruba/resource_security_rule.go
@@ -49,20 +49,30 @@ func NewSecurityRule() *SecurityRule {
 
 // Setters — chainable, general → specific
 
-// IntoSecurityGroup binds this SecurityRule to its parent SecurityGroup. Required before Create.
-func (r *SecurityRule) IntoSecurityGroup(sg Ref) *SecurityRule { r.intoSecurityGroup(sg); return r }
+// InSecurityGroup binds this SecurityRule to its parent SecurityGroup. Required before Create.
+func (r *SecurityRule) InSecurityGroup(sg Ref) *SecurityRule { r.intoSecurityGroup(sg); return r }
 
 // Named sets the resource name. Required by the API.
 func (r *SecurityRule) Named(n string) *SecurityRule { r.named(n); return r }
 
-// AddTag appends a tag for filtering and accounting.
-func (r *SecurityRule) AddTag(t string) *SecurityRule { r.addTag(t); return r }
+// Tagged appends tags for filtering and accounting. Repeated calls append.
+func (r *SecurityRule) Tagged(ts ...string) *SecurityRule {
+	for _, t := range ts {
+		r.addTag(t)
+	}
+	return r
+}
 
-// RemoveTag removes a previously-added tag. No-op if absent.
-func (r *SecurityRule) RemoveTag(t string) *SecurityRule { r.removeTag(t); return r }
+// Untagged removes each listed tag. No-op for tags not present.
+func (r *SecurityRule) Untagged(ts ...string) *SecurityRule {
+	for _, t := range ts {
+		r.removeTag(t)
+	}
+	return r
+}
 
-// ReplaceTags replaces the entire tag set with the given values.
-func (r *SecurityRule) ReplaceTags(ts ...string) *SecurityRule { r.replaceTags(ts...); return r }
+// RetaggedAs replaces the entire tag set with the given values.
+func (r *SecurityRule) RetaggedAs(ts ...string) *SecurityRule { r.replaceTags(ts...); return r }
 
 // InRegion sets the region for this resource.
 func (r *SecurityRule) InRegion(region Region) *SecurityRule { r.inRegion(region); return r }
@@ -85,27 +95,27 @@ func (r *SecurityRule) WithPort(port string) *SecurityRule {
 	return r
 }
 
-// WithTargetCIDR sets the target as an IP/CIDR endpoint.
-// Mutually exclusive with WithTargetSecurityGroup — setting both records a setter-time error.
-func (r *SecurityRule) WithTargetCIDR(cidr string) *SecurityRule {
+// TargetingCIDR sets the target as an IP/CIDR endpoint.
+// Mutually exclusive with TargetingSecurityGroup — setting both records a setter-time error.
+func (r *SecurityRule) TargetingCIDR(cidr string) *SecurityRule {
 	if r.target != nil && r.target.Kind == types.EndpointTypeSecurityGroup {
-		r.addErr(fmt.Errorf("WithTargetCIDR: target already set to SecurityGroup; pick one"))
+		r.addErr(fmt.Errorf("TargetingCIDR: target already set to SecurityGroup; pick one"))
 		return r
 	}
 	r.target = &types.RuleTarget{Kind: types.EndpointTypeIP, Value: cidr}
 	return r
 }
 
-// WithTargetSecurityGroup sets the target as another SecurityGroup endpoint.
-// Mutually exclusive with WithTargetCIDR — setting both records a setter-time error.
-func (r *SecurityRule) WithTargetSecurityGroup(sg Ref) *SecurityRule {
+// TargetingSecurityGroup sets the target as another SecurityGroup endpoint.
+// Mutually exclusive with TargetingCIDR — setting both records a setter-time error.
+func (r *SecurityRule) TargetingSecurityGroup(sg Ref) *SecurityRule {
 	if r.target != nil && r.target.Kind == types.EndpointTypeIP {
-		r.addErr(fmt.Errorf("WithTargetSecurityGroup: target already set to CIDR; pick one"))
+		r.addErr(fmt.Errorf("TargetingSecurityGroup: target already set to CIDR; pick one"))
 		return r
 	}
 	uri := sg.URI()
 	if uri == "" {
-		r.addErr(fmt.Errorf("WithTargetSecurityGroup: target SecurityGroup Ref has empty URI"))
+		r.addErr(fmt.Errorf("TargetingSecurityGroup: target SecurityGroup Ref has empty URI"))
 		return r
 	}
 	r.target = &types.RuleTarget{Kind: types.EndpointTypeSecurityGroup, Value: uri}
@@ -298,7 +308,7 @@ func (a *securityRulesClientAdapter) Create(ctx context.Context, rule *SecurityR
 		return rule, err
 	}
 	if rule.SecurityGroupID() == "" || rule.VPCID() == "" || rule.ProjectID() == "" {
-		return rule, fmt.Errorf("Create: security rule has no SecurityGroup — call IntoSecurityGroup first")
+		return rule, fmt.Errorf("Create: security rule has no SecurityGroup — call InSecurityGroup first")
 	}
 	co := applyCallOptions(opts)
 	rp := co.toRequestParameters()
@@ -377,7 +387,7 @@ func (a *securityRulesClientAdapter) Update(ctx context.Context, rule *SecurityR
 		return rule, fmt.Errorf("Update: security rule has no ID — call Get first or seed from response metadata")
 	}
 	if rule.SecurityGroupID() == "" || rule.VPCID() == "" || rule.ProjectID() == "" {
-		return rule, fmt.Errorf("Update: security rule has no SecurityGroup — call IntoSecurityGroup first")
+		return rule, fmt.Errorf("Update: security rule has no SecurityGroup — call InSecurityGroup first")
 	}
 	co := applyCallOptions(opts)
 	rp := co.toRequestParameters()

--- a/pkg/aruba/resource_security_rule_test.go
+++ b/pkg/aruba/resource_security_rule_test.go
@@ -28,16 +28,16 @@ func TestSecurityRule_FluentSetters(t *testing.T) {
 	sg.fromResponse(securityGroupTestResponse("sg-1", "my-sg", "/projects/p1/providers/Aruba.Network/vpcs/v1/securityGroups/sg-1", "p1"))
 
 	rule := NewSecurityRule().
-		IntoSecurityGroup(sg).
+		InSecurityGroup(sg).
 		Named("allow-ssh").
-		AddTag("t1").
-		AddTag("t2").
-		AddTag("t1"). // dedupe
+		Tagged("t1").
+		Tagged("t2").
+		Tagged("t1"). // dedupe
 		InRegion(RegionITBGBergamo).
 		WithDirection(RuleDirectionIngress).
 		WithProtocol(RuleProtocolTCP).
 		WithPort("22").
-		WithTargetCIDR("0.0.0.0/0")
+		TargetingCIDR("0.0.0.0/0")
 
 	if rule.Name() != "allow-ssh" {
 		t.Errorf("Name() = %q", rule.Name())
@@ -76,12 +76,12 @@ func TestSecurityRule_FluentSetters(t *testing.T) {
 		t.Errorf("Err() = %v", rule.Err())
 	}
 
-	rule.RemoveTag("t1")
+	rule.Untagged("t1")
 	if tags := rule.Tags(); len(tags) != 1 || tags[0] != "t2" {
 		t.Errorf("after RemoveTag Tags() = %v", tags)
 	}
 
-	rule.ReplaceTags("x", "y")
+	rule.RetaggedAs("x", "y")
 	if tags := rule.Tags(); len(tags) != 2 || tags[0] != "x" || tags[1] != "y" {
 		t.Errorf("after ReplaceTags Tags() = %v", tags)
 	}
@@ -95,7 +95,7 @@ func TestSecurityRule_IntoSecurityGroup_TypedRef(t *testing.T) {
 	sg := &SecurityGroup{}
 	sg.fromResponse(securityGroupTestResponse("sg-1", "my-sg", "/projects/p1/providers/Aruba.Network/vpcs/v1/securityGroups/sg-1", "p1"))
 
-	rule := NewSecurityRule().IntoSecurityGroup(sg)
+	rule := NewSecurityRule().InSecurityGroup(sg)
 
 	if rule.SecurityGroupID() != "sg-1" {
 		t.Errorf("SecurityGroupID() = %q", rule.SecurityGroupID())
@@ -116,7 +116,7 @@ func TestSecurityRule_IntoSecurityGroup_TypedRef(t *testing.T) {
 // --------------------------------------------------------------------------
 
 func TestSecurityRule_IntoSecurityGroup_URIRef(t *testing.T) {
-	rule := NewSecurityRule().IntoSecurityGroup(URI("/projects/p/providers/Aruba.Network/vpcs/v/securityGroups/sg"))
+	rule := NewSecurityRule().InSecurityGroup(URI("/projects/p/providers/Aruba.Network/vpcs/v/securityGroups/sg"))
 
 	if rule.SecurityGroupID() != "sg" {
 		t.Errorf("SecurityGroupID() = %q", rule.SecurityGroupID())
@@ -137,7 +137,7 @@ func TestSecurityRule_IntoSecurityGroup_URIRef(t *testing.T) {
 // --------------------------------------------------------------------------
 
 func TestSecurityRule_IntoSecurityGroup_BadRef(t *testing.T) {
-	rule := NewSecurityRule().IntoSecurityGroup(URI("/garbage"))
+	rule := NewSecurityRule().InSecurityGroup(URI("/garbage"))
 	if rule.Err() == nil {
 		t.Error("expected Err() != nil for unresolvable Ref, got nil")
 	}
@@ -150,8 +150,8 @@ func TestSecurityRule_IntoSecurityGroup_BadRef(t *testing.T) {
 func TestSecurityRule_TargetMutuallyExclusive_CIDRThenSG(t *testing.T) {
 	otherSG := URI("/projects/p/providers/Aruba.Network/vpcs/v/securityGroups/sg-other")
 	rule := NewSecurityRule().
-		WithTargetCIDR("10.0.0.0/8").
-		WithTargetSecurityGroup(otherSG)
+		TargetingCIDR("10.0.0.0/8").
+		TargetingSecurityGroup(otherSG)
 
 	if rule.Err() == nil {
 		t.Fatal("expected error after setting SecurityGroup target over CIDR target")
@@ -168,8 +168,8 @@ func TestSecurityRule_TargetMutuallyExclusive_CIDRThenSG(t *testing.T) {
 func TestSecurityRule_TargetMutuallyExclusive_SGThenCIDR(t *testing.T) {
 	otherSG := URI("/projects/p/providers/Aruba.Network/vpcs/v/securityGroups/sg-other")
 	rule := NewSecurityRule().
-		WithTargetSecurityGroup(otherSG).
-		WithTargetCIDR("10.0.0.0/8")
+		TargetingSecurityGroup(otherSG).
+		TargetingCIDR("10.0.0.0/8")
 
 	if rule.Err() == nil {
 		t.Fatal("expected error after setting CIDR target over SecurityGroup target")
@@ -184,7 +184,7 @@ func TestSecurityRule_TargetMutuallyExclusive_SGThenCIDR(t *testing.T) {
 }
 
 func TestSecurityRule_TargetSecurityGroup_EmptyURI(t *testing.T) {
-	rule := NewSecurityRule().WithTargetSecurityGroup(URI(""))
+	rule := NewSecurityRule().TargetingSecurityGroup(URI(""))
 	if rule.Err() == nil {
 		t.Error("expected error when target SecurityGroup Ref has empty URI")
 	}
@@ -200,13 +200,13 @@ func TestSecurityRule_TargetSecurityGroup_EmptyURI(t *testing.T) {
 func TestSecurityRule_ToRequestRoundTrip(t *testing.T) {
 	rule := NewSecurityRule().Named(
 		"allow-ssh").
-		AddTag("t1").
-		AddTag("t2").
+		Tagged("t1").
+		Tagged("t2").
 		InRegion(RegionITBGBergamo).
 		WithDirection(RuleDirectionIngress).
 		WithProtocol(RuleProtocolTCP).
 		WithPort("22").
-		WithTargetCIDR("0.0.0.0/0")
+		TargetingCIDR("0.0.0.0/0")
 
 	req := rule.RawRequest()
 
@@ -509,13 +509,13 @@ func TestSecurityGroupRulesClientAdapter_Create_Success(t *testing.T) {
 	sg.fromResponse(securityGroupTestResponse("sg", "my-sg", "/projects/p/providers/Aruba.Network/vpcs/v/securityGroups/sg", "p"))
 
 	rule := NewSecurityRule().
-		IntoSecurityGroup(sg).
+		InSecurityGroup(sg).
 		Named("allow-ssh").
 		InRegion(RegionITBGBergamo).
 		WithDirection(RuleDirectionIngress).
 		WithProtocol(RuleProtocolTCP).
 		WithPort("22").
-		WithTargetCIDR("0.0.0.0/0")
+		TargetingCIDR("0.0.0.0/0")
 
 	result, err := adapter.Create(context.Background(), rule)
 	if err != nil {
@@ -566,7 +566,7 @@ func TestSecurityGroupRulesClientAdapter_Create_MetadataValidationError(t *testi
 	sg := &SecurityGroup{}
 	sg.fromResponse(securityGroupTestResponse("sg", "my-sg", "/projects/p/providers/Aruba.Network/vpcs/v/securityGroups/sg", "p"))
 
-	rule := NewSecurityRule().IntoSecurityGroup(sg).
+	rule := NewSecurityRule().InSecurityGroup(sg).
 		Named("rule")
 	result, err := adapter.Create(context.Background(), rule)
 	if err == nil {
@@ -591,7 +591,7 @@ func TestSecurityGroupRulesClientAdapter_Create_NonTwoXX(t *testing.T) {
 	sg := &SecurityGroup{}
 	sg.fromResponse(securityGroupTestResponse("sg", "my-sg", "/projects/p/providers/Aruba.Network/vpcs/v/securityGroups/sg", "p"))
 
-	rule := NewSecurityRule().IntoSecurityGroup(sg)
+	rule := NewSecurityRule().InSecurityGroup(sg)
 	result, err := adapter.Create(context.Background(), rule)
 	if err == nil {
 		t.Fatal("expected error on 422")
@@ -709,7 +709,7 @@ func TestSecurityGroupRulesClientAdapter_Update_NoID(t *testing.T) {
 	sg := &SecurityGroup{}
 	sg.fromResponse(securityGroupTestResponse("sg", "my-sg", "/projects/p/providers/Aruba.Network/vpcs/v/securityGroups/sg", "p"))
 
-	rule := NewSecurityRule().IntoSecurityGroup(sg).
+	rule := NewSecurityRule().InSecurityGroup(sg).
 		Named("x")
 	_, err := adapter.Update(context.Background(), rule)
 	if err == nil {
@@ -796,10 +796,10 @@ func TestSecurityGroupRulesClientAdapter_Delete_NonTwoXX(t *testing.T) {
 // InRegion exercises the 0% branch.
 func TestSecurityRule_InRegion(t *testing.T) {
 	rule := NewSecurityRule().
-		AddTag("a").
-		AddTag("b").
-		RemoveTag("a").
-		ReplaceTags("x", "y").
+		Tagged("a").
+		Tagged("b").
+		Untagged("a").
+		RetaggedAs("x", "y").
 		InRegion("ITMI-Milano-1")
 
 	if rule.Region() != "ITMI-Milano-1" {
@@ -917,7 +917,7 @@ func TestSecurityGroupRulesClientAdapter_Create_WithBuilderError(t *testing.T) {
 		callCount++
 		w.WriteHeader(http.StatusCreated)
 	})
-	rule := NewSecurityRule().IntoSecurityGroup(URI("/garbage"))
+	rule := NewSecurityRule().InSecurityGroup(URI("/garbage"))
 	_, err := adapter.Create(context.Background(), rule)
 	if err == nil {
 		t.Fatal("expected error for builder error")
@@ -969,7 +969,7 @@ func TestSecurityGroupRulesClientAdapter_Update_WithBuilderError(t *testing.T) {
 		callCount++
 		w.WriteHeader(http.StatusOK)
 	})
-	rule := NewSecurityRule().IntoSecurityGroup(URI("/garbage"))
+	rule := NewSecurityRule().InSecurityGroup(URI("/garbage"))
 	_, err := adapter.Update(context.Background(), rule)
 	if err == nil {
 		t.Fatal("expected error for builder error")

--- a/pkg/aruba/resource_snapshot.go
+++ b/pkg/aruba/resource_snapshot.go
@@ -74,14 +74,8 @@ func (s *Snapshot) RetaggedAs(ts ...string) *Snapshot { s.replaceTags(ts...); re
 // InRegion sets the region for this resource.
 func (s *Snapshot) InRegion(region Region) *Snapshot { s.inRegion(region); return s }
 
-// BilledHourly sets hourly billing.
-func (s *Snapshot) BilledHourly() *Snapshot { v := BillingPeriodHour; s.billingPeriod = &v; return s }
-
-// BilledMonthly sets monthly billing.
-func (s *Snapshot) BilledMonthly() *Snapshot { v := BillingPeriodMonth; s.billingPeriod = &v; return s }
-
-// BilledYearly sets yearly billing.
-func (s *Snapshot) BilledYearly() *Snapshot { v := BillingPeriodYear; s.billingPeriod = &v; return s }
+// BilledBy sets the billing cadence. Accepted periods are resource-specific; check the API reference.
+func (s *Snapshot) BilledBy(period BillingPeriod) *Snapshot { s.billingPeriod = &period; return s }
 
 // FromVolume binds the source BlockStorage via its URI. Pass any Ref (typed or
 // aruba.URI(...)). Empty URIs are recorded on the error sink and the field

--- a/pkg/aruba/resource_snapshot.go
+++ b/pkg/aruba/resource_snapshot.go
@@ -13,7 +13,7 @@ import (
 
 // Snapshot is the wrapper for an Aruba Cloud Snapshot (a direct child of a
 // Project, derived from a BlockStorage volume). Construct with
-// aruba.NewSnapshot() and bind it via IntoProject(project) and FromVolume(bs).
+// aruba.NewSnapshot() and bind it via InProject(project) and FromVolume(bs).
 type Snapshot struct {
 	errMixin
 	metadataMixin
@@ -46,26 +46,42 @@ func NewSnapshot() *Snapshot {
 
 // Setters — chainable, general → specific
 
-// IntoProject binds this Snapshot to its parent project. Required before Create.
-func (s *Snapshot) IntoProject(p Ref) *Snapshot { s.intoProject(p); return s }
+// InProject binds this Snapshot to its parent project. Required before Create.
+func (s *Snapshot) InProject(p Ref) *Snapshot { s.intoProject(p); return s }
 
 // Named sets the resource name. Required by the API.
 func (s *Snapshot) Named(n string) *Snapshot { s.named(n); return s }
 
-// AddTag appends a tag for filtering and accounting.
-func (s *Snapshot) AddTag(t string) *Snapshot { s.addTag(t); return s }
+// Tagged appends tags for filtering and accounting. Repeated calls append.
+func (s *Snapshot) Tagged(ts ...string) *Snapshot {
+	for _, t := range ts {
+		s.addTag(t)
+	}
+	return s
+}
 
-// RemoveTag removes a previously-added tag. No-op if absent.
-func (s *Snapshot) RemoveTag(t string) *Snapshot { s.removeTag(t); return s }
+// Untagged removes each listed tag. No-op for tags not present.
+func (s *Snapshot) Untagged(ts ...string) *Snapshot {
+	for _, t := range ts {
+		s.removeTag(t)
+	}
+	return s
+}
 
-// ReplaceTags replaces the entire tag set with the given values.
-func (s *Snapshot) ReplaceTags(ts ...string) *Snapshot { s.replaceTags(ts...); return s }
+// RetaggedAs replaces the entire tag set with the given values.
+func (s *Snapshot) RetaggedAs(ts ...string) *Snapshot { s.replaceTags(ts...); return s }
 
 // InRegion sets the region for this resource.
 func (s *Snapshot) InRegion(region Region) *Snapshot { s.inRegion(region); return s }
 
-// WithBillingPeriod sets the billing period. Defaults to hourly when unset.
-func (s *Snapshot) WithBillingPeriod(p BillingPeriod) *Snapshot { s.billingPeriod = &p; return s }
+// BilledHourly sets hourly billing.
+func (s *Snapshot) BilledHourly() *Snapshot { v := BillingPeriodHour; s.billingPeriod = &v; return s }
+
+// BilledMonthly sets monthly billing.
+func (s *Snapshot) BilledMonthly() *Snapshot { v := BillingPeriodMonth; s.billingPeriod = &v; return s }
+
+// BilledYearly sets yearly billing.
+func (s *Snapshot) BilledYearly() *Snapshot { v := BillingPeriodYear; s.billingPeriod = &v; return s }
 
 // FromVolume binds the source BlockStorage via its URI. Pass any Ref (typed or
 // aruba.URI(...)). Empty URIs are recorded on the error sink and the field
@@ -128,8 +144,8 @@ func (s *Snapshot) Type() types.BlockStorageType {
 // Zone returns the availability zone of the snapshot, or "" if unset.
 func (s *Snapshot) Zone() Zone { return snapshotDerefZone(s.zone) }
 
-// Bootable returns whether the snapshot was taken from a bootable volume, or false if unset.
-func (s *Snapshot) Bootable() bool {
+// IsBootable returns whether the snapshot was taken from a bootable volume, or false if unset.
+func (s *Snapshot) IsBootable() bool {
 	if s.bootable == nil {
 		return false
 	}
@@ -262,7 +278,7 @@ func (a *snapshotsClientAdapter) Create(ctx context.Context, snap *Snapshot, opt
 		return snap, err
 	}
 	if snap.ProjectID() == "" {
-		return snap, fmt.Errorf("Create: Snapshot has no project — call IntoProject first")
+		return snap, fmt.Errorf("Create: Snapshot has no project — call InProject first")
 	}
 	co := applyCallOptions(opts)
 	rp := co.toRequestParameters()
@@ -335,7 +351,7 @@ func (a *snapshotsClientAdapter) Update(ctx context.Context, snap *Snapshot, opt
 		return snap, fmt.Errorf("Update: Snapshot has no ID — call Get first or seed from response metadata")
 	}
 	if snap.ProjectID() == "" {
-		return snap, fmt.Errorf("Update: Snapshot has no project — call IntoProject first")
+		return snap, fmt.Errorf("Update: Snapshot has no project — call InProject first")
 	}
 	co := applyCallOptions(opts)
 	rp := co.toRequestParameters()

--- a/pkg/aruba/resource_snapshot_test.go
+++ b/pkg/aruba/resource_snapshot_test.go
@@ -27,13 +27,13 @@ func TestSnapshot_FluentSetters(t *testing.T) {
 	proj.fromResponse(projectTestResponse("p-1", "my-proj", "/projects/p-1"))
 
 	snap := NewSnapshot().
-		IntoProject(proj).
+		InProject(proj).
 		Named("my-snap").
-		AddTag("backup").
-		AddTag("storage").
-		AddTag("backup"). // dedupe
+		Tagged("backup").
+		Tagged("storage").
+		Tagged("backup"). // dedupe
 		InRegion(RegionITBGBergamo).
-		WithBillingPeriod(BillingPeriodHour)
+		BilledHourly()
 
 	if snap.Name() != "my-snap" {
 		t.Errorf("Name() = %q", snap.Name())
@@ -54,12 +54,12 @@ func TestSnapshot_FluentSetters(t *testing.T) {
 		t.Errorf("Err() = %v", snap.Err())
 	}
 
-	snap.RemoveTag("backup")
+	snap.Untagged("backup")
 	if tags := snap.Tags(); len(tags) != 1 || tags[0] != "storage" {
 		t.Errorf("after RemoveTag Tags() = %v", tags)
 	}
 
-	snap.ReplaceTags("x", "y")
+	snap.RetaggedAs("x", "y")
 	if tags := snap.Tags(); len(tags) != 2 || tags[0] != "x" || tags[1] != "y" {
 		t.Errorf("after ReplaceTags Tags() = %v", tags)
 	}
@@ -72,7 +72,7 @@ func TestSnapshot_FluentSetters(t *testing.T) {
 func TestSnapshot_IntoProject_TypedRef(t *testing.T) {
 	proj := &Project{}
 	proj.fromResponse(projectTestResponse("p-42", "n", "/projects/p-42"))
-	snap := NewSnapshot().IntoProject(proj)
+	snap := NewSnapshot().InProject(proj)
 	if snap.ProjectID() != "p-42" {
 		t.Errorf("ProjectID() = %q", snap.ProjectID())
 	}
@@ -82,7 +82,7 @@ func TestSnapshot_IntoProject_TypedRef(t *testing.T) {
 }
 
 func TestSnapshot_IntoProject_URIRef(t *testing.T) {
-	snap := NewSnapshot().IntoProject(URI("/projects/p-uri"))
+	snap := NewSnapshot().InProject(URI("/projects/p-uri"))
 	if snap.ProjectID() != "p-uri" {
 		t.Errorf("ProjectID() = %q", snap.ProjectID())
 	}
@@ -92,7 +92,7 @@ func TestSnapshot_IntoProject_URIRef(t *testing.T) {
 }
 
 func TestSnapshot_IntoProject_BadRef(t *testing.T) {
-	snap := NewSnapshot().IntoProject(URI("/garbage"))
+	snap := NewSnapshot().InProject(URI("/garbage"))
 	if snap.Err() == nil {
 		t.Error("expected Err() != nil for unresolvable Ref")
 	}
@@ -145,9 +145,9 @@ func TestSnapshot_ToRequestRoundTrip(t *testing.T) {
 	volURI := "/projects/p/providers/Aruba.Storage/blockStorages/bs-1"
 	snap := NewSnapshot().Named(
 		"snap-rt").
-		AddTag("t1").AddTag("t2").
+		Tagged("t1").Tagged("t2").
 		InRegion(RegionITBGBergamo).
-		WithBillingPeriod(BillingPeriodHour).
+		BilledHourly().
 		FromVolume(URI(volURI))
 
 	req := snap.RawRequest()
@@ -265,8 +265,8 @@ func TestSnapshot_FromResponseHydration(t *testing.T) {
 	if snap.BillingPeriod() != BillingPeriodHour {
 		t.Errorf("BillingPeriod() = %q", snap.BillingPeriod())
 	}
-	if !snap.Bootable() {
-		t.Error("Bootable() should be true")
+	if !snap.IsBootable() {
+		t.Error("IsBootable() should be true")
 	}
 	if snap.VolumeURI() != "/projects/p/providers/Aruba.Storage/blockStorages/bs-1" {
 		t.Errorf("VolumeURI() = %q", snap.VolumeURI())
@@ -472,10 +472,10 @@ func TestSnapshotsClientAdapter_Create_Success(t *testing.T) {
 
 	// No OfVolume → Volume.URI == "" → no BlockStorage dependency.
 	snap := NewSnapshot().
-		IntoProject(URI("/projects/p")).
+		InProject(URI("/projects/p")).
 		Named("my-snap").
 		InRegion(RegionITBGBergamo).
-		WithBillingPeriod(BillingPeriodHour)
+		BilledHourly()
 
 	result, err := adapter.Create(context.Background(), snap)
 	if err != nil {
@@ -523,7 +523,7 @@ func TestSnapshotsClientAdapter_Create_MetadataValidationError(t *testing.T) {
 		fmt.Fprint(w, `{"metadata":{"name":"snap","uri":"/projects/p/providers/Aruba.Storage/snapshots/x"},"properties":{},"status":{}}`)
 	})
 
-	snap := NewSnapshot().IntoProject(URI("/projects/p")).
+	snap := NewSnapshot().InProject(URI("/projects/p")).
 		Named("snap")
 	result, err := adapter.Create(context.Background(), snap)
 	if err == nil {
@@ -545,7 +545,7 @@ func TestSnapshotsClientAdapter_Create_NonTwoXX(t *testing.T) {
 		fmt.Fprint(w, testutil.ErrorBodyJSON("Validation Failed", "name is required", 422))
 	})
 
-	snap := NewSnapshot().IntoProject(URI("/projects/p"))
+	snap := NewSnapshot().InProject(URI("/projects/p"))
 	result, err := adapter.Create(context.Background(), snap)
 	if err == nil {
 		t.Fatal("expected error on 422")
@@ -583,7 +583,7 @@ func TestSnapshotsClientAdapter_Create_WithVolume(t *testing.T) {
 	adapter := &snapshotsClientAdapter{low: fake}
 
 	snap := NewSnapshot().
-		IntoProject(URI("/projects/p")).
+		InProject(URI("/projects/p")).
 		Named("my-snap").
 		FromVolume(URI(volURI))
 
@@ -654,7 +654,7 @@ func TestSnapshotsClientAdapter_Update_Success(t *testing.T) {
 
 	snap := &Snapshot{}
 	snap.fromResponse(snapshotTestResponse("snap-1", "my-snap", "/projects/p/providers/Aruba.Storage/snapshots/snap-1", "p"))
-	snap.WithBillingPeriod(BillingPeriodHour)
+	snap.BilledHourly()
 
 	result, err := adapter.Update(context.Background(), snap)
 	if err != nil {
@@ -675,7 +675,7 @@ func TestSnapshotsClientAdapter_Update_NoID(t *testing.T) {
 		w.WriteHeader(http.StatusOK)
 	})
 
-	snap := NewSnapshot().IntoProject(URI("/projects/p")).
+	snap := NewSnapshot().InProject(URI("/projects/p")).
 		Named("x")
 	_, err := adapter.Update(context.Background(), snap)
 	if err == nil {
@@ -756,8 +756,8 @@ func TestSnapshot_Accessors_ZeroValue(t *testing.T) {
 	if snap.Type() != "" {
 		t.Errorf("Type() zero value = %q, want \"\"", snap.Type())
 	}
-	if snap.Bootable() != false {
-		t.Error("Bootable() zero value should be false")
+	if snap.IsBootable() != false {
+		t.Error("IsBootable() zero value should be false")
 	}
 }
 
@@ -825,7 +825,7 @@ func TestSnapshotsClientAdapter_Update_NonTwoXX(t *testing.T) {
 
 	snap := &Snapshot{}
 	snap.fromResponse(snapshotTestResponse("snap-1", "my-snap", "/projects/p/providers/Aruba.Storage/snapshots/snap-1", "p"))
-	snap.WithBillingPeriod("Invalid")
+	snap.BilledHourly()
 
 	_, err := adapter.Update(context.Background(), snap)
 	if err == nil {

--- a/pkg/aruba/resource_snapshot_test.go
+++ b/pkg/aruba/resource_snapshot_test.go
@@ -33,7 +33,7 @@ func TestSnapshot_FluentSetters(t *testing.T) {
 		Tagged("storage").
 		Tagged("backup"). // dedupe
 		InRegion(RegionITBGBergamo).
-		BilledHourly()
+		BilledBy(BillingPeriodHour)
 
 	if snap.Name() != "my-snap" {
 		t.Errorf("Name() = %q", snap.Name())
@@ -147,7 +147,7 @@ func TestSnapshot_ToRequestRoundTrip(t *testing.T) {
 		"snap-rt").
 		Tagged("t1").Tagged("t2").
 		InRegion(RegionITBGBergamo).
-		BilledHourly().
+		BilledBy(BillingPeriodHour).
 		FromVolume(URI(volURI))
 
 	req := snap.RawRequest()
@@ -475,7 +475,7 @@ func TestSnapshotsClientAdapter_Create_Success(t *testing.T) {
 		InProject(URI("/projects/p")).
 		Named("my-snap").
 		InRegion(RegionITBGBergamo).
-		BilledHourly()
+		BilledBy(BillingPeriodHour)
 
 	result, err := adapter.Create(context.Background(), snap)
 	if err != nil {
@@ -654,7 +654,7 @@ func TestSnapshotsClientAdapter_Update_Success(t *testing.T) {
 
 	snap := &Snapshot{}
 	snap.fromResponse(snapshotTestResponse("snap-1", "my-snap", "/projects/p/providers/Aruba.Storage/snapshots/snap-1", "p"))
-	snap.BilledHourly()
+	snap.BilledBy(BillingPeriodHour)
 
 	result, err := adapter.Update(context.Background(), snap)
 	if err != nil {
@@ -825,7 +825,7 @@ func TestSnapshotsClientAdapter_Update_NonTwoXX(t *testing.T) {
 
 	snap := &Snapshot{}
 	snap.fromResponse(snapshotTestResponse("snap-1", "my-snap", "/projects/p/providers/Aruba.Storage/snapshots/snap-1", "p"))
-	snap.BilledHourly()
+	snap.BilledBy(BillingPeriodHour)
 
 	_, err := adapter.Update(context.Background(), snap)
 	if err == nil {

--- a/pkg/aruba/resource_storage_backup.go
+++ b/pkg/aruba/resource_storage_backup.go
@@ -43,20 +43,30 @@ func NewStorageBackup() *StorageBackup {
 
 // Setters — chainable, general → specific
 
-// IntoProject binds this StorageBackup to its parent project. Required before Create.
-func (b *StorageBackup) IntoProject(p Ref) *StorageBackup { b.intoProject(p); return b }
+// InProject binds this StorageBackup to its parent project. Required before Create.
+func (b *StorageBackup) InProject(p Ref) *StorageBackup { b.intoProject(p); return b }
 
 // Named sets the resource name. Required by the API.
 func (b *StorageBackup) Named(n string) *StorageBackup { b.named(n); return b }
 
-// AddTag appends a tag for filtering and accounting.
-func (b *StorageBackup) AddTag(t string) *StorageBackup { b.addTag(t); return b }
+// Tagged appends tags for filtering and accounting. Repeated calls append.
+func (b *StorageBackup) Tagged(ts ...string) *StorageBackup {
+	for _, t := range ts {
+		b.addTag(t)
+	}
+	return b
+}
 
-// RemoveTag removes a previously-added tag. No-op if absent.
-func (b *StorageBackup) RemoveTag(t string) *StorageBackup { b.removeTag(t); return b }
+// Untagged removes each listed tag. No-op for tags not present.
+func (b *StorageBackup) Untagged(ts ...string) *StorageBackup {
+	for _, t := range ts {
+		b.removeTag(t)
+	}
+	return b
+}
 
-// ReplaceTags replaces the entire tag set with the given values.
-func (b *StorageBackup) ReplaceTags(ts ...string) *StorageBackup { b.replaceTags(ts...); return b }
+// RetaggedAs replaces the entire tag set with the given values.
+func (b *StorageBackup) RetaggedAs(ts ...string) *StorageBackup { b.replaceTags(ts...); return b }
 
 // InRegion sets the region for this resource.
 func (b *StorageBackup) InRegion(region Region) *StorageBackup { b.inRegion(region); return b }
@@ -68,16 +78,31 @@ func (b *StorageBackup) OfType(t types.StorageBackupType) *StorageBackup {
 	return b
 }
 
-// WithRetentionDays sets the number of days the backup is retained.
-func (b *StorageBackup) WithRetentionDays(days int) *StorageBackup {
+// RetainedForDays sets the number of days the backup is retained.
+func (b *StorageBackup) RetainedForDays(days int) *StorageBackup {
 	v := days
 	b.retentionDays = &v
 	return b
 }
 
-// WithBillingPeriod sets the billing period. Defaults to hourly when unset.
-func (b *StorageBackup) WithBillingPeriod(p BillingPeriod) *StorageBackup {
-	b.billingPeriod = &p
+// BilledHourly sets hourly billing.
+func (b *StorageBackup) BilledHourly() *StorageBackup {
+	v := BillingPeriodHour
+	b.billingPeriod = &v
+	return b
+}
+
+// BilledMonthly sets monthly billing.
+func (b *StorageBackup) BilledMonthly() *StorageBackup {
+	v := BillingPeriodMonth
+	b.billingPeriod = &v
+	return b
+}
+
+// BilledYearly sets yearly billing.
+func (b *StorageBackup) BilledYearly() *StorageBackup {
+	v := BillingPeriodYear
+	b.billingPeriod = &v
 	return b
 }
 
@@ -258,7 +283,7 @@ func (a *storageBackupsClientAdapter) Create(ctx context.Context, b *StorageBack
 		return b, err
 	}
 	if b.ProjectID() == "" {
-		return b, fmt.Errorf("Create: StorageBackup has no project — call IntoProject first")
+		return b, fmt.Errorf("Create: StorageBackup has no project — call InProject first")
 	}
 	co := applyCallOptions(opts)
 	rp := co.toRequestParameters()
@@ -331,7 +356,7 @@ func (a *storageBackupsClientAdapter) Update(ctx context.Context, b *StorageBack
 		return b, fmt.Errorf("Update: StorageBackup has no ID — call Get first or seed from response metadata")
 	}
 	if b.ProjectID() == "" {
-		return b, fmt.Errorf("Update: StorageBackup has no project — call IntoProject first")
+		return b, fmt.Errorf("Update: StorageBackup has no project — call InProject first")
 	}
 	co := applyCallOptions(opts)
 	rp := co.toRequestParameters()

--- a/pkg/aruba/resource_storage_backup.go
+++ b/pkg/aruba/resource_storage_backup.go
@@ -85,24 +85,9 @@ func (b *StorageBackup) RetainedForDays(days int) *StorageBackup {
 	return b
 }
 
-// BilledHourly sets hourly billing.
-func (b *StorageBackup) BilledHourly() *StorageBackup {
-	v := BillingPeriodHour
-	b.billingPeriod = &v
-	return b
-}
-
-// BilledMonthly sets monthly billing.
-func (b *StorageBackup) BilledMonthly() *StorageBackup {
-	v := BillingPeriodMonth
-	b.billingPeriod = &v
-	return b
-}
-
-// BilledYearly sets yearly billing.
-func (b *StorageBackup) BilledYearly() *StorageBackup {
-	v := BillingPeriodYear
-	b.billingPeriod = &v
+// BilledBy sets the billing cadence. Accepted periods are resource-specific; check the API reference.
+func (b *StorageBackup) BilledBy(period BillingPeriod) *StorageBackup {
+	b.billingPeriod = &period
 	return b
 }
 

--- a/pkg/aruba/resource_storage_backup_test.go
+++ b/pkg/aruba/resource_storage_backup_test.go
@@ -35,7 +35,7 @@ func TestStorageBackup_FluentSetters(t *testing.T) {
 		InRegion(RegionITBGBergamo).
 		OfType(StorageBackupTypeFull).
 		RetainedForDays(30).
-		BilledHourly()
+		BilledBy(BillingPeriodHour)
 
 	if bkp.Name() != "my-backup" {
 		t.Errorf("Name() = %q", bkp.Name())
@@ -172,7 +172,7 @@ func TestStorageBackup_ToRequestRoundTrip(t *testing.T) {
 		OfType(StorageBackupTypeFull).
 		FromVolume(URI(volURI)).
 		RetainedForDays(14).
-		BilledHourly()
+		BilledBy(BillingPeriodHour)
 
 	req := bkp.RawRequest()
 
@@ -476,7 +476,7 @@ func TestStorageBackupsClientAdapter_Create_Success(t *testing.T) {
 		InRegion(RegionITBGBergamo).
 		OfType(StorageBackupTypeFull).
 		RetainedForDays(30).
-		BilledHourly()
+		BilledBy(BillingPeriodHour)
 
 	result, err := adapter.Create(context.Background(), bkp)
 	if err != nil {
@@ -931,16 +931,15 @@ func TestStorageBackup_BillingPeriod_WireTranslation(t *testing.T) {
 	cases := []struct {
 		sdk  BillingPeriod
 		wire string
-		set  func(*StorageBackup) *StorageBackup
 	}{
-		{BillingPeriodHour, "Hourly", (*StorageBackup).BilledHourly},
-		{BillingPeriodMonth, "Monthly", (*StorageBackup).BilledMonthly},
-		{BillingPeriodYear, "Yearly", (*StorageBackup).BilledYearly},
+		{BillingPeriodHour, "Hourly"},
+		{BillingPeriodMonth, "Monthly"},
+		{BillingPeriodYear, "Yearly"},
 	}
 
 	for _, c := range cases {
 		// outbound: SDK constant → wire value
-		req := c.set(NewStorageBackup().Named("x").InRegion(RegionITBGBergamo)).RawRequest()
+		req := NewStorageBackup().Named("x").InRegion(RegionITBGBergamo).BilledBy(c.sdk).RawRequest()
 		if got := string(*req.Properties.BillingPeriod); got != c.wire {
 			t.Errorf("toRequest(%q) wire = %q, want %q", c.sdk, got, c.wire)
 		}

--- a/pkg/aruba/resource_storage_backup_test.go
+++ b/pkg/aruba/resource_storage_backup_test.go
@@ -27,15 +27,15 @@ func TestStorageBackup_FluentSetters(t *testing.T) {
 	proj.fromResponse(projectTestResponse("p-1", "my-proj", "/projects/p-1"))
 
 	bkp := NewStorageBackup().
-		IntoProject(proj).
+		InProject(proj).
 		Named("my-backup").
-		AddTag("backup").
-		AddTag("storage").
-		AddTag("backup"). // dedupe
+		Tagged("backup").
+		Tagged("storage").
+		Tagged("backup"). // dedupe
 		InRegion(RegionITBGBergamo).
 		OfType(StorageBackupTypeFull).
-		WithRetentionDays(30).
-		WithBillingPeriod(BillingPeriodHour)
+		RetainedForDays(30).
+		BilledHourly()
 
 	if bkp.Name() != "my-backup" {
 		t.Errorf("Name() = %q", bkp.Name())
@@ -62,12 +62,12 @@ func TestStorageBackup_FluentSetters(t *testing.T) {
 		t.Errorf("Err() = %v", bkp.Err())
 	}
 
-	bkp.RemoveTag("backup")
+	bkp.Untagged("backup")
 	if tags := bkp.Tags(); len(tags) != 1 || tags[0] != "storage" {
 		t.Errorf("after RemoveTag Tags() = %v", tags)
 	}
 
-	bkp.ReplaceTags("x", "y")
+	bkp.RetaggedAs("x", "y")
 	if tags := bkp.Tags(); len(tags) != 2 || tags[0] != "x" || tags[1] != "y" {
 		t.Errorf("after ReplaceTags Tags() = %v", tags)
 	}
@@ -80,7 +80,7 @@ func TestStorageBackup_FluentSetters(t *testing.T) {
 func TestStorageBackup_IntoProject_TypedRef(t *testing.T) {
 	proj := &Project{}
 	proj.fromResponse(projectTestResponse("p-42", "n", "/projects/p-42"))
-	bkp := NewStorageBackup().IntoProject(proj)
+	bkp := NewStorageBackup().InProject(proj)
 	if bkp.ProjectID() != "p-42" {
 		t.Errorf("ProjectID() = %q", bkp.ProjectID())
 	}
@@ -90,7 +90,7 @@ func TestStorageBackup_IntoProject_TypedRef(t *testing.T) {
 }
 
 func TestStorageBackup_IntoProject_URIRef(t *testing.T) {
-	bkp := NewStorageBackup().IntoProject(URI("/projects/p-uri"))
+	bkp := NewStorageBackup().InProject(URI("/projects/p-uri"))
 	if bkp.ProjectID() != "p-uri" {
 		t.Errorf("ProjectID() = %q", bkp.ProjectID())
 	}
@@ -100,7 +100,7 @@ func TestStorageBackup_IntoProject_URIRef(t *testing.T) {
 }
 
 func TestStorageBackup_IntoProject_BadRef(t *testing.T) {
-	bkp := NewStorageBackup().IntoProject(URI("/garbage"))
+	bkp := NewStorageBackup().InProject(URI("/garbage"))
 	if bkp.Err() == nil {
 		t.Error("expected Err() != nil for unresolvable Ref")
 	}
@@ -167,12 +167,12 @@ func TestStorageBackup_ToRequestRoundTrip(t *testing.T) {
 	volURI := "/projects/p/providers/Aruba.Storage/blockStorages/bs-1"
 	bkp := NewStorageBackup().Named(
 		"bkp-rt").
-		AddTag("t1").AddTag("t2").
+		Tagged("t1").Tagged("t2").
 		InRegion(RegionITBGBergamo).
 		OfType(StorageBackupTypeFull).
 		FromVolume(URI(volURI)).
-		WithRetentionDays(14).
-		WithBillingPeriod(BillingPeriodHour)
+		RetainedForDays(14).
+		BilledHourly()
 
 	req := bkp.RawRequest()
 
@@ -471,12 +471,12 @@ func TestStorageBackupsClientAdapter_Create_Success(t *testing.T) {
 	})
 
 	bkp := NewStorageBackup().
-		IntoProject(URI("/projects/p")).
+		InProject(URI("/projects/p")).
 		Named("my-backup").
 		InRegion(RegionITBGBergamo).
 		OfType(StorageBackupTypeFull).
-		WithRetentionDays(30).
-		WithBillingPeriod(BillingPeriodHour)
+		RetainedForDays(30).
+		BilledHourly()
 
 	result, err := adapter.Create(context.Background(), bkp)
 	if err != nil {
@@ -518,7 +518,7 @@ func TestStorageBackupsClientAdapter_Create_FromVolume(t *testing.T) {
 	adapter := &storageBackupsClientAdapter{low: fake}
 
 	bkp := NewStorageBackup().
-		IntoProject(URI("/projects/p")).
+		InProject(URI("/projects/p")).
 		Named("my-backup").
 		FromVolume(URI(volURI))
 
@@ -559,7 +559,7 @@ func TestStorageBackupsClientAdapter_Create_MetadataValidationError(t *testing.T
 		fmt.Fprint(w, `{"metadata":{"name":"bkp","uri":"/projects/p/providers/Aruba.Storage/backups/x"},"properties":{},"status":{}}`)
 	})
 
-	bkp := NewStorageBackup().IntoProject(URI("/projects/p")).
+	bkp := NewStorageBackup().InProject(URI("/projects/p")).
 		Named("bkp")
 	result, err := adapter.Create(context.Background(), bkp)
 	if err == nil {
@@ -581,7 +581,7 @@ func TestStorageBackupsClientAdapter_Create_NonTwoXX(t *testing.T) {
 		fmt.Fprint(w, testutil.ErrorBodyJSON("Validation Failed", "name is required", 422))
 	})
 
-	bkp := NewStorageBackup().IntoProject(URI("/projects/p"))
+	bkp := NewStorageBackup().InProject(URI("/projects/p"))
 	result, err := adapter.Create(context.Background(), bkp)
 	if err == nil {
 		t.Fatal("expected error on 422")
@@ -653,7 +653,7 @@ func TestStorageBackupsClientAdapter_Update_Success(t *testing.T) {
 
 	bkp := &StorageBackup{}
 	bkp.fromResponse(storageBackupTestResponse("bkp-1", "my-backup", "/projects/p/providers/Aruba.Storage/backups/bkp-1", "p"))
-	bkp.WithRetentionDays(30)
+	bkp.RetainedForDays(30)
 
 	result, err := adapter.Update(context.Background(), bkp)
 	if err != nil {
@@ -674,7 +674,7 @@ func TestStorageBackupsClientAdapter_Update_NoID(t *testing.T) {
 		w.WriteHeader(http.StatusOK)
 	})
 
-	bkp := NewStorageBackup().IntoProject(URI("/projects/p")).
+	bkp := NewStorageBackup().InProject(URI("/projects/p")).
 		Named("x")
 	_, err := adapter.Update(context.Background(), bkp)
 	if err == nil {
@@ -821,7 +821,7 @@ func TestStorageBackupsClientAdapter_Update_NonTwoXX(t *testing.T) {
 
 	bkp := &StorageBackup{}
 	bkp.fromResponse(storageBackupTestResponse("bkp-1", "my-backup", "/projects/p/providers/Aruba.Storage/backups/bkp-1", "p"))
-	bkp.WithRetentionDays(99999)
+	bkp.RetainedForDays(99999)
 
 	_, err := adapter.Update(context.Background(), bkp)
 	if err == nil {
@@ -931,17 +931,16 @@ func TestStorageBackup_BillingPeriod_WireTranslation(t *testing.T) {
 	cases := []struct {
 		sdk  BillingPeriod
 		wire string
+		set  func(*StorageBackup) *StorageBackup
 	}{
-		{BillingPeriodHour, "Hourly"},
-		{BillingPeriodMonth, "Monthly"},
-		{BillingPeriodYear, "Yearly"},
+		{BillingPeriodHour, "Hourly", (*StorageBackup).BilledHourly},
+		{BillingPeriodMonth, "Monthly", (*StorageBackup).BilledMonthly},
+		{BillingPeriodYear, "Yearly", (*StorageBackup).BilledYearly},
 	}
 
 	for _, c := range cases {
 		// outbound: SDK constant → wire value
-		req := NewStorageBackup().
-			Named("x").InRegion(RegionITBGBergamo).
-			WithBillingPeriod(c.sdk).RawRequest()
+		req := c.set(NewStorageBackup().Named("x").InRegion(RegionITBGBergamo)).RawRequest()
 		if got := string(*req.Properties.BillingPeriod); got != c.wire {
 			t.Errorf("toRequest(%q) wire = %q, want %q", c.sdk, got, c.wire)
 		}

--- a/pkg/aruba/resource_storage_restore.go
+++ b/pkg/aruba/resource_storage_restore.go
@@ -13,7 +13,7 @@ import (
 
 // StorageRestore is the wrapper for an Aruba Cloud Storage Restore (a direct
 // child of a StorageBackup, grandchild of a Project). Construct with
-// aruba.NewStorageRestore() and bind it via IntoBackup(backup) and ToVolume(volume).
+// aruba.NewStorageRestore() and bind it via FromBackup(backup) and ToVolume(volume).
 type StorageRestore struct {
 	errMixin
 	metadataMixin
@@ -39,20 +39,30 @@ func NewStorageRestore() *StorageRestore {
 
 // Setters — chainable, general → specific
 
-// IntoBackup binds this StorageRestore to its parent StorageBackup. Required before Create.
-func (r *StorageRestore) IntoBackup(b Ref) *StorageRestore { r.intoBackup(b); return r }
+// FromBackup binds this StorageRestore to its parent StorageBackup. Required before Create.
+func (r *StorageRestore) FromBackup(b Ref) *StorageRestore { r.intoBackup(b); return r }
 
 // Named sets the resource name. Required by the API.
 func (r *StorageRestore) Named(n string) *StorageRestore { r.named(n); return r }
 
-// AddTag appends a tag for filtering and accounting.
-func (r *StorageRestore) AddTag(t string) *StorageRestore { r.addTag(t); return r }
+// Tagged appends tags for filtering and accounting. Repeated calls append.
+func (r *StorageRestore) Tagged(ts ...string) *StorageRestore {
+	for _, t := range ts {
+		r.addTag(t)
+	}
+	return r
+}
 
-// RemoveTag removes a previously-added tag. No-op if absent.
-func (r *StorageRestore) RemoveTag(t string) *StorageRestore { r.removeTag(t); return r }
+// Untagged removes each listed tag. No-op for tags not present.
+func (r *StorageRestore) Untagged(ts ...string) *StorageRestore {
+	for _, t := range ts {
+		r.removeTag(t)
+	}
+	return r
+}
 
-// ReplaceTags replaces the entire tag set with the given values.
-func (r *StorageRestore) ReplaceTags(ts ...string) *StorageRestore { r.replaceTags(ts...); return r }
+// RetaggedAs replaces the entire tag set with the given values.
+func (r *StorageRestore) RetaggedAs(ts ...string) *StorageRestore { r.replaceTags(ts...); return r }
 
 // InRegion sets the region for this resource.
 func (r *StorageRestore) InRegion(region Region) *StorageRestore { r.inRegion(region); return r }
@@ -194,7 +204,7 @@ func (a *storageRestoresClientAdapter) Create(ctx context.Context, r *StorageRes
 		return r, err
 	}
 	if r.BackupID() == "" || r.ProjectID() == "" {
-		return r, fmt.Errorf("Create: StorageRestore has no parent backup — call IntoBackup first")
+		return r, fmt.Errorf("Create: StorageRestore has no parent backup — call FromBackup first")
 	}
 	if r.targetRef == nil {
 		return r, fmt.Errorf("Create: StorageRestore has no target — call ToVolume first")
@@ -275,7 +285,7 @@ func (a *storageRestoresClientAdapter) Update(ctx context.Context, r *StorageRes
 		return r, fmt.Errorf("Update: StorageRestore has no ID — call Get first or seed from response metadata")
 	}
 	if r.BackupID() == "" || r.ProjectID() == "" {
-		return r, fmt.Errorf("Update: StorageRestore has no parent backup — call IntoBackup first")
+		return r, fmt.Errorf("Update: StorageRestore has no parent backup — call FromBackup first")
 	}
 	co := applyCallOptions(opts)
 	rp := co.toRequestParameters()

--- a/pkg/aruba/resource_storage_restore_test.go
+++ b/pkg/aruba/resource_storage_restore_test.go
@@ -27,11 +27,11 @@ func TestStorageRestore_FluentSetters(t *testing.T) {
 	bkp.fromResponse(storageBackupTestResponse("bkp-1", "my-backup", "/projects/p/providers/Aruba.Storage/backups/bkp-1", "p"))
 
 	r := NewStorageRestore().
-		IntoBackup(bkp).
+		FromBackup(bkp).
 		Named("my-restore").
-		AddTag("restore").
-		AddTag("storage").
-		AddTag("restore"). // dedupe
+		Tagged("restore").
+		Tagged("storage").
+		Tagged("restore"). // dedupe
 		InRegion(RegionITBGBergamo).
 		ToVolume(URI("/projects/p/providers/Aruba.Storage/blockStorages/bs-1"))
 
@@ -57,12 +57,12 @@ func TestStorageRestore_FluentSetters(t *testing.T) {
 		t.Errorf("Err() = %v", r.Err())
 	}
 
-	r.RemoveTag("restore")
+	r.Untagged("restore")
 	if tags := r.Tags(); len(tags) != 1 || tags[0] != "storage" {
 		t.Errorf("after RemoveTag Tags() = %v", tags)
 	}
 
-	r.ReplaceTags("x", "y")
+	r.RetaggedAs("x", "y")
 	if tags := r.Tags(); len(tags) != 2 || tags[0] != "x" || tags[1] != "y" {
 		t.Errorf("after ReplaceTags Tags() = %v", tags)
 	}
@@ -76,7 +76,7 @@ func TestStorageRestore_IntoBackup_TypedRef(t *testing.T) {
 	bkp := &StorageBackup{}
 	bkp.fromResponse(storageBackupTestResponse("bkp-42", "n", "/projects/p/providers/Aruba.Storage/backups/bkp-42", "p"))
 
-	r := NewStorageRestore().IntoBackup(bkp)
+	r := NewStorageRestore().FromBackup(bkp)
 	if r.BackupID() != "bkp-42" {
 		t.Errorf("BackupID() = %q", r.BackupID())
 	}
@@ -89,7 +89,7 @@ func TestStorageRestore_IntoBackup_TypedRef(t *testing.T) {
 }
 
 func TestStorageRestore_IntoBackup_URIRef(t *testing.T) {
-	r := NewStorageRestore().IntoBackup(URI("/projects/p-uri/providers/Aruba.Storage/backups/bkp-uri"))
+	r := NewStorageRestore().FromBackup(URI("/projects/p-uri/providers/Aruba.Storage/backups/bkp-uri"))
 	if r.BackupID() != "bkp-uri" {
 		t.Errorf("BackupID() = %q", r.BackupID())
 	}
@@ -102,7 +102,7 @@ func TestStorageRestore_IntoBackup_URIRef(t *testing.T) {
 }
 
 func TestStorageRestore_IntoBackup_BadRef(t *testing.T) {
-	r := NewStorageRestore().IntoBackup(URI("/something/else"))
+	r := NewStorageRestore().FromBackup(URI("/something/else"))
 	if r.Err() == nil {
 		t.Error("expected Err() != nil for unresolvable Ref")
 	}
@@ -154,7 +154,7 @@ func TestStorageRestore_ToRequestRoundTrip(t *testing.T) {
 	volURI := "/projects/p/providers/Aruba.Storage/blockStorages/bs-1"
 	r := NewStorageRestore().Named(
 		"rt-restore").
-		AddTag("t1").AddTag("t2").
+		Tagged("t1").Tagged("t2").
 		InRegion(RegionITBGBergamo).
 		ToVolume(URI(volURI))
 
@@ -433,7 +433,7 @@ func TestStorageRestoresClientAdapter_Create_Success(t *testing.T) {
 	bkp.fromResponse(storageBackupTestResponse("bkp-1", "n", "/projects/p/providers/Aruba.Storage/backups/bkp-1", "p"))
 
 	r := NewStorageRestore().
-		IntoBackup(bkp).
+		FromBackup(bkp).
 		Named("my-restore").
 		InRegion(RegionITBGBergamo).
 		ToVolume(URI("/projects/p/providers/Aruba.Storage/blockStorages/bs-1"))
@@ -486,7 +486,7 @@ func TestStorageRestoresClientAdapter_Create_NoTarget(t *testing.T) {
 	bkp := &StorageBackup{}
 	bkp.fromResponse(storageBackupTestResponse("bkp-1", "n", "/projects/p/providers/Aruba.Storage/backups/bkp-1", "p"))
 
-	_, err := adapter.Create(context.Background(), NewStorageRestore().IntoBackup(bkp).
+	_, err := adapter.Create(context.Background(), NewStorageRestore().FromBackup(bkp).
 		Named("x"))
 	if err == nil {
 		t.Fatal("expected error when StorageRestore has no target")
@@ -507,7 +507,7 @@ func TestStorageRestoresClientAdapter_Create_MetadataValidationError(t *testing.
 	bkp := &StorageBackup{}
 	bkp.fromResponse(storageBackupTestResponse("bkp-1", "n", "/projects/p/providers/Aruba.Storage/backups/bkp-1", "p"))
 
-	r := NewStorageRestore().IntoBackup(bkp).
+	r := NewStorageRestore().FromBackup(bkp).
 		Named("r").ToVolume(URI("/v"))
 	result, err := adapter.Create(context.Background(), r)
 	if err == nil {
@@ -532,7 +532,7 @@ func TestStorageRestoresClientAdapter_Create_NonTwoXX(t *testing.T) {
 	bkp := &StorageBackup{}
 	bkp.fromResponse(storageBackupTestResponse("bkp-1", "n", "/projects/p/providers/Aruba.Storage/backups/bkp-1", "p"))
 
-	r := NewStorageRestore().IntoBackup(bkp).ToVolume(URI("/v"))
+	r := NewStorageRestore().FromBackup(bkp).ToVolume(URI("/v"))
 	result, err := adapter.Create(context.Background(), r)
 	if err == nil {
 		t.Fatal("expected error on 422")
@@ -645,7 +645,7 @@ func TestStorageRestoresClientAdapter_Update_NoID(t *testing.T) {
 	bkp := &StorageBackup{}
 	bkp.fromResponse(storageBackupTestResponse("bkp-1", "n", "/projects/p/providers/Aruba.Storage/backups/bkp-1", "p"))
 
-	r := NewStorageRestore().IntoBackup(bkp).
+	r := NewStorageRestore().FromBackup(bkp).
 		Named("x")
 	_, err := adapter.Update(context.Background(), r)
 	if err == nil {

--- a/pkg/aruba/resource_subnet.go
+++ b/pkg/aruba/resource_subnet.go
@@ -51,20 +51,30 @@ func NewSubnet() *Subnet {
 
 // Setters — chainable, general → specific
 
-// IntoVPC binds this Subnet to its parent VPC. Required before Create.
-func (s *Subnet) IntoVPC(v Ref) *Subnet { s.intoVPC(v); return s }
+// InVPC binds this Subnet to its parent VPC. Required before Create.
+func (s *Subnet) InVPC(v Ref) *Subnet { s.intoVPC(v); return s }
 
 // Named sets the resource name. Required by the API.
 func (s *Subnet) Named(n string) *Subnet { s.named(n); return s }
 
-// AddTag appends a tag for filtering and accounting.
-func (s *Subnet) AddTag(t string) *Subnet { s.addTag(t); return s }
+// Tagged appends tags for filtering and accounting. Repeated calls append.
+func (s *Subnet) Tagged(ts ...string) *Subnet {
+	for _, t := range ts {
+		s.addTag(t)
+	}
+	return s
+}
 
-// RemoveTag removes a previously-added tag. No-op if absent.
-func (s *Subnet) RemoveTag(t string) *Subnet { s.removeTag(t); return s }
+// Untagged removes each listed tag. No-op for tags not present.
+func (s *Subnet) Untagged(ts ...string) *Subnet {
+	for _, t := range ts {
+		s.removeTag(t)
+	}
+	return s
+}
 
-// ReplaceTags replaces the entire tag set with the given values.
-func (s *Subnet) ReplaceTags(ts ...string) *Subnet { s.replaceTags(ts...); return s }
+// RetaggedAs replaces the entire tag set with the given values.
+func (s *Subnet) RetaggedAs(ts ...string) *Subnet { s.replaceTags(ts...); return s }
 
 // InRegion sets the region for this resource.
 func (s *Subnet) InRegion(region Region) *Subnet { s.inRegion(region); return s }
@@ -249,7 +259,7 @@ func (a *subnetsClientAdapter) Create(ctx context.Context, s *Subnet, opts ...Ca
 		return s, err
 	}
 	if s.VPCID() == "" || s.ProjectID() == "" {
-		return s, fmt.Errorf("Create: subnet has no VPC — call IntoVPC first")
+		return s, fmt.Errorf("Create: subnet has no VPC — call InVPC first")
 	}
 	co := applyCallOptions(opts)
 	rp := co.toRequestParameters()
@@ -321,7 +331,7 @@ func (a *subnetsClientAdapter) Update(ctx context.Context, s *Subnet, opts ...Ca
 		return s, fmt.Errorf("Update: subnet has no ID — call Get first or seed from response metadata")
 	}
 	if s.VPCID() == "" || s.ProjectID() == "" {
-		return s, fmt.Errorf("Update: subnet has no VPC — call IntoVPC first")
+		return s, fmt.Errorf("Update: subnet has no VPC — call InVPC first")
 	}
 	co := applyCallOptions(opts)
 	rp := co.toRequestParameters()

--- a/pkg/aruba/resource_subnet_dhcp.go
+++ b/pkg/aruba/resource_subnet_dhcp.go
@@ -23,15 +23,17 @@ func (d *SubnetDHCP) WithRange(start string, count int) *SubnetDHCP {
 	return d
 }
 
-// AddRoute appends a static route advertised via DHCP.
-func (d *SubnetDHCP) AddRoute(addr, gw string) *SubnetDHCP {
-	d.inner.Routes = append(d.inner.Routes, types.SubnetDHCPRoute{Address: addr, Gateway: gw})
+// WithRoutes appends static routes advertised via DHCP. Repeated calls append.
+func (d *SubnetDHCP) WithRoutes(routes ...SubnetDHCPRoute) *SubnetDHCP {
+	for _, r := range routes {
+		d.inner.Routes = append(d.inner.Routes, types.SubnetDHCPRoute{Address: r.Address, Gateway: r.Gateway})
+	}
 	return d
 }
 
-// AddDNS appends a DNS server advertised via DHCP.
-func (d *SubnetDHCP) AddDNS(ip string) *SubnetDHCP {
-	d.inner.DNS = append(d.inner.DNS, ip)
+// WithDNSServers appends DNS servers advertised via DHCP. Repeated calls append.
+func (d *SubnetDHCP) WithDNSServers(ips ...string) *SubnetDHCP {
+	d.inner.DNS = append(d.inner.DNS, ips...)
 	return d
 }
 

--- a/pkg/aruba/resource_subnet_test.go
+++ b/pkg/aruba/resource_subnet_test.go
@@ -27,11 +27,11 @@ func TestSubnet_FluentSetters(t *testing.T) {
 	parent.fromResponse(vpcTestResponse("vpc-1", "my-vpc", "/projects/p1/providers/Aruba.Network/vpcs/vpc-1", "p1"))
 
 	s := NewSubnet().
-		IntoVPC(parent).
+		InVPC(parent).
 		Named("my-subnet").
-		AddTag("net").
-		AddTag("infra").
-		AddTag("net"). // dedupe
+		Tagged("net").
+		Tagged("infra").
+		Tagged("net"). // dedupe
 		InRegion(RegionITBGBergamo).
 		OfType(SubnetTypeAdvanced).
 		NotDefault().
@@ -65,12 +65,12 @@ func TestSubnet_FluentSetters(t *testing.T) {
 		t.Errorf("Err() = %v", s.Err())
 	}
 
-	s.RemoveTag("net")
+	s.Untagged("net")
 	if tags := s.Tags(); len(tags) != 1 || tags[0] != "infra" {
 		t.Errorf("after RemoveTag Tags() = %v", tags)
 	}
 
-	s.ReplaceTags("x", "y")
+	s.RetaggedAs("x", "y")
 	if tags := s.Tags(); len(tags) != 2 || tags[0] != "x" || tags[1] != "y" {
 		t.Errorf("after ReplaceTags Tags() = %v", tags)
 	}
@@ -81,7 +81,7 @@ func TestSubnet_FluentSetters(t *testing.T) {
 // --------------------------------------------------------------------------
 
 func TestSubnet_IntoVPC_BadRef(t *testing.T) {
-	s := NewSubnet().IntoVPC(URI("/garbage"))
+	s := NewSubnet().InVPC(URI("/garbage"))
 	if s.Err() == nil {
 		t.Error("expected Err() != nil for unresolvable Ref, got nil")
 	}
@@ -95,10 +95,10 @@ func TestSubnet_DHCPSubBuilder(t *testing.T) {
 	d := NewSubnetDHCP().
 		Enabled().
 		WithRange("10.0.0.10", 50).
-		AddRoute("0.0.0.0/0", "10.0.0.1").
-		AddRoute("192.168.0.0/16", "10.0.0.2").
-		AddDNS("1.1.1.1").
-		AddDNS("8.8.8.8")
+		WithRoutes(SubnetDHCPRoute{Address: "0.0.0.0/0", Gateway: "10.0.0.1"}).
+		WithRoutes(SubnetDHCPRoute{Address: "192.168.0.0/16", Gateway: "10.0.0.2"}).
+		WithDNSServers("1.1.1.1").
+		WithDNSServers("8.8.8.8")
 
 	if !d.IsEnabled() {
 		t.Error("IsEnabled() should be true")
@@ -159,8 +159,8 @@ func TestSubnet_DHCPSubBuilder_NoRange(t *testing.T) {
 func TestSubnet_ToRequestRoundTrip(t *testing.T) {
 	s := NewSubnet().Named(
 		"sn-1").
-		AddTag("t1").
-		AddTag("t2").
+		Tagged("t1").
+		Tagged("t2").
 		InRegion(RegionITBGBergamo).
 		OfType(SubnetTypeBasic).
 		AsDefault().
@@ -168,8 +168,8 @@ func TestSubnet_ToRequestRoundTrip(t *testing.T) {
 		WithDHCP(NewSubnetDHCP().
 			Enabled().
 			WithRange("10.1.2.10", 20).
-			AddRoute("0.0.0.0/0", "10.1.2.1").
-			AddDNS("9.9.9.9"))
+			WithRoutes(SubnetDHCPRoute{Address: "0.0.0.0/0", Gateway: "10.1.2.1"}).
+			WithDNSServers("9.9.9.9"))
 
 	req := s.RawRequest()
 
@@ -448,7 +448,7 @@ func TestSubnetsClientAdapter_Create_Success(t *testing.T) {
 	vpc.fromResponse(vpcTestResponse("v", "my-vpc", "/projects/p/providers/Aruba.Network/vpcs/v", "p"))
 
 	s := NewSubnet().
-		IntoVPC(vpc).
+		InVPC(vpc).
 		Named("my-subnet").
 		OfType(SubnetTypeAdvanced).
 		WithCIDR("10.0.0.0/24")
@@ -502,7 +502,7 @@ func TestSubnetsClientAdapter_Create_MetadataValidationError(t *testing.T) {
 	vpc := &VPC{}
 	vpc.fromResponse(vpcTestResponse("v", "n", "/projects/p/providers/Aruba.Network/vpcs/v", "p"))
 
-	result, err := adapter.Create(context.Background(), NewSubnet().IntoVPC(vpc).
+	result, err := adapter.Create(context.Background(), NewSubnet().InVPC(vpc).
 		Named("sn"))
 	if err == nil {
 		t.Fatal("expected MetadataValidationError, got nil")
@@ -526,7 +526,7 @@ func TestSubnetsClientAdapter_Create_NonTwoXX(t *testing.T) {
 	vpc := &VPC{}
 	vpc.fromResponse(vpcTestResponse("v", "n", "/projects/p/providers/Aruba.Network/vpcs/v", "p"))
 
-	result, err := adapter.Create(context.Background(), NewSubnet().IntoVPC(vpc))
+	result, err := adapter.Create(context.Background(), NewSubnet().InVPC(vpc))
 	if err == nil {
 		t.Fatal("expected error on 422")
 	}
@@ -627,7 +627,7 @@ func TestSubnetsClientAdapter_Update_NoID(t *testing.T) {
 	vpc := &VPC{}
 	vpc.fromResponse(vpcTestResponse("v", "n", "/projects/p/providers/Aruba.Network/vpcs/v", "p"))
 
-	s := NewSubnet().IntoVPC(vpc).
+	s := NewSubnet().InVPC(vpc).
 		Named("x")
 	_, err := adapter.Update(context.Background(), s)
 	if err == nil {
@@ -817,7 +817,7 @@ func TestSubnetsClientAdapter_Create_WithBuilderError(t *testing.T) {
 		callCount++
 		w.WriteHeader(http.StatusCreated)
 	})
-	s := NewSubnet().IntoVPC(URI("/garbage"))
+	s := NewSubnet().InVPC(URI("/garbage"))
 	_, err := adapter.Create(context.Background(), s)
 	if err == nil {
 		t.Fatal("expected error for builder error")
@@ -869,7 +869,7 @@ func TestSubnetsClientAdapter_Update_WithBuilderError(t *testing.T) {
 		callCount++
 		w.WriteHeader(http.StatusOK)
 	})
-	s := NewSubnet().IntoVPC(URI("/garbage"))
+	s := NewSubnet().InVPC(URI("/garbage"))
 	_, err := adapter.Update(context.Background(), s)
 	if err == nil {
 		t.Fatal("expected error for builder error")

--- a/pkg/aruba/resource_user.go
+++ b/pkg/aruba/resource_user.go
@@ -49,8 +49,8 @@ func NewUser() *User {
 
 // Setters — chainable, general → specific
 
-// IntoDBaaS binds this User to its parent DBaaS instance. Required before Create.
-func (u *User) IntoDBaaS(parent Ref) *User { u.intoDBaaS(parent); return u }
+// InDBaaS binds this User to its parent DBaaS instance. Required before Create.
+func (u *User) InDBaaS(parent Ref) *User { u.intoDBaaS(parent); return u }
 
 // WithUsername sets the username. Used as the path identifier; required before Create.
 func (u *User) WithUsername(name string) *User { u.username = &name; return u }
@@ -215,10 +215,10 @@ func (a *usersClientAdapter) Create(ctx context.Context, u *User, opts ...CallOp
 		return u, err
 	}
 	if u.ProjectID() == "" {
-		return u, fmt.Errorf("Create: User has no parent project — call IntoDBaaS first")
+		return u, fmt.Errorf("Create: User has no parent project — call InDBaaS first")
 	}
 	if u.DBaaSID() == "" {
-		return u, fmt.Errorf("Create: User has no parent DBaaS — call IntoDBaaS first")
+		return u, fmt.Errorf("Create: User has no parent DBaaS — call InDBaaS first")
 	}
 	if u.Username() == "" {
 		return u, fmt.Errorf("Create: User has no username — call WithUsername first")
@@ -261,10 +261,10 @@ func (a *usersClientAdapter) Update(ctx context.Context, u *User, opts ...CallOp
 		return u, fmt.Errorf("Update: User has no ID — call WithUsername first")
 	}
 	if u.DBaaSID() == "" {
-		return u, fmt.Errorf("Update: User has no parent DBaaS — call IntoDBaaS first")
+		return u, fmt.Errorf("Update: User has no parent DBaaS — call InDBaaS first")
 	}
 	if u.ProjectID() == "" {
-		return u, fmt.Errorf("Update: User has no parent project — call IntoDBaaS first")
+		return u, fmt.Errorf("Update: User has no parent project — call InDBaaS first")
 	}
 	if u.password == nil {
 		return u, fmt.Errorf("Update: password is required — call WithPassword first")

--- a/pkg/aruba/resource_user_test.go
+++ b/pkg/aruba/resource_user_test.go
@@ -43,7 +43,7 @@ func TestUser_NoPasswordAccessor(t *testing.T) {
 
 func TestUser_FluentSetters(t *testing.T) {
 	u := NewUser().
-		IntoDBaaS(URI("/projects/p-1/providers/Aruba.Database/dbaas/d-1")).
+		InDBaaS(URI("/projects/p-1/providers/Aruba.Database/dbaas/d-1")).
 		WithUsername("alice").
 		WithPassword(testPassword)
 
@@ -77,7 +77,7 @@ func TestUser_IntoDBaaS_TypedRef(t *testing.T) {
 	dbaas := &DBaaS{}
 	dbaas.fromResponse(dbaasTestResponse("d-1", "my-dbaas", "/projects/p-1/providers/Aruba.Database/dbaas/d-1"))
 
-	u := NewUser().IntoDBaaS(dbaas)
+	u := NewUser().InDBaaS(dbaas)
 	if u.DBaaSID() != "d-1" {
 		t.Errorf("DBaaSID() = %q", u.DBaaSID())
 	}
@@ -90,7 +90,7 @@ func TestUser_IntoDBaaS_TypedRef(t *testing.T) {
 }
 
 func TestUser_IntoDBaaS_URIRef(t *testing.T) {
-	u := NewUser().IntoDBaaS(URI("/projects/p-uri/providers/Aruba.Database/dbaas/d-uri"))
+	u := NewUser().InDBaaS(URI("/projects/p-uri/providers/Aruba.Database/dbaas/d-uri"))
 	if u.DBaaSID() != "d-uri" {
 		t.Errorf("DBaaSID() = %q", u.DBaaSID())
 	}
@@ -103,7 +103,7 @@ func TestUser_IntoDBaaS_URIRef(t *testing.T) {
 }
 
 func TestUser_IntoDBaaS_BadRef(t *testing.T) {
-	u := NewUser().IntoDBaaS(URI("/something/garbage"))
+	u := NewUser().InDBaaS(URI("/something/garbage"))
 	if u.Err() == nil {
 		t.Error("expected Err() to be set for unresolvable parent")
 	}
@@ -115,7 +115,7 @@ func TestUser_IntoDBaaS_BadRef(t *testing.T) {
 
 func TestUser_URI_Constructed(t *testing.T) {
 	u := NewUser().
-		IntoDBaaS(URI("/projects/p-1/providers/Aruba.Database/dbaas/d-1")).
+		InDBaaS(URI("/projects/p-1/providers/Aruba.Database/dbaas/d-1")).
 		WithUsername("alice")
 	want := "/projects/p-1/providers/Aruba.Database/dbaas/d-1/users/alice"
 	if u.URI() != want {
@@ -257,7 +257,7 @@ func TestUser_FromResponse_PreservesPassword(t *testing.T) {
 
 func TestUserIDsFromRef_TypedRef(t *testing.T) {
 	u := NewUser().
-		IntoDBaaS(URI("/projects/p/providers/Aruba.Database/dbaas/d-1")).
+		InDBaaS(URI("/projects/p/providers/Aruba.Database/dbaas/d-1")).
 		WithUsername("alice")
 	pid, did, name, err := userIDsFromRef(u)
 	if err != nil {
@@ -332,7 +332,7 @@ func TestUsersClientAdapter_Create_Success(t *testing.T) {
 	})
 
 	u := NewUser().
-		IntoDBaaS(URI("/projects/p/providers/Aruba.Database/dbaas/d-1")).
+		InDBaaS(URI("/projects/p/providers/Aruba.Database/dbaas/d-1")).
 		WithUsername("my-user").
 		WithPassword(testPassword)
 
@@ -379,7 +379,7 @@ func TestUsersClientAdapter_Create_NoUsername(t *testing.T) {
 		callCount++
 	})
 	u := NewUser().
-		IntoDBaaS(URI("/projects/p/providers/Aruba.Database/dbaas/d-1")).
+		InDBaaS(URI("/projects/p/providers/Aruba.Database/dbaas/d-1")).
 		WithPassword(testPassword) // no WithUsername
 	_, err := adapter.Create(context.Background(), u)
 	if err == nil {
@@ -396,7 +396,7 @@ func TestUsersClientAdapter_Create_NoPassword(t *testing.T) {
 		callCount++
 	})
 	u := NewUser().
-		IntoDBaaS(URI("/projects/p/providers/Aruba.Database/dbaas/d-1")).
+		InDBaaS(URI("/projects/p/providers/Aruba.Database/dbaas/d-1")).
 		WithUsername("alice") // no WithPassword
 	_, err := adapter.Create(context.Background(), u)
 	if err == nil {
@@ -415,7 +415,7 @@ func TestUsersClientAdapter_Create_NonTwoXX(t *testing.T) {
 	})
 
 	u := NewUser().
-		IntoDBaaS(URI("/projects/p/providers/Aruba.Database/dbaas/d-1")).
+		InDBaaS(URI("/projects/p/providers/Aruba.Database/dbaas/d-1")).
 		WithUsername("my-user").
 		WithPassword(testPassword)
 	_, err := adapter.Create(context.Background(), u)
@@ -443,7 +443,7 @@ func TestUsersClientAdapter_Update_Success(t *testing.T) {
 	})
 
 	u := NewUser().
-		IntoDBaaS(URI("/projects/p/providers/Aruba.Database/dbaas/d-1")).
+		InDBaaS(URI("/projects/p/providers/Aruba.Database/dbaas/d-1")).
 		WithUsername("my-user").
 		WithPassword(testPassword)
 
@@ -484,7 +484,7 @@ func TestUsersClientAdapter_Update_NoPassword(t *testing.T) {
 		callCount++
 	})
 	u := NewUser().
-		IntoDBaaS(URI("/projects/p/providers/Aruba.Database/dbaas/d-1")).
+		InDBaaS(URI("/projects/p/providers/Aruba.Database/dbaas/d-1")).
 		WithUsername("alice") // no WithPassword
 	_, err := adapter.Update(context.Background(), u)
 	if err == nil {
@@ -529,7 +529,7 @@ func TestUsersClientAdapter_Get_TypedRef(t *testing.T) {
 	})
 
 	u := NewUser().
-		IntoDBaaS(URI("/projects/p/providers/Aruba.Database/dbaas/d-1")).
+		InDBaaS(URI("/projects/p/providers/Aruba.Database/dbaas/d-1")).
 		WithUsername("my-user")
 
 	result, err := adapter.Get(context.Background(), u)
@@ -596,7 +596,7 @@ func TestUsersClientAdapter_Create_Conflict(t *testing.T) {
 		fmt.Fprint(w, `{"title":"Conflict","detail":"username taken"}`)
 	})
 	u := NewUser().
-		IntoDBaaS(URI("/projects/p/providers/Aruba.Database/dbaas/d-1")).
+		InDBaaS(URI("/projects/p/providers/Aruba.Database/dbaas/d-1")).
 		WithUsername("alice").
 		WithPassword(testPassword)
 	_, err := adapter.Create(context.Background(), u)
@@ -659,7 +659,7 @@ func TestUsersClientAdapter_Update_NonTwoXX(t *testing.T) {
 		fmt.Fprint(w, `{"title":"Conflict","detail":"concurrent update"}`)
 	})
 	u := NewUser().
-		IntoDBaaS(URI("/projects/p/providers/Aruba.Database/dbaas/d-1")).
+		InDBaaS(URI("/projects/p/providers/Aruba.Database/dbaas/d-1")).
 		WithUsername("alice").
 		WithPassword(testPassword)
 	_, err := adapter.Update(context.Background(), u)
@@ -727,7 +727,7 @@ func TestUsersClientAdapter_Create_ErrMixin(t *testing.T) {
 		callCount++
 	})
 	// IntoDBaaS with bad URI sets errMixin
-	u := NewUser().IntoDBaaS(URI("/garbage")).WithUsername("alice").WithPassword(testPassword)
+	u := NewUser().InDBaaS(URI("/garbage")).WithUsername("alice").WithPassword(testPassword)
 	_, err := adapter.Create(context.Background(), u)
 	if err == nil {
 		t.Fatal("expected error from errMixin")

--- a/pkg/aruba/resource_vpc.go
+++ b/pkg/aruba/resource_vpc.go
@@ -49,20 +49,30 @@ func NewVPC() *VPC {
 
 // Setters — chainable, general → specific
 
-// IntoProject binds this VPC to its parent project. Required before Create.
-func (v *VPC) IntoProject(p Ref) *VPC { v.intoProject(p); return v }
+// InProject binds this VPC to its parent project. Required before Create.
+func (v *VPC) InProject(p Ref) *VPC { v.intoProject(p); return v }
 
 // Named sets the resource name. Required by the API.
 func (v *VPC) Named(n string) *VPC { v.named(n); return v }
 
-// AddTag appends a tag for filtering and accounting.
-func (v *VPC) AddTag(t string) *VPC { v.addTag(t); return v }
+// Tagged appends tags for filtering and accounting. Repeated calls append.
+func (v *VPC) Tagged(ts ...string) *VPC {
+	for _, t := range ts {
+		v.addTag(t)
+	}
+	return v
+}
 
-// RemoveTag removes a previously-added tag. No-op if absent.
-func (v *VPC) RemoveTag(t string) *VPC { v.removeTag(t); return v }
+// Untagged removes each listed tag. No-op for tags not present.
+func (v *VPC) Untagged(ts ...string) *VPC {
+	for _, t := range ts {
+		v.removeTag(t)
+	}
+	return v
+}
 
-// ReplaceTags replaces the entire tag set with the given values.
-func (v *VPC) ReplaceTags(ts ...string) *VPC { v.replaceTags(ts...); return v }
+// RetaggedAs replaces the entire tag set with the given values.
+func (v *VPC) RetaggedAs(ts ...string) *VPC { v.replaceTags(ts...); return v }
 
 // InRegion sets the region for this resource.
 func (v *VPC) InRegion(region Region) *VPC { v.inRegion(region); return v }
@@ -73,8 +83,11 @@ func (v *VPC) AsDefault() *VPC { t := true; v.defaultVPC = &t; return v }
 // NotDefault explicitly unsets the default flag.
 func (v *VPC) NotDefault() *VPC { f := false; v.defaultVPC = &f; return v }
 
-// WithPreset enables or disables preset subnet/security-group creation.
-func (v *VPC) WithPreset(b bool) *VPC { v.preset = &b; return v }
+// WithPreset marks the VPC to use preset networking.
+func (v *VPC) WithPreset() *VPC { t := true; v.preset = &t; return v }
+
+// WithoutPreset disables VPC preset networking.
+func (v *VPC) WithoutPreset() *VPC { f := false; v.preset = &f; return v }
 
 // Getters — general → specific
 
@@ -195,7 +208,7 @@ func (a *vpcsClientAdapter) Create(ctx context.Context, v *VPC, opts ...CallOpti
 		return v, err
 	}
 	if v.ProjectID() == "" {
-		return v, fmt.Errorf("Create: VPC has no project — call IntoProject first")
+		return v, fmt.Errorf("Create: VPC has no project — call InProject first")
 	}
 	co := applyCallOptions(opts)
 	rp := co.toRequestParameters()
@@ -266,7 +279,7 @@ func (a *vpcsClientAdapter) Update(ctx context.Context, v *VPC, opts ...CallOpti
 		return v, fmt.Errorf("Update: VPC has no ID — call Get first or seed from response metadata")
 	}
 	if v.ProjectID() == "" {
-		return v, fmt.Errorf("Update: VPC has no project — call IntoProject first")
+		return v, fmt.Errorf("Update: VPC has no project — call InProject first")
 	}
 	co := applyCallOptions(opts)
 	rp := co.toRequestParameters()

--- a/pkg/aruba/resource_vpc_peering.go
+++ b/pkg/aruba/resource_vpc_peering.go
@@ -46,30 +46,40 @@ func NewVPCPeering() *VPCPeering {
 
 // Setters — chainable, general → specific
 
-// IntoVPC binds this VPCPeering to its parent VPC. Required before Create.
-func (p *VPCPeering) IntoVPC(v Ref) *VPCPeering { p.intoVPC(v); return p }
+// InVPC binds this VPCPeering to its parent VPC. Required before Create.
+func (p *VPCPeering) InVPC(v Ref) *VPCPeering { p.intoVPC(v); return p }
 
 // Named sets the resource name. Required by the API.
 func (p *VPCPeering) Named(n string) *VPCPeering { p.named(n); return p }
 
-// AddTag appends a tag for filtering and accounting.
-func (p *VPCPeering) AddTag(t string) *VPCPeering { p.addTag(t); return p }
+// Tagged appends tags for filtering and accounting. Repeated calls append.
+func (p *VPCPeering) Tagged(ts ...string) *VPCPeering {
+	for _, t := range ts {
+		p.addTag(t)
+	}
+	return p
+}
 
-// RemoveTag removes a previously-added tag. No-op if absent.
-func (p *VPCPeering) RemoveTag(t string) *VPCPeering { p.removeTag(t); return p }
+// Untagged removes each listed tag. No-op for tags not present.
+func (p *VPCPeering) Untagged(ts ...string) *VPCPeering {
+	for _, t := range ts {
+		p.removeTag(t)
+	}
+	return p
+}
 
-// ReplaceTags replaces the entire tag set with the given values.
-func (p *VPCPeering) ReplaceTags(ts ...string) *VPCPeering { p.replaceTags(ts...); return p }
+// RetaggedAs replaces the entire tag set with the given values.
+func (p *VPCPeering) RetaggedAs(ts ...string) *VPCPeering { p.replaceTags(ts...); return p }
 
 // InRegion sets the region for this resource.
 func (p *VPCPeering) InRegion(region Region) *VPCPeering { p.inRegion(region); return p }
 
-// WithRemoteVPC stores the remote VPC URI in the request body Properties.
+// PeeredWith stores the remote VPC URI in the request body Properties.
 // Records a setter-time error if the supplied Ref's URI is empty.
-func (p *VPCPeering) WithRemoteVPC(v Ref) *VPCPeering {
+func (p *VPCPeering) PeeredWith(v Ref) *VPCPeering {
 	uri := v.URI()
 	if uri == "" {
-		p.addErr(fmt.Errorf("WithRemoteVPC: remote VPC Ref has empty URI"))
+		p.addErr(fmt.Errorf("PeeredWith: remote VPC Ref has empty URI"))
 		return p
 	}
 	p.remoteVPC = &types.ReferenceResource{URI: uri}
@@ -201,7 +211,7 @@ func (a *vpcPeeringsClientAdapter) Create(ctx context.Context, peering *VPCPeeri
 		return peering, err
 	}
 	if peering.VPCID() == "" || peering.ProjectID() == "" {
-		return peering, fmt.Errorf("Create: VPC peering has no VPC — call IntoVPC first")
+		return peering, fmt.Errorf("Create: VPC peering has no VPC — call InVPC first")
 	}
 	co := applyCallOptions(opts)
 	rp := co.toRequestParameters()
@@ -277,7 +287,7 @@ func (a *vpcPeeringsClientAdapter) Update(ctx context.Context, peering *VPCPeeri
 		return peering, fmt.Errorf("Update: VPC peering has no ID — call Get first or seed from response metadata")
 	}
 	if peering.VPCID() == "" || peering.ProjectID() == "" {
-		return peering, fmt.Errorf("Update: VPC peering has no VPC — call IntoVPC first")
+		return peering, fmt.Errorf("Update: VPC peering has no VPC — call InVPC first")
 	}
 	co := applyCallOptions(opts)
 	rp := co.toRequestParameters()

--- a/pkg/aruba/resource_vpc_peering_route.go
+++ b/pkg/aruba/resource_vpc_peering_route.go
@@ -17,7 +17,7 @@ func VPCPeeringRouteRef(projectID, vpcID, peeringID, routeID string) Ref {
 // ---- Wrapper ----
 
 // VPCPeeringRoute is the wrapper for an Aruba Cloud VPC Peering Route (a child of a VPCPeering).
-// Construct with aruba.NewVPCPeeringRoute() and bind it via IntoVPCPeering(peering).
+// Construct with aruba.NewVPCPeeringRoute() and bind it via InVPCPeering(peering).
 //
 // Wraps types.VPCPeeringRouteResponse / types.VPCPeeringRouteRequest. The wrapper carries
 // pointer-typed private fields so unset values round-trip through
@@ -38,7 +38,7 @@ type VPCPeeringRoute struct {
 }
 
 // NewVPCPeeringRoute returns a fresh *VPCPeeringRoute ready for fluent setters and a Create call.
-// Binds vpcPeeringScopedMixin's error sink so IntoVPCPeering failures surface via Err().
+// Binds vpcPeeringScopedMixin's error sink so InVPCPeering failures surface via Err().
 func NewVPCPeeringRoute() *VPCPeeringRoute {
 	r := &VPCPeeringRoute{}
 	r.vpcPeeringScopedMixin = bindVPCPeeringScoped(&r.errMixin)
@@ -47,20 +47,33 @@ func NewVPCPeeringRoute() *VPCPeeringRoute {
 
 // Setters — chainable, general → specific
 
-// IntoVPCPeering binds this VPCPeeringRoute to its parent VPCPeering. Required before Create.
-func (r *VPCPeeringRoute) IntoVPCPeering(p Ref) *VPCPeeringRoute { r.intoVPCPeering(p); return r }
+// InVPCPeering binds this VPCPeeringRoute to its parent VPCPeering. Required before Create.
+func (r *VPCPeeringRoute) InVPCPeering(p Ref) *VPCPeeringRoute { r.intoVPCPeering(p); return r }
 
 // Named sets the resource name. Required by the API.
 func (r *VPCPeeringRoute) Named(n string) *VPCPeeringRoute { r.named(n); return r }
 
-// AddTag appends a tag for filtering and accounting.
-func (r *VPCPeeringRoute) AddTag(t string) *VPCPeeringRoute { r.addTag(t); return r }
+// Tagged appends tags for filtering and accounting. Repeated calls append.
+func (r *VPCPeeringRoute) Tagged(ts ...string) *VPCPeeringRoute {
+	for _, t := range ts {
+		r.addTag(t)
+	}
+	return r
+}
 
-// RemoveTag removes a previously-added tag. No-op if absent.
-func (r *VPCPeeringRoute) RemoveTag(t string) *VPCPeeringRoute { r.removeTag(t); return r }
+// Untagged removes each listed tag. No-op for tags not present.
+func (r *VPCPeeringRoute) Untagged(ts ...string) *VPCPeeringRoute {
+	for _, t := range ts {
+		r.removeTag(t)
+	}
+	return r
+}
 
-// ReplaceTags replaces the entire tag set with the given values.
-func (r *VPCPeeringRoute) ReplaceTags(ts ...string) *VPCPeeringRoute { r.replaceTags(ts...); return r }
+// RetaggedAs replaces the entire tag set with the given values.
+func (r *VPCPeeringRoute) RetaggedAs(ts ...string) *VPCPeeringRoute {
+	r.replaceTags(ts...)
+	return r
+}
 
 // InRegion sets the region for this resource.
 func (r *VPCPeeringRoute) InRegion(region Region) *VPCPeeringRoute { r.inRegion(region); return r }
@@ -74,9 +87,24 @@ func (r *VPCPeeringRoute) WithRemoteCIDR(cidr string) *VPCPeeringRoute {
 	return r
 }
 
-// WithBillingPeriod sets the billing period. Defaults to hourly when unset.
-func (r *VPCPeeringRoute) WithBillingPeriod(p BillingPeriod) *VPCPeeringRoute {
-	r.billingPeriod = &p
+// BilledHourly sets hourly billing.
+func (r *VPCPeeringRoute) BilledHourly() *VPCPeeringRoute {
+	v := BillingPeriodHour
+	r.billingPeriod = &v
+	return r
+}
+
+// BilledMonthly sets monthly billing.
+func (r *VPCPeeringRoute) BilledMonthly() *VPCPeeringRoute {
+	v := BillingPeriodMonth
+	r.billingPeriod = &v
+	return r
+}
+
+// BilledYearly sets yearly billing.
+func (r *VPCPeeringRoute) BilledYearly() *VPCPeeringRoute {
+	v := BillingPeriodYear
+	r.billingPeriod = &v
 	return r
 }
 
@@ -233,7 +261,7 @@ func (a *vpcPeeringRoutesClientAdapter) Create(ctx context.Context, route *VPCPe
 		return route, err
 	}
 	if route.VPCPeeringID() == "" || route.VPCID() == "" || route.ProjectID() == "" {
-		return route, fmt.Errorf("Create: VPC peering route has no parent peering — call IntoVPCPeering first")
+		return route, fmt.Errorf("Create: VPC peering route has no parent peering — call InVPCPeering first")
 	}
 	co := applyCallOptions(opts)
 	rp := co.toRequestParameters()
@@ -312,7 +340,7 @@ func (a *vpcPeeringRoutesClientAdapter) Update(ctx context.Context, route *VPCPe
 		return route, fmt.Errorf("Update: VPC peering route has no ID — call Get first or seed from response metadata")
 	}
 	if route.VPCPeeringID() == "" || route.VPCID() == "" || route.ProjectID() == "" {
-		return route, fmt.Errorf("Update: VPC peering route has no parent peering — call IntoVPCPeering first")
+		return route, fmt.Errorf("Update: VPC peering route has no parent peering — call InVPCPeering first")
 	}
 	co := applyCallOptions(opts)
 	rp := co.toRequestParameters()

--- a/pkg/aruba/resource_vpc_peering_route.go
+++ b/pkg/aruba/resource_vpc_peering_route.go
@@ -87,24 +87,9 @@ func (r *VPCPeeringRoute) WithRemoteCIDR(cidr string) *VPCPeeringRoute {
 	return r
 }
 
-// BilledHourly sets hourly billing.
-func (r *VPCPeeringRoute) BilledHourly() *VPCPeeringRoute {
-	v := BillingPeriodHour
-	r.billingPeriod = &v
-	return r
-}
-
-// BilledMonthly sets monthly billing.
-func (r *VPCPeeringRoute) BilledMonthly() *VPCPeeringRoute {
-	v := BillingPeriodMonth
-	r.billingPeriod = &v
-	return r
-}
-
-// BilledYearly sets yearly billing.
-func (r *VPCPeeringRoute) BilledYearly() *VPCPeeringRoute {
-	v := BillingPeriodYear
-	r.billingPeriod = &v
+// BilledBy sets the billing cadence. Accepted periods are resource-specific; check the API reference.
+func (r *VPCPeeringRoute) BilledBy(period BillingPeriod) *VPCPeeringRoute {
+	r.billingPeriod = &period
 	return r
 }
 

--- a/pkg/aruba/resource_vpc_peering_route_test.go
+++ b/pkg/aruba/resource_vpc_peering_route_test.go
@@ -37,7 +37,7 @@ func TestVPCPeeringRoute_FluentSetters(t *testing.T) {
 		InRegion(RegionITBGBergamo).
 		WithLocalCIDR("10.0.0.0/24").
 		WithRemoteCIDR("192.168.0.0/24").
-		BilledHourly()
+		BilledBy(BillingPeriodHour)
 
 	if r.Name() != "my-route" {
 		t.Errorf("Name() = %q", r.Name())
@@ -155,7 +155,7 @@ func TestVPCPeeringRoute_ToRequestRoundTrip(t *testing.T) {
 		InRegion(RegionITBGBergamo).
 		WithLocalCIDR("10.0.0.0/24").
 		WithRemoteCIDR("192.168.0.0/24").
-		BilledHourly()
+		BilledBy(BillingPeriodHour)
 
 	req := r.RawRequest()
 
@@ -469,7 +469,7 @@ func TestVPCPeeringRoutesClientAdapter_Create_Success(t *testing.T) {
 		InRegion(RegionITBGBergamo).
 		WithLocalCIDR("10.0.0.0/24").
 		WithRemoteCIDR("192.168.0.0/24").
-		BilledHourly()
+		BilledBy(BillingPeriodHour)
 
 	result, err := adapter.Create(context.Background(), route)
 	if err != nil {

--- a/pkg/aruba/resource_vpc_peering_route_test.go
+++ b/pkg/aruba/resource_vpc_peering_route_test.go
@@ -29,15 +29,15 @@ func TestVPCPeeringRoute_FluentSetters(t *testing.T) {
 		"/projects/p1/providers/Aruba.Network/vpcs/v1/vpcPeerings/peer-1", "p1"))
 
 	r := NewVPCPeeringRoute().
-		IntoVPCPeering(parent).
+		InVPCPeering(parent).
 		Named("my-route").
-		AddTag("route").
-		AddTag("billing").
-		AddTag("route"). // dedupe
+		Tagged("route").
+		Tagged("billing").
+		Tagged("route"). // dedupe
 		InRegion(RegionITBGBergamo).
 		WithLocalCIDR("10.0.0.0/24").
 		WithRemoteCIDR("192.168.0.0/24").
-		WithBillingPeriod(BillingPeriodHour)
+		BilledHourly()
 
 	if r.Name() != "my-route" {
 		t.Errorf("Name() = %q", r.Name())
@@ -70,12 +70,12 @@ func TestVPCPeeringRoute_FluentSetters(t *testing.T) {
 		t.Errorf("Err() = %v", r.Err())
 	}
 
-	r.RemoveTag("route")
+	r.Untagged("route")
 	if tags := r.Tags(); len(tags) != 1 || tags[0] != "billing" {
 		t.Errorf("after RemoveTag Tags() = %v", tags)
 	}
 
-	r.ReplaceTags("x", "y")
+	r.RetaggedAs("x", "y")
 	if tags := r.Tags(); len(tags) != 2 || tags[0] != "x" || tags[1] != "y" {
 		t.Errorf("after ReplaceTags Tags() = %v", tags)
 	}
@@ -90,7 +90,7 @@ func TestVPCPeeringRoute_IntoVPCPeering_TypedRef(t *testing.T) {
 	parent.fromResponse(vpcPeeringTestResponse("peer-1", "my-peering",
 		"/projects/p1/providers/Aruba.Network/vpcs/v1/vpcPeerings/peer-1", "p1"))
 
-	r := NewVPCPeeringRoute().IntoVPCPeering(parent)
+	r := NewVPCPeeringRoute().InVPCPeering(parent)
 
 	if r.VPCPeeringID() != "peer-1" {
 		t.Errorf("VPCPeeringID() = %q", r.VPCPeeringID())
@@ -115,7 +115,7 @@ func TestVPCPeeringRoute_IntoVPCPeering_TypedRef(t *testing.T) {
 // --------------------------------------------------------------------------
 
 func TestVPCPeeringRoute_IntoVPCPeering_URIRef_CamelCase(t *testing.T) {
-	r := NewVPCPeeringRoute().IntoVPCPeering(
+	r := NewVPCPeeringRoute().InVPCPeering(
 		URI("/projects/p/providers/Aruba.Network/vpcs/v/vpcPeerings/peer"))
 
 	if r.VPCPeeringID() != "peer" {
@@ -137,7 +137,7 @@ func TestVPCPeeringRoute_IntoVPCPeering_URIRef_CamelCase(t *testing.T) {
 // --------------------------------------------------------------------------
 
 func TestVPCPeeringRoute_IntoVPCPeering_BadRef(t *testing.T) {
-	r := NewVPCPeeringRoute().IntoVPCPeering(URI("/garbage"))
+	r := NewVPCPeeringRoute().InVPCPeering(URI("/garbage"))
 	if r.Err() == nil {
 		t.Error("expected Err() != nil for unresolvable Ref, got nil")
 	}
@@ -150,12 +150,12 @@ func TestVPCPeeringRoute_IntoVPCPeering_BadRef(t *testing.T) {
 func TestVPCPeeringRoute_ToRequestRoundTrip(t *testing.T) {
 	r := NewVPCPeeringRoute().Named(
 		"my-route").
-		AddTag("t1").
-		AddTag("t2").
+		Tagged("t1").
+		Tagged("t2").
 		InRegion(RegionITBGBergamo).
 		WithLocalCIDR("10.0.0.0/24").
 		WithRemoteCIDR("192.168.0.0/24").
-		WithBillingPeriod(BillingPeriodHour)
+		BilledHourly()
 
 	req := r.RawRequest()
 
@@ -464,12 +464,12 @@ func TestVPCPeeringRoutesClientAdapter_Create_Success(t *testing.T) {
 		"/projects/p/providers/Aruba.Network/vpcs/v/vpcPeerings/peer-1", "p"))
 
 	route := NewVPCPeeringRoute().
-		IntoVPCPeering(peering).
+		InVPCPeering(peering).
 		Named("my-route").
 		InRegion(RegionITBGBergamo).
 		WithLocalCIDR("10.0.0.0/24").
 		WithRemoteCIDR("192.168.0.0/24").
-		WithBillingPeriod(BillingPeriodHour)
+		BilledHourly()
 
 	result, err := adapter.Create(context.Background(), route)
 	if err != nil {
@@ -533,7 +533,7 @@ func TestVPCPeeringRoutesClientAdapter_Create_MetadataValidationError(t *testing
 	peering.fromResponse(vpcPeeringTestResponse("peer-1", "my-peering",
 		"/projects/p/providers/Aruba.Network/vpcs/v/vpcPeerings/peer-1", "p"))
 
-	route := NewVPCPeeringRoute().IntoVPCPeering(peering).
+	route := NewVPCPeeringRoute().InVPCPeering(peering).
 		Named("route")
 	result, err := adapter.Create(context.Background(), route)
 	if err == nil {
@@ -559,7 +559,7 @@ func TestVPCPeeringRoutesClientAdapter_Create_NonTwoXX(t *testing.T) {
 	peering.fromResponse(vpcPeeringTestResponse("peer-1", "my-peering",
 		"/projects/p/providers/Aruba.Network/vpcs/v/vpcPeerings/peer-1", "p"))
 
-	route := NewVPCPeeringRoute().IntoVPCPeering(peering)
+	route := NewVPCPeeringRoute().InVPCPeering(peering)
 	result, err := adapter.Create(context.Background(), route)
 	if err == nil {
 		t.Fatal("expected error on 422")
@@ -664,7 +664,7 @@ func TestVPCPeeringRoutesClientAdapter_Update_NoID(t *testing.T) {
 	})
 
 	r := NewVPCPeeringRoute().
-		IntoVPCPeering(URI("/projects/p/providers/Aruba.Network/vpcs/v/vpcPeerings/peer-1")).
+		InVPCPeering(URI("/projects/p/providers/Aruba.Network/vpcs/v/vpcPeerings/peer-1")).
 		Named("x")
 
 	_, err := adapter.Update(context.Background(), r)
@@ -754,10 +754,10 @@ func TestVPCPeeringRoutesClientAdapter_Delete_NonTwoXX(t *testing.T) {
 // InRegion exercises the 0% branch.
 func TestVPCPeeringRoute_InRegion(t *testing.T) {
 	r := NewVPCPeeringRoute().
-		AddTag("a").
-		AddTag("b").
-		RemoveTag("a").
-		ReplaceTags("x", "y").
+		Tagged("a").
+		Tagged("b").
+		Untagged("a").
+		RetaggedAs("x", "y").
 		InRegion("ITMI-Milano-1")
 
 	if r.Region() != "ITMI-Milano-1" {
@@ -846,7 +846,7 @@ func TestVPCPeeringRoutesClientAdapter_Create_WithBuilderError(t *testing.T) {
 		callCount++
 		w.WriteHeader(http.StatusCreated)
 	})
-	route := NewVPCPeeringRoute().IntoVPCPeering(URI("/garbage"))
+	route := NewVPCPeeringRoute().InVPCPeering(URI("/garbage"))
 	_, err := adapter.Create(context.Background(), route)
 	if err == nil {
 		t.Fatal("expected error for builder error")
@@ -899,7 +899,7 @@ func TestVPCPeeringRoutesClientAdapter_Update_WithBuilderError(t *testing.T) {
 		callCount++
 		w.WriteHeader(http.StatusOK)
 	})
-	route := NewVPCPeeringRoute().IntoVPCPeering(URI("/garbage"))
+	route := NewVPCPeeringRoute().InVPCPeering(URI("/garbage"))
 	_, err := adapter.Update(context.Background(), route)
 	if err == nil {
 		t.Fatal("expected error for builder error")

--- a/pkg/aruba/resource_vpc_peering_test.go
+++ b/pkg/aruba/resource_vpc_peering_test.go
@@ -28,13 +28,13 @@ func TestVPCPeering_FluentSetters(t *testing.T) {
 	parent.fromResponse(vpcTestResponse("v1", "my-vpc", "/projects/p1/providers/Aruba.Network/vpcs/v1", "p1"))
 
 	p := NewVPCPeering().
-		IntoVPC(parent).
+		InVPC(parent).
 		Named("my-peering").
-		AddTag("peering").
-		AddTag("cross-vpc").
-		AddTag("peering"). // dedupe
+		Tagged("peering").
+		Tagged("cross-vpc").
+		Tagged("peering"). // dedupe
 		InRegion(RegionITBGBergamo).
-		WithRemoteVPC(URI("/projects/p2/network/vpcs/v2"))
+		PeeredWith(URI("/projects/p2/network/vpcs/v2"))
 
 	if p.Name() != "my-peering" {
 		t.Errorf("Name() = %q", p.Name())
@@ -58,12 +58,12 @@ func TestVPCPeering_FluentSetters(t *testing.T) {
 		t.Errorf("Err() = %v", p.Err())
 	}
 
-	p.RemoveTag("peering")
+	p.Untagged("peering")
 	if tags := p.Tags(); len(tags) != 1 || tags[0] != "cross-vpc" {
 		t.Errorf("after RemoveTag Tags() = %v", tags)
 	}
 
-	p.ReplaceTags("x", "y")
+	p.RetaggedAs("x", "y")
 	if tags := p.Tags(); len(tags) != 2 || tags[0] != "x" || tags[1] != "y" {
 		t.Errorf("after ReplaceTags Tags() = %v", tags)
 	}
@@ -77,7 +77,7 @@ func TestVPCPeering_IntoVPC_TypedRef(t *testing.T) {
 	parent := &VPC{}
 	parent.fromResponse(vpcTestResponse("v1", "my-vpc", "/projects/p1/providers/Aruba.Network/vpcs/v1", "p1"))
 
-	p := NewVPCPeering().IntoVPC(parent)
+	p := NewVPCPeering().InVPC(parent)
 
 	if p.VPCID() != "v1" {
 		t.Errorf("VPCID() = %q", p.VPCID())
@@ -95,7 +95,7 @@ func TestVPCPeering_IntoVPC_TypedRef(t *testing.T) {
 // --------------------------------------------------------------------------
 
 func TestVPCPeering_IntoVPC_URIRef(t *testing.T) {
-	p := NewVPCPeering().IntoVPC(URI("/projects/p/network/vpcs/v"))
+	p := NewVPCPeering().InVPC(URI("/projects/p/network/vpcs/v"))
 
 	if p.VPCID() != "v" {
 		t.Errorf("VPCID() = %q", p.VPCID())
@@ -113,7 +113,7 @@ func TestVPCPeering_IntoVPC_URIRef(t *testing.T) {
 // --------------------------------------------------------------------------
 
 func TestVPCPeering_IntoVPC_BadRef(t *testing.T) {
-	p := NewVPCPeering().IntoVPC(URI("/garbage"))
+	p := NewVPCPeering().InVPC(URI("/garbage"))
 	if p.Err() == nil {
 		t.Error("expected Err() != nil for unresolvable Ref, got nil")
 	}
@@ -127,7 +127,7 @@ func TestVPCPeering_WithRemoteVPC_TypedRef(t *testing.T) {
 	remote := &VPC{}
 	remote.fromResponse(vpcTestResponse("v2", "remote-vpc", "/projects/p2/providers/Aruba.Network/vpcs/v2", "p2"))
 
-	p := NewVPCPeering().WithRemoteVPC(remote)
+	p := NewVPCPeering().PeeredWith(remote)
 
 	if p.RemoteVPCURI() != "/projects/p2/providers/Aruba.Network/vpcs/v2" {
 		t.Errorf("RemoteVPCURI() = %q", p.RemoteVPCURI())
@@ -138,7 +138,7 @@ func TestVPCPeering_WithRemoteVPC_TypedRef(t *testing.T) {
 }
 
 func TestVPCPeering_WithRemoteVPC_URIRef(t *testing.T) {
-	p := NewVPCPeering().WithRemoteVPC(URI("/projects/p2/network/vpcs/v2"))
+	p := NewVPCPeering().PeeredWith(URI("/projects/p2/network/vpcs/v2"))
 
 	if p.RemoteVPCURI() != "/projects/p2/network/vpcs/v2" {
 		t.Errorf("RemoteVPCURI() = %q", p.RemoteVPCURI())
@@ -149,7 +149,7 @@ func TestVPCPeering_WithRemoteVPC_URIRef(t *testing.T) {
 }
 
 func TestVPCPeering_WithRemoteVPC_EmptyURI(t *testing.T) {
-	p := NewVPCPeering().WithRemoteVPC(URI(""))
+	p := NewVPCPeering().PeeredWith(URI(""))
 
 	if p.Err() == nil {
 		t.Fatal("expected Err() != nil for empty URI remote VPC")
@@ -169,10 +169,10 @@ func TestVPCPeering_WithRemoteVPC_EmptyURI(t *testing.T) {
 func TestVPCPeering_ToRequestRoundTrip(t *testing.T) {
 	p := NewVPCPeering().Named(
 		"my-peering").
-		AddTag("t1").
-		AddTag("t2").
+		Tagged("t1").
+		Tagged("t2").
 		InRegion(RegionITBGBergamo).
-		WithRemoteVPC(URI("/projects/p2/network/vpcs/v2"))
+		PeeredWith(URI("/projects/p2/network/vpcs/v2"))
 
 	req := p.RawRequest()
 
@@ -427,10 +427,10 @@ func TestVPCPeeringsClientAdapter_Create_Success(t *testing.T) {
 	vpc.fromResponse(vpcTestResponse("v", "my-vpc", "/projects/p/providers/Aruba.Network/vpcs/v", "p"))
 
 	p := NewVPCPeering().
-		IntoVPC(vpc).
+		InVPC(vpc).
 		Named("my-peering").
 		InRegion(RegionITBGBergamo).
-		WithRemoteVPC(URI("/projects/p2/network/vpcs/v2"))
+		PeeredWith(URI("/projects/p2/network/vpcs/v2"))
 
 	result, err := adapter.Create(context.Background(), p)
 	if err != nil {
@@ -484,7 +484,7 @@ func TestVPCPeeringsClientAdapter_Create_MetadataValidationError(t *testing.T) {
 	vpc := &VPC{}
 	vpc.fromResponse(vpcTestResponse("v", "my-vpc", "/projects/p/providers/Aruba.Network/vpcs/v", "p"))
 
-	p := NewVPCPeering().IntoVPC(vpc).
+	p := NewVPCPeering().InVPC(vpc).
 		Named("peering")
 	result, err := adapter.Create(context.Background(), p)
 	if err == nil {
@@ -509,7 +509,7 @@ func TestVPCPeeringsClientAdapter_Create_NonTwoXX(t *testing.T) {
 	vpc := &VPC{}
 	vpc.fromResponse(vpcTestResponse("v", "my-vpc", "/projects/p/providers/Aruba.Network/vpcs/v", "p"))
 
-	p := NewVPCPeering().IntoVPC(vpc)
+	p := NewVPCPeering().InVPC(vpc)
 	result, err := adapter.Create(context.Background(), p)
 	if err == nil {
 		t.Fatal("expected error on 422")
@@ -610,7 +610,7 @@ func TestVPCPeeringsClientAdapter_Update_NoID(t *testing.T) {
 		w.WriteHeader(http.StatusOK)
 	})
 
-	p := NewVPCPeering().IntoVPC(URI("/projects/p/network/vpcs/v")).
+	p := NewVPCPeering().InVPC(URI("/projects/p/network/vpcs/v")).
 		Named("x")
 	_, err := adapter.Update(context.Background(), p)
 	if err == nil {
@@ -697,10 +697,10 @@ func TestVPCPeeringsClientAdapter_Delete_NonTwoXX(t *testing.T) {
 // InRegion exercises the 0% branch.
 func TestVPCPeering_InRegion(t *testing.T) {
 	p := NewVPCPeering().
-		AddTag("a").
-		AddTag("b").
-		RemoveTag("a").
-		ReplaceTags("x", "y").
+		Tagged("a").
+		Tagged("b").
+		Untagged("a").
+		RetaggedAs("x", "y").
 		InRegion("ITMI-Milano-1")
 
 	if p.Region() != "ITMI-Milano-1" {
@@ -788,7 +788,7 @@ func TestVPCPeeringsClientAdapter_Create_WithBuilderError(t *testing.T) {
 		callCount++
 		w.WriteHeader(http.StatusCreated)
 	})
-	peering := NewVPCPeering().IntoVPC(URI("/garbage"))
+	peering := NewVPCPeering().InVPC(URI("/garbage"))
 	_, err := adapter.Create(context.Background(), peering)
 	if err == nil {
 		t.Fatal("expected error for builder error")
@@ -840,7 +840,7 @@ func TestVPCPeeringsClientAdapter_Update_WithBuilderError(t *testing.T) {
 		callCount++
 		w.WriteHeader(http.StatusOK)
 	})
-	peering := NewVPCPeering().IntoVPC(URI("/garbage"))
+	peering := NewVPCPeering().InVPC(URI("/garbage"))
 	_, err := adapter.Update(context.Background(), peering)
 	if err == nil {
 		t.Fatal("expected error for builder error")

--- a/pkg/aruba/resource_vpc_test.go
+++ b/pkg/aruba/resource_vpc_test.go
@@ -28,14 +28,14 @@ func TestVPC_FluentSetters(t *testing.T) {
 	parent.fromResponse(projectTestResponse("proj-1", "my-proj", "/projects/proj-1"))
 
 	v := NewVPC().
-		IntoProject(parent).
+		InProject(parent).
 		Named("my-vpc").
-		AddTag("net").
-		AddTag("infra").
-		AddTag("net"). // dedupe
+		Tagged("net").
+		Tagged("infra").
+		Tagged("net"). // dedupe
 		InRegion(RegionITBGBergamo).
 		AsDefault().
-		WithPreset(true)
+		WithPreset()
 
 	if v.Name() != "my-vpc" {
 		t.Errorf("Name() = %q", v.Name())
@@ -59,12 +59,12 @@ func TestVPC_FluentSetters(t *testing.T) {
 		t.Errorf("Err() = %v", v.Err())
 	}
 
-	v.RemoveTag("net")
+	v.Untagged("net")
 	if tags := v.Tags(); len(tags) != 1 || tags[0] != "infra" {
 		t.Errorf("after RemoveTag Tags() = %v", tags)
 	}
 
-	v.ReplaceTags("x", "y")
+	v.RetaggedAs("x", "y")
 	if tags := v.Tags(); len(tags) != 2 || tags[0] != "x" || tags[1] != "y" {
 		t.Errorf("after ReplaceTags Tags() = %v", tags)
 	}
@@ -75,7 +75,7 @@ func TestVPC_FluentSetters(t *testing.T) {
 // --------------------------------------------------------------------------
 
 func TestVPC_IntoProject_BadRef(t *testing.T) {
-	v := NewVPC().IntoProject(URI("/garbage"))
+	v := NewVPC().InProject(URI("/garbage"))
 	if v.Err() == nil {
 		t.Error("expected Err() != nil for unresolvable Ref, got nil")
 	}
@@ -88,11 +88,11 @@ func TestVPC_IntoProject_BadRef(t *testing.T) {
 func TestVPC_ToRequestRoundTrip(t *testing.T) {
 	v := NewVPC().Named(
 		"vpc-1").
-		AddTag("t1").
-		AddTag("t2").
+		Tagged("t1").
+		Tagged("t2").
 		InRegion(RegionITBGBergamo).
 		AsDefault().
-		WithPreset(false)
+		WithoutPreset()
 
 	req := v.RawRequest()
 
@@ -311,7 +311,7 @@ func TestVPCsClientAdapter_Create_Success(t *testing.T) {
 	})
 
 	vpc := NewVPC().
-		IntoProject(URI("/projects/p")).
+		InProject(URI("/projects/p")).
 		Named("my-vpc").
 		NotDefault()
 
@@ -358,7 +358,7 @@ func TestVPCsClientAdapter_Create_MetadataValidationError(t *testing.T) {
 		fmt.Fprint(w, `{"metadata":{"name":"v","uri":"/projects/p/providers/Aruba.Network/vpcs/x"},"properties":{},"status":{}}`)
 	})
 
-	vpc := NewVPC().IntoProject(URI("/projects/p")).
+	vpc := NewVPC().InProject(URI("/projects/p")).
 		Named("v")
 	result, err := adapter.Create(context.Background(), vpc)
 	if err == nil {
@@ -380,7 +380,7 @@ func TestVPCsClientAdapter_Create_NonTwoXX(t *testing.T) {
 		fmt.Fprint(w, testutil.ErrorBodyJSON("Validation Failed", "name is required", 422))
 	})
 
-	vpc := NewVPC().IntoProject(URI("/projects/p"))
+	vpc := NewVPC().InProject(URI("/projects/p"))
 	result, err := adapter.Create(context.Background(), vpc)
 	if err == nil {
 		t.Fatal("expected error on 422")
@@ -473,7 +473,7 @@ func TestVPCsClientAdapter_Update_NoID(t *testing.T) {
 		w.WriteHeader(http.StatusOK)
 	})
 
-	v := NewVPC().IntoProject(URI("/projects/p")).
+	v := NewVPC().InProject(URI("/projects/p")).
 		Named("x")
 	_, err := adapter.Update(context.Background(), v)
 	if err == nil {
@@ -693,7 +693,7 @@ func TestVPCsClientAdapter_Create_WithBuilderError(t *testing.T) {
 		callCount++
 		w.WriteHeader(http.StatusCreated)
 	})
-	v := NewVPC().IntoProject(URI("/garbage"))
+	v := NewVPC().InProject(URI("/garbage"))
 	_, err := adapter.Create(context.Background(), v)
 	if err == nil {
 		t.Fatal("expected error for builder error")
@@ -745,7 +745,7 @@ func TestVPCsClientAdapter_Update_WithBuilderError(t *testing.T) {
 		callCount++
 		w.WriteHeader(http.StatusOK)
 	})
-	v := NewVPC().IntoProject(URI("/garbage"))
+	v := NewVPC().InProject(URI("/garbage"))
 	_, err := adapter.Update(context.Background(), v)
 	if err == nil {
 		t.Fatal("expected error for builder error")

--- a/pkg/aruba/resource_vpn_route.go
+++ b/pkg/aruba/resource_vpn_route.go
@@ -17,7 +17,7 @@ func VPNRouteRef(projectID, tunnelID, routeID string) Ref {
 // ---- Wrapper ----
 
 // VPNRoute is the wrapper for an Aruba Cloud VPN Route (a child of a VPNTunnel).
-// Construct with aruba.NewVPNRoute() and bind it via IntoVPNTunnel(tunnel).
+// Construct with aruba.NewVPNRoute() and bind it via InVPNTunnel(tunnel).
 //
 // Wraps types.VPNRouteResponse / types.VPNRouteRequest. The wrapper carries
 // pointer-typed private fields so unset values round-trip through
@@ -39,7 +39,7 @@ type VPNRoute struct {
 }
 
 // NewVPNRoute returns a fresh *VPNRoute ready for fluent setters and a Create call.
-// Binds vpnTunnelScopedMixin's error sink so IntoVPNTunnel failures surface via Err().
+// Binds vpnTunnelScopedMixin's error sink so InVPNTunnel failures surface via Err().
 func NewVPNRoute() *VPNRoute {
 	r := &VPNRoute{}
 	r.vpnTunnelScopedMixin = bindVPNTunnelScoped(&r.errMixin)
@@ -48,20 +48,30 @@ func NewVPNRoute() *VPNRoute {
 
 // Setters — chainable, general → specific
 
-// IntoVPNTunnel binds this VPNRoute to its parent VPNTunnel. Required before Create.
-func (r *VPNRoute) IntoVPNTunnel(t Ref) *VPNRoute { r.intoVPNTunnel(t); return r }
+// InVPNTunnel binds this VPNRoute to its parent VPNTunnel. Required before Create.
+func (r *VPNRoute) InVPNTunnel(t Ref) *VPNRoute { r.intoVPNTunnel(t); return r }
 
 // Named sets the resource name. Required by the API.
 func (r *VPNRoute) Named(n string) *VPNRoute { r.named(n); return r }
 
-// AddTag appends a tag for filtering and accounting.
-func (r *VPNRoute) AddTag(tag string) *VPNRoute { r.addTag(tag); return r }
+// Tagged appends tags for filtering and accounting. Repeated calls append.
+func (r *VPNRoute) Tagged(ts ...string) *VPNRoute {
+	for _, tag := range ts {
+		r.addTag(tag)
+	}
+	return r
+}
 
-// RemoveTag removes a previously-added tag. No-op if absent.
-func (r *VPNRoute) RemoveTag(tag string) *VPNRoute { r.removeTag(tag); return r }
+// Untagged removes each listed tag. No-op for tags not present.
+func (r *VPNRoute) Untagged(ts ...string) *VPNRoute {
+	for _, tag := range ts {
+		r.removeTag(tag)
+	}
+	return r
+}
 
-// ReplaceTags replaces the entire tag set with the given values.
-func (r *VPNRoute) ReplaceTags(tags ...string) *VPNRoute { r.replaceTags(tags...); return r }
+// RetaggedAs replaces the entire tag set with the given values.
+func (r *VPNRoute) RetaggedAs(tags ...string) *VPNRoute { r.replaceTags(tags...); return r }
 
 // InRegion sets the region for this resource.
 func (r *VPNRoute) InRegion(region Region) *VPNRoute { r.inRegion(region); return r }
@@ -198,7 +208,7 @@ func (a *vpnRoutesClientAdapter) Create(ctx context.Context, r *VPNRoute, opts .
 		return r, err
 	}
 	if r.VPNTunnelID() == "" || r.ProjectID() == "" {
-		return r, fmt.Errorf("Create: VPN route has no parent tunnel — call IntoVPNTunnel first")
+		return r, fmt.Errorf("Create: VPN route has no parent tunnel — call InVPNTunnel first")
 	}
 	co := applyCallOptions(opts)
 	rp := co.toRequestParameters()
@@ -274,7 +284,7 @@ func (a *vpnRoutesClientAdapter) Update(ctx context.Context, r *VPNRoute, opts .
 		return r, fmt.Errorf("Update: VPN route has no ID — call Get first or seed from response metadata")
 	}
 	if r.VPNTunnelID() == "" || r.ProjectID() == "" {
-		return r, fmt.Errorf("Update: VPN route has no parent tunnel — call IntoVPNTunnel first")
+		return r, fmt.Errorf("Update: VPN route has no parent tunnel — call InVPNTunnel first")
 	}
 	co := applyCallOptions(opts)
 	rp := co.toRequestParameters()

--- a/pkg/aruba/resource_vpn_route_test.go
+++ b/pkg/aruba/resource_vpn_route_test.go
@@ -29,11 +29,11 @@ func TestVPNRoute_FluentSetters(t *testing.T) {
 		"/projects/p/providers/Aruba.Network/vpnTunnels/t-1", "p"))
 
 	r := NewVPNRoute().
-		IntoVPNTunnel(tun).
+		InVPNTunnel(tun).
 		Named("my-route").
-		AddTag("cloud").
-		AddTag("vpn").
-		AddTag("cloud"). // dedupe
+		Tagged("cloud").
+		Tagged("vpn").
+		Tagged("cloud"). // dedupe
 		InRegion(RegionITBGBergamo).
 		WithCloudSubnet("10.0.0.0/24").
 		WithOnPremSubnet("192.168.0.0/24")
@@ -63,12 +63,12 @@ func TestVPNRoute_FluentSetters(t *testing.T) {
 		t.Errorf("Err() = %v", r.Err())
 	}
 
-	r.RemoveTag("cloud")
+	r.Untagged("cloud")
 	if tags := r.Tags(); len(tags) != 1 || tags[0] != "vpn" {
 		t.Errorf("after RemoveTag Tags() = %v", tags)
 	}
 
-	r.ReplaceTags("x", "y")
+	r.RetaggedAs("x", "y")
 	if tags := r.Tags(); len(tags) != 2 || tags[0] != "x" || tags[1] != "y" {
 		t.Errorf("after ReplaceTags Tags() = %v", tags)
 	}
@@ -83,7 +83,7 @@ func TestVPNRoute_IntoVPNTunnel_TypedRef(t *testing.T) {
 	tun.fromResponse(vpnTunnelTestResponse("t-1", "n",
 		"/projects/p/providers/Aruba.Network/vpnTunnels/t-1", "p"))
 
-	r := NewVPNRoute().IntoVPNTunnel(tun)
+	r := NewVPNRoute().InVPNTunnel(tun)
 
 	if r.VPNTunnelID() != "t-1" {
 		t.Errorf("VPNTunnelID() = %q", r.VPNTunnelID())
@@ -101,7 +101,7 @@ func TestVPNRoute_IntoVPNTunnel_TypedRef(t *testing.T) {
 // --------------------------------------------------------------------------
 
 func TestVPNRoute_IntoVPNTunnel_URIRef_CamelCase(t *testing.T) {
-	r := NewVPNRoute().IntoVPNTunnel(URI("/projects/p/providers/Aruba.Network/vpnTunnels/t-1"))
+	r := NewVPNRoute().InVPNTunnel(URI("/projects/p/providers/Aruba.Network/vpnTunnels/t-1"))
 
 	if r.Err() != nil {
 		t.Fatalf("unexpected Err() = %v", r.Err())
@@ -123,7 +123,7 @@ func TestVPNRoute_IntoVPNTunnel_URIRef_CamelCase(t *testing.T) {
 // --------------------------------------------------------------------------
 
 func TestVPNRoute_IntoVPNTunnel_BadRef(t *testing.T) {
-	r := NewVPNRoute().IntoVPNTunnel(URI("/garbage"))
+	r := NewVPNRoute().InVPNTunnel(URI("/garbage"))
 	if r.Err() == nil {
 		t.Error("expected Err() != nil for unresolvable Ref")
 	}
@@ -136,7 +136,7 @@ func TestVPNRoute_IntoVPNTunnel_BadRef(t *testing.T) {
 func TestVPNRoute_ToRequestRoundTrip(t *testing.T) {
 	r := NewVPNRoute().Named(
 		"my-route").
-		AddTag("t1").
+		Tagged("t1").
 		InRegion(RegionITBGBergamo).
 		WithCloudSubnet("10.1.0.0/16").
 		WithOnPremSubnet("172.16.0.0/12")
@@ -419,7 +419,7 @@ func TestVPNRoutesClientAdapter_Create_Success(t *testing.T) {
 	})
 
 	route := NewVPNRoute().
-		IntoVPNTunnel(URI("/projects/p/providers/Aruba.Network/vpnTunnels/t-1")).
+		InVPNTunnel(URI("/projects/p/providers/Aruba.Network/vpnTunnels/t-1")).
 		Named("my-route").
 		InRegion(RegionITBGBergamo).
 		WithCloudSubnet("10.0.0.0/24").
@@ -478,7 +478,7 @@ func TestVPNRoutesClientAdapter_Create_MetadataValidationError(t *testing.T) {
 	})
 
 	route := NewVPNRoute().
-		IntoVPNTunnel(URI("/projects/p/providers/Aruba.Network/vpnTunnels/t-1")).
+		InVPNTunnel(URI("/projects/p/providers/Aruba.Network/vpnTunnels/t-1")).
 		Named("route")
 
 	result, err := adapter.Create(context.Background(), route)
@@ -502,7 +502,7 @@ func TestVPNRoutesClientAdapter_Create_NonTwoXX(t *testing.T) {
 	})
 
 	route := NewVPNRoute().
-		IntoVPNTunnel(URI("/projects/p/providers/Aruba.Network/vpnTunnels/t-1"))
+		InVPNTunnel(URI("/projects/p/providers/Aruba.Network/vpnTunnels/t-1"))
 	result, err := adapter.Create(context.Background(), route)
 	if err == nil {
 		t.Fatal("expected error on 422")
@@ -603,7 +603,7 @@ func TestVPNRoutesClientAdapter_Update_NoID(t *testing.T) {
 	})
 
 	r := NewVPNRoute().
-		IntoVPNTunnel(URI("/projects/p/providers/Aruba.Network/vpnTunnels/t-1")).
+		InVPNTunnel(URI("/projects/p/providers/Aruba.Network/vpnTunnels/t-1")).
 		Named("x")
 
 	_, err := adapter.Update(context.Background(), r)
@@ -685,10 +685,10 @@ func TestVPNRoutesClientAdapter_Delete_NonTwoXX(t *testing.T) {
 // InRegion exercises the 0% branch.
 func TestVPNRoute_InRegion(t *testing.T) {
 	r := NewVPNRoute().
-		AddTag("a").
-		AddTag("b").
-		RemoveTag("a").
-		ReplaceTags("x", "y").
+		Tagged("a").
+		Tagged("b").
+		Untagged("a").
+		RetaggedAs("x", "y").
 		InRegion("ITMI-Milano-1")
 
 	if r.Region() != "ITMI-Milano-1" {
@@ -777,7 +777,7 @@ func TestVPNRoutesClientAdapter_Create_WithBuilderError(t *testing.T) {
 		callCount++
 		w.WriteHeader(http.StatusCreated)
 	})
-	r := NewVPNRoute().IntoVPNTunnel(URI("/garbage"))
+	r := NewVPNRoute().InVPNTunnel(URI("/garbage"))
 	_, err := adapter.Create(context.Background(), r)
 	if err == nil {
 		t.Fatal("expected error for builder error")
@@ -830,7 +830,7 @@ func TestVPNRoutesClientAdapter_Update_WithBuilderError(t *testing.T) {
 		callCount++
 		w.WriteHeader(http.StatusOK)
 	})
-	r := NewVPNRoute().IntoVPNTunnel(URI("/garbage"))
+	r := NewVPNRoute().InVPNTunnel(URI("/garbage"))
 	_, err := adapter.Update(context.Background(), r)
 	if err == nil {
 		t.Fatal("expected error for builder error")
@@ -1025,7 +1025,7 @@ func TestVPNRoutesClientAdapter_Create_CloudSubnetAsObject(t *testing.T) {
 	})
 
 	route := NewVPNRoute().
-		IntoVPNTunnel(URI("/projects/p/providers/Aruba.Network/vpnTunnels/t-1")).
+		InVPNTunnel(URI("/projects/p/providers/Aruba.Network/vpnTunnels/t-1")).
 		Named("my-route").
 		InRegion(RegionITBGBergamo).
 		WithCloudSubnet("10.1.0.0/24").

--- a/pkg/aruba/resource_vpn_tunnel.go
+++ b/pkg/aruba/resource_vpn_tunnel.go
@@ -92,18 +92,8 @@ func (t *VPNTunnel) WithVPNClientProtocol(s VPNClientProtocol) *VPNTunnel {
 	return t
 }
 
-// BilledHourly sets hourly billing.
-func (t *VPNTunnel) BilledHourly() *VPNTunnel { v := BillingPeriodHour; t.billingPeriod = &v; return t }
-
-// BilledMonthly sets monthly billing.
-func (t *VPNTunnel) BilledMonthly() *VPNTunnel {
-	v := BillingPeriodMonth
-	t.billingPeriod = &v
-	return t
-}
-
-// BilledYearly sets yearly billing.
-func (t *VPNTunnel) BilledYearly() *VPNTunnel { v := BillingPeriodYear; t.billingPeriod = &v; return t }
+// BilledBy sets the billing cadence. Accepted periods are resource-specific; check the API reference.
+func (t *VPNTunnel) BilledBy(period BillingPeriod) *VPNTunnel { t.billingPeriod = &period; return t }
 
 // WithPeerClientPublicIP sets the public IP of the remote VPN peer.
 func (t *VPNTunnel) WithPeerClientPublicIP(s string) *VPNTunnel {

--- a/pkg/aruba/resource_vpn_tunnel.go
+++ b/pkg/aruba/resource_vpn_tunnel.go
@@ -17,7 +17,7 @@ func VPNTunnelRef(projectID, tunnelID string) Ref {
 // ---- Wrapper ----
 
 // VPNTunnel is the wrapper for an Aruba Cloud VPN Tunnel (a child of a Project).
-// Construct with aruba.NewVPNTunnel() and bind it via IntoProject(project).
+// Construct with aruba.NewVPNTunnel() and bind it via InProject(project).
 //
 // Wraps types.VPNTunnelResponse / types.VPNTunnelRequest. The wrapper carries
 // pointer-typed private fields so unset values round-trip through
@@ -46,7 +46,7 @@ type VPNTunnel struct {
 }
 
 // NewVPNTunnel returns a fresh *VPNTunnel ready for fluent setters and a Create call.
-// Binds projectScopedMixin's error sink so IntoProject failures surface via Err().
+// Binds projectScopedMixin's error sink so InProject failures surface via Err().
 func NewVPNTunnel() *VPNTunnel {
 	t := &VPNTunnel{}
 	t.projectScopedMixin = bindProjectScoped(&t.errMixin)
@@ -55,20 +55,30 @@ func NewVPNTunnel() *VPNTunnel {
 
 // Setters — chainable, general → specific
 
-// IntoProject binds this VPNTunnel to its parent project. Required before Create.
-func (t *VPNTunnel) IntoProject(p Ref) *VPNTunnel { t.intoProject(p); return t }
+// InProject binds this VPNTunnel to its parent project. Required before Create.
+func (t *VPNTunnel) InProject(p Ref) *VPNTunnel { t.intoProject(p); return t }
 
 // Named sets the resource name. Required by the API.
 func (t *VPNTunnel) Named(n string) *VPNTunnel { t.named(n); return t }
 
-// AddTag appends a tag for filtering and accounting.
-func (t *VPNTunnel) AddTag(tag string) *VPNTunnel { t.addTag(tag); return t }
+// Tagged appends tags for filtering and accounting. Repeated calls append.
+func (t *VPNTunnel) Tagged(ts ...string) *VPNTunnel {
+	for _, tag := range ts {
+		t.addTag(tag)
+	}
+	return t
+}
 
-// RemoveTag removes a previously-added tag. No-op if absent.
-func (t *VPNTunnel) RemoveTag(tag string) *VPNTunnel { t.removeTag(tag); return t }
+// Untagged removes each listed tag. No-op for tags not present.
+func (t *VPNTunnel) Untagged(ts ...string) *VPNTunnel {
+	for _, tag := range ts {
+		t.removeTag(tag)
+	}
+	return t
+}
 
-// ReplaceTags replaces the entire tag set with the given values.
-func (t *VPNTunnel) ReplaceTags(tags ...string) *VPNTunnel { t.replaceTags(tags...); return t }
+// RetaggedAs replaces the entire tag set with the given values.
+func (t *VPNTunnel) RetaggedAs(tags ...string) *VPNTunnel { t.replaceTags(tags...); return t }
 
 // InRegion sets the region for this resource.
 func (t *VPNTunnel) InRegion(r Region) *VPNTunnel { t.inRegion(r); return t }
@@ -82,8 +92,18 @@ func (t *VPNTunnel) WithVPNClientProtocol(s VPNClientProtocol) *VPNTunnel {
 	return t
 }
 
-// WithBillingPeriod sets the billing period. Defaults to hourly when unset.
-func (t *VPNTunnel) WithBillingPeriod(s BillingPeriod) *VPNTunnel { t.billingPeriod = &s; return t }
+// BilledHourly sets hourly billing.
+func (t *VPNTunnel) BilledHourly() *VPNTunnel { v := BillingPeriodHour; t.billingPeriod = &v; return t }
+
+// BilledMonthly sets monthly billing.
+func (t *VPNTunnel) BilledMonthly() *VPNTunnel {
+	v := BillingPeriodMonth
+	t.billingPeriod = &v
+	return t
+}
+
+// BilledYearly sets yearly billing.
+func (t *VPNTunnel) BilledYearly() *VPNTunnel { v := BillingPeriodYear; t.billingPeriod = &v; return t }
 
 // WithPeerClientPublicIP sets the public IP of the remote VPN peer.
 func (t *VPNTunnel) WithPeerClientPublicIP(s string) *VPNTunnel {
@@ -314,7 +334,7 @@ func (a *vpnTunnelsClientAdapter) Create(ctx context.Context, t *VPNTunnel, opts
 		return t, err
 	}
 	if t.ProjectID() == "" {
-		return t, fmt.Errorf("Create: VPN tunnel has no project — call IntoProject first")
+		return t, fmt.Errorf("Create: VPN tunnel has no project — call InProject first")
 	}
 	co := applyCallOptions(opts)
 	rp := co.toRequestParameters()
@@ -387,7 +407,7 @@ func (a *vpnTunnelsClientAdapter) Update(ctx context.Context, t *VPNTunnel, opts
 		return t, fmt.Errorf("Update: VPN tunnel has no ID — call Get first or seed from response metadata")
 	}
 	if t.ProjectID() == "" {
-		return t, fmt.Errorf("Update: VPN tunnel has no project — call IntoProject first")
+		return t, fmt.Errorf("Update: VPN tunnel has no project — call InProject first")
 	}
 	co := applyCallOptions(opts)
 	rp := co.toRequestParameters()

--- a/pkg/aruba/resource_vpn_tunnel_test.go
+++ b/pkg/aruba/resource_vpn_tunnel_test.go
@@ -28,15 +28,15 @@ func TestVPNTunnel_FluentSetters(t *testing.T) {
 	proj.fromResponse(projectTestResponse("p1", "my-project", "/projects/p1"))
 
 	tun := NewVPNTunnel().
-		IntoProject(proj).
+		InProject(proj).
 		Named("my-tunnel").
-		AddTag("vpn").
-		AddTag("ipsec").
-		AddTag("vpn"). // dedupe
+		Tagged("vpn").
+		Tagged("ipsec").
+		Tagged("vpn"). // dedupe
 		InRegion(RegionITBGBergamo).
 		OfType(VPNTypeSiteToSite).
 		WithVPNClientProtocol(VPNClientProtocolIKEv2).
-		WithBillingPeriod(BillingPeriodHour).
+		BilledHourly().
 		WithPeerClientPublicIP("1.2.3.4")
 
 	if tun.Name() != "my-tunnel" {
@@ -67,12 +67,12 @@ func TestVPNTunnel_FluentSetters(t *testing.T) {
 		t.Errorf("Err() = %v", tun.Err())
 	}
 
-	tun.RemoveTag("vpn")
+	tun.Untagged("vpn")
 	if tags := tun.Tags(); len(tags) != 1 || tags[0] != "ipsec" {
 		t.Errorf("after RemoveTag Tags() = %v", tags)
 	}
 
-	tun.ReplaceTags("x", "y")
+	tun.RetaggedAs("x", "y")
 	if tags := tun.Tags(); len(tags) != 2 || tags[0] != "x" || tags[1] != "y" {
 		t.Errorf("after ReplaceTags Tags() = %v", tags)
 	}
@@ -86,7 +86,7 @@ func TestVPNTunnel_IntoProject_TypedRef(t *testing.T) {
 	proj := &Project{}
 	proj.fromResponse(projectTestResponse("p1", "my-project", "/projects/p1"))
 
-	tun := NewVPNTunnel().IntoProject(proj)
+	tun := NewVPNTunnel().InProject(proj)
 
 	if tun.ProjectID() != "p1" {
 		t.Errorf("ProjectID() = %q", tun.ProjectID())
@@ -97,7 +97,7 @@ func TestVPNTunnel_IntoProject_TypedRef(t *testing.T) {
 }
 
 func TestVPNTunnel_IntoProject_URIRef(t *testing.T) {
-	tun := NewVPNTunnel().IntoProject(URI("/projects/p"))
+	tun := NewVPNTunnel().InProject(URI("/projects/p"))
 
 	if tun.ProjectID() != "p" {
 		t.Errorf("ProjectID() = %q", tun.ProjectID())
@@ -108,7 +108,7 @@ func TestVPNTunnel_IntoProject_URIRef(t *testing.T) {
 }
 
 func TestVPNTunnel_IntoProject_BadRef(t *testing.T) {
-	tun := NewVPNTunnel().IntoProject(URI("/garbage"))
+	tun := NewVPNTunnel().InProject(URI("/garbage"))
 	if tun.Err() == nil {
 		t.Error("expected Err() != nil for unresolvable Ref, got nil")
 	}
@@ -348,11 +348,11 @@ func TestVPNPSK_Build_NilReceiver(t *testing.T) {
 func TestVPNTunnel_ToRequestRoundTrip(t *testing.T) {
 	tun := NewVPNTunnel().Named(
 		"my-tunnel").
-		AddTag("t1").
+		Tagged("t1").
 		InRegion(RegionITBGBergamo).
 		OfType(VPNTypeSiteToSite).
 		WithVPNClientProtocol(VPNClientProtocolIKEv2).
-		WithBillingPeriod(BillingPeriodHour).
+		BilledHourly().
 		WithPeerClientPublicIP("1.2.3.4").
 		WithIPConfig(
 			NewVPNIPConfig().
@@ -712,7 +712,7 @@ func TestVPNTunnelsClientAdapter_Create_Success(t *testing.T) {
 	})
 
 	tun := NewVPNTunnel().
-		IntoProject(URI("/projects/p")).
+		InProject(URI("/projects/p")).
 		Named("my-tunnel").
 		InRegion(RegionITBGBergamo).
 		OfType(VPNTypeSiteToSite).
@@ -771,7 +771,7 @@ func TestVPNTunnelsClientAdapter_Create_MetadataValidationError(t *testing.T) {
 		fmt.Fprint(w, `{"metadata":{"name":"tunnel","uri":"/projects/p/providers/Aruba.Network/vpnTunnels/x"},"properties":{},"status":{}}`)
 	})
 
-	tun := NewVPNTunnel().IntoProject(URI("/projects/p")).
+	tun := NewVPNTunnel().InProject(URI("/projects/p")).
 		Named("tunnel")
 	result, err := adapter.Create(context.Background(), tun)
 	if err == nil {
@@ -793,7 +793,7 @@ func TestVPNTunnelsClientAdapter_Create_NonTwoXX(t *testing.T) {
 		fmt.Fprint(w, testutil.ErrorBodyJSON("Validation Failed", "name is required", 422))
 	})
 
-	tun := NewVPNTunnel().IntoProject(URI("/projects/p"))
+	tun := NewVPNTunnel().InProject(URI("/projects/p"))
 	result, err := adapter.Create(context.Background(), tun)
 	if err == nil {
 		t.Fatal("expected error on 422")
@@ -891,7 +891,7 @@ func TestVPNTunnelsClientAdapter_Update_NoID(t *testing.T) {
 		w.WriteHeader(http.StatusOK)
 	})
 
-	tun := NewVPNTunnel().IntoProject(URI("/projects/p")).
+	tun := NewVPNTunnel().InProject(URI("/projects/p")).
 		Named("x")
 	_, err := adapter.Update(context.Background(), tun)
 	if err == nil {
@@ -978,10 +978,10 @@ func TestVPNTunnelsClientAdapter_Delete_NonTwoXX(t *testing.T) {
 // InRegion exercises the 0% branch.
 func TestVPNTunnel_InRegion(t *testing.T) {
 	tun := NewVPNTunnel().
-		AddTag("a").
-		AddTag("b").
-		RemoveTag("a").
-		ReplaceTags("x", "y").
+		Tagged("a").
+		Tagged("b").
+		Untagged("a").
+		RetaggedAs("x", "y").
 		InRegion("ITMI-Milano-1")
 
 	if tun.Region() != "ITMI-Milano-1" {
@@ -1120,7 +1120,7 @@ func TestVPNTunnelsClientAdapter_Create_WithBuilderError(t *testing.T) {
 		callCount++
 		w.WriteHeader(http.StatusCreated)
 	})
-	tun := NewVPNTunnel().IntoProject(URI("/garbage"))
+	tun := NewVPNTunnel().InProject(URI("/garbage"))
 	_, err := adapter.Create(context.Background(), tun)
 	if err == nil {
 		t.Fatal("expected error for builder error")
@@ -1173,7 +1173,7 @@ func TestVPNTunnelsClientAdapter_Update_WithBuilderError(t *testing.T) {
 		callCount++
 		w.WriteHeader(http.StatusOK)
 	})
-	tun := NewVPNTunnel().IntoProject(URI("/garbage"))
+	tun := NewVPNTunnel().InProject(URI("/garbage"))
 	_, err := adapter.Update(context.Background(), tun)
 	if err == nil {
 		t.Fatal("expected error for builder error")

--- a/pkg/aruba/resource_vpn_tunnel_test.go
+++ b/pkg/aruba/resource_vpn_tunnel_test.go
@@ -36,7 +36,7 @@ func TestVPNTunnel_FluentSetters(t *testing.T) {
 		InRegion(RegionITBGBergamo).
 		OfType(VPNTypeSiteToSite).
 		WithVPNClientProtocol(VPNClientProtocolIKEv2).
-		BilledHourly().
+		BilledBy(BillingPeriodHour).
 		WithPeerClientPublicIP("1.2.3.4")
 
 	if tun.Name() != "my-tunnel" {
@@ -352,7 +352,7 @@ func TestVPNTunnel_ToRequestRoundTrip(t *testing.T) {
 		InRegion(RegionITBGBergamo).
 		OfType(VPNTypeSiteToSite).
 		WithVPNClientProtocol(VPNClientProtocolIKEv2).
-		BilledHourly().
+		BilledBy(BillingPeriodHour).
 		WithPeerClientPublicIP("1.2.3.4").
 		WithIPConfig(
 			NewVPNIPConfig().


### PR DESCRIPTION
## Summary

- **Breaking rename** of all setter methods across 34 `pkg/aruba` wrapper files so a chained create call reads as a natural-language sentence:
  ```go
  aruba.NewCloudServer().Named("web-01").
      InProject(proj).InRegion(aruba.RegionITBGBergamo).InZone(aruba.ZoneITBG1).
      OfFlavor(aruba.CloudServerFlavorCSO4A8).
      BootingFrom(bootVolume).UsingKeyPair(keyPair).
      OnSubnets(subnet).WithSecurityGroups(sg).WithVPC(vpc).WithElasticIP(eip).
      Tagged("prod","frontend").BilledBy(aruba.BillingPeriodHour)
  ```
- Collection setters are now **variadic and plural-named** (`OnSubnets`, `WithSecurityGroups`, `WithNodePools`, `WithSteps`, `WithRoutes`, `WithDNSServers`) — a single call accepts one or many items; repeated calls append.
- **No aliases** — old names deleted entirely. The SDK is Alpha/unstable; breaking changes are expected. Full rename map in `CHANGELOG.md` and `ai/CONVENTIONS.md`.

## Rename highlights

| Old | New |
|---|---|
| `Into*` | `In*` (`InProject`, `InVPC`, `InKMS`, …) |
| `AddTag` / `RemoveTag` / `ReplaceTags` | `Tagged(…)` / `Untagged(…)` / `RetaggedAs(…)` — variadic |
| `WithBillingPeriod(BillingPeriod)` | `BilledBy(BillingPeriod)` — single typed-argument setter across all 12 billable resources |
| `WithSizeGB(n)` | `SizedGB(n)` |
| `SetBootable()` / `UnsetBootable()` | `AsBootable()` / `NotBootable()` |
| `WithBootVolume` / `WithKeyPair` | `BootingFrom` / `UsingKeyPair` |
| `AddSubnet` / `AddSecurityGroup` | `OnSubnets(…)` / `WithSecurityGroups(…)` variadic |
| `WithHA(bool)` | `HighlyAvailable()` |
| `AddNodePool` / `ClearNodePools` | `WithNodePools(…)` variadic / `WithoutNodePools()` |
| `WithEnabled(bool)` | `Enabled()` / `Disabled()` |
| `AddStep` | `WithSteps(…)` variadic |
| `WithPreset(bool)` / `WithVPCPreset(bool)` | `With*/Without*` no-arg pairs |
| `WithTargetCIDR` / `WithTargetSecurityGroup` | `TargetingCIDR` / `TargetingSecurityGroup` |
| `WithRetentionDays` / `IntoBackup` | `RetainedForDays` / `FromBackup` |
| `AddRoute(addr,gw)` / `AddDNS(ip)` | `WithRoutes(…SubnetDHCPRoute)` / `WithDNSServers(…string)` variadic |

## Scope

- 34 wrapper definition files (`pkg/aruba/resource_*.go`)
- 27 test files (`pkg/aruba/*_test.go`)
- 19 example files (`examples/all-resources/`)
- 14 current-version doc files (EN + IT Docusaurus)
- `README.md`, `ai/CONVENTIONS.md`, `ai/ARCHITECTURE.md`, `CHANGELOG.md`

## Test plan

- [x] `go build ./...` — passes
- [x] `go build ./examples/all-resources/` — passes
- [x] `go vet ./...` — passes
- [x] `go test ./...` — all packages pass
- [x] `golangci-lint run` — only 1 pre-existing `unparam` warning on `appendRef` (unrelated to this PR)
- [x] `cd docs/website && npm run build` — Docusaurus build succeeds for both EN and IT locales

🤖 Generated with [Claude Code](https://claude.com/claude-code)