### PR TITLE
fix: resolve issues for v1.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,55 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ---
 
+## [0.3.1] — 2026-05-27
+
+### Added
+
+- **Flattened getter taxonomy** (`pkg/aruba`) — every Family-A wrapper now exposes a
+  consistent set of response-side scalar getters so callers no longer need `.Raw().Properties.X`
+  for common values. New getters per wrapper:
+  - `Project`: `Raw()`, `RawJSON()`, `RawYAML()`, `RawRequest()` (closes #304)
+  - `CloudServer`: `ElasticIP()`, `Subnets() []string`, `SecurityGroups() []string`, `UserData()`
+  - `VPNTunnel`: `RoutesNumber()`
+  - `VPNRoute`: `VPNTunnelURI()`, `CloudSubnetCIDR()`
+  - `ElasticIP`: `AssociatedResourceURI()`
+  - `SecurityGroup`: `Rules() []types.LinkedResource`
+  - `Subnet`: `Network() string`
+  - `DBaaS`: `EngineVersion()`, `EngineType()`, `PrivateIPAddress()`, `FlavorCPU()`, `FlavorRAMMB()`, `EndpointURL()`
+  - `KaaS`: `PodCIDR()`, `NodeCIDR()`, `IdentityClientID()`, `NodePools() []*NodePool`
+  - `NodePool`: `Name()`
+  - `Job`: `ScheduleAt()`, `ExecuteUntil()`, `NextExecutionAt()`, `Steps() []*JobStep`
+  - `AuditEvent`: `EventTypeName()`, `IdentityName()`, `OperationName()`
+
+- **`pkg/aruba.Version` constant** (`pkg/aruba/version.go`) — single source of truth for the
+  SDK version string. Updated on each release.
+
+- **Automatic User-Agent injection** (`Options.WithUserAgent`) — every outbound request now
+  carries `User-Agent: sdk-go@<version>` by default. Override with
+  `options.WithUserAgent("my-app@1.2.3")` (closes #310).
+
+### Fixed
+
+- **`VPNTunnel` round-trip rehydration** — `fromResponse` now reconstructs `IKE`, `ESP`, `PSK`,
+  and `IPConfig` sub-builders from the server response, so `Get → Update` no longer strips VPN
+  client settings (closes #306).
+
+- **`CloudServer` round-trip rehydration** — `fromResponse` now rehydrates `subnetRefs` from
+  `NetworkInterfaces[].Subnet`, so `Get → Update` preserves subnet attachments (closes #307).
+
+- **`VPNRoute.CloudSubnetCIDR()` empty on GET** — `SubnetCIDROrRef.UnmarshalJSON` now handles
+  the flat `{network:{address:"…"}}` shape returned by the GET endpoint in addition to the
+  existing plain-string and `properties.network.address` forms (closes #308).
+
+- **`Project` Raw parity** — `*aruba.Project` now stores the server response and exposes
+  `Raw()`, `RawJSON()`, `RawYAML()`, and `RawRequest()`, matching every other Family-A wrapper
+  (closes #304).
+
+- **`Job` step API verified** — existing `NewJobStep` + `Job.WithSteps(…)` surface already
+  satisfies the issue intent; no API changes required (closes #305 by verification).
+
+---
+
 ## [0.3.0] — 2026-05-26
 
 ### Changed (Breaking)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -101,6 +101,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
   Create. Both helpers now print/check the composite `{user, database, role}` identifier so
   successful grants are no longer reported as `<not created>`.
 
+- **`examples/all-resources` VPN Route `cloudSubnet`** — the route was hardcoded to `10.0.0.0/24`,
+  which did not match the example's actual VPC topology and was rejected by the API. The example now
+  reads the CIDR from the Basic Subnet (`subnet.CIDR()`) and waits for that subnet to reach `Active`
+  before creating the route.
+
 - **`examples/all-resources` resource summary** — unified `summaryRow` helper; every
   `ResourceCollection` field is now printed (four entries were previously omitted);
   nil/failed entries show `<not created>` instead of being silently skipped.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,79 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ---
 
+## [Unreleased]
+
+### Changed (Breaking)
+
+All exported structs in `pkg/types/` now carry a strict three-way suffix declaring their wire role:
+`*Request` (sent to the API), `*Response` (received from the API), or `*Common` (appears on both sides).
+Scalar enums, the generic transport envelope `Response[T]`, and utility/error types are exempt.
+This is a compile-time breaking change for any code that references `pkg/types` directly;
+code that uses only the `pkg/aruba` wrappers is unaffected.
+
+**`*PropertiesResult` → `*PropertiesResponse`** (finishes the v0.3.1 cleanup started with `ContainerRegistryPropertiesResult`):
+- `CloudServerPropertiesResult` → `CloudServerPropertiesResponse`
+- `KeyPairPropertiesResult` → `KeyPairPropertiesResponse`
+- `StorageBackupPropertiesResult` → `StorageBackupPropertiesResponse`
+- `StorageRestorePropertiesResult` → `StorageRestorePropertiesResponse`
+
+**`*List` → `*ListResponse`** (27 collection envelopes; the base `ListResponse` is unchanged):
+`ProjectListResponse`, `VPCListResponse`, `SubnetListResponse`, `SecurityGroupListResponse`,
+`SecurityRuleListResponse`, `ElasticIPListResponse` (previously `ElasticList`),
+`LoadBalancerListResponse`, `VPCPeeringListResponse`, `VPCPeeringRouteListResponse`,
+`VPNTunnelListResponse`, `VPNRouteListResponse`, `CloudServerListResponse`, `KaaSListResponse`,
+`ContainerRegistryListResponse`, `DBaaSListResponse`, `DBaaSBackupListResponse` (previously `BackupList`),
+`DatabaseListResponse`, `DatabaseUserListResponse` (previously `UserList`), `GrantListResponse`,
+`BlockStorageListResponse`, `SnapshotListResponse`, `StorageBackupListResponse`, `StorageRestoreListResponse`,
+`KmsListResponse`, `KeyListResponse`, `KmipListResponse`, `JobListResponse`.
+
+**New `*Common` suffix for cross-side shared shapes** (used on both request and response side):
+`LinkedResourceCommon`, `ReferenceResourceCommon`, `BillingPlanCommon`, `UserCredentialCommon`,
+`GrantUserCommon`, `GrantRoleCommon`, `RuleTargetCommon`,
+`SubnetNetworkCommon`, `SubnetDHCPCommon`, `SubnetDHCPRangeCommon`, `SubnetDHCPRouteCommon`,
+`IPConfigurationsCommon`, `SubnetInfoCommon`, `VPNClientSettingsCommon`,
+`IKESettingsCommon`, `ESPSettingsCommon`, `PSKSettingsCommon`, `StorageKubernetesCommon`.
+
+**Bare nested types renamed with role suffix** (response-only shapes without a suffix):
+- `VolumeInfo` → `VolumeInfoResponse`
+- `MetricMetadata` → `MetricMetadataResponse`
+- `MetricData` → `MetricDataResponse`
+- `ExecutedAlertAction` → `ExecutedAlertActionResponse`
+- `AlertAction` → `AlertActionResponse`
+- `CloudServerNetworkInterfaceDetails` → `CloudServerNetworkInterfaceResponse`
+- `ContainerRegistryData` / `…DataPrivate` / `…DataInfo` → `…DataResponse` / `…DataPrivateResponse` / `…DataInfoResponse`
+
+**Audit types renamed with domain prefix** (bare names collided with unrelated types):
+`AuditEvent` → `AuditEventResponse`, `Operation` → `EventOperationResponse`,
+`EventInfo` → `EventInfoResponse`, `EventCategory` → `EventCategoryResponse`,
+`RegionInfo` → `EventRegionInfoResponse`, `Status` → `EventStatusResponse`,
+`SubStatus` → `EventSubStatusResponse`, `Caller` → `EventCallerResponse`,
+`Identity` → `EventIdentityResponse`, `Action` → `EventActionResponse`,
+`LogFormatVersion` → `EventLogFormatVersionResponse`.
+
+**KaaS nested types renamed** (request-only shapes without a suffix, plus disambiguation):
+`NodeCIDRProperties` → `NodeCIDRPropertiesRequest`, `KubernetesVersionInfo` → `KubernetesVersionInfoRequest`,
+`KubernetesVersionInfoUpdate` → `KubernetesVersionInfoUpdateRequest`, `NodePoolProperties` → `NodePoolPropertiesRequest`,
+`SecurityGroupProperties` → `KaaSSecurityGroupPropertiesRequest`, `IdentityProperties` → `KaaSIdentityPropertiesRequest`,
+`APIServerAccessProfileProperties` → `KaaSAPIServerAccessProfilePropertiesRequest`,
+`InstanceResponse` → `KaaSNodePoolInstanceResponse`, `DataCenterResponse` → `KaaSNodePoolDataCenterResponse`.
+
+**DBaaS nested types renamed** (request-only shapes without a suffix):
+`DBaaSEngine` → `DBaaSEngineRequest`, `DBaaSFlavorSpec` → `DBaaSFlavorRequest`,
+`DBaaSStorage` → `DBaaSStorageRequest`, `DBaaSNetworking` → `DBaaSNetworkingRequest`,
+`DBaaSAutoscaling` → `DBaaSAutoscalingRequest`.
+
+**`resource.go` name-order stragglers corrected**:
+`ProjectResponseMetadata` → `ProjectMetadataResponse`, `TypologyResponseMetadata` → `TypologyMetadataResponse`,
+`CategoryResponseMetadata` → `CategoryMetadataResponse`, `ResourceStatus` → `ResourceStatusResponse`,
+`PreviousStatus` → `PreviousStatusResponse`, `DisableStatusInfo` → `DisableStatusInfoResponse`.
+
+**Other**:
+- `VPCProperties` (inner nested struct in `VPCPropertiesRequest`) → `VPCPropertiesInnerRequest`.
+- Added `pkg/types/doc.go` with the canonical in-source statement of the naming rule.
+
+---
+
 ## [0.3.1] — 2026-05-28
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -92,6 +92,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
   never wired in the example; also `"vpn"` tag violated the server's ≥4-char minimum. Fixed by
   wiring `NewVPNIPConfig()` and renaming tags to `"vpn-tunnel"` / `"vpn-route"`.
 
+- **`examples/all-resources` VPN tunnel CIDR** — VPN tunnel `ipConfigurations.subnet.cidr` was
+  reusing the basic subnet's `192.168.0.0/24`, causing the platform to reject the Create with
+  `subnet.cidr overlaps with an existing subnet`. Tunnel now uses `192.168.10.0/24`.
+
+- **`examples/all-resources` DBaaS Grant reporting** — create banner and final summary both gated
+  on `Grant.ID() != ""`, but grants are composite-keyed and `ID()` is intentionally empty after
+  Create. Both helpers now print/check the composite `{user, database, role}` identifier so
+  successful grants are no longer reported as `<not created>`.
+
 - **`examples/all-resources` resource summary** — unified `summaryRow` helper; every
   `ResourceCollection` field is now printed (four entries were previously omitted);
   nil/failed entries show `<not created>` instead of being silently skipped.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,14 +68,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
   `Raw()`, `RawJSON()`, `RawYAML()`, and `RawRequest()`, matching every other Family-A wrapper
   (closes #304).
 
-- **`Job` step `typology` field added** — the server requires a `typology` value on each
-  `Step` for dispatch, even though the field is absent from the public Create-Job request schema.
-  `JobStep` (request DTO) renamed to `JobStepRequest` for symmetry with `JobStepResponse`;
-  `Typology *string` added (pointer + `omitempty` so existing callers are wire-neutral).
-  `OfTypology(string)` setter exposed on the wrapper builder together with typed constants
-  (`JobStepTypologyCloudServer`, `JobStepTypologyKeyPair`, `JobStepTypologyElasticIP`,
-  `JobStepTypologyContainerRegistry`). The response-side `Typology` field is now round-tripped
-  through `fromResponse` / `toRequest` so `Get → Update` flows preserve it (closes #305).
+- **`JobStep` request DTO renamed** — `JobStep` renamed to `JobStepRequest` for symmetry
+  with `JobStepResponse` (closes #305).
 
 - **`ContainerRegistry` admin-password** — `UserCredential.Password` field added to the wire DTO
   and `WithAdminPassword(string)` setter added to the wrapper. Omitting a password while supplying

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,22 +9,32 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 | Branch | Version series | Status |
 |--------|----------------|--------|
-| `main` | **v0.2.x** | Active development — new features, ongoing releases |
+| `main` | **v0.3.x** | Active development — new features, ongoing releases |
 | `legacy` | **v0.1.x** | Maintenance — bug fixes and security patches only |
 
-- **`main` — v0.2.x (current)**: Introduces the `pkg/aruba/` wrapper
-  layer — a major, breaking redesign of the public API surface. Adopters
-  upgrading from v0.1.x should expect compile-time breakage; see the
-  [v0.2.0](#020--2026-05-13) section below for a full
-  migration summary.
+- **`main` — v0.3.x (current)**: Builds on the `pkg/aruba/` wrapper
+  layer introduced in v0.2.0. v0.3.0 formalised the getter/setter taxonomy;
+  v0.3.1 added async polling helpers, User-Agent injection, and a series of
+  round-trip and example fixes. See [v0.3.0](#030--2026-05-21) and
+  [v0.3.1](#031--2026-05-28) below for migration details.
 - **`legacy` — v0.1.x (maintenance)**: Supported for **6 months** after
-  the v0.2.0 release date with bug-fix and security-patch releases only
-  (tagged `v0.1.29`, `v0.1.30`, …). No new features will be backported.
-  Once the support window closes the `legacy` branch will be archived.
+  the v0.2.0 release date with bug-fix and security-patch releases only.
+  No new features will be backported. Once the support window closes the
+  `legacy` branch will be archived.
 
 ---
 
 ## [Unreleased]
+
+### Documentation
+
+- Alpha-stage warning banners removed from `docs/website/docs/intro.md`, `docs/website/i18n/it/…/intro.md`, and `README.md`.
+- `ai/CONVENTIONS.md`, `ai/ARCHITECTURE.md`, `ai/REPO.md`, `ai/DEVEX.md` aligned with post-naming-refactor implementation.
+- `ai/TECH_DEBT.md` reset: resolved items archived, new debt items (TD-023 through TD-027) catalogued.
+- `pkg/aruba/doc.go`, `pkg/async/doc.go`, `pkg/multitenant/doc.go`, `pkg/util/middleware/doc.go` added — package-level in-source documentation for every major public package.
+- `docs/website/docs/resources.md` (EN) and Italian mirror: every resource section now lists its setter vocabulary grouped by canonical chain order and links to the corresponding `examples/all-resources/resource_<name>.go` file.
+- `docs/website/docs/working-at-low-level.md` (EN + IT): stale `types.LinkedResource` → `types.LinkedResourceCommon` after the naming refactor.
+- `README.md`: fixed stale `httpErr.Message` field reference (→ `httpErr.Error()`), corrected `WaitUntilReady` settled-state list (7 states, not 4), fixed `WaitUntilStates` signature to use `[]types.State`, and corrected the quick-start snippet to capture the `Create` return value.
 
 ### Changed (Breaking)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -71,10 +71,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 - **`JobStep` request DTO renamed** — `JobStep` renamed to `JobStepRequest` for symmetry
   with `JobStepResponse` (closes #305).
 
-- **`ContainerRegistry` admin-password** — `UserCredential.Password` field added to the wire DTO
-  and `WithAdminPassword(string)` setter added to the wrapper. Omitting a password while supplying
-  a username caused the provisioner to fail silently (~30 min after creation) with `state:Failed`
-  and no error reason.
+- **`ContainerRegistry` `data` block** — `ContainerRegistryResponse` now includes a `Data *ContainerRegistryData`
+  field (JSON: `"data"`) with `Private` (credential readiness) and `Info` (endpoints/version) sub-objects,
+  matching the API spec. New response-side getters: `IsPasswordSet()`, `AdminPasswordLastSetAt()`,
+  `FQDN()`, `PublicBaseURL()`, `PrivateBaseURL()`, `Version()`.
+
+### Removed
+
+- **`ContainerRegistry` admin-password** — `UserCredential.Password` and `WithAdminPassword(string)` removed.
+  The admin password is generated internally by the Aruba provisioner and is never settable on Create; the
+  field has no corresponding parameter in the API spec. The credential readiness state is now exposed via
+  `IsPasswordSet()` / `AdminPasswordLastSetAt()` from the response `data.private` block.
+
+### Changed
+
+- **`ContainerRegistryPropertiesResult` renamed** to `ContainerRegistryPropertiesResponse` in `pkg/types`
+  for consistency with the request/response naming convention used by every other resource family.
 
 - **`examples/all-resources` VPN tunnel** — `ipConfigurations` (VPC + Subnet + ElasticIP) was
   never wired in the example; also `"vpn"` tag violated the server's ≥4-char minimum. Fixed by

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,7 +24,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ---
 
-## [0.3.1] — 2026-05-27
+## [0.3.1] — 2026-05-28
 
 ### Added
 
@@ -68,8 +68,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
   `Raw()`, `RawJSON()`, `RawYAML()`, and `RawRequest()`, matching every other Family-A wrapper
   (closes #304).
 
-- **`Job` step API verified** — existing `NewJobStep` + `Job.WithSteps(…)` surface already
-  satisfies the issue intent; no API changes required (closes #305 by verification).
+- **`Job` step `typology` field added** — the server requires a `typology` value on each
+  `Step` for dispatch, even though the field is absent from the public Create-Job request schema.
+  `JobStep` (request DTO) renamed to `JobStepRequest` for symmetry with `JobStepResponse`;
+  `Typology *string` added (pointer + `omitempty` so existing callers are wire-neutral).
+  `OfTypology(string)` setter exposed on the wrapper builder together with typed constants
+  (`JobStepTypologyCloudServer`, `JobStepTypologyKeyPair`, `JobStepTypologyElasticIP`,
+  `JobStepTypologyContainerRegistry`). The response-side `Typology` field is now round-tripped
+  through `fromResponse` / `toRequest` so `Get → Update` flows preserve it (closes #305).
+
+- **`ContainerRegistry` admin-password** — `UserCredential.Password` field added to the wire DTO
+  and `WithAdminPassword(string)` setter added to the wrapper. Omitting a password while supplying
+  a username caused the provisioner to fail silently (~30 min after creation) with `state:Failed`
+  and no error reason.
+
+- **`examples/all-resources` VPN tunnel** — `ipConfigurations` (VPC + Subnet + ElasticIP) was
+  never wired in the example; also `"vpn"` tag violated the server's ≥4-char minimum. Fixed by
+  wiring `NewVPNIPConfig()` and renaming tags to `"vpn-tunnel"` / `"vpn-route"`.
+
+- **`examples/all-resources` resource summary** — unified `summaryRow` helper; every
+  `ResourceCollection` field is now printed (four entries were previously omitted);
+  nil/failed entries show `<not created>` instead of being silently skipped.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -6,9 +6,7 @@
 [![Codecov](https://codecov.io/gh/Arubacloud/sdk-go/branch/main/graph/badge.svg)](https://codecov.io/gh/Arubacloud/sdk-go)
 [![License](https://img.shields.io/github/license/Arubacloud/sdk-go)](LICENSE)
 
-See [`CHANGELOG.md`](CHANGELOG.md) for the full release history and the v0.1.x → v0.2.x branch policy.
-
-> **Note**: This SDK is currently in its **Alpha** stage. The API is not yet stable, and breaking changes may be introduced in future releases without prior notice.
+See [`CHANGELOG.md`](CHANGELOG.md) for the full release history and branch policy.
 
 Official Go SDK for the Aruba Cloud API. Manage cloud resources — compute instances, VPCs, storage, databases, and more — from Go code.
 
@@ -58,12 +56,12 @@ func main() {
 	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
 	defer cancel()
 
-	proj := aruba.NewProject().
-		Named("my-first-project").
-		Tagged("go-sdk").
-		DescribedAs("Created from the Go SDK Quick Start")
-
-	if _, err := arubaClient.FromProject().Create(ctx, proj); err != nil {
+	proj, err := arubaClient.FromProject().Create(ctx,
+		aruba.NewProject().
+			Named("my-first-project").
+			Tagged("go-sdk").
+			DescribedAs("Created from the Go SDK Quick Start"))
+	if err != nil {
 		log.Fatalf("create project: %v", err)
 	}
 
@@ -139,7 +137,7 @@ vpc, err := arubaClient.FromNetwork().VPCs().Get(ctx, vpcRef)
 if err != nil {
     var httpErr *aruba.HTTPError
     if errors.As(err, &httpErr) {
-        log.Fatalf("API error %d: %s", httpErr.StatusCode, httpErr.Message)
+        log.Fatalf("API error %d: %s", httpErr.StatusCode, httpErr.Error())
     }
     log.Fatalf("transport error: %v", err)
 }
@@ -171,9 +169,9 @@ For per-resource builders (`aruba.NewVPC()`, `aruba.NewKaaS()`, …) and the ful
 
 Most cloud resources reach their terminal state asynchronously. Every wrapper that has a status mixin exposes:
 
-- `WaitUntilReady(ctx, opts...)` — accepts `Active`, `NotUsed`, `InUse`, `Used`. The 95% answer.
+- `WaitUntilReady(ctx, opts...)` — accepts `Active`, `Running`, `Stopped`, `NotUsed`, `Reserved`, `InUse`, `Used`. The 95% answer.
 - `WaitUntilActive(ctx, opts...)` — strictly `Active`.
-- `WaitUntilStates(ctx, []string{"Foo", "Bar"}, opts...)` — arbitrary target list.
+- `WaitUntilStates(ctx, []types.State{types.StateStopped}, opts...)` — arbitrary target list.
 - Specialized: `BlockStorage`/`ElasticIP` add `WaitUntilNotUsed`/`WaitUntilUsed`; `Kmip` adds `WaitUntilCertificateAvailable`.
 
 ```go

--- a/ai/ARCHITECTURE.md
+++ b/ai/ARCHITECTURE.md
@@ -226,7 +226,7 @@ The mixins were split into three files by responsibility:
 | `regionalMixin` | `mixin_common.go` | Holds `Region`; `toLocation()` emits `types.LocationRequest`. Embedded by `zonalMixin`. |
 | `zonalMixin` | `mixin_common.go` | Extends `regionalMixin` with an availability-zone pointer (wire field `dataCenter`). |
 | `responseMetadataMixin` | `mixin_common.go` | Holds the post-server `*types.ResourceMetadataResponse`; exposes `ID()`, `RespURI()`, `CreatedAt()`, `Version()`, etc. |
-| `linkedMixin` | `mixin_common.go` | Stores `[]types.LinkedResource` returned by the API. |
+| `linkedMixin` | `mixin_common.go` | Stores `[]types.LinkedResourceCommon` returned by the API. |
 | `httpEnvelopeMixin` | `mixin_common.go` | Captures StatusCode / Headers / RawBody / `*http.Response` / parsed ErrorResponse after every adapter call. Embedded by every single-resource wrapper and by `List[T]`. |
 | `projectScopedMixin` | `mixin_scoped.go` | Direct child of a Project; `intoProject(Ref)` extracts `projectID` via `extractID`. |
 | `vpcScopedMixin` | `mixin_scoped.go` | Direct child of a VPC; inherits `projectID` from parent. |
@@ -238,7 +238,7 @@ The mixins were split into three files by responsibility:
 | `vpnTunnelScopedMixin` | `mixin_scoped.go` | Direct child of a VPN tunnel; tolerates both `vpn-tunnels` and `vpnTunnels` URI forms. |
 | `vpcPeeringScopedMixin` | `mixin_scoped.go` | Direct child of a VPC peering; inherits `vpcID` + `projectID`. |
 | `refreshMixin` | `mixin_refresh.go` | Holds the `refresh func(ctx) error` callback (a `Get` closure installed by adapters) and `WaitUntilGone` — polls `refresh`, treats HTTP 404 as success, any other error as transient. Embedded by `statusMixin` and by Family-B pollable resources (`Kmip`, `Grant`, `Database`, `User`, `Key`). |
-| `statusMixin` | `mixin_status.go` | Embeds `refreshMixin`; holds `*types.ResourceStatus`; powers `WaitUntilActive`, `WaitUntilReady`, `WaitUntilStates` against typed `[]types.State` targets, plus `WaitUntilGone` promoted from `refreshMixin`. |
+| `statusMixin` | `mixin_status.go` | Embeds `refreshMixin`; holds `*types.ResourceStatusResponse`; powers `WaitUntilActive`, `WaitUntilReady`, `WaitUntilStates` against typed `[]types.State` targets, plus `WaitUntilGone` promoted from `refreshMixin`. |
 
 `populateHTTPEnvelope[T]` is a package-level generic function in `mixin_common.go` (Go does not allow generic methods on structs).
 

--- a/ai/ARCHITECTURE.md
+++ b/ai/ARCHITECTURE.md
@@ -269,7 +269,7 @@ type Ref interface { URI() string; ID() string }
 
 ### `List[T Wrapper]` (`pkg/aruba/list.go`)
 
-Generic paginated container, constrained to `Wrapper { URI(); ID() }`. Embeds `httpEnvelopeMixin` (same HTTP envelope accessors as single-resource wrappers). Carries `items`, `total`, pagination link URLs (`self/prev/next/first/last`), `callerOpts`, `raw` (JSON-safe wire payload, a `*types.XxxList`), and a `refetch` callback. Navigation methods: `Items()`, `Total()`, `HasNext()`, `Next(ctx)`, `All(ctx, yield)`. Convenience marshalers `RawJSON() []byte` and `RawYAML() []byte` are available on `List[T]` and on every single-resource wrapper.
+Generic paginated container, constrained to `Wrapper { URI(); ID() }`. Embeds `httpEnvelopeMixin` (same HTTP envelope accessors as single-resource wrappers). Carries `items`, `total`, pagination link URLs (`self/prev/next/first/last`), `callerOpts`, `raw` (JSON-safe wire payload, a `*types.XxxListResponse`), and a `refetch` callback. Navigation methods: `Items()`, `Total()`, `HasNext()`, `Next(ctx)`, `All(ctx, yield)`. Convenience marshalers `RawJSON() []byte` and `RawYAML() []byte` are available on `List[T]` and on every single-resource wrapper.
 
 Adapters construct lists via `newListFromResponse[T Wrapper, L listPayload](items, resp, opts, refetch)` — a generic helper that extracts pagination from `resp.Data.BaseList()` (promoted from the embedded `types.ListResponse`), stores `resp.Data` as the JSON-safe `raw` payload, and populates the HTTP envelope mixin. The low-level `newList(...)` constructor is preserved for use in unit tests.
 

--- a/ai/ARCHITECTURE.md
+++ b/ai/ARCHITECTURE.md
@@ -185,7 +185,10 @@ Every resource method in `internal/clients/<service>/` follows this sequence:
 ## Adding a new resource
 
 1. Define request/response types in `pkg/types/<domain>.<resource>.go`.
-2. Add API path constants to `internal/clients/<service>/path.go`.
+2. Add API path constants to `internal/clients/<service>/path.go`. Path segment names must follow
+   the server-canonical **lowerCamelCase** rule documented in the header comment of each `path.go`
+   and in `ai/CONVENTIONS.md` § "URI segment casing". Using the wrong case causes silent
+   provisioning failures because downstream provisioners store and re-emit request URIs verbatim.
 3. Add per-operation API version constants to `internal/clients/<service>/version.go`.
 4. Create the resource file `internal/clients/<service>/<resource>.go` — define the interface and `*Impl` struct, implement all methods following the standard flow above.
 5. Expose the resource from the service group file `internal/clients/<service>/<group>.go`.

--- a/ai/ARCHITECTURE.md
+++ b/ai/ARCHITECTURE.md
@@ -344,3 +344,23 @@ Call chain: `arubaClient.FromCompute().CloudServers().Create(ctx, cs)` → `clou
 - `*NodePool.WithAutoscaling(min, max)` sets `autoscaling=true` + `minCount` + `maxCount` in one call (see `resource_kaas_nodepool.go`).
 
 **Sub-builders without an adapter** — used only inside a parent, no CRUD: `JobStep` (inside `Job.WithSteps`), `NodePool` (inside `KaaS.WithNodePools`), `VPNIKE` / `VPNESP` / `VPNPSK` / `VPNIPConfig` (inside `VPNTunnel`), `SubnetDHCP` (inside `Subnet`). Each has its own `errMixin` drained into the parent at attachment time.
+
+### Flattened-getter taxonomy
+
+Every Family-A wrapper exposes a standard set of read accessors so callers never need to reach into `wrapper.Raw().Properties.X`. The layers, in order:
+
+| Layer | Getters | Source mixin / field |
+|---|---|---|
+| **Identity** | `ID()`, `URI()`, `<Resource>ID()` | `responseMetadataMixin` + wrapper |
+| **Naming** | `Name()`, `Tags()` | `metadataMixin` |
+| **Geography** | `Region()`, `Zone()` (zonal only) | `regionalMixin` / `zonalMixin` |
+| **Lineage** | `Project()`, `CreatedAt()`, `UpdatedAt()`, `Version()` | `responseMetadataMixin` |
+| **Lifecycle** | `State()`, `IsDisabled()`, `DisableReasons()`, `FailureReason()`, `PreviousState()` | `statusMixin` |
+| **Linked** | `LinkedResources()` | `linkedMixin` |
+| **Raw envelope** | `Raw()`, `RawJSON()`, `RawYAML()`, `RawRequest()`, `RawHTTP()`, `StatusCode()`, `Headers()`, `RawError()` | wrapper + `httpEnvelopeMixin` |
+| **Wait** | `WaitUntilActive`, `WaitUntilReady`, `WaitUntilStates`, `WaitUntilGone` | `statusMixin` |
+| **Resource-specific scalars** | flat getters for every useful `Properties.*` field | wrapper |
+
+**Response-preferring pattern:** getters that overlap with a request-side cache read `response.Properties.X` first, fall back to the locally-cached pointer, and return `""` / zero only when both are unset. Use this pattern whenever the same field can be set by the caller (e.g. `OnSubnets`) and returned by the server (e.g. `NetworkInterfaces`).
+
+**`fromResponse` round-trip invariant:** after `fromResponse(resp)`, calling `toRequest()` must produce a valid PUT body that preserves every server-side field. Concretely: if a field appears in the response (subnet refs, VPN sub-builder settings, etc.) it must be rehydrated into the wrapper's corresponding local pointer / slice so that `toRequest()` re-emits it. Getters that return locally-cached-only values (because the API does not echo them in GET responses) must document this limitation with a short comment.

--- a/ai/CONVENTIONS.md
+++ b/ai/CONVENTIONS.md
@@ -15,10 +15,13 @@
 |---|---|---|
 | Input/request struct | `Request` | `CloudServerRequest` |
 | Single output struct | `Response` | `CloudServerResponse` |
-| Collection output struct | `List` (embeds `ListResponse`) | `CloudServerList` |
+| Collection output struct | `ListResponse` (embeds `ListResponse`) | `CloudServerListResponse` |
+| Struct used on both request AND response sides | `Common` | `LinkedResourceCommon`, `BillingPlanCommon` |
 | Service client interface | none (domain name) | `CloudServersClient` |
 | Service client implementation | `Impl` (unexported) | `cloudServersClientImpl` |
 | Constructor | `New<TypeName>` | `NewCloudServersClientImpl` |
+
+The `*Result` suffix is **not** used — it was a legacy straggler and has been removed. Enum/scalar types (`State`, `Region`, `BillingPeriod`, `RuleProtocol`, …) carry no Request/Response/Common suffix because their wire role is determined by the parent field. See `pkg/types/doc.go` for the canonical in-source statement of this rule.
 
 ### Files
 

--- a/ai/CONVENTIONS.md
+++ b/ai/CONVENTIONS.md
@@ -216,9 +216,9 @@ func (r *Resource) SomeField() string {
 
 ### Wait conventions
 
-- Resources that embed `statusMixin` (`pkg/aruba/mixin_status.go`) get `WaitUntilActive`, `WaitUntilReady`, and `WaitUntilStates(ctx, targets, opts...)` for free.
-- Adapters install a `refresh` closure after `Create` / `Get` / `List` — without it, `WaitUntilStates` returns an immediate error.
-- Family B resources without `statusMixin` define their own `WaitUntil*` that drive `pkg/async.WaitFor` directly (e.g. `*Kmip.WaitUntilCertificateAvailable` in `resource_kmip.go`).
+- `refreshMixin` (`pkg/aruba/mixin_refresh.go`) owns the `refresh` callback and `WaitUntilGone`. Adapters install the closure after `Create` / `Get` / `List` — without it, any `WaitUntil*` call returns an immediate error.
+- `statusMixin` (`pkg/aruba/mixin_status.go`) embeds `refreshMixin` and adds `WaitUntilActive`, `WaitUntilReady`, and `WaitUntilStates(ctx, targets, opts...)`. All Family-A resources embed `statusMixin`.
+- Family B resources embed `refreshMixin` directly (no `statusMixin`) and gain `WaitUntilGone` only. Those that need custom polling define their own `WaitUntil*` driving `pkg/async.WaitFor` (e.g. `*Kmip.WaitUntilCertificateAvailable` in `resource_kmip.go`).
 
 ### URI segment casing
 

--- a/ai/CONVENTIONS.md
+++ b/ai/CONVENTIONS.md
@@ -219,7 +219,27 @@ func (r *Resource) SomeField() string {
 
 ### URI segment casing
 
-- URI segments use the **exact casing published at <https://api.arubacloud.com/docs/>**. Examples: `securityGroups`, `securityRules`, `loadBalancers`, `keyPairs`, `blockStorages`, `vpnTunnels`, `vpcPeerings`.
-- Each resource has **one canonical segment**. `*IDsFromRef` helpers and scoped-mixin lookups use that single form — no fallbacks, no alternative spellings.
+- URI segments follow the server-canonical **lowerCamelCase** rule:
+  - Single-word / acronym collections stay **lowercase**: `vpcs`, `subnets`, `kaas`, `kms`,
+    `dbaas`, `backups`, `restores`, `snapshots`, `registries`, `jobs`.
+  - Compound collections use **lowerCamelCase**: `cloudServers`, `keyPairs`, `elasticIps`,
+    `securityGroups`, `securityRules`, `blockStorages`, `loadBalancers`, `vpnTunnels`,
+    `vpcPeerings`, `vpcPeeringRoutes`, `vpnRoutes`.
+  - This was verified against the server's `metadata.uri` echoes in a live end-to-end run
+    (2026-05-28). Commit `f548a4f` aligned all `internal/clients/*/path.go` constants to this
+    convention.
+- **Do not revert to all-lowercase.** Downstream provisioners store and re-emit request URIs
+  verbatim — a casing change causes silent provisioning failures. The header comment at the top
+  of every `internal/clients/*/path.go` repeats this warning.
+- Each resource has **one canonical segment**. `*IDsFromRef` helpers and scoped-mixin lookups use
+  that single form — no fallbacks, no alternative spellings.
 - `parseURIIDs` in `pkg/aruba/ref.go` preserves case; never normalise segment keys to lowercase.
-- Ref helper templates (`<Resource>Ref(...)`) and `internal/clients/<domain>/path.go` constants must use the same canonical segment so outgoing requests and incoming `Metadata.URI` values remain self-consistent.
+- Ref helper templates (`<Resource>Ref(...)`) and `internal/clients/<domain>/path.go` constants
+  must use the same canonical segment so outgoing requests and incoming `Metadata.URI` values
+  remain self-consistent.
+
+### Tag format constraint
+
+The server enforces a minimum tag length of **4 characters** per tag (see `pkg/types/error.go`).
+Tags shorter than 4 characters return HTTP 400. In `examples/all-resources/` and any test that
+supplies inline tag literals, ensure every string in `Tagged(...)` is ≥4 chars.

--- a/ai/CONVENTIONS.md
+++ b/ai/CONVENTIONS.md
@@ -187,6 +187,30 @@ Setter signatures take the alias type, not `string`.
 - `Get` / `Delete` / `List` accept `Ref` (not a typed wrapper) so callers can pass `aruba.URI("/...")` or any `Ref`-satisfying value.
 - Family B adapters (Database, Key, Kmip, User, Grant) do the most pre-flight validation because their deep parent chains aren't caught by the API until late; Family A adapters mostly only check `ProjectID() != ""`.
 
+### Getter taxonomy
+
+Every Family-A wrapper exposes a standard set of read accessors. Callers should always use these instead of reaching into `wrapper.Raw().Properties.X`.
+
+**Naming rules:**
+- Simple scalar field from `Properties`: use the field name directly — `Name()`, `State()`, `Region()`.
+- URI of a linked resource: `<LinkedResource>URI()` (e.g. `VPNTunnelURI()`, `AssociatedResourceURI()`).
+- Convenience alias for a commonly-read nested field: keep the same name as the logical concept — `CloudSubnetCIDR()` is an alias for `CloudSubnet()` on `VPNRoute`.
+- Collection of linked URIs: plural noun — `Subnets() []string`, `SecurityGroups() []string`.
+
+**Response-preferring fallback rule:** when a field can be set by the caller (via a chainable setter) *and* returned by the server, the getter must read the response field first and fall back to the local pointer. This ensures `Get → display` works without the caller having to re-set anything. Boilerplate:
+```go
+func (r *Resource) SomeField() string {
+    if r.response != nil && r.response.Properties.SomeField != "" {
+        return r.response.Properties.SomeField
+    }
+    return derefString(r.someField)
+}
+```
+
+**When to expose vs. defer to `Raw()`:** expose a getter whenever the field is needed for display, filtering, or round-trip `Get → Update` flows. Fields that are rarely read, deeply nested, or opaque blobs are fine behind `Raw()`. A getter that just wraps `Raw().Properties.X` with no fallback logic adds no value — skip it and document the field location in the type's doc comment instead.
+
+**`fromResponse` round-trip invariant:** after `fromResponse(resp)`, calling `toRequest()` must reproduce every caller-settable field that the server returned. Rehydrate local pointers / slices inside `fromResponse` when the API echoes them in GET responses. If the API does not echo a field (e.g. password, user-data), the getter must document the limitation.
+
 ### Wait conventions
 
 - Resources that embed `statusMixin` (`pkg/aruba/mixin_status.go`) get `WaitUntilActive`, `WaitUntilReady`, and `WaitUntilStates(ctx, targets, opts...)` for free.

--- a/ai/DEVEX.md
+++ b/ai/DEVEX.md
@@ -35,4 +35,13 @@ The CI pipeline uses golangci-lint v2.11.4 (timeout 5 min). Active linters: `err
 
 ## Docs site
 
-The Docusaurus site lives in `docs/website/`. Use `make docs-serve` (local dev) and `make docs-build` (production build). See `docs/README.md` for the full versioning and Italian-translation workflow.
+The Docusaurus site lives in `docs/website/`. Key doc targets:
+
+```bash
+make docs-serve       # local dev server (English locale)
+make docs-serve-it    # local dev server with Italian locale
+make docs-build       # production build (both locales)
+make docs-test        # build + validate (runs in CI)
+```
+
+See `docs/README.md` for the full versioning and Italian-translation workflow.

--- a/ai/REPO.md
+++ b/ai/REPO.md
@@ -7,7 +7,7 @@
 ## Package layout
 
 ```
-pkg/aruba/               — Public client entry point, Options builder, and wrapper layer
+pkg/aruba/               — Public client entry point, Options builder, and wrapper layer (pkg/aruba/doc.go)
 pkg/aruba/resource_*.go  — Fluent builder wrappers + adapters; New* factory constructors are co-located in each file
 pkg/aruba/mixin_common.go   — Cross-cutting mixins (errMixin, metadataMixin, regionalMixin, zonalMixin, responseMetadataMixin, linkedMixin, httpEnvelopeMixin)
 pkg/aruba/mixin_scoped.go   — Parent-scope mixins (projectScopedMixin, vpcScopedMixin, securityGroupScopedMixin, dbaasScopedMixin, databaseScopedMixin, backupScopedMixin, kmsScopedMixin, vpnTunnelScopedMixin, vpcPeeringScopedMixin)
@@ -21,9 +21,10 @@ pkg/aruba/call_options.go   — CallOption and per-call option types
 pkg/aruba/errors.go      — *HTTPError wrapper
 pkg/aruba/client_root.go    — Root Client interface (exposes FromCompute(), FromNetwork(), etc.)
 pkg/aruba/client_<domain>.go — Per-domain service-group interfaces (client_compute.go, client_network.go, …)
-pkg/types/           — All request/response/common data models (Request/Response/Common naming rule); includes typed State with predicate methods
-pkg/async/           — Polling utilities for long-running operations
-pkg/multitenant/     — Multi-tenant client management
+pkg/types/           — All request/response/common data models (Request/Response/Common naming rule); includes typed State with predicate methods. Package convention codified in pkg/types/doc.go.
+pkg/async/           — Polling utilities for long-running operations (pkg/async/doc.go)
+pkg/multitenant/     — Multi-tenant client management (pkg/multitenant/doc.go)
+pkg/util/middleware/ — HTTP interceptor helpers (WithCustomHeaders, WithUserAgent, etc.); package name is restclient
 internal/clients/    — Service-specific HTTP client implementations (one dir per service)
 internal/impl/       — Pluggable subsystems: auth, interceptor, logger
 internal/restclient/ — Low-level HTTP execution layer

--- a/ai/REPO.md
+++ b/ai/REPO.md
@@ -21,7 +21,7 @@ pkg/aruba/call_options.go   — CallOption and per-call option types
 pkg/aruba/errors.go      — *HTTPError wrapper
 pkg/aruba/client_root.go    — Root Client interface (exposes FromCompute(), FromNetwork(), etc.)
 pkg/aruba/client_<domain>.go — Per-domain service-group interfaces (client_compute.go, client_network.go, …)
-pkg/types/           — All request/response data models; includes typed State with predicate methods
+pkg/types/           — All request/response/common data models (Request/Response/Common naming rule); includes typed State with predicate methods
 pkg/async/           — Polling utilities for long-running operations
 pkg/multitenant/     — Multi-tenant client management
 internal/clients/    — Service-specific HTTP client implementations (one dir per service)

--- a/ai/TECH_DEBT.md
+++ b/ai/TECH_DEBT.md
@@ -228,6 +228,28 @@ All `*.Create` methods returned success even when the API response omitted requi
 
 ---
 
+### TD-022 · Schedule Job `typology` is required on each Step but absent from public docs
+
+The server rejects a `Create Job` request with `Steps: Not found configuration for typology " "`
+when `typology` is missing from any Step in the request body, even though the field does not
+appear in the public Create-Job request schema at `https://api.arubacloud.com/docs/documents/schedule/create-job/`.
+
+The values come from `category.typology.id` in any `GET /jobs/:id` response (e.g. `"cloudServer"`,
+`"keyPair"`, `"elasticIp"`, `"containerRegistry"`). Typed constants `JobStepTypology*` were added
+in `pkg/aruba/resource_job_step.go` (v0.3.1). If a new target typology is exercised that does not
+yet have a constant, add one — the server's typology vocabulary can be discovered from any GET
+response for a job targeting that resource type.
+
+`typologyName` (the display string, e.g. `"Cloud Server"`) was deliberately **not** added as a
+request-side field in v0.3.1. Re-evaluate only if a future live run surfaces an error naming
+`typologyName` explicitly.
+
+**Effort:** XS per new typology constant.
+
+**Impact:** Medium — missing typology causes an unconditional HTTP 400 on job creation.
+
+---
+
 ### TD-020 · Test coverage limited to happy path and empty-ID validation — [#130](https://github.com/Arubacloud/sdk-go/issues/130)
 All `internal/clients/*/_test.go` files — existing tests cover successful responses and empty project/resource IDs. Missing: HTTP 4xx/5xx error responses, malformed JSON bodies, network-level errors, `nil` params handling, and request body marshaling failures.
 

--- a/ai/TECH_DEBT.md
+++ b/ai/TECH_DEBT.md
@@ -18,97 +18,20 @@ Issues are grouped by severity. Address Critical items before new features ship;
 | [TD-015](#td-015) | `DefaultWaitFor` timeout too short | Medium | XS | Medium |
 | [TD-016](#td-016) | No structured logging | Medium | L | Medium |
 | [TD-017](#td-017) | `WARN` writes to stdout | Medium | XS | Low |
+| [TD-023](#td-023) | `KaasSecurityGroupPropertiesResponse` mixed casing | Low | XS | Low |
+| [TD-024](#td-024) | Stale TODO comments in `pkg/aruba/aruba.go` | Low | XS | Low |
+| [TD-025](#td-025) | `pkg/util/middleware` package name is `restclient` | Low | S | Low |
+| [TD-026](#td-026) | No lint rule enforces Request/Response/Common naming | Low | S | Medium |
+| [TD-027](#td-027) | `Dto` suffix on enum-string constants | Low | XS | Low |
 | [TD-020](#td-020) | Test coverage gaps | Low | XL | High |
-| [TD-021](#td-021) | Create responses validate metadata ID/URI/Name | Low | M | Medium |
 
 ### Recommended execution order
 
-**Wave 1 — Quick Wins** (XS effort, ship same PR): TD-009, TD-014, TD-015, TD-017
+**Wave 1 — Quick Wins** (XS effort, ship same PR): TD-009, TD-014, TD-015, TD-017, TD-023, TD-024, TD-027
 
-**Wave 2 — High-value focused fixes** (S effort, High+ impact): TD-003, TD-012
+**Wave 2 — High-value focused fixes** (S effort, High+ impact): TD-003, TD-012, TD-025, TD-026
 
-**Wave 3 — Medium fixes** (S effort, Medium/Low impact): *(all resolved)*
-
-**Wave 4 — Large refactors** (L/XL, plan separately): TD-010, TD-016, TD-020, TD-021
-
----
-
-## Resolved
-
-### TD-006 · Goroutine leak in `WaitFor` on context cancellation — [#116](https://github.com/Arubacloud/sdk-go/issues/116) · **Closed as invalid**
-The original claim was that the goroutine writes to `resultCh` unconditionally without guarding on `ctx.Done()`. Investigation of `pkg/async/async_client.go` shows:
-1. The goroutine checks `ctxTimeout.Done()` via `select` before each retry attempt (lines 115-120) and after each failed attempt before sleeping (lines 146-152).
-2. The result channel is buffered (`make(chan Result[T], 1)`), so the single channel send the goroutine performs can never block.
-
-No goroutine leak exists. Issue #116 closed as invalid.
-
----
-
-### TD-004 · Interceptor `Bind()` and `Intercept()` are not thread-safe — [#114](https://github.com/Arubacloud/sdk-go/issues/114) · **Closed as working as intended**
-The original claim was that concurrent calls to `Bind()` and `Intercept()` produce an unsynchronized read/write on the `interceptFuncs` slice. The proposed fix was a `sync.RWMutex` guarding both methods.
-
-Investigation shows that `Bind` is a construction/setup method — it is only ever called from `tokenmanager.NewStandard` (`internal/impl/auth/tokenmanager/standard/standard.go:54`) during client bootstrap, before the interceptor enters the hot request path. A sibling constructor `NewInterceptorWithFuncs` exists for fully-initialized construction. The race only materialises if a caller mutates the interceptor after bootstrap, which is not the intended usage.
-
-The root cause was the absence of a documented contract. Resolved by adding godoc to `Interceptable.Bind` (`internal/ports/interceptor/interceptor.go`) and the standard impl (`internal/impl/interceptor/standard/standard.go`) stating that `Bind` is construction-only and not safe for concurrent use with `Intercept`. Adding a mutex to the hot path to defend against an unsupported usage pattern was rejected as an unnecessary tradeoff. Issue #114 closed as working as intended.
-
----
-
-### TD-008 · Polling loop always sleeps before the first attempt, discards final state — [#118](https://github.com/Arubacloud/sdk-go/issues/118) · **Resolved**
-`internal/restclient/polling.go` — two bugs in `WaitForResourceState`: (1) `time.Sleep(config.Interval)` was called at the top of the loop, wasting a full interval before the first status check; (2) when the last attempt's getter returned an error, the `continue` skipped the timeout-with-state branch, causing the final timeout error to be generic rather than including the last known state.
-
-Resolved by restructuring the loop: the sleep moved to the bottom, guarded by `if attempt < config.MaxAttempts`; a `lastState` / `lastErr` pair is tracked across iterations so the post-loop timeout error always carries the last observed state (or wraps the last getter error when no state was ever retrieved). `slices.Contains` replaces the manual success/failure loops. First polling tests added in `internal/restclient/polling_test.go`. Issue #118 closed.
-
----
-
-### TD-013 · Memory proxy `SaveToken` increments ticket before confirming persistent write — [#123](https://github.com/Arubacloud/sdk-go/issues/123) · **Resolved**
-`internal/impl/auth/tokenrepository/memory/memory.go` — `saveTicket++` ran before `r.persistentRepository.SaveToken(...)`, violating the double-checked-locking invariant that "a changed ticket means the cache was successfully refreshed". On a failed persistent write the ticket was already bumped, causing concurrent `FetchToken` calls to skip the persistent re-fetch and serve a stale (or nil) in-memory token.
-
-Resolved by reordering: persistent write first; on success, increment ticket and update cache; on error, return immediately leaving both unchanged. Two regression tests added to `memory_test.go`: a unit assertion on the `saveTicket` counter after a failed save, and a behavioural subtest that verifies a subsequent `FetchToken` still reaches the persistent store. Issue #123 closed.
-
----
-
-### TD-019 · Missing compile-time interface satisfaction checks — [#129](https://github.com/Arubacloud/sdk-go/issues/129) · **Resolved**
-Guards were missing for all ~24 resource-level client impls under `internal/clients/`. Adding them directly inside those packages would create an import cycle (`pkg/aruba/builder.go` already imports every internal client package). The guards are in `pkg/aruba/assertions_test.go` as a `TestCompileTimeInterfaceGuards` function that declares typed local variables via `:=` — a compile-time-only check that runs no code in production binaries.
-
-The security domain is intentionally excluded: `KMSClient`, `KeyClient`, and `KmipClient` in `pkg/aruba/security.go` are type aliases to concrete pointer types, not interfaces, so satisfaction guards would be degenerate.
-
-The issue description incorrectly identified both logger implementations as missing guards; both already had them (`internal/impl/logger/native/logger.go:11`, `internal/impl/logger/noop/logger.go:6`). Three `for i := 0; i < N; i++` loops in test files were also modernized to `for range N` while in the area. Issue #129 closed.
-
-When TD-018 was subsequently resolved (#146), the multi-arg constructor calls in `assertions.go` were updated to use real (non-nil-dep) sentinel instances to avoid init-time panics.
-
----
-
-### TD-018 · Injected concrete dependencies not nil-checked in constructors — [#128](https://github.com/Arubacloud/sdk-go/issues/128) · **Resolved**
-The issue named two constructors (`NewSecurityGroupsClientImpl`, `NewSecurityGroupRulesClientImpl`). A repo-wide grep (`^func New\w+ClientImpl\(.*,.*\)` against `internal/clients/`) found five constructors in total that accept injected `*xxxClientImpl` dependencies beyond the standard `*restclient.Client`: the two network ones named in the issue, `NewSubnetsClientImpl` (also network), `NewSnapshotsClientImpl`, and `NewRestoreClientImpl` (storage).
-
-All five now `panic("... is required and cannot be nil")` when the injected dep is nil. Corresponding panic-on-nil tests added to the paired test files. `pkg/aruba/assertions_test.go` updated to wire real sentinel instances for the affected constructors (avoiding init-time panics). Issue #128 closed.
-
----
-
-### TD-001 · Parameter order swap in file token repository constructor — [#111](https://github.com/Arubacloud/sdk-go/issues/111) · **Resolved**
-`pkg/aruba/builder.go` now calls `NewFileTokenRepository(clientID, options.baseDir)` (correct order). Verified in the current code.
-
----
-
-### TD-002 · Static token is never stored — access token parameter silently ignored — [#112](https://github.com/Arubacloud/sdk-go/issues/112) · **Resolved**
-`internal/impl/auth/tokenrepository/memory/memory.go` — `NewTokenRepositoryWithAccessToken` now returns `&TokenRepository{token: &auth.Token{AccessToken: accessToken}}`. Verified in the current code.
-
----
-
-### TD-005 · Typo in builder function name: `buildDetebaseClient` — [#115](https://github.com/Arubacloud/sdk-go/issues/115) · **Resolved**
-The function is now correctly named `buildDatabaseClient` in `pkg/aruba/builder.go`. Verified in the current code.
-
----
-
-### TD-007 · Variable shadowing creates unreachable `AsyncClient` in `WaitFor` nil-call path — [#117](https://github.com/Arubacloud/sdk-go/issues/117) · **Resolved**
-`pkg/async/async_client.go` — the nil-check on `callFunc` was moved before the outer `asyncClient` variable is created, eliminating the shadowing. Both early-return paths return their own `AsyncClient` directly with no outer variable to shadow. Verified in the current code.
-
----
-
-### TD-011 · Silent failure when parsing error response body — [#121](https://github.com/Arubacloud/sdk-go/issues/121) · **Resolved**
-`pkg/types/utils.go` — when a 4xx/5xx response body could not be unmarshalled as JSON, the error was silently discarded and `response.Error` remained `nil`.
-
-Resolved by adding a `DebugLogger` interface to `pkg/types` (one method: `Debugf`) and making `ParseResponseBody` accept it as a required parameter. On JSON-unmarshal failure the function now calls `logger.Debugf(...)` naming the HTTP status code, rather than WARN as the issue proposed — non-JSON error bodies are expected behaviour from this API (proxy HTML pages, plain-text 502s). Using a local interface keeps `pkg/types` independent of `internal/ports/logger`. All 31 call-site files across `internal/clients/` were updated to pass `c.client.Logger()`. Four unit tests added in `pkg/types/utils_test.go`. Issue #121 closed.
+**Wave 3 — Large refactors** (L/XL, plan separately): TD-010, TD-016, TD-020
 
 ---
 
@@ -182,13 +105,15 @@ Replace all manual implementations with calls to this helper.
 ---
 
 ### TD-015 · `DefaultWaitFor` timeout of 60 s is too short for cloud operations — [#125](https://github.com/Arubacloud/sdk-go/issues/125)
-`pkg/async/async_client.go` — cloud resource provisioning (VMs, databases, VPCs) routinely takes several minutes. The defaults (`retries=10`, `baseDelay=10s`, `timeout=60s`) mean callers must always pass custom values or operations will time out spuriously.
+`pkg/async/async_client.go` — constants are `DefaultRetries=60`, `DefaultBaseDelay=10s`, `DefaultTimeout=600s`. The original issue filed against a 60 s default has been resolved in code (timeout is now 600 s). However, the constant names (`DefaultRetries=60`) could be confused with a 60 s timeout. The documentation should explicitly state that timeout is 600 s (10 minutes) and retries is the poll-attempt count.
 
-**Fix:** Raise defaults to at least `retries=36`, `baseDelay=10s`, `timeout=600s`, or expose a named constant set (e.g., `LongOperationDefaults`) for callers to use.
+**Status:** Resolved in code; remaining work is documentation clarity.
 
-**Effort:** XS — change 3 constants; add a release note as defaults are a breaking change for callers relying on them.
+**Fix:** Add inline godoc to the three constants in `pkg/async/async_client.go` clarifying units.
 
-**Impact:** Medium — prevents spurious timeouts for any caller using `DefaultWaitFor` on real cloud resources.
+**Effort:** XS — add 3 short doc comments.
+
+**Impact:** Medium — prevents callers from misreading `DefaultRetries=60` as "60 second timeout".
 
 ---
 
@@ -216,46 +141,64 @@ Replace all manual implementations with calls to this helper.
 
 ## Low
 
-### TD-021 · Create responses do not contract-test resource ID exposure (Metadata.ID / URI) — [#175](https://github.com/Arubacloud/sdk-go/issues/175)
+### TD-023 · `KaasSecurityGroupPropertiesResponse` uses mixed PascalCase (`Kaas` vs `KaaS`) — (new)
+`pkg/types/container.kaas.go:240` — the response-side struct is named `KaasSecurityGroupPropertiesResponse` while the symmetrical request-side struct at line 91 is named `KaaSSecurityGroupPropertiesRequest` (correct). The Go type name `Kaas` (lowercase second 'a') differs from the acronym's canonical casing `KaaS`. The wire JSON tag is unaffected, but the API surface is inconsistent.
 
-All `*.Create` methods returned success even when the API response omitted required identity fields (`metadata.id`, `metadata.uri`, `metadata.name`). Downstream consumers (e.g., acloud-cli) silently received `nil` pointers and fell back to broken workarounds.
+**Fix:** Rename `KaasSecurityGroupPropertiesResponse` → `KaaSSecurityGroupPropertiesResponse` in `pkg/types/container.kaas.go` and its one usage in `resource_kaas_test.go`.
 
-**Fix:** Added `ResourceMetadataResponse.Validate()` and called it in every Create method. URI was initially included but later removed: the Aruba Cloud API does not consistently populate `metadata.uri` on Create responses, causing false-positive failures in production (acloud-cli `project create` error). The validator now only requires `id` and `name`. Added `pkg/types/resource_test.go` unit tests and "missing id/name" subtests in each Create test file.
+**Effort:** XS — rename 1 type and update 1 test reference.
 
-**Effort:** M — 21 impl files + 21 test files; mechanical but thorough.
-
-**Impact:** Medium — eliminates a class of silent nil-pointer bugs at the API boundary.
+**Impact:** Low — cosmetic inconsistency; does not affect serialisation.
 
 ---
 
-### TD-022 · Schedule Job creation failure `"Not found configuration for typology ' '"` — root cause under investigation
+### TD-024 · Stale TODO comments in `pkg/aruba/aruba.go` — (new)
+`pkg/aruba/aruba.go` contains four TODO comments describing planned variations of `NewClient` and options loading from file/URL that have not been implemented and are not on any active roadmap:
+- `// TODO: Two variations of NewClient`
+- `// TODO: DefaultOptions() function`
+- `// TODO: LoadOptionsFromPath(path path.Path)`
+- `// TODO: LoadOptionsFromURL(url net.URL)`
 
-In the v0.3.1 live run (`examples/all-resources/ create.log`), `Create Job` returned HTTP 400 with
-`Steps: Not found configuration for typology " "` (empty/space typology). The initial diagnosis
-was that `typology` is a required request field absent from the public schema. **This hypothesis
-is incorrect.** The Terraform provider `Arubacloud/terraform-provider-arubacloud` uses the same
-SDK types without a `typology` field and the example at
-`examples/test/schedule/03-schedule.tf` was confirmed live-tested and works (2026-05-28).
+`DefaultOptions` already exists (in `options.go`). The other two (file/URL loading) may or may not be planned. These comments add noise to the public package entrypoint file.
 
-**True root cause (hypothesis):** the server derives the step typology from `resourceUri`. If
-`resourceUri` arrives as empty string (which happens when `Targeting(ref)` is called on a `Ref`
-whose `URI()` returns `""`, e.g. a CloudServer that was queried before `metadata.uri` is
-populated), the server cannot determine the typology and returns the `" "` (empty-typology) error.
+**Fix:** Remove stale TODOs; if file/URL loading is genuinely planned, open a GitHub issue and remove the in-code notes.
 
-**v0.3.1 change:** `JobStep` renamed to `JobStepRequest` for symmetry with `JobStepResponse`.
-`Typology` was added to `JobStepRequest` and then removed after confirmation that the Terraform
-provider example works without it. The request DTO contains no `typology` field.
+**Effort:** XS — delete 4 comment blocks.
 
-**Next step:** a live `-mode=create` run is needed to identify the true root cause. If Jobs fail
-again, investigate whether `resources.CloudServer.URI()` is empty at job-creation time (after
-`WaitUntilReady` the URI should be populated from the GET response, but verify in the run log).
-The Terraform provider confirms that a non-empty `resourceUri` + bare `action_uri` + HTTP verb
-is the complete and sufficient request shape.
+**Impact:** Low — cosmetic; improves readability of the package entrypoint.
 
-**Effort:** XS per new typology constant.
+---
 
-**Impact:** Medium — empty resourceUri (or a server bug in typology derivation) causes an
-unconditional HTTP 400 on job creation.
+### TD-025 · `pkg/util/middleware` package is named `restclient`, not `middleware` — (new)
+`pkg/util/middleware/middleware.go` declares `package restclient`. The directory path is `pkg/util/middleware/` but the Go package name is `restclient`. Callers import it as `github.com/Arubacloud/sdk-go/pkg/util/middleware` but refer to it as `restclient.WithCustomHeaders(...)`. This diverges from Go's convention that the directory name and package name match and is flagged by `golangci-lint` (gopkg convention linters). The package itself also has an internal TODO: "review the placement of this file".
+
+**Fix:** Either (a) rename the package declaration to `middleware`, or (b) move the file to `internal/` since it wraps an internal interceptor type and has no external callers yet.
+
+**Effort:** S — rename + update any callers.
+
+**Impact:** Low — cosmetic confusion; the package has no known external callers in the repo.
+
+---
+
+### TD-026 · No lint rule enforces the `Request`/`Response`/`Common` naming convention — (new)
+The `forbidigo` linter slot exists in `.golangci.yml` but is not configured. Without a lint rule, a new struct added to `pkg/types/` with an old-style suffix (`*Result`, `*List`) will silently violate the convention until caught in code review.
+
+**Fix:** Add a `forbidigo` rule (or a custom `revive` rule) that fails on exported struct names in `pkg/types/` matching `[A-Z][A-Za-z]+List$` or `[A-Z][A-Za-z]+Result$`.
+
+**Effort:** S — configure linter, adjust any existing violations first.
+
+**Impact:** Medium — prevents naming-convention regression; ensures the refactor done in the Unreleased block is durable.
+
+---
+
+### TD-027 · `Dto` suffix on endpoint-type enum strings — (new)
+`pkg/types/network.load-balancer.go` (and possibly related files) contain constants like `EndpointTypeDto` and `DeactiveReasonDto` — suffixes inherited from generated code. These are wire-string enum values; the `Dto` suffix is inconsistent with the rest of the enum naming in `pkg/types/` and leaks an internal detail into the public API surface.
+
+**Fix:** Rename affected constants (confirm full list via `git grep -n 'Dto'`). These are enum-string values, not struct types, so they are out of scope for the Request/Response/Common rename but should be cleaned up separately.
+
+**Effort:** XS per constant — alias old names during a deprecation window or do a hard rename.
+
+**Impact:** Low — cosmetic; no functional impact.
 
 ---
 
@@ -269,3 +212,21 @@ All `internal/clients/*/_test.go` files — existing tests cover successful resp
 **Impact:** High — major regression safety net; issues like TD-011 and TD-014 would have been caught by these tests.
 
 ---
+
+## Resolved (historical summary)
+
+| ID | Summary | Version |
+|---|---|---|
+| TD-001 | Parameter order swap in file token repository constructor | v0.2.x |
+| TD-002 | Static token silently ignored in memory repository | v0.2.x |
+| TD-004 | `Bind()`/`Intercept()` concurrency — closed as working-as-intended | — |
+| TD-005 | Typo `buildDetebaseClient` | v0.2.x |
+| TD-006 | Goroutine leak in `WaitFor` — closed as invalid | — |
+| TD-007 | Variable shadowing in `WaitFor` nil-call path | v0.2.x |
+| TD-008 | Polling loop: sleep before first attempt, discard final state | v0.2.x |
+| TD-011 | Silent failure parsing error response body | v0.2.x |
+| TD-013 | `SaveToken` increments ticket before confirming persistent write | v0.2.x |
+| TD-018 | Injected concrete dependencies not nil-checked in constructors | v0.3.0 |
+| TD-019 | Missing compile-time interface satisfaction checks | v0.3.0 |
+| TD-021 | Create responses do not validate metadata ID/URI/Name | v0.3.1 |
+| TD-022 | Schedule Job `typology` field root cause — `typology` field removed; Terraform confirms shape is correct | v0.3.1 |

--- a/ai/TECH_DEBT.md
+++ b/ai/TECH_DEBT.md
@@ -242,19 +242,15 @@ SDK types without a `typology` field and the example at
 whose `URI()` returns `""`, e.g. a CloudServer that was queried before `metadata.uri` is
 populated), the server cannot determine the typology and returns the `" "` (empty-typology) error.
 
-**v0.3.1 mitigation applied:** `Typology *string \`json:"typology,omitempty"\`` added to
-`JobStepRequest`; `OfTypology(string)` setter and `JobStepTypology*` constants added to
-`pkg/aruba/resource_job_step.go`; the example now calls `.OfTypology(aruba.JobStepTypologyCloudServer)`.
-Providing explicit `typology` gives the server a fallback when it cannot parse the URI, and it is
-consistent with the field the server returns in GET responses. The change is wire-neutral for
-callers that do not call `OfTypology` (pointer + omitempty → field omitted).
+**v0.3.1 change:** `JobStep` renamed to `JobStepRequest` for symmetry with `JobStepResponse`.
+`Typology` was added to `JobStepRequest` and then removed after confirmation that the Terraform
+provider example works without it. The request DTO contains no `typology` field.
 
-**Next step:** a live `-mode=create` run will confirm whether this is sufficient. If Jobs still
-fail, investigate whether `resources.CloudServer.URI()` is empty at job-creation time (after
+**Next step:** a live `-mode=create` run is needed to identify the true root cause. If Jobs fail
+again, investigate whether `resources.CloudServer.URI()` is empty at job-creation time (after
 `WaitUntilReady` the URI should be populated from the GET response, but verify in the run log).
-
-`typologyName` was deliberately **not** added in v0.3.1. Re-evaluate only if a live run surfaces
-a new error naming `typologyName` explicitly.
+The Terraform provider confirms that a non-empty `resourceUri` + bare `action_uri` + HTTP verb
+is the complete and sufficient request shape.
 
 **Effort:** XS per new typology constant.
 

--- a/ai/TECH_DEBT.md
+++ b/ai/TECH_DEBT.md
@@ -228,25 +228,38 @@ All `*.Create` methods returned success even when the API response omitted requi
 
 ---
 
-### TD-022 · Schedule Job `typology` is required on each Step but absent from public docs
+### TD-022 · Schedule Job creation failure `"Not found configuration for typology ' '"` — root cause under investigation
 
-The server rejects a `Create Job` request with `Steps: Not found configuration for typology " "`
-when `typology` is missing from any Step in the request body, even though the field does not
-appear in the public Create-Job request schema at `https://api.arubacloud.com/docs/documents/schedule/create-job/`.
+In the v0.3.1 live run (`examples/all-resources/ create.log`), `Create Job` returned HTTP 400 with
+`Steps: Not found configuration for typology " "` (empty/space typology). The initial diagnosis
+was that `typology` is a required request field absent from the public schema. **This hypothesis
+is incorrect.** The Terraform provider `Arubacloud/terraform-provider-arubacloud` uses the same
+SDK types without a `typology` field and the example at
+`examples/test/schedule/03-schedule.tf` was confirmed live-tested and works (2026-05-28).
 
-The values come from `category.typology.id` in any `GET /jobs/:id` response (e.g. `"cloudServer"`,
-`"keyPair"`, `"elasticIp"`, `"containerRegistry"`). Typed constants `JobStepTypology*` were added
-in `pkg/aruba/resource_job_step.go` (v0.3.1). If a new target typology is exercised that does not
-yet have a constant, add one — the server's typology vocabulary can be discovered from any GET
-response for a job targeting that resource type.
+**True root cause (hypothesis):** the server derives the step typology from `resourceUri`. If
+`resourceUri` arrives as empty string (which happens when `Targeting(ref)` is called on a `Ref`
+whose `URI()` returns `""`, e.g. a CloudServer that was queried before `metadata.uri` is
+populated), the server cannot determine the typology and returns the `" "` (empty-typology) error.
 
-`typologyName` (the display string, e.g. `"Cloud Server"`) was deliberately **not** added as a
-request-side field in v0.3.1. Re-evaluate only if a future live run surfaces an error naming
-`typologyName` explicitly.
+**v0.3.1 mitigation applied:** `Typology *string \`json:"typology,omitempty"\`` added to
+`JobStepRequest`; `OfTypology(string)` setter and `JobStepTypology*` constants added to
+`pkg/aruba/resource_job_step.go`; the example now calls `.OfTypology(aruba.JobStepTypologyCloudServer)`.
+Providing explicit `typology` gives the server a fallback when it cannot parse the URI, and it is
+consistent with the field the server returns in GET responses. The change is wire-neutral for
+callers that do not call `OfTypology` (pointer + omitempty → field omitted).
+
+**Next step:** a live `-mode=create` run will confirm whether this is sufficient. If Jobs still
+fail, investigate whether `resources.CloudServer.URI()` is empty at job-creation time (after
+`WaitUntilReady` the URI should be populated from the GET response, but verify in the run log).
+
+`typologyName` was deliberately **not** added in v0.3.1. Re-evaluate only if a live run surfaces
+a new error naming `typologyName` explicitly.
 
 **Effort:** XS per new typology constant.
 
-**Impact:** Medium — missing typology causes an unconditional HTTP 400 on job creation.
+**Impact:** Medium — empty resourceUri (or a server bug in typology derivation) causes an
+unconditional HTTP 400 on job creation.
 
 ---
 

--- a/docs/website/docs/intro.md
+++ b/docs/website/docs/intro.md
@@ -4,8 +4,6 @@ sidebar_position: 1
 
 # Quick Start
 
-> **Note**: This SDK is currently in its **Alpha** stage. The API is not yet stable, and breaking changes may be introduced in future releases without prior notice. Please use with caution and be prepared for updates.
-
 Welcome to the official Go SDK for the Aruba Cloud API. This SDK provides a convenient and powerful way for Go developers to interact with the Aruba Cloud API. The primary goal is to simplify the management of cloud resources, allowing you to programmatically create, read, update, and delete resources such as compute instances, virtual private clouds (VPCs), block storage, and more.
 
 ## Installation

--- a/docs/website/docs/intro.md
+++ b/docs/website/docs/intro.md
@@ -75,3 +75,4 @@ func main() {
 - Understand [Response Handling](./response-handling) for robust error handling
 - Learn about [Filtering](./filters) to query resources efficiently
 - Read about [Multitenancy](./multitenancy) to manage tenant-specific clients
+- See [Working at Low Level](./working-at-low-level) for advanced escape hatches (`pkg/types`, `pkg/async`)

--- a/docs/website/docs/options.md
+++ b/docs/website/docs/options.md
@@ -226,6 +226,32 @@ recommended for production applications to avoid fetching a new token on every s
   </tbody>
 </table>
 
+## HTTP Client Identity
+
+<p>The SDK automatically sets a <code>User-Agent</code> header on every outbound request so that API access logs
+can be attributed to the SDK version. By default the header value is <code>sdk-go@&lt;version&gt;</code>
+(e.g. <code>sdk-go@0.3.1</code>), derived from the <code>aruba.Version</code> constant defined in
+<code>pkg/aruba/version.go</code>.</p>
+
+<table>
+  <thead>
+    <tr>
+      <th>Option Setter</th>
+      <th>Description</th>
+      <th>Notes</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td><code>WithUserAgent(ua)</code></td>
+      <td>Overrides the default <code>User-Agent</code> header value sent with every request.</td>
+      <td>Use this when building a tool on top of the SDK and you want the API logs to show your tool's
+      identity instead of (or in addition to) the raw SDK version. Example:
+      <code>WithUserAgent("acloud-cli@1.0.0")</code>.</td>
+    </tr>
+  </tbody>
+</table>
+
 ## Advanced / Custom Dependencies
 
 <p>These options are for advanced use cases where you need to inject your own custom components into the SDK's

--- a/docs/website/docs/resources.md
+++ b/docs/website/docs/resources.md
@@ -47,6 +47,21 @@ fmt.Println(result.ID(), result.Name(), result.State())
 The Aruba API validates tag values against `^[A-Za-z0-9-]{4,30}$`: **alphanumerics and hyphens only, length 4 to 30**. Colons, dots, underscores, spaces, and other punctuation are rejected with `400 — One or more validation error occurred`. The SDK does not validate tag values client-side, so an invalid tag only fails when the request reaches the server.
 :::
 
+### Reading wrapper state
+
+Every wrapper promotes the most-used response fields to flat accessors. Prefer these over `wrapper.Raw().Properties.X`:
+
+```go
+fmt.Println(result.ID())        // UUID
+fmt.Println(result.Name())      // resource name
+fmt.Println(result.State())     // lifecycle state
+fmt.Println(result.Region())    // region slug
+fmt.Println(result.RawJSON())   // full JSON wire payload (for --output json)
+fmt.Println(result.RawYAML())   // full YAML wire payload (for --output yaml)
+```
+
+Resource-specific scalars (e.g. `cs.Subnets()`, `vpnRoute.CloudSubnetCIDR()`, `kaas.PodCIDR()`) are documented in each resource's **Response accessors** section below. See [Response Handling](./response-handling#reading-wrapper-state) for the complete accessor taxonomy.
+
 ---
 
 ## Project
@@ -81,6 +96,9 @@ fmt.Printf("✓ Project: %s (ID: %s)\n", proj.Name(), proj.ID())
 - `IsDefault()` — whether this is the default project
 - `Tags()` — `[]string` tag list
 - `CreatedAt()`, `UpdatedAt()` — timestamps
+- `Raw()` — underlying `*types.ProjectResponse` wire struct
+- `RawJSON()` / `RawYAML()` — serialized payload for `--output json/yaml` flags
+- `RawRequest()` — `types.ProjectRequest` for round-trip `Get → Update` flows
 
 :::tip Runnable example
 Full end-to-end example: [`examples/all-resources/resource_project.go`](https://github.com/Arubacloud/sdk-go/blob/main/examples/all-resources/resource_project.go)

--- a/docs/website/docs/resources.md
+++ b/docs/website/docs/resources.md
@@ -62,6 +62,8 @@ fmt.Println(result.RawYAML())   // full YAML wire payload (for --output yaml)
 
 Resource-specific scalars (e.g. `cs.Subnets()`, `vpnRoute.CloudSubnetCIDR()`, `kaas.PodCIDR()`) are documented in each resource's **Response accessors** section below. See [Response Handling](./response-handling#reading-wrapper-state) for the complete accessor taxonomy.
 
+Each resource section also lists its **Setters** (chainable builder methods grouped by the canonical chain order from `ai/CONVENTIONS.md`) and a link to the runnable example in `examples/all-resources/`.
+
 ---
 
 ## Project
@@ -99,6 +101,12 @@ fmt.Printf("✓ Project: %s (ID: %s)\n", proj.Name(), proj.ID())
 - `Raw()` — underlying `*types.ProjectResponse` wire struct
 - `RawJSON()` / `RawYAML()` — serialized payload for `--output json/yaml` flags
 - `RawRequest()` — `types.ProjectRequest` for round-trip `Get → Update` flows
+
+**Setters**:
+- *Name*: `Named(string)`
+- *Labels*: `Tagged(...string)`, `Untagged(...string)`, `RetaggedAs(...string)`
+- *Descriptive scalars*: `DescribedAs(string)`
+- *Boolean state*: `AsDefault()`, `NotDefault()`
 
 :::tip Runnable example
 Full end-to-end example: [`examples/all-resources/resource_project.go`](https://github.com/Arubacloud/sdk-go/blob/main/examples/all-resources/resource_project.go)
@@ -205,6 +213,20 @@ if err := cs.SetPassword(ctx, "NewStr0ngP@ss!"); err != nil { log.Fatalf("SetPas
 - `WaitUntilReady(ctx, opts...)`, `WaitUntilActive(ctx, opts...)`, `WaitUntilStates(ctx, []types.State{...}, opts...)`, `WaitUntilGone(ctx, opts...)`
 - `Raw()` — underlying wire struct
 
+**Setters**:
+- *Classifier*: `OfFlavor(CloudServerFlavor)`
+- *Name*: `Named(string)`
+- *Labels*: `Tagged(...string)`, `Untagged(...string)`, `RetaggedAs(...string)`
+- *Containment*: `InProject(Ref)`
+- *Geography*: `InRegion(Region)`, `InZone(Zone)`
+- *Descriptive scalars*: `WithUserData(string)`
+- *Origin*: `BootingFrom(Ref)`
+- *Attached config*: `WithVPC(Ref)`, `WithSecurityGroups(...Ref)`, `WithElasticIP(Ref)`
+- *Network placement*: `OnSubnets(...Ref)`
+- *Active relationship*: `UsingKeyPair(Ref)`
+- *Boolean state*: `WithVPCPreset()`, `WithoutVPCPreset()`
+- *Billing*: `BilledBy(BillingPeriod)`
+
 :::tip Runnable example
 Full end-to-end example: [`examples/all-resources/resource_cloud_server.go`](https://github.com/Arubacloud/sdk-go/blob/main/examples/all-resources/resource_cloud_server.go)
 :::
@@ -240,6 +262,13 @@ fmt.Printf("✓ KeyPair: %s (ID: %s)\n", kp.Name(), kp.ID())
 - `PublicKey()` — public key string
 - `Region()` — region slug
 - `Raw()` — underlying wire struct
+
+**Setters**:
+- *Name*: `Named(string)`
+- *Labels*: `Tagged(...string)`, `Untagged(...string)`, `RetaggedAs(...string)`
+- *Containment*: `InProject(Ref)`
+- *Geography*: `InRegion(Region)`
+- *Descriptive scalars*: `WithPublicKey(string)`
 
 :::tip Runnable example
 Full end-to-end example: [`examples/all-resources/resource_key_pair.go`](https://github.com/Arubacloud/sdk-go/blob/main/examples/all-resources/resource_key_pair.go)
@@ -317,6 +346,16 @@ if err != nil {
 - `WaitUntilReady(ctx, opts...)`, `WaitUntilActive(ctx, opts...)`, `WaitUntilStates(ctx, []types.State{...}, opts...)`, `WaitUntilGone(ctx, opts...)`
 - `Raw()` — underlying wire struct
 
+**Setters**:
+- *Name*: `Named(string)`
+- *Labels*: `Tagged(...string)`, `Untagged(...string)`, `RetaggedAs(...string)`
+- *Containment*: `InProject(Ref)`
+- *Geography*: `InRegion(Region)`
+- *Descriptive scalars*: `WithKubernetesVersion(KubernetesVersion)`, `WithPodCIDR(string)`, `WithMaxStorageQuotaGB(int)`, `WithIdentity(string, string)`
+- *Attached config*: `WithVPC(Ref)`, `WithSubnet(Ref)`, `WithSecurityGroup(Ref)`, `WithNodeCIDR(string, string)`, `WithNodePools(...*NodePool)`, `WithoutNodePools()`, `ReplaceNodePools(...*NodePool)`
+- *Boolean state*: `HighlyAvailable()`
+- *Billing*: `BilledBy(BillingPeriod)`
+
 :::tip Runnable example
 Full end-to-end example: [`examples/all-resources/resource_kaas.go`](https://github.com/Arubacloud/sdk-go/blob/main/examples/all-resources/resource_kaas.go)
 :::
@@ -367,6 +406,16 @@ fmt.Printf("✓ Registry: %s (public IP: %s)\n", reg.Name(), reg.PublicIP())
 - `State()`, `FailureReason()`, `PreviousState()`, `IsDisabled()`, `DisableReasons()`
 - `WaitUntilReady(ctx, opts...)`, `WaitUntilActive(ctx, opts...)`, `WaitUntilStates(ctx, []types.State{...}, opts...)`, `WaitUntilGone(ctx, opts...)`
 - `Raw()` — underlying wire struct
+
+**Setters**:
+- *Classifier*: `OfSize(ContainerRegistrySizeFlavor)`
+- *Name*: `Named(string)`
+- *Labels*: `Tagged(...string)`, `Untagged(...string)`, `RetaggedAs(...string)`
+- *Containment*: `InProject(Ref)`
+- *Geography*: `InRegion(Region)`
+- *Descriptive scalars*: `WithAdminUsername(string)`
+- *Attached config*: `WithElasticIP(Ref)`, `WithVPC(Ref)`, `WithSubnet(Ref)`, `WithSecurityGroup(Ref)`, `WithBlockStorage(Ref)`
+- *Billing*: `BilledBy(BillingPeriod)`
 
 :::tip Runnable example
 Full end-to-end example: [`examples/all-resources/resource_container_registry.go`](https://github.com/Arubacloud/sdk-go/blob/main/examples/all-resources/resource_container_registry.go)
@@ -427,6 +476,16 @@ fmt.Printf("✓ DBaaS: %s (engine: %s)\n", db.Name(), db.Engine())
 - `WaitUntilReady(ctx, opts...)`, `WaitUntilActive(ctx, opts...)`, `WaitUntilStates(ctx, []types.State{...}, opts...)`, `WaitUntilGone(ctx, opts...)`
 - `Raw()` — underlying wire struct
 
+**Setters**:
+- *Classifier*: `OfEngine(DatabaseEngine)`, `OfFlavor(DBaaSFlavor)`
+- *Name*: `Named(string)`
+- *Labels*: `Tagged(...string)`, `Untagged(...string)`, `RetaggedAs(...string)`
+- *Containment*: `InProject(Ref)`
+- *Geography*: `InRegion(Region)`, `InZone(Zone)`
+- *Descriptive scalars*: `SizedGB(int)`, `WithAutoscaling(min, max int)`, `WithoutAutoscaling()`
+- *Attached config*: `WithVPC(Ref)`, `WithSubnet(Ref)`, `WithSecurityGroup(Ref)`, `WithElasticIP(Ref)`
+- *Billing*: `BilledBy(BillingPeriod)`
+
 :::tip Runnable example
 Full end-to-end example: [`examples/all-resources/resource_dbaas.go`](https://github.com/Arubacloud/sdk-go/blob/main/examples/all-resources/resource_dbaas.go)
 :::
@@ -466,6 +525,10 @@ fmt.Printf("✓ Database: %s\n", database.Name())
 - `State()`, `FailureReason()`, `PreviousState()`, `IsDisabled()`, `DisableReasons()`
 - `WaitUntilReady(ctx, opts...)`, `WaitUntilActive(ctx, opts...)`, `WaitUntilStates(ctx, []types.State{...}, opts...)`, `WaitUntilGone(ctx, opts...)`
 - `Raw()` — underlying wire struct
+
+**Setters**:
+- *Name*: `Named(string)`
+- *Containment*: `InDBaaS(Ref)`
 
 :::tip Runnable example
 Full end-to-end example: [`examples/all-resources/resource_database.go`](https://github.com/Arubacloud/sdk-go/blob/main/examples/all-resources/resource_database.go)
@@ -509,6 +572,11 @@ fmt.Printf("✓ User: %s\n", user.Name())
 - `WaitUntilReady(ctx, opts...)`, `WaitUntilActive(ctx, opts...)`, `WaitUntilStates(ctx, []types.State{...}, opts...)`, `WaitUntilGone(ctx, opts...)`
 - `Raw()` — underlying wire struct
 
+**Setters**:
+- *Name*: `WithUsername(string)`
+- *Containment*: `InDBaaS(Ref)`
+- *Descriptive scalars*: `WithPassword(string)`
+
 :::tip Runnable example
 Full end-to-end example: [`examples/all-resources/resource_dbaas_user.go`](https://github.com/Arubacloud/sdk-go/blob/main/examples/all-resources/resource_dbaas_user.go)
 :::
@@ -549,6 +617,10 @@ fmt.Printf("✓ Grant: %s (privileges: %s)\n", grant.Name(), grant.Privileges())
 - `State()`, `FailureReason()`, `PreviousState()`, `IsDisabled()`, `DisableReasons()`
 - `WaitUntilReady(ctx, opts...)`, `WaitUntilActive(ctx, opts...)`, `WaitUntilStates(ctx, []types.State{...}, opts...)`, `WaitUntilGone(ctx, opts...)`
 - `Raw()` — underlying wire struct
+
+**Setters**:
+- *Containment*: `InDatabase(Ref)`
+- *Active relationship*: `ForUser(string)`, `OfRole(string)`
 
 :::tip Runnable example
 Full end-to-end example: [`examples/all-resources/resource_grant.go`](https://github.com/Arubacloud/sdk-go/blob/main/examples/all-resources/resource_grant.go)
@@ -595,6 +667,13 @@ fmt.Printf("✓ DBaaS Backup: %s\n", backup.Name())
 - `State()`, `FailureReason()`, `PreviousState()`, `IsDisabled()`, `DisableReasons()`
 - `WaitUntilReady(ctx, opts...)`, `WaitUntilActive(ctx, opts...)`, `WaitUntilStates(ctx, []types.State{...}, opts...)`, `WaitUntilGone(ctx, opts...)`
 - `Raw()` — underlying wire struct
+
+**Setters**:
+- *Name*: `Named(string)`
+- *Labels*: `Tagged(...string)`, `Untagged(...string)`, `RetaggedAs(...string)`
+- *Containment*: `InProject(Ref)`, `FromDBaaS(Ref)`, `FromDatabase(Ref)`
+- *Geography*: `InRegion(Region)`, `InZone(Zone)`
+- *Billing*: `BilledBy(BillingPeriod)`
 
 :::tip Runnable example
 DBaaS Backup operations are covered in the DBaaS example: [`examples/all-resources/resource_dbaas.go`](https://github.com/Arubacloud/sdk-go/blob/main/examples/all-resources/resource_dbaas.go)
@@ -708,6 +787,13 @@ fmt.Printf("✓ VPC: %s\n", vpc.Name())
 - `WaitUntilReady(ctx, opts...)`, `WaitUntilActive(ctx, opts...)`, `WaitUntilStates(ctx, []types.State{...}, opts...)`, `WaitUntilGone(ctx, opts...)`
 - `Raw()` — underlying wire struct
 
+**Setters**:
+- *Name*: `Named(string)`
+- *Labels*: `Tagged(...string)`, `Untagged(...string)`, `RetaggedAs(...string)`
+- *Containment*: `InProject(Ref)`
+- *Geography*: `InRegion(Region)`
+- *Boolean state*: `AsDefault()`, `NotDefault()`, `WithPreset()`, `WithoutPreset()`
+
 :::tip Runnable example
 Full end-to-end example: [`examples/all-resources/resource_vpc.go`](https://github.com/Arubacloud/sdk-go/blob/main/examples/all-resources/resource_vpc.go)
 :::
@@ -740,7 +826,7 @@ subnet, err := arubaClient.FromNetwork().Subnets().Create(
         WithDHCP(aruba.NewSubnetDHCP().
             Enabled().
             WithRange("192.168.1.10", 50).
-            WithRoutes(aruba.SubnetDHCPRoute{Address: "0.0.0.0/0", Gateway: "192.168.1.1"}).
+            WithRoutes(aruba.SubnetDHCPRouteCommon{Address: "0.0.0.0/0", Gateway: "192.168.1.1"}).
             WithDNSServers("8.8.8.8", "8.8.4.4")).
         NotDefault())
 if err != nil {
@@ -764,6 +850,16 @@ fmt.Printf("✓ Subnet: %s (CIDR: %s)\n", subnet.Name(), subnet.CIDR())
 - `State()`, `FailureReason()`, `PreviousState()`, `IsDisabled()`, `DisableReasons()`
 - `WaitUntilReady(ctx, opts...)`, `WaitUntilActive(ctx, opts...)`, `WaitUntilStates(ctx, []types.State{...}, opts...)`, `WaitUntilGone(ctx, opts...)`
 - `Raw()` — underlying wire struct
+
+**Setters**:
+- *Classifier*: `OfType(SubnetType)`
+- *Name*: `Named(string)`
+- *Labels*: `Tagged(...string)`, `Untagged(...string)`, `RetaggedAs(...string)`
+- *Containment*: `InVPC(Ref)`
+- *Geography*: `InRegion(Region)`
+- *Descriptive scalars*: `WithCIDR(string)`
+- *Attached config*: `WithDHCP(*SubnetDHCPCommon)`
+- *Boolean state*: `AsDefault()`, `NotDefault()`
 
 :::tip Runnable example
 Full end-to-end example: [`examples/all-resources/resource_subnet.go`](https://github.com/Arubacloud/sdk-go/blob/main/examples/all-resources/resource_subnet.go)
@@ -809,6 +905,13 @@ fmt.Printf("✓ Elastic IP: %s (%s)\n", eip.Name(), eip.Address())
 - `WaitUntilReady(ctx, opts...)`, `WaitUntilActive(ctx, opts...)`, `WaitUntilNotUsed(ctx, opts...)`, `WaitUntilUsed(ctx, opts...)`, `WaitUntilStates(ctx, []types.State{...}, opts...)`, `WaitUntilGone(ctx, opts...)`
 - `Raw()` — underlying wire struct
 
+**Setters**:
+- *Name*: `Named(string)`
+- *Labels*: `Tagged(...string)`, `Untagged(...string)`, `RetaggedAs(...string)`
+- *Containment*: `InProject(Ref)`
+- *Geography*: `InRegion(Region)`
+- *Billing*: `BilledBy(BillingPeriod)`
+
 :::tip Runnable example
 Full end-to-end example: [`examples/all-resources/resource_elastic_ip.go`](https://github.com/Arubacloud/sdk-go/blob/main/examples/all-resources/resource_elastic_ip.go)
 :::
@@ -849,6 +952,12 @@ fmt.Printf("✓ Security Group: %s (ID: %s)\n", sg.Name(), sg.ID())
 - `State()`, `FailureReason()`, `PreviousState()`, `IsDisabled()`, `DisableReasons()`
 - `WaitUntilReady(ctx, opts...)`, `WaitUntilActive(ctx, opts...)`, `WaitUntilStates(ctx, []types.State{...}, opts...)`, `WaitUntilGone(ctx, opts...)`
 - `Raw()` — underlying wire struct
+
+**Setters**:
+- *Name*: `Named(string)`
+- *Labels*: `Tagged(...string)`, `Untagged(...string)`, `RetaggedAs(...string)`
+- *Containment*: `InVPC(Ref)`
+- *Boolean state*: `AsDefault()`, `NotDefault()`
 
 :::tip Runnable example
 Full end-to-end example: [`examples/all-resources/resource_security_group.go`](https://github.com/Arubacloud/sdk-go/blob/main/examples/all-resources/resource_security_group.go)
@@ -899,6 +1008,14 @@ fmt.Printf("✓ Security Rule: %s\n", rule.Name())
 - `State()`, `FailureReason()`, `PreviousState()`, `IsDisabled()`, `DisableReasons()`
 - `WaitUntilGone(ctx, opts...)`
 - `Raw()` — underlying wire struct
+
+**Setters**:
+- *Name*: `Named(string)`
+- *Labels*: `Tagged(...string)`, `Untagged(...string)`, `RetaggedAs(...string)`
+- *Containment*: `InSecurityGroup(Ref)`
+- *Geography*: `InRegion(Region)`
+- *Descriptive scalars*: `WithDirection(RuleDirection)`, `WithProtocol(RuleProtocol)`, `WithPort(string)`
+- *Active relationship*: `TargetingCIDR(string)`, `TargetingSecurityGroup(Ref)`
 
 :::tip Runnable example
 Exercised as part of the orchestrator: [`examples/all-resources/orchestrator_create.go`](https://github.com/Arubacloud/sdk-go/blob/main/examples/all-resources/orchestrator_create.go)
@@ -978,6 +1095,13 @@ fmt.Printf("✓ VPC Peering: %s\n", peering.Name())
 - `WaitUntilReady(ctx, opts...)`, `WaitUntilActive(ctx, opts...)`, `WaitUntilStates(ctx, []types.State{...}, opts...)`, `WaitUntilGone(ctx, opts...)`
 - `Raw()` — underlying wire struct
 
+**Setters**:
+- *Name*: `Named(string)`
+- *Labels*: `Tagged(...string)`, `Untagged(...string)`, `RetaggedAs(...string)`
+- *Containment*: `InVPC(Ref)`
+- *Geography*: `InRegion(Region)`
+- *Active relationship*: `PeeredWith(Ref)`
+
 :::tip Runnable example
 Exercised as part of the orchestrator: [`examples/all-resources/orchestrator_create.go`](https://github.com/Arubacloud/sdk-go/blob/main/examples/all-resources/orchestrator_create.go)
 :::
@@ -1021,6 +1145,14 @@ fmt.Printf("✓ Peering Route: %s (CIDR: %s)\n", route.Name(), route.CIDR())
 - `State()`, `FailureReason()`, `PreviousState()`, `IsDisabled()`, `DisableReasons()`
 - `WaitUntilReady(ctx, opts...)`, `WaitUntilActive(ctx, opts...)`, `WaitUntilStates(ctx, []types.State{...}, opts...)`, `WaitUntilGone(ctx, opts...)`
 - `Raw()` — underlying wire struct
+
+**Setters**:
+- *Name*: `Named(string)`
+- *Labels*: `Tagged(...string)`, `Untagged(...string)`, `RetaggedAs(...string)`
+- *Containment*: `InVPCPeering(Ref)`
+- *Geography*: `InRegion(Region)`
+- *Descriptive scalars*: `WithLocalCIDR(string)`, `WithRemoteCIDR(string)`
+- *Billing*: `BilledBy(BillingPeriod)`
 
 :::tip Runnable example
 Exercised as part of the orchestrator: [`examples/all-resources/orchestrator_create.go`](https://github.com/Arubacloud/sdk-go/blob/main/examples/all-resources/orchestrator_create.go)
@@ -1081,6 +1213,16 @@ fmt.Printf("✓ VPN Tunnel: %s (gateway: %s)\n", tunnel.Name(), tunnel.PeerClien
 - `WaitUntilReady(ctx, opts...)`, `WaitUntilActive(ctx, opts...)`, `WaitUntilStates(ctx, []types.State{...}, opts...)`, `WaitUntilGone(ctx, opts...)`
 - `Raw()` — underlying wire struct
 
+**Setters**:
+- *Classifier*: `OfType(VPNType)`
+- *Name*: `Named(string)`
+- *Labels*: `Tagged(...string)`, `Untagged(...string)`, `RetaggedAs(...string)`
+- *Containment*: `InProject(Ref)`
+- *Geography*: `InRegion(Region)`
+- *Descriptive scalars*: `WithVPNClientProtocol(VPNClientProtocol)`, `WithPeerClientPublicIP(string)`
+- *Attached config*: `WithIPConfig(*VPNIPConfig)`, `WithIKESettings(*VPNIKE)`, `WithESPSettings(*VPNESP)`, `WithPSKSettings(*VPNPSK)`
+- *Billing*: `BilledBy(BillingPeriod)`
+
 :::tip Runnable example
 Exercised as part of the orchestrator: [`examples/all-resources/orchestrator_create.go`](https://github.com/Arubacloud/sdk-go/blob/main/examples/all-resources/orchestrator_create.go)
 :::
@@ -1124,6 +1266,13 @@ fmt.Printf("✓ VPN Route: %s (CIDR: %s)\n", vpnRoute.Name(), vpnRoute.CIDR())
 - `State()`, `FailureReason()`, `PreviousState()`, `IsDisabled()`, `DisableReasons()`
 - `WaitUntilReady(ctx, opts...)`, `WaitUntilActive(ctx, opts...)`, `WaitUntilStates(ctx, []types.State{...}, opts...)`, `WaitUntilGone(ctx, opts...)`
 - `Raw()` — underlying wire struct
+
+**Setters**:
+- *Name*: `Named(string)`
+- *Labels*: `Tagged(...string)`, `Untagged(...string)`, `RetaggedAs(...string)`
+- *Containment*: `InVPNTunnel(Ref)`
+- *Geography*: `InRegion(Region)`
+- *Descriptive scalars*: `WithCloudSubnet(string)`, `WithOnPremSubnet(string)`
 
 :::tip Runnable example
 Exercised as part of the orchestrator: [`examples/all-resources/orchestrator_create.go`](https://github.com/Arubacloud/sdk-go/blob/main/examples/all-resources/orchestrator_create.go)
@@ -1181,6 +1330,15 @@ fmt.Printf("✓ Recurring Job: %s (cron: %s)\n", cronJob.Name(), cronJob.Cron())
 - `State()`, `FailureReason()`, `PreviousState()`, `IsDisabled()`, `DisableReasons()`
 - `Raw()` — underlying wire struct
 
+**Setters**:
+- *Classifier*: `OfType(JobType)`
+- *Name*: `Named(string)`
+- *Labels*: `Tagged(...string)`, `Untagged(...string)`, `RetaggedAs(...string)`
+- *Containment*: `InProject(Ref)`
+- *Geography*: `InRegion(Region)`
+- *Descriptive scalars*: `OneShotAt(time.Time)`, `StartingAt(time.Time)`, `WithCron(string)`, `RecurringUntil(time.Time)`, `WithSteps(...*JobStep)`
+- *Boolean state*: `Enabled()`, `Disabled()`
+
 :::tip Runnable example
 Full end-to-end example: [`examples/all-resources/resource_job.go`](https://github.com/Arubacloud/sdk-go/blob/main/examples/all-resources/resource_job.go)
 :::
@@ -1225,6 +1383,13 @@ fmt.Printf("✓ KMS: %s (ID: %s)\n", kms.Name(), kms.ID())
 - `WaitUntilReady(ctx, opts...)`, `WaitUntilActive(ctx, opts...)`, `WaitUntilStates(ctx, []types.State{...}, opts...)`, `WaitUntilGone(ctx, opts...)`
 - `Raw()` — underlying wire struct
 
+**Setters**:
+- *Name*: `Named(string)`
+- *Labels*: `Tagged(...string)`, `Untagged(...string)`, `RetaggedAs(...string)`
+- *Containment*: `InProject(Ref)`
+- *Geography*: `InRegion(Region)`
+- *Billing*: `BilledBy(BillingPeriod)`
+
 :::tip Runnable example
 Full end-to-end example: [`examples/all-resources/resource_kms.go`](https://github.com/Arubacloud/sdk-go/blob/main/examples/all-resources/resource_kms.go)
 :::
@@ -1266,6 +1431,11 @@ fmt.Printf("✓ Key: %s (algorithm: %s)\n", key.Name(), key.Algorithm())
 - `State()`, `FailureReason()`, `PreviousState()`, `IsDisabled()`, `DisableReasons()`
 - `WaitUntilGone(ctx, opts...)`
 - `Raw()` — underlying wire struct
+
+**Setters**:
+- *Classifier*: `OfAlgorithm(KeyAlgorithm)`
+- *Name*: `Named(string)`
+- *Containment*: `InKMS(Ref)`
 
 :::tip Runnable example
 Key operations are covered in the KMS example: [`examples/all-resources/resource_kms.go`](https://github.com/Arubacloud/sdk-go/blob/main/examples/all-resources/resource_kms.go)
@@ -1317,6 +1487,10 @@ fmt.Println("Key:",  cert.Key())
 - `State()`, `FailureReason()`, `PreviousState()`, `IsDisabled()`, `DisableReasons()`
 - `WaitUntilReady(ctx, opts...)`, `WaitUntilCertificateAvailable(ctx, opts...)`, `WaitUntilStates(ctx, []types.State{...}, opts...)`, `WaitUntilGone(ctx, opts...)`
 - `Raw()` — underlying wire struct
+
+**Setters**:
+- *Name*: `Named(string)`
+- *Containment*: `InKMS(Ref)`
 
 :::tip Runnable example
 KMIP operations are covered in the KMS example: [`examples/all-resources/resource_kms.go`](https://github.com/Arubacloud/sdk-go/blob/main/examples/all-resources/resource_kms.go)
@@ -1392,6 +1566,17 @@ bs, err := arubaClient.FromStorage().Volumes().Create(
 - `WaitUntilReady(ctx, opts...)`, `WaitUntilActive(ctx, opts...)`, `WaitUntilNotUsed(ctx, opts...)`, `WaitUntilUsed(ctx, opts...)`, `WaitUntilStates(ctx, []types.State{...}, opts...)`, `WaitUntilGone(ctx, opts...)`
 - `Raw()` — underlying wire struct
 
+**Setters**:
+- *Classifier*: `OfType(BlockStorageType)`
+- *Name*: `Named(string)`
+- *Labels*: `Tagged(...string)`, `Untagged(...string)`, `RetaggedAs(...string)`
+- *Containment*: `InProject(Ref)`
+- *Geography*: `InRegion(Region)`, `InZone(Zone)`
+- *Descriptive scalars*: `SizedGB(int)`
+- *Origin*: `FromImage(string)`, `FromSnapshot(Ref)`
+- *Boolean state*: `AsBootable()`, `NotBootable()`
+- *Billing*: `BilledBy(BillingPeriod)`
+
 :::tip Runnable example
 Full end-to-end example: [`examples/all-resources/resource_block_storage.go`](https://github.com/Arubacloud/sdk-go/blob/main/examples/all-resources/resource_block_storage.go)
 :::
@@ -1439,6 +1624,14 @@ fmt.Printf("✓ Snapshot: %s\n", snap.Name())
 - `State()`, `FailureReason()`, `PreviousState()`, `IsDisabled()`, `DisableReasons()`
 - `WaitUntilReady(ctx, opts...)`, `WaitUntilActive(ctx, opts...)`, `WaitUntilStates(ctx, []types.State{...}, opts...)`, `WaitUntilGone(ctx, opts...)`
 - `Raw()` — underlying wire struct
+
+**Setters**:
+- *Name*: `Named(string)`
+- *Labels*: `Tagged(...string)`, `Untagged(...string)`, `RetaggedAs(...string)`
+- *Containment*: `InProject(Ref)`
+- *Geography*: `InRegion(Region)`
+- *Origin*: `FromVolume(Ref)`
+- *Billing*: `BilledBy(BillingPeriod)`
 
 :::tip Runnable example
 Full end-to-end example: [`examples/all-resources/resource_snapshot.go`](https://github.com/Arubacloud/sdk-go/blob/main/examples/all-resources/resource_snapshot.go)
@@ -1489,6 +1682,16 @@ fmt.Printf("✓ Storage Backup: %s\n", backup.Name())
 - `WaitUntilReady(ctx, opts...)`, `WaitUntilActive(ctx, opts...)`, `WaitUntilStates(ctx, []types.State{...}, opts...)`, `WaitUntilGone(ctx, opts...)`
 - `Raw()` — underlying wire struct
 
+**Setters**:
+- *Classifier*: `OfType(StorageBackupType)`
+- *Name*: `Named(string)`
+- *Labels*: `Tagged(...string)`, `Untagged(...string)`, `RetaggedAs(...string)`
+- *Containment*: `InProject(Ref)`
+- *Geography*: `InRegion(Region)`
+- *Descriptive scalars*: `RetainedForDays(int)`
+- *Origin*: `FromVolume(Ref)`
+- *Billing*: `BilledBy(BillingPeriod)`
+
 :::tip Runnable example
 Full end-to-end example: [`examples/all-resources/resource_storage_backup.go`](https://github.com/Arubacloud/sdk-go/blob/main/examples/all-resources/resource_storage_backup.go)
 :::
@@ -1529,6 +1732,13 @@ fmt.Printf("✓ Storage Restore: %s\n", restore.Name())
 - `State()`, `FailureReason()`, `PreviousState()`, `IsDisabled()`, `DisableReasons()`
 - `WaitUntilReady(ctx, opts...)`, `WaitUntilActive(ctx, opts...)`, `WaitUntilStates(ctx, []types.State{...}, opts...)`, `WaitUntilGone(ctx, opts...)`
 - `Raw()` — underlying wire struct
+
+**Setters**:
+- *Name*: `Named(string)`
+- *Labels*: `Tagged(...string)`, `Untagged(...string)`, `RetaggedAs(...string)`
+- *Containment*: `FromBackup(Ref)`
+- *Geography*: `InRegion(Region)`
+- *Origin*: `ToVolume(Ref)`
 
 :::tip Runnable example
 Full end-to-end example: [`examples/all-resources/resource_storage_restore.go`](https://github.com/Arubacloud/sdk-go/blob/main/examples/all-resources/resource_storage_restore.go)

--- a/docs/website/docs/resources.md
+++ b/docs/website/docs/resources.md
@@ -1677,12 +1677,12 @@ The following types are the underlying wire-level structs. You normally access t
 | `ResourceMetadataRequest` | `resource.go` | Name + tags for Create |
 | `RegionalResourceMetadataRequest` | `resource.go` | Extends metadata with Location |
 | `ResourceMetadataResponse` | `resource.go` | ID, URI, Name, timestamps |
-| `ResourceStatus` | `resource.go` | State field |
-| `ReferenceResource` | `resource.go` | `{uri: "…"}` link to another resource |
+| `ResourceStatusResponse` | `resource.go` | State field |
+| `ReferenceResourceCommon` | `resource.go` | `{uri: "…"}` link to another resource |
 | `RequestParameters` | `parameters.go` | Low-level filter/sort/limit/offset struct (prefer `CallOption` helpers) |
-| `ProjectRequest` / `ProjectResponse` / `ProjectList` | `project.project.go` | |
-| `VPCRequest` / `VPCResponse` / `VPCList` | `network.vpc.go` | |
-| `SubnetRequest` / `SubnetResponse` / `SubnetList` | `network.subnet.go` | |
+| `ProjectRequest` / `ProjectResponse` / `ProjectListResponse` | `project.project.go` | |
+| `VPCRequest` / `VPCResponse` / `VPCListResponse` | `network.vpc.go` | |
+| `SubnetRequest` / `SubnetResponse` / `SubnetListResponse` | `network.subnet.go` | |
 | `SecurityGroupRequest` / `SecurityGroupResponse` | `network.security-group.go` | |
 | `SecurityRuleRequest` / `SecurityRuleResponse` | `network.security-rule.go` | |
 | `ElasticIPRequest` / `ElasticIPResponse` | `network.elastic-ip.go` | |
@@ -1697,7 +1697,7 @@ The following types are the underlying wire-level structs. You normally access t
 | `BlockStorageRequest` / `BlockStorageResponse` | `storage.block-storage.go` | |
 | `SnapshotRequest` / `SnapshotResponse` | `storage.snapshot.go` | |
 | `StorageBackupRequest` / `StorageBackupResponse` | `storage.backup.go` | |
-| `JobRequest` / `JobResponse` / `JobList` | `schedule.job.go` | |
+| `JobRequest` / `JobResponse` / `JobListResponse` | `schedule.job.go` | |
 | `AlertResponse` / `AlertsListResponse` | `metrics.alert.go` | |
 | `MetricResponse` / `MetricListResponse` | `metrics.metric.go` | |
 | `AuditEvent` / `AuditEventListResponse` | `audit.event.go` | |

--- a/docs/website/docs/response-handling.md
+++ b/docs/website/docs/response-handling.md
@@ -161,6 +161,62 @@ if err := rule.Err(); err != nil {
 }
 ```
 
+## Reading Wrapper State
+
+Every Family-A wrapper promotes the most-used response fields to flat accessors. You should always prefer these over reaching into `wrapper.Raw().Properties.X`:
+
+```go
+cs, err := arubaClient.FromCompute().CloudServers().Get(ctx, ref)
+if err != nil { /* … */ }
+
+// Prefer flat getters
+fmt.Println(cs.Name())          // resource name
+fmt.Println(cs.State())         // lifecycle state (Active, Creating, …)
+fmt.Println(cs.ID())            // UUID
+fmt.Println(cs.Region())        // region slug
+fmt.Println(cs.Subnets())       // []string of subnet URIs
+fmt.Println(cs.ElasticIP())     // elastic IP URI, if set at creation time
+fmt.Println(cs.UserData())      // cloud-init / user-data, if set at creation time
+
+// Fall back to Raw() only for fields not yet promoted
+raw := cs.Raw()
+fmt.Println(raw.Properties.SomeUnpromotedField)
+```
+
+### Standard getter layers
+
+| Category | Example getters |
+|---|---|
+| Identity | `ID()`, `URI()`, `CloudServerID()` |
+| Naming | `Name()`, `Tags()` |
+| Geography | `Region()`, `Zone()` |
+| Lineage | `Project()`, `CreatedAt()`, `UpdatedAt()`, `Version()` |
+| Lifecycle | `State()`, `IsDisabled()`, `DisableReasons()`, `FailureReason()` |
+| Linked resources | `LinkedResources()` |
+| Raw envelope | `Raw()`, `RawJSON()`, `RawYAML()`, `RawRequest()`, `StatusCode()`, `Headers()`, `RawError()` |
+| Resource-specific | e.g. `cs.Subnets()`, `vpnRoute.CloudSubnetCIDR()`, `kaas.PodCIDR()` |
+
+### `RawJSON()` / `RawYAML()` for CLI output
+
+The `RawJSON()` and `RawYAML()` methods are designed for CLI-style `--output json` / `--output yaml` flags. They marshal the underlying wire struct, not just the promoted fields:
+
+```go
+cs, _ := arubaClient.FromCompute().CloudServers().Get(ctx, ref)
+fmt.Println(string(cs.RawJSON()))   // full JSON wire payload
+fmt.Println(string(cs.RawYAML()))   // full YAML wire payload
+```
+
+### `RawRequest()` for round-trip updates
+
+`RawRequest()` produces a `types.<X>Request` value representing the full current state of the wrapper — useful for `Get → mutate → Update` flows:
+
+```go
+cs, _ := arubaClient.FromCompute().CloudServers().Get(ctx, ref)
+// The wrapper already contains all server-side fields; just override what changed.
+cs.Named("new-name")
+_, err = arubaClient.FromCompute().CloudServers().Update(ctx, cs)
+```
+
 ## Best Practices
 
 1. **Always check `err` first** — it covers both network failures and API errors.

--- a/docs/website/docs/walkthrough.md
+++ b/docs/website/docs/walkthrough.md
@@ -106,7 +106,7 @@ subnet, err := arubaClient.FromNetwork().Subnets().Create(
         WithDHCP(aruba.NewSubnetDHCP().
             Enabled().
             WithRange("192.168.1.10", 50).
-            WithRoutes(aruba.SubnetDHCPRoute{Address: "10.0.0.0/8", Gateway: "192.168.1.1"}).
+            WithRoutes(aruba.SubnetDHCPRouteCommon{Address: "10.0.0.0/8", Gateway: "192.168.1.1"}).
             WithDNSServers("8.8.8.8", "8.8.4.4")).
         NotDefault())
 if err != nil {

--- a/docs/website/docs/working-at-low-level.md
+++ b/docs/website/docs/working-at-low-level.md
@@ -33,7 +33,7 @@ For lists, `Raw()` returns `any` and you type-assert to the concrete list type:
 vpcList, err := arubaClient.FromNetwork().VPCs().List(ctx, proj)
 if err != nil { /* … */ }
 
-raw := vpcList.Raw().(*types.VPCList)     // requires pkg/types import
+raw := vpcList.Raw().(*types.VPCListResponse)     // requires pkg/types import
 fmt.Println("server total:", raw.Total)   // same as vpcList.Total() — shown for illustration
 fmt.Println("self link:", raw.Self)
 ```

--- a/docs/website/docs/working-at-low-level.md
+++ b/docs/website/docs/working-at-low-level.md
@@ -102,7 +102,7 @@ if err != nil {
 
 ## Iterating `LinkedResources()`
 
-Every resource wrapper exposes `LinkedResources()` which returns `[]types.LinkedResource`. Each entry has a `URI string` and a `StrictCorrelation bool`:
+Every resource wrapper exposes `LinkedResources()` which returns `[]types.LinkedResourceCommon`. Each entry has a `URI string` and a `StrictCorrelation bool`:
 
 ```go
 import (
@@ -121,7 +121,7 @@ for _, lr := range vpc.LinkedResources() {
 }
 ```
 
-> If you only need the linked URI strings — for example, to pass them back to another SDK call as `aruba.URI(lr.URI)` — you don't need `types.LinkedResource` at all:
+> If you only need the linked URI strings — for example, to pass them back to another SDK call as `aruba.URI(lr.URI)` — you don't need `types.LinkedResourceCommon` at all:
 >
 > ```go
 > for _, lr := range vpc.LinkedResources() {

--- a/docs/website/i18n/it/docusaurus-plugin-content-docs/current/intro.md
+++ b/docs/website/i18n/it/docusaurus-plugin-content-docs/current/intro.md
@@ -75,3 +75,4 @@ func main() {
 - Comprendi la [Gestione delle Risposte](./response-handling) per una gestione robusta degli errori
 - Scopri il [Filtraggio](./filters) per interrogare le risorse in modo efficiente
 - Leggi [Multitenancy](./multitenancy) per gestire client specifici per tenant
+- Vedi [Utilizzo a Basso Livello](./working-at-low-level) per funzionalità avanzate (`pkg/types`, `pkg/async`)

--- a/docs/website/i18n/it/docusaurus-plugin-content-docs/current/intro.md
+++ b/docs/website/i18n/it/docusaurus-plugin-content-docs/current/intro.md
@@ -4,8 +4,6 @@ sidebar_position: 1
 
 # Guida Rapida
 
-> **Nota**: Questo SDK è attualmente nella fase **Alpha**. L'API non è ancora stabile e potrebbero essere introdotte modifiche incompatibili nelle versioni future senza preavviso. Si prega di utilizzarlo con cautela e di essere pronti agli aggiornamenti.
-
 Benvenuto nell'SDK ufficiale Go per l'API Aruba Cloud. Questo SDK fornisce un modo comodo e potente per gli sviluppatori Go di interagire con l'API Aruba Cloud. L'obiettivo principale è semplificare la gestione delle risorse cloud, permettendoti di creare, leggere, aggiornare ed eliminare programmaticamente risorse come istanze di calcolo, virtual private cloud (VPC), storage a blocchi e altro ancora.
 
 ## Installazione

--- a/docs/website/i18n/it/docusaurus-plugin-content-docs/current/resources.md
+++ b/docs/website/i18n/it/docusaurus-plugin-content-docs/current/resources.md
@@ -1593,12 +1593,12 @@ I seguenti tipi sono le struct wire di basso livello. Normalmente vi si accede s
 | `ResourceMetadataRequest` | `resource.go` | Nome + tag per Create |
 | `RegionalResourceMetadataRequest` | `resource.go` | Estende i metadati con Location |
 | `ResourceMetadataResponse` | `resource.go` | ID, URI, Name, timestamp |
-| `ResourceStatus` | `resource.go` | Campo State |
-| `ReferenceResource` | `resource.go` | Link `{uri: "…"}` a un'altra risorsa |
+| `ResourceStatusResponse` | `resource.go` | Campo State |
+| `ReferenceResourceCommon` | `resource.go` | Link `{uri: "…"}` a un'altra risorsa |
 | `RequestParameters` | `parameters.go` | Struct filter/sort/limit/offset di basso livello (preferire gli helper `CallOption`) |
-| `ProjectRequest` / `ProjectResponse` / `ProjectList` | `project.project.go` | |
-| `VPCRequest` / `VPCResponse` / `VPCList` | `network.vpc.go` | |
-| `SubnetRequest` / `SubnetResponse` / `SubnetList` | `network.subnet.go` | |
+| `ProjectRequest` / `ProjectResponse` / `ProjectListResponse` | `project.project.go` | |
+| `VPCRequest` / `VPCResponse` / `VPCListResponse` | `network.vpc.go` | |
+| `SubnetRequest` / `SubnetResponse` / `SubnetListResponse` | `network.subnet.go` | |
 | `SecurityGroupRequest` / `SecurityGroupResponse` | `network.security-group.go` | |
 | `SecurityRuleRequest` / `SecurityRuleResponse` | `network.security-rule.go` | |
 | `ElasticIPRequest` / `ElasticIPResponse` | `network.elastic-ip.go` | |
@@ -1613,7 +1613,7 @@ I seguenti tipi sono le struct wire di basso livello. Normalmente vi si accede s
 | `BlockStorageRequest` / `BlockStorageResponse` | `storage.block-storage.go` | |
 | `SnapshotRequest` / `SnapshotResponse` | `storage.snapshot.go` | |
 | `StorageBackupRequest` / `StorageBackupResponse` | `storage.backup.go` | |
-| `JobRequest` / `JobResponse` / `JobList` | `schedule.job.go` | |
+| `JobRequest` / `JobResponse` / `JobListResponse` | `schedule.job.go` | |
 | `AlertResponse` / `AlertsListResponse` | `metrics.alert.go` | |
 | `MetricResponse` / `MetricListResponse` | `metrics.metric.go` | |
 | `AuditEvent` / `AuditEventListResponse` | `audit.event.go` | |

--- a/docs/website/i18n/it/docusaurus-plugin-content-docs/current/resources.md
+++ b/docs/website/i18n/it/docusaurus-plugin-content-docs/current/resources.md
@@ -47,6 +47,8 @@ fmt.Println(result.ID(), result.Name(), result.State())
 L'API di Aruba valida i valori dei tag contro `^[A-Za-z0-9-]{4,30}$`: **solo caratteri alfanumerici e trattini, lunghezza da 4 a 30**. Due punti, punti, underscore, spazi e altra punteggiatura vengono rifiutati con `400 — One or more validation error occurred`. L'SDK non valida i tag lato client, quindi un tag non valido fallisce solo quando la richiesta raggiunge il server.
 :::
 
+Ogni sezione di risorsa elenca anche i suoi **Setter** (metodi builder concatenabili raggruppati per l'ordine canonico della catena da `ai/CONVENTIONS.md`) e un collegamento all'esempio eseguibile in `examples/all-resources/`.
+
 ---
 
 ## Progetto
@@ -81,6 +83,12 @@ fmt.Printf("✓ Progetto: %s (ID: %s)\n", proj.Name(), proj.ID())
 - `IsDefault()` — se questo è il progetto predefinito
 - `Tags()` — lista di tag `[]string`
 - `CreatedAt()`, `UpdatedAt()` — timestamp
+
+**Setter**:
+- *Name*: `Named(string)`
+- *Labels*: `Tagged(...string)`, `Untagged(...string)`, `RetaggedAs(...string)`
+- *Descriptive scalars*: `DescribedAs(string)`
+- *Boolean state*: `AsDefault()`, `NotDefault()`
 
 :::tip Esempio eseguibile
 Esempio end-to-end completo: [`examples/all-resources/resource_project.go`](https://github.com/Arubacloud/sdk-go/blob/main/examples/all-resources/resource_project.go)
@@ -187,6 +195,20 @@ if err := cs.SetPassword(ctx, "NewStr0ngP@ss!"); err != nil { log.Fatalf("SetPas
 - `WaitUntilReady(ctx, opts...)`, `WaitUntilActive(ctx, opts...)`, `WaitUntilStates(ctx, []types.State{...}, opts...)`, `WaitUntilGone(ctx, opts...)`
 - `Raw()` — struct wire sottostante
 
+**Setter**:
+- *Classifier*: `OfFlavor(CloudServerFlavor)`
+- *Name*: `Named(string)`
+- *Labels*: `Tagged(...string)`, `Untagged(...string)`, `RetaggedAs(...string)`
+- *Containment*: `InProject(Ref)`
+- *Geography*: `InRegion(Region)`, `InZone(Zone)`
+- *Descriptive scalars*: `WithUserData(string)`
+- *Origin*: `BootingFrom(Ref)`
+- *Attached config*: `WithVPC(Ref)`, `WithSecurityGroups(...Ref)`, `WithElasticIP(Ref)`
+- *Network placement*: `OnSubnets(...Ref)`
+- *Active relationship*: `UsingKeyPair(Ref)`
+- *Boolean state*: `WithVPCPreset()`, `WithoutVPCPreset()`
+- *Billing*: `BilledBy(BillingPeriod)`
+
 :::tip Esempio eseguibile
 Esempio end-to-end completo: [`examples/all-resources/resource_cloud_server.go`](https://github.com/Arubacloud/sdk-go/blob/main/examples/all-resources/resource_cloud_server.go)
 :::
@@ -222,6 +244,13 @@ fmt.Printf("✓ KeyPair: %s (ID: %s)\n", kp.Name(), kp.ID())
 - `PublicKey()` — stringa della chiave pubblica
 - `Region()` — slug della regione
 - `Raw()` — struct wire sottostante
+
+**Setter**:
+- *Name*: `Named(string)`
+- *Labels*: `Tagged(...string)`, `Untagged(...string)`, `RetaggedAs(...string)`
+- *Containment*: `InProject(Ref)`
+- *Geography*: `InRegion(Region)`
+- *Descriptive scalars*: `WithPublicKey(string)`
 
 :::tip Esempio eseguibile
 Esempio end-to-end completo: [`examples/all-resources/resource_key_pair.go`](https://github.com/Arubacloud/sdk-go/blob/main/examples/all-resources/resource_key_pair.go)
@@ -299,6 +328,16 @@ if err != nil {
 - `WaitUntilReady(ctx, opts...)`, `WaitUntilActive(ctx, opts...)`, `WaitUntilStates(ctx, []types.State{...}, opts...)`, `WaitUntilGone(ctx, opts...)`
 - `Raw()` — struct wire sottostante
 
+**Setter**:
+- *Name*: `Named(string)`
+- *Labels*: `Tagged(...string)`, `Untagged(...string)`, `RetaggedAs(...string)`
+- *Containment*: `InProject(Ref)`
+- *Geography*: `InRegion(Region)`
+- *Descriptive scalars*: `WithKubernetesVersion(KubernetesVersion)`, `WithPodCIDR(string)`, `WithMaxStorageQuotaGB(int)`, `WithIdentity(string, string)`
+- *Attached config*: `WithVPC(Ref)`, `WithSubnet(Ref)`, `WithSecurityGroup(Ref)`, `WithNodeCIDR(string, string)`, `WithNodePools(...*NodePool)`, `WithoutNodePools()`, `ReplaceNodePools(...*NodePool)`
+- *Boolean state*: `HighlyAvailable()`
+- *Billing*: `BilledBy(BillingPeriod)`
+
 :::tip Esempio eseguibile
 Esempio end-to-end completo: [`examples/all-resources/resource_kaas.go`](https://github.com/Arubacloud/sdk-go/blob/main/examples/all-resources/resource_kaas.go)
 :::
@@ -350,6 +389,16 @@ fmt.Printf("✓ Registry: %s (IP pubblico: %s)\n", reg.Name(), reg.PublicIP())
 - `State()`, `FailureReason()`, `PreviousState()`, `IsDisabled()`, `DisableReasons()`
 - `WaitUntilReady(ctx, opts...)`, `WaitUntilActive(ctx, opts...)`, `WaitUntilStates(ctx, []types.State{...}, opts...)`, `WaitUntilGone(ctx, opts...)`
 - `Raw()` — struct wire sottostante
+
+**Setter**:
+- *Classifier*: `OfSize(ContainerRegistrySizeFlavor)`
+- *Name*: `Named(string)`
+- *Labels*: `Tagged(...string)`, `Untagged(...string)`, `RetaggedAs(...string)`
+- *Containment*: `InProject(Ref)`
+- *Geography*: `InRegion(Region)`
+- *Descriptive scalars*: `WithAdminUsername(string)`
+- *Attached config*: `WithElasticIP(Ref)`, `WithVPC(Ref)`, `WithSubnet(Ref)`, `WithSecurityGroup(Ref)`, `WithBlockStorage(Ref)`
+- *Billing*: `BilledBy(BillingPeriod)`
 
 :::tip Esempio eseguibile
 Esempio end-to-end completo: [`examples/all-resources/resource_container_registry.go`](https://github.com/Arubacloud/sdk-go/blob/main/examples/all-resources/resource_container_registry.go)
@@ -411,6 +460,16 @@ fmt.Printf("✓ DBaaS: %s (engine: %s)\n", db.Name(), db.Engine())
 - `WaitUntilReady(ctx, opts...)`, `WaitUntilActive(ctx, opts...)`, `WaitUntilStates(ctx, []types.State{...}, opts...)`, `WaitUntilGone(ctx, opts...)`
 - `Raw()` — struct wire sottostante
 
+**Setter**:
+- *Classifier*: `OfEngine(DatabaseEngine)`, `OfFlavor(DBaaSFlavor)`
+- *Name*: `Named(string)`
+- *Labels*: `Tagged(...string)`, `Untagged(...string)`, `RetaggedAs(...string)`
+- *Containment*: `InProject(Ref)`
+- *Geography*: `InRegion(Region)`, `InZone(Zone)`
+- *Descriptive scalars*: `SizedGB(int)`, `WithAutoscaling(min, max int)`, `WithoutAutoscaling()`
+- *Attached config*: `WithVPC(Ref)`, `WithSubnet(Ref)`, `WithSecurityGroup(Ref)`, `WithElasticIP(Ref)`
+- *Billing*: `BilledBy(BillingPeriod)`
+
 :::tip Esempio eseguibile
 Esempio end-to-end completo: [`examples/all-resources/resource_dbaas.go`](https://github.com/Arubacloud/sdk-go/blob/main/examples/all-resources/resource_dbaas.go)
 :::
@@ -450,6 +509,10 @@ fmt.Printf("✓ Database: %s\n", database.Name())
 - `State()`, `FailureReason()`, `PreviousState()`, `IsDisabled()`, `DisableReasons()`
 - `WaitUntilReady(ctx, opts...)`, `WaitUntilActive(ctx, opts...)`, `WaitUntilStates(ctx, []types.State{...}, opts...)`, `WaitUntilGone(ctx, opts...)`
 - `Raw()` — struct wire sottostante
+
+**Setter**:
+- *Name*: `Named(string)`
+- *Containment*: `InDBaaS(Ref)`
 
 :::tip Esempio eseguibile
 Esempio end-to-end completo: [`examples/all-resources/resource_database.go`](https://github.com/Arubacloud/sdk-go/blob/main/examples/all-resources/resource_database.go)
@@ -491,6 +554,11 @@ fmt.Printf("✓ Utente: %s\n", user.Name())
 - `WaitUntilReady(ctx, opts...)`, `WaitUntilActive(ctx, opts...)`, `WaitUntilStates(ctx, []types.State{...}, opts...)`, `WaitUntilGone(ctx, opts...)`
 - `Raw()` — struct wire sottostante
 
+**Setter**:
+- *Name*: `WithUsername(string)`
+- *Containment*: `InDBaaS(Ref)`
+- *Descriptive scalars*: `WithPassword(string)`
+
 :::tip Esempio eseguibile
 Esempio end-to-end completo: [`examples/all-resources/resource_dbaas_user.go`](https://github.com/Arubacloud/sdk-go/blob/main/examples/all-resources/resource_dbaas_user.go)
 :::
@@ -531,6 +599,10 @@ fmt.Printf("✓ Grant: %s\n", grant.ID())
 - `State()`, `FailureReason()`, `PreviousState()`, `IsDisabled()`, `DisableReasons()`
 - `WaitUntilReady(ctx, opts...)`, `WaitUntilActive(ctx, opts...)`, `WaitUntilStates(ctx, []types.State{...}, opts...)`, `WaitUntilGone(ctx, opts...)`
 - `Raw()` — struct wire sottostante
+
+**Setter**:
+- *Containment*: `InDatabase(Ref)`
+- *Active relationship*: `ForUser(string)`, `OfRole(string)`
 
 :::tip Esempio eseguibile
 Esempio end-to-end completo: [`examples/all-resources/resource_grant.go`](https://github.com/Arubacloud/sdk-go/blob/main/examples/all-resources/resource_grant.go)
@@ -575,6 +647,13 @@ fmt.Printf("✓ DBaaS Backup: %s\n", backup.Name())
 - `State()`, `FailureReason()`, `PreviousState()`, `IsDisabled()`, `DisableReasons()`
 - `WaitUntilReady(ctx, opts...)`, `WaitUntilActive(ctx, opts...)`, `WaitUntilStates(ctx, []types.State{...}, opts...)`, `WaitUntilGone(ctx, opts...)`
 - `Raw()` — struct wire sottostante
+
+**Setter**:
+- *Name*: `Named(string)`
+- *Labels*: `Tagged(...string)`, `Untagged(...string)`, `RetaggedAs(...string)`
+- *Containment*: `InProject(Ref)`, `FromDBaaS(Ref)`, `FromDatabase(Ref)`
+- *Geography*: `InRegion(Region)`, `InZone(Zone)`
+- *Billing*: `BilledBy(BillingPeriod)`
 
 :::tip Esempio eseguibile
 Le operazioni DBaaS Backup sono coperte nell'esempio DBaaS: [`examples/all-resources/resource_dbaas.go`](https://github.com/Arubacloud/sdk-go/blob/main/examples/all-resources/resource_dbaas.go)
@@ -688,6 +767,13 @@ fmt.Printf("✓ VPC: %s\n", vpc.Name())
 - `WaitUntilReady(ctx, opts...)`, `WaitUntilActive(ctx, opts...)`, `WaitUntilStates(ctx, []types.State{...}, opts...)`, `WaitUntilGone(ctx, opts...)`
 - `Raw()` — struct wire sottostante
 
+**Setter**:
+- *Name*: `Named(string)`
+- *Labels*: `Tagged(...string)`, `Untagged(...string)`, `RetaggedAs(...string)`
+- *Containment*: `InProject(Ref)`
+- *Geography*: `InRegion(Region)`
+- *Boolean state*: `AsDefault()`, `NotDefault()`, `WithPreset()`, `WithoutPreset()`
+
 :::tip Esempio eseguibile
 Esempio end-to-end completo: [`examples/all-resources/resource_vpc.go`](https://github.com/Arubacloud/sdk-go/blob/main/examples/all-resources/resource_vpc.go)
 :::
@@ -745,6 +831,16 @@ fmt.Printf("✓ Subnet: %s (CIDR: %s)\n", subnet.Name(), subnet.CIDR())
 - `WaitUntilReady(ctx, opts...)`, `WaitUntilActive(ctx, opts...)`, `WaitUntilStates(ctx, []types.State{...}, opts...)`, `WaitUntilGone(ctx, opts...)`
 - `Raw()` — struct wire sottostante
 
+**Setter**:
+- *Classifier*: `OfType(SubnetType)`
+- *Name*: `Named(string)`
+- *Labels*: `Tagged(...string)`, `Untagged(...string)`, `RetaggedAs(...string)`
+- *Containment*: `InVPC(Ref)`
+- *Geography*: `InRegion(Region)`
+- *Descriptive scalars*: `WithCIDR(string)`
+- *Attached config*: `WithDHCP(*SubnetDHCPCommon)`
+- *Boolean state*: `AsDefault()`, `NotDefault()`
+
 :::tip Esempio eseguibile
 Esempio end-to-end completo: [`examples/all-resources/resource_subnet.go`](https://github.com/Arubacloud/sdk-go/blob/main/examples/all-resources/resource_subnet.go)
 :::
@@ -789,6 +885,13 @@ fmt.Printf("✓ Elastic IP: %s (%s)\n", eip.Name(), eip.Address())
 - `WaitUntilReady(ctx, opts...)`, `WaitUntilActive(ctx, opts...)`, `WaitUntilStates(ctx, []types.State{...}, opts...)`, `WaitUntilGone(ctx, opts...)`
 - `Raw()` — struct wire sottostante
 
+**Setter**:
+- *Name*: `Named(string)`
+- *Labels*: `Tagged(...string)`, `Untagged(...string)`, `RetaggedAs(...string)`
+- *Containment*: `InProject(Ref)`
+- *Geography*: `InRegion(Region)`
+- *Billing*: `BilledBy(BillingPeriod)`
+
 :::tip Esempio eseguibile
 Esempio end-to-end completo: [`examples/all-resources/resource_elastic_ip.go`](https://github.com/Arubacloud/sdk-go/blob/main/examples/all-resources/resource_elastic_ip.go)
 :::
@@ -829,6 +932,12 @@ fmt.Printf("✓ Security Group: %s (ID: %s)\n", sg.Name(), sg.ID())
 - `State()`, `FailureReason()`, `PreviousState()`, `IsDisabled()`, `DisableReasons()`
 - `WaitUntilReady(ctx, opts...)`, `WaitUntilActive(ctx, opts...)`, `WaitUntilStates(ctx, []types.State{...}, opts...)`, `WaitUntilGone(ctx, opts...)`
 - `Raw()` — struct wire sottostante
+
+**Setter**:
+- *Name*: `Named(string)`
+- *Labels*: `Tagged(...string)`, `Untagged(...string)`, `RetaggedAs(...string)`
+- *Containment*: `InVPC(Ref)`
+- *Boolean state*: `AsDefault()`, `NotDefault()`
 
 :::tip Esempio eseguibile
 Esempio end-to-end completo: [`examples/all-resources/resource_security_group.go`](https://github.com/Arubacloud/sdk-go/blob/main/examples/all-resources/resource_security_group.go)
@@ -879,6 +988,14 @@ fmt.Printf("✓ Security Rule: %s\n", rule.Name())
 - `State()`, `FailureReason()`, `PreviousState()`, `IsDisabled()`, `DisableReasons()`
 - `WaitUntilGone(ctx, opts...)`
 - `Raw()` — struct wire sottostante
+
+**Setter**:
+- *Name*: `Named(string)`
+- *Labels*: `Tagged(...string)`, `Untagged(...string)`, `RetaggedAs(...string)`
+- *Containment*: `InSecurityGroup(Ref)`
+- *Geography*: `InRegion(Region)`
+- *Descriptive scalars*: `WithDirection(RuleDirection)`, `WithProtocol(RuleProtocol)`, `WithPort(string)`
+- *Active relationship*: `TargetingCIDR(string)`, `TargetingSecurityGroup(Ref)`
 
 :::tip Esempio eseguibile
 Eseguito come parte dell'orchestratore: [`examples/all-resources/orchestrator_create.go`](https://github.com/Arubacloud/sdk-go/blob/main/examples/all-resources/orchestrator_create.go)
@@ -958,6 +1075,13 @@ fmt.Printf("✓ VPC Peering: %s\n", peering.Name())
 - `WaitUntilReady(ctx, opts...)`, `WaitUntilActive(ctx, opts...)`, `WaitUntilStates(ctx, []types.State{...}, opts...)`, `WaitUntilGone(ctx, opts...)`
 - `Raw()` — struct wire sottostante
 
+**Setter**:
+- *Name*: `Named(string)`
+- *Labels*: `Tagged(...string)`, `Untagged(...string)`, `RetaggedAs(...string)`
+- *Containment*: `InVPC(Ref)`
+- *Geography*: `InRegion(Region)`
+- *Active relationship*: `PeeredWith(Ref)`
+
 :::tip Esempio eseguibile
 Eseguito come parte dell'orchestratore: [`examples/all-resources/orchestrator_create.go`](https://github.com/Arubacloud/sdk-go/blob/main/examples/all-resources/orchestrator_create.go)
 :::
@@ -1001,6 +1125,14 @@ fmt.Printf("✓ Peering Route: %s (CIDR: %s)\n", route.Name(), route.CIDR())
 - `State()`, `FailureReason()`, `PreviousState()`, `IsDisabled()`, `DisableReasons()`
 - `WaitUntilReady(ctx, opts...)`, `WaitUntilActive(ctx, opts...)`, `WaitUntilStates(ctx, []types.State{...}, opts...)`, `WaitUntilGone(ctx, opts...)`
 - `Raw()` — struct wire sottostante
+
+**Setter**:
+- *Name*: `Named(string)`
+- *Labels*: `Tagged(...string)`, `Untagged(...string)`, `RetaggedAs(...string)`
+- *Containment*: `InVPCPeering(Ref)`
+- *Geography*: `InRegion(Region)`
+- *Descriptive scalars*: `WithLocalCIDR(string)`, `WithRemoteCIDR(string)`
+- *Billing*: `BilledBy(BillingPeriod)`
 
 :::tip Esempio eseguibile
 Eseguito come parte dell'orchestratore: [`examples/all-resources/orchestrator_create.go`](https://github.com/Arubacloud/sdk-go/blob/main/examples/all-resources/orchestrator_create.go)
@@ -1058,6 +1190,16 @@ fmt.Printf("✓ VPN Tunnel: %s (gateway: %s)\n", tunnel.Name(), tunnel.PeerClien
 - `WaitUntilReady(ctx, opts...)`, `WaitUntilActive(ctx, opts...)`, `WaitUntilStates(ctx, []types.State{...}, opts...)`, `WaitUntilGone(ctx, opts...)`
 - `Raw()` — struct wire sottostante
 
+**Setter**:
+- *Classifier*: `OfType(VPNType)`
+- *Name*: `Named(string)`
+- *Labels*: `Tagged(...string)`, `Untagged(...string)`, `RetaggedAs(...string)`
+- *Containment*: `InProject(Ref)`
+- *Geography*: `InRegion(Region)`
+- *Descriptive scalars*: `WithVPNClientProtocol(VPNClientProtocol)`, `WithPeerClientPublicIP(string)`
+- *Attached config*: `WithIPConfig(*VPNIPConfig)`, `WithIKESettings(*VPNIKE)`, `WithESPSettings(*VPNESP)`, `WithPSKSettings(*VPNPSK)`
+- *Billing*: `BilledBy(BillingPeriod)`
+
 :::tip Esempio eseguibile
 Eseguito come parte dell'orchestratore: [`examples/all-resources/orchestrator_create.go`](https://github.com/Arubacloud/sdk-go/blob/main/examples/all-resources/orchestrator_create.go)
 :::
@@ -1101,6 +1243,13 @@ fmt.Printf("✓ VPN Route: %s (CIDR: %s)\n", vpnRoute.Name(), vpnRoute.CIDR())
 - `State()`, `FailureReason()`, `PreviousState()`, `IsDisabled()`, `DisableReasons()`
 - `WaitUntilReady(ctx, opts...)`, `WaitUntilActive(ctx, opts...)`, `WaitUntilStates(ctx, []types.State{...}, opts...)`, `WaitUntilGone(ctx, opts...)`
 - `Raw()` — struct wire sottostante
+
+**Setter**:
+- *Name*: `Named(string)`
+- *Labels*: `Tagged(...string)`, `Untagged(...string)`, `RetaggedAs(...string)`
+- *Containment*: `InVPNTunnel(Ref)`
+- *Geography*: `InRegion(Region)`
+- *Descriptive scalars*: `WithCloudSubnet(string)`, `WithOnPremSubnet(string)`
 
 :::tip Esempio eseguibile
 Eseguito come parte dell'orchestratore: [`examples/all-resources/orchestrator_create.go`](https://github.com/Arubacloud/sdk-go/blob/main/examples/all-resources/orchestrator_create.go)
@@ -1158,6 +1307,15 @@ fmt.Printf("✓ Job ricorrente: %s (cron: %s)\n", cronJob.Name(), cronJob.Cron()
 - `State()`, `FailureReason()`, `PreviousState()`, `IsDisabled()`, `DisableReasons()`
 - `Raw()` — struct wire sottostante
 
+**Setter**:
+- *Classifier*: `OfType(JobType)`
+- *Name*: `Named(string)`
+- *Labels*: `Tagged(...string)`, `Untagged(...string)`, `RetaggedAs(...string)`
+- *Containment*: `InProject(Ref)`
+- *Geography*: `InRegion(Region)`
+- *Descriptive scalars*: `OneShotAt(time.Time)`, `StartingAt(time.Time)`, `WithCron(string)`, `RecurringUntil(time.Time)`, `WithSteps(...*JobStep)`
+- *Boolean state*: `Enabled()`, `Disabled()`
+
 :::tip Esempio eseguibile
 Esempio end-to-end completo: [`examples/all-resources/resource_job.go`](https://github.com/Arubacloud/sdk-go/blob/main/examples/all-resources/resource_job.go)
 :::
@@ -1203,6 +1361,13 @@ fmt.Printf("✓ KMS: %s (ID: %s)\n", kms.Name(), kms.ID())
 - `WaitUntilReady(ctx, opts...)`, `WaitUntilActive(ctx, opts...)`, `WaitUntilStates(ctx, []types.State{...}, opts...)`, `WaitUntilGone(ctx, opts...)`
 - `Raw()` — struct wire sottostante
 
+**Setter**:
+- *Name*: `Named(string)`
+- *Labels*: `Tagged(...string)`, `Untagged(...string)`, `RetaggedAs(...string)`
+- *Containment*: `InProject(Ref)`
+- *Geography*: `InRegion(Region)`
+- *Billing*: `BilledBy(BillingPeriod)`
+
 :::tip Esempio eseguibile
 Esempio end-to-end completo: [`examples/all-resources/resource_kms.go`](https://github.com/Arubacloud/sdk-go/blob/main/examples/all-resources/resource_kms.go)
 :::
@@ -1244,6 +1409,11 @@ fmt.Printf("✓ Chiave: %s (algoritmo: %s)\n", key.Name(), key.Algorithm())
 - `State()`, `FailureReason()`, `PreviousState()`, `IsDisabled()`, `DisableReasons()`
 - `WaitUntilGone(ctx, opts...)`
 - `Raw()` — struct wire sottostante
+
+**Setter**:
+- *Classifier*: `OfAlgorithm(KeyAlgorithm)`
+- *Name*: `Named(string)`
+- *Containment*: `InKMS(Ref)`
 
 :::tip Esempio eseguibile
 Le operazioni Key sono coperte nell'esempio KMS: [`examples/all-resources/resource_kms.go`](https://github.com/Arubacloud/sdk-go/blob/main/examples/all-resources/resource_kms.go)
@@ -1296,6 +1466,10 @@ fmt.Println("Key:",  cert.Key())
 - `State()`, `FailureReason()`, `PreviousState()`, `IsDisabled()`, `DisableReasons()`
 - `WaitUntilReady(ctx, opts...)`, `WaitUntilActive(ctx, opts...)`, `WaitUntilStates(ctx, []types.State{...}, opts...)`, `WaitUntilGone(ctx, opts...)`
 - `Raw()` — struct wire sottostante
+
+**Setter**:
+- *Name*: `Named(string)`
+- *Containment*: `InKMS(Ref)`
 
 :::tip Esempio eseguibile
 Le operazioni KMIP sono coperte nell'esempio KMS: [`examples/all-resources/resource_kms.go`](https://github.com/Arubacloud/sdk-go/blob/main/examples/all-resources/resource_kms.go)
@@ -1371,6 +1545,17 @@ bs, err := arubaClient.FromStorage().Volumes().Create(
 - `WaitUntilReady(ctx, opts...)`, `WaitUntilActive(ctx, opts...)`, `WaitUntilStates(ctx, []types.State{...}, opts...)`, `WaitUntilGone(ctx, opts...)`
 - `Raw()` — struct wire sottostante
 
+**Setter**:
+- *Classifier*: `OfType(BlockStorageType)`
+- *Name*: `Named(string)`
+- *Labels*: `Tagged(...string)`, `Untagged(...string)`, `RetaggedAs(...string)`
+- *Containment*: `InProject(Ref)`
+- *Geography*: `InRegion(Region)`, `InZone(Zone)`
+- *Descriptive scalars*: `SizedGB(int)`
+- *Origin*: `FromImage(string)`, `FromSnapshot(Ref)`
+- *Boolean state*: `AsBootable()`, `NotBootable()`
+- *Billing*: `BilledBy(BillingPeriod)`
+
 :::tip Esempio eseguibile
 Esempio end-to-end completo: [`examples/all-resources/resource_block_storage.go`](https://github.com/Arubacloud/sdk-go/blob/main/examples/all-resources/resource_block_storage.go)
 :::
@@ -1418,6 +1603,14 @@ fmt.Printf("✓ Snapshot: %s\n", snap.Name())
 - `State()`, `FailureReason()`, `PreviousState()`, `IsDisabled()`, `DisableReasons()`
 - `WaitUntilReady(ctx, opts...)`, `WaitUntilActive(ctx, opts...)`, `WaitUntilStates(ctx, []types.State{...}, opts...)`, `WaitUntilGone(ctx, opts...)`
 - `Raw()` — struct wire sottostante
+
+**Setter**:
+- *Name*: `Named(string)`
+- *Labels*: `Tagged(...string)`, `Untagged(...string)`, `RetaggedAs(...string)`
+- *Containment*: `InProject(Ref)`
+- *Geography*: `InRegion(Region)`
+- *Origin*: `FromVolume(Ref)`
+- *Billing*: `BilledBy(BillingPeriod)`
 
 :::tip Esempio eseguibile
 Esempio end-to-end completo: [`examples/all-resources/resource_snapshot.go`](https://github.com/Arubacloud/sdk-go/blob/main/examples/all-resources/resource_snapshot.go)
@@ -1467,6 +1660,16 @@ fmt.Printf("✓ Storage Backup: %s\n", backup.Name())
 - `WaitUntilReady(ctx, opts...)`, `WaitUntilActive(ctx, opts...)`, `WaitUntilStates(ctx, []types.State{...}, opts...)`, `WaitUntilGone(ctx, opts...)`
 - `Raw()` — struct wire sottostante
 
+**Setter**:
+- *Classifier*: `OfType(StorageBackupType)`
+- *Name*: `Named(string)`
+- *Labels*: `Tagged(...string)`, `Untagged(...string)`, `RetaggedAs(...string)`
+- *Containment*: `InProject(Ref)`
+- *Geography*: `InRegion(Region)`
+- *Descriptive scalars*: `RetainedForDays(int)`
+- *Origin*: `FromVolume(Ref)`
+- *Billing*: `BilledBy(BillingPeriod)`
+
 :::tip Esempio eseguibile
 Esempio end-to-end completo: [`examples/all-resources/resource_storage_backup.go`](https://github.com/Arubacloud/sdk-go/blob/main/examples/all-resources/resource_storage_backup.go)
 :::
@@ -1507,6 +1710,13 @@ fmt.Printf("✓ Storage Restore: %s\n", restore.Name())
 - `State()`, `FailureReason()`, `PreviousState()`, `IsDisabled()`, `DisableReasons()`
 - `WaitUntilReady(ctx, opts...)`, `WaitUntilActive(ctx, opts...)`, `WaitUntilStates(ctx, []types.State{...}, opts...)`, `WaitUntilGone(ctx, opts...)`
 - `Raw()` — struct wire sottostante
+
+**Setter**:
+- *Name*: `Named(string)`
+- *Labels*: `Tagged(...string)`, `Untagged(...string)`, `RetaggedAs(...string)`
+- *Containment*: `FromBackup(Ref)`
+- *Geography*: `InRegion(Region)`
+- *Origin*: `ToVolume(Ref)`
 
 :::tip Esempio eseguibile
 Esempio end-to-end completo: [`examples/all-resources/resource_storage_restore.go`](https://github.com/Arubacloud/sdk-go/blob/main/examples/all-resources/resource_storage_restore.go)

--- a/docs/website/i18n/it/docusaurus-plugin-content-docs/current/walkthrough.md
+++ b/docs/website/i18n/it/docusaurus-plugin-content-docs/current/walkthrough.md
@@ -106,7 +106,7 @@ subnet, err := arubaClient.FromNetwork().Subnets().Create(
         WithDHCP(aruba.NewSubnetDHCP().
             Enabled().
             WithRange("192.168.1.10", 50).
-            WithRoutes(aruba.SubnetDHCPRoute{Address: "10.0.0.0/8", Gateway: "192.168.1.1"}).
+            WithRoutes(aruba.SubnetDHCPRouteCommon{Address: "10.0.0.0/8", Gateway: "192.168.1.1"}).
             WithDNSServers("8.8.8.8", "8.8.4.4")).
         NotDefault())
 if err != nil {

--- a/docs/website/i18n/it/docusaurus-plugin-content-docs/current/working-at-low-level.md
+++ b/docs/website/i18n/it/docusaurus-plugin-content-docs/current/working-at-low-level.md
@@ -33,7 +33,7 @@ Per le liste, `Raw()` restituisce `any` e devi fare il type assert al tipo lista
 vpcList, err := arubaClient.FromNetwork().VPCs().List(ctx, proj)
 if err != nil { /* … */ }
 
-raw := vpcList.Raw().(*types.VPCList)     // richiede l'import di pkg/types
+raw := vpcList.Raw().(*types.VPCListResponse)     // richiede l'import di pkg/types
 fmt.Println("server total:", raw.Total)   // equivalente a vpcList.Total() — mostrato per illustrazione
 fmt.Println("self link:", raw.Self)
 ```

--- a/docs/website/i18n/it/docusaurus-plugin-content-docs/current/working-at-low-level.md
+++ b/docs/website/i18n/it/docusaurus-plugin-content-docs/current/working-at-low-level.md
@@ -102,7 +102,7 @@ if err != nil {
 
 ## Iterare `LinkedResources()`
 
-Ogni wrapper di risorsa espone `LinkedResources()` che restituisce `[]types.LinkedResource`. Ogni elemento ha un `URI string` e un `StrictCorrelation bool`:
+Ogni wrapper di risorsa espone `LinkedResources()` che restituisce `[]types.LinkedResourceCommon`. Ogni elemento ha un `URI string` e un `StrictCorrelation bool`:
 
 ```go
 import (
@@ -121,7 +121,7 @@ for _, lr := range vpc.LinkedResources() {
 }
 ```
 
-> Se hai bisogno solo delle stringhe URI — ad esempio per passarle a un'altra chiamata SDK come `aruba.URI(lr.URI)` — non hai bisogno di `types.LinkedResource`:
+> Se hai bisogno solo delle stringhe URI — ad esempio per passarle a un'altra chiamata SDK come `aruba.URI(lr.URI)` — non hai bisogno di `types.LinkedResourceCommon`:
 >
 > ```go
 > for _, lr := range vpc.LinkedResources() {

--- a/examples/all-resources/common.go
+++ b/examples/all-resources/common.go
@@ -56,6 +56,8 @@ const (
 	NameGrant                     = "grant"
 	NameJobRecurring              = "job-recurring"
 	NameJobOneShot                = "job-oneshot"
+	NameVPNTunnel                 = "vpn-tunnel"
+	NameVPNRoute                  = "vpn-route"
 )
 
 // namePrefix and nameSuffix are set once in main() before any create/update
@@ -144,6 +146,8 @@ type ResourceCollection struct {
 	Grant                    *aruba.Grant
 	JobRecurring             *aruba.Job
 	JobOneShot               *aruba.Job
+	VPNTunnel                *aruba.VPNTunnel
+	VPNRoute                 *aruba.VPNRoute
 
 	// Populated by fetchAllResources for the delete flow. Contains every
 	// BlockStorage and ElasticIP in the project so the pre-delete inventory
@@ -550,5 +554,12 @@ func printResourceSummary(resources *ResourceCollection) {
 	}
 	if resources.JobOneShot != nil && resources.JobOneShot.JobID() != "" {
 		fmt.Println("- OneShot Job ID:", resources.JobOneShot.JobID())
+	}
+	if resources.VPNTunnel != nil && resources.VPNTunnel.VPNTunnelID() != "" {
+		fmt.Printf("- VPN Tunnel: %s (ID: %s)\n", resources.VPNTunnel.Name(), resources.VPNTunnel.VPNTunnelID())
+	}
+	if resources.VPNRoute != nil && resources.VPNRoute.VPNRouteID() != "" {
+		fmt.Printf("- VPN Route: %s (ID: %s, cloudSubnet: %s)\n",
+			resources.VPNRoute.Name(), resources.VPNRoute.VPNRouteID(), resources.VPNRoute.CloudSubnetCIDR())
 	}
 }

--- a/examples/all-resources/common.go
+++ b/examples/all-resources/common.go
@@ -582,7 +582,7 @@ func printResourceSummary(resources *ResourceCollection) {
 	} else {
 		fmt.Println("- DBaaS User: <not created>")
 	}
-	if resources.Grant != nil && resources.Grant.ID() != "" {
+	if resources.Grant != nil && resources.Grant.Username() != "" {
 		fmt.Printf("- DBaaS Grant: %s on %s (%s)\n",
 			resources.Grant.Username(), resources.Grant.DatabaseName(), resources.Grant.RoleName())
 	} else {

--- a/examples/all-resources/common.go
+++ b/examples/all-resources/common.go
@@ -456,112 +456,200 @@ func printDeleteError(pretty string, err error) {
 	log.Printf("✗ Failed to delete %s: %s", pretty, formatErr(err))
 }
 
+// summaryRow formats a single resource summary line.
+// When name and id are both empty the resource was not created.
+func summaryRow(label, name, id string, extras ...string) string {
+	if name == "" && id == "" {
+		return fmt.Sprintf("- %s: <not created>", label)
+	}
+	tail := id
+	if len(extras) > 0 {
+		tail = id + ", " + strings.Join(extras, ", ")
+	}
+	return fmt.Sprintf("- %s: %s (ID: %s)", label, name, tail)
+}
+
+// eipRow returns a summary line for an ElasticIP (which may be nil).
+func eipRow(label string, eip *aruba.ElasticIP) string {
+	if eip != nil {
+		return summaryRow(label, eip.Name(), eip.ID())
+	}
+	return summaryRow(label, "", "")
+}
+
+// bsRow returns a summary line for a BlockStorage (which may be nil).
+func bsRow(label string, bs *aruba.BlockStorage) string {
+	if bs != nil {
+		return summaryRow(label, bs.Name(), bs.ID())
+	}
+	return summaryRow(label, "", "")
+}
+
 // printResourceSummary prints a summary of all created resources.
 func printResourceSummary(resources *ResourceCollection) {
 	fmt.Println("\n=== SDK Example Complete ===")
-	fmt.Println("Successfully created resources:")
+	fmt.Println("Resources created:")
+
+	// Project
 	if resources.Project != nil {
-		fmt.Println("- Project ID:", resources.Project.ID())
+		fmt.Println(summaryRow("Project", resources.Project.Name(), resources.Project.ID()))
+	} else {
+		fmt.Println(summaryRow("Project", "", ""))
 	}
 
-	if resources.CloudServerEIP != nil && resources.CloudServerEIP.ID() != "" {
-		fmt.Println("- Cloud Server ElasticIP ID:", resources.CloudServerEIP.ID())
+	// Elastic IPs
+	fmt.Println(eipRow("ElasticIP (Cloud Server)", resources.CloudServerEIP))
+	fmt.Println(eipRow("ElasticIP (DBaaS)", resources.DBaaSEIP))
+	fmt.Println(eipRow("ElasticIP (Container Registry)", resources.ContainerRegistryEIP))
+	fmt.Println(eipRow("ElasticIP (VPN Tunnel)", resources.VPNTunnelEIP))
+
+	// Block Storages
+	fmt.Println(bsRow("BlockStorage (Cloud Server)", resources.CloudServerBlockStorage))
+	fmt.Println(bsRow("BlockStorage (Container Registry)", resources.ContainerRegistryStorage))
+	fmt.Println(bsRow("BlockStorage (Restore Target)", resources.RestoreTargetStorage))
+
+	// Snapshot / Backup / Restore
+	if resources.Snapshot != nil {
+		fmt.Println(summaryRow("Snapshot", resources.Snapshot.Name(), resources.Snapshot.ID()))
+	} else {
+		fmt.Println(summaryRow("Snapshot", "", ""))
 	}
-	if resources.DBaaSEIP != nil && resources.DBaaSEIP.ID() != "" {
-		fmt.Println("- DBaaS ElasticIP ID:", resources.DBaaSEIP.ID())
+	if resources.Backup != nil {
+		fmt.Println(summaryRow("Storage Backup", resources.Backup.Name(), resources.Backup.BackupID()))
+	} else {
+		fmt.Println(summaryRow("Storage Backup", "", ""))
 	}
-	if resources.ContainerRegistryEIP != nil && resources.ContainerRegistryEIP.ID() != "" {
-		fmt.Println("- CR ElasticIP ID:", resources.ContainerRegistryEIP.ID())
+	if resources.Restore != nil {
+		fmt.Println(summaryRow("Storage Restore", resources.Restore.Name(), resources.Restore.RestoreID()))
+	} else {
+		fmt.Println(summaryRow("Storage Restore", "", ""))
 	}
 
-	if resources.CloudServerBlockStorage != nil && resources.CloudServerBlockStorage.ID() != "" {
-		fmt.Println("- Cloud Server Block Storage ID:", resources.CloudServerBlockStorage.ID())
+	// Network
+	if resources.VPC != nil {
+		fmt.Println(summaryRow("VPC", resources.VPC.Name(), resources.VPC.ID()))
+	} else {
+		fmt.Println(summaryRow("VPC", "", ""))
 	}
-	if resources.ContainerRegistryStorage != nil && resources.ContainerRegistryStorage.ID() != "" {
-		fmt.Println("- CR Block Storage ID:", resources.ContainerRegistryStorage.ID())
+	if resources.SubnetAdvanced != nil {
+		fmt.Println(summaryRow("Subnet (Advanced)", resources.SubnetAdvanced.Name(), resources.SubnetAdvanced.ID()))
+	} else {
+		fmt.Println(summaryRow("Subnet (Advanced)", "", ""))
 	}
-
-	if resources.Snapshot != nil && resources.Snapshot.ID() != "" {
-		fmt.Printf("- Snapshot: %s (ID: %s)\n", resources.Snapshot.Name(), resources.Snapshot.ID())
-	}
-
-	if resources.VPC != nil && resources.VPC.ID() != "" {
-		fmt.Println("- VPC ID:", resources.VPC.ID())
-	}
-
-	if resources.SubnetAdvanced != nil && resources.SubnetAdvanced.ID() != "" {
-		fmt.Println("- Advanced Subnet ID:", resources.SubnetAdvanced.ID())
-	}
-	if resources.SubnetBasic != nil && resources.SubnetBasic.ID() != "" {
-		fmt.Println("- Basic Subnet ID:", resources.SubnetBasic.ID())
+	if resources.SubnetBasic != nil {
+		fmt.Println(summaryRow("Subnet (Basic)", resources.SubnetBasic.Name(), resources.SubnetBasic.ID()))
+	} else {
+		fmt.Println(summaryRow("Subnet (Basic)", "", ""))
 	}
 
-	if resources.SecurityGroup != nil && resources.SecurityGroup.ID() != "" {
-		fmt.Println("- Security Group ID:", resources.SecurityGroup.ID())
+	// Security
+	if resources.SecurityGroup != nil {
+		fmt.Println(summaryRow("Security Group", resources.SecurityGroup.Name(), resources.SecurityGroup.ID()))
+	} else {
+		fmt.Println(summaryRow("Security Group", "", ""))
 	}
-
 	for _, r := range resources.SecurityRulesIngress {
-		if r != nil && r.ID() != "" {
-			fmt.Printf("- Security Rule (Ingress/%s) ID: %s\n", r.Name(), r.ID())
+		if r != nil {
+			fmt.Println(summaryRow("Security Rule (Ingress/"+r.Name()+")", r.Name(), r.ID()))
 		}
 	}
-	if resources.SecurityRuleEgress != nil && resources.SecurityRuleEgress.ID() != "" {
-		fmt.Println("- Security Rule (Egress) ID:", resources.SecurityRuleEgress.ID())
+	if resources.SecurityRuleEgress != nil {
+		fmt.Println(summaryRow("Security Rule (Egress)", resources.SecurityRuleEgress.Name(), resources.SecurityRuleEgress.ID()))
+	} else {
+		fmt.Println(summaryRow("Security Rule (Egress)", "", ""))
 	}
 
-	if resources.KeyPair != nil && resources.KeyPair.KeyPairID() != "" {
-		fmt.Printf("- SSH Key Pair: %s (ID: %s)\n", resources.KeyPair.Name(), resources.KeyPair.KeyPairID())
+	// SSH Key Pair
+	if resources.KeyPair != nil {
+		fmt.Println(summaryRow("SSH Key Pair", resources.KeyPair.Name(), resources.KeyPair.KeyPairID()))
+	} else {
+		fmt.Println(summaryRow("SSH Key Pair", "", ""))
 	}
 
-	if resources.DBaaS != nil && resources.DBaaS.DBaaSID() != "" {
-		fmt.Printf("- DBaaS: %s (ID: %s)\n", resources.DBaaS.Name(), resources.DBaaS.DBaaSID())
+	// Database stack
+	if resources.DBaaS != nil {
+		fmt.Println(summaryRow("DBaaS", resources.DBaaS.Name(), resources.DBaaS.DBaaSID()))
+	} else {
+		fmt.Println(summaryRow("DBaaS", "", ""))
 	}
-
-	if resources.KaaS != nil && resources.KaaS.KaaSID() != "" {
-		fmt.Println("- KaaS Cluster ID:", resources.KaaS.KaaSID())
-	}
-
-	if resources.CloudServer != nil && resources.CloudServer.CloudServerID() != "" {
-		fmt.Printf("- Cloud Server: %s (ID: %s)\n", resources.CloudServer.Name(), resources.CloudServer.CloudServerID())
-	}
-
-	if resources.KMS != nil && resources.KMS.KMSID() != "" {
-		fmt.Println("- KMS Instance ID:", resources.KMS.KMSID())
-	}
-
-	if resources.KMSKey != nil && resources.KMSKey.KeyID() != "" {
-		fmt.Println("- KMS Key ID:", resources.KMSKey.KeyID())
-	}
-
-	if resources.Kmip != nil && resources.Kmip.KmipID() != "" {
-		fmt.Println("- KMIP Service ID:", resources.Kmip.KmipID())
-	}
-
-	if resources.KmipCert != nil {
-		fmt.Println("- KMIP Certificate: Downloaded successfully")
-	}
-
 	if resources.Database != nil && resources.Database.ID() != "" {
 		fmt.Printf("- DBaaS Database: %s\n", resources.Database.Name())
+	} else {
+		fmt.Println("- DBaaS Database: <not created>")
 	}
 	if resources.DBaaSUser != nil && resources.DBaaSUser.ID() != "" {
 		fmt.Printf("- DBaaS User: %s\n", resources.DBaaSUser.Username())
+	} else {
+		fmt.Println("- DBaaS User: <not created>")
 	}
 	if resources.Grant != nil && resources.Grant.ID() != "" {
 		fmt.Printf("- DBaaS Grant: %s on %s (%s)\n",
 			resources.Grant.Username(), resources.Grant.DatabaseName(), resources.Grant.RoleName())
+	} else {
+		fmt.Println("- DBaaS Grant: <not created>")
 	}
-	if resources.JobRecurring != nil && resources.JobRecurring.JobID() != "" {
-		fmt.Println("- Recurring Job ID:", resources.JobRecurring.JobID())
+
+	// Compute & container platforms
+	if resources.KaaS != nil {
+		fmt.Println(summaryRow("KaaS Cluster", resources.KaaS.Name(), resources.KaaS.KaaSID()))
+	} else {
+		fmt.Println(summaryRow("KaaS Cluster", "", ""))
 	}
-	if resources.JobOneShot != nil && resources.JobOneShot.JobID() != "" {
-		fmt.Println("- OneShot Job ID:", resources.JobOneShot.JobID())
+	if resources.CloudServer != nil {
+		fmt.Println(summaryRow("Cloud Server", resources.CloudServer.Name(), resources.CloudServer.CloudServerID()))
+	} else {
+		fmt.Println(summaryRow("Cloud Server", "", ""))
 	}
-	if resources.VPNTunnel != nil && resources.VPNTunnel.VPNTunnelID() != "" {
-		fmt.Printf("- VPN Tunnel: %s (ID: %s)\n", resources.VPNTunnel.Name(), resources.VPNTunnel.VPNTunnelID())
+	if resources.ContainerRegistry != nil {
+		fmt.Println(summaryRow("Container Registry", resources.ContainerRegistry.Name(), resources.ContainerRegistry.ContainerRegistryID()))
+	} else {
+		fmt.Println(summaryRow("Container Registry", "", ""))
 	}
-	if resources.VPNRoute != nil && resources.VPNRoute.VPNRouteID() != "" {
-		fmt.Printf("- VPN Route: %s (ID: %s, cloudSubnet: %s)\n",
-			resources.VPNRoute.Name(), resources.VPNRoute.VPNRouteID(), resources.VPNRoute.CloudSubnetCIDR())
+
+	// Schedule jobs
+	if resources.JobRecurring != nil {
+		fmt.Println(summaryRow("Job (Recurring)", resources.JobRecurring.Name(), resources.JobRecurring.JobID()))
+	} else {
+		fmt.Println(summaryRow("Job (Recurring)", "", ""))
+	}
+	if resources.JobOneShot != nil {
+		fmt.Println(summaryRow("Job (One-Shot)", resources.JobOneShot.Name(), resources.JobOneShot.JobID()))
+	} else {
+		fmt.Println(summaryRow("Job (One-Shot)", "", ""))
+	}
+
+	// VPN stack
+	if resources.VPNTunnel != nil {
+		fmt.Println(summaryRow("VPN Tunnel", resources.VPNTunnel.Name(), resources.VPNTunnel.VPNTunnelID()))
+	} else {
+		fmt.Println(summaryRow("VPN Tunnel", "", ""))
+	}
+	if resources.VPNRoute != nil {
+		fmt.Println(summaryRow("VPN Route", resources.VPNRoute.Name(), resources.VPNRoute.VPNRouteID(),
+			"cloudSubnet="+resources.VPNRoute.CloudSubnetCIDR()))
+	} else {
+		fmt.Println(summaryRow("VPN Route", "", ""))
+	}
+
+	// KMS stack
+	if resources.KMS != nil {
+		fmt.Println(summaryRow("KMS Instance", resources.KMS.Name(), resources.KMS.KMSID()))
+	} else {
+		fmt.Println(summaryRow("KMS Instance", "", ""))
+	}
+	if resources.KMSKey != nil {
+		fmt.Println(summaryRow("KMS Key", resources.KMSKey.Name(), resources.KMSKey.KeyID()))
+	} else {
+		fmt.Println(summaryRow("KMS Key", "", ""))
+	}
+	if resources.Kmip != nil {
+		fmt.Println(summaryRow("KMIP Service", resources.Kmip.Name(), resources.Kmip.KmipID()))
+	} else {
+		fmt.Println(summaryRow("KMIP Service", "", ""))
+	}
+	if resources.KmipCert != nil {
+		fmt.Println("- KMIP Certificate: downloaded")
+	} else {
+		fmt.Println("- KMIP Certificate: <not created>")
 	}
 }

--- a/examples/all-resources/common.go
+++ b/examples/all-resources/common.go
@@ -25,6 +25,7 @@ const (
 	NameElasticIPCS               = "cs-eip"
 	NameElasticIPDBaaS            = "dbaas-eip"
 	NameElasticIPCR               = "cr-eip"
+	NameElasticIPVPN              = "vpn-eip"
 	NameBlockStorageCS            = "cs-bs"
 	NameBlockStorageCR            = "cr-bs"
 	NameBlockStorageRestoreTarget = "restore-target-bs"
@@ -120,6 +121,7 @@ type ResourceCollection struct {
 	CloudServerEIP           *aruba.ElasticIP    // used exclusively by CloudServer
 	DBaaSEIP                 *aruba.ElasticIP    // used exclusively by DBaaS
 	ContainerRegistryEIP     *aruba.ElasticIP    // used exclusively by ContainerRegistry
+	VPNTunnelEIP             *aruba.ElasticIP    // used exclusively by VPN Tunnel ipConfigurations
 	CloudServerBlockStorage  *aruba.BlockStorage // boot volume for CloudServer
 	ContainerRegistryStorage *aruba.BlockStorage // storage for ContainerRegistry
 	RestoreTargetStorage     *aruba.BlockStorage // dedicated unattached volume used as Restore destination

--- a/examples/all-resources/orchestrator_create.go
+++ b/examples/all-resources/orchestrator_create.go
@@ -132,7 +132,7 @@ func createAllResources(ctx context.Context, arubaClient aruba.Client) *Resource
 	printPhase(7, 8, "VPN stack")
 
 	// 19. Create VPN Tunnel (self-wait included).
-	resources.VPNTunnel = createVPNTunnel(ctx, arubaClient, resources.Project, resources.VPC, resources.SubnetBasic, resources.VPNTunnelEIP)
+	resources.VPNTunnel = createVPNTunnel(ctx, arubaClient, resources.Project, resources.VPC, resources.VPNTunnelEIP)
 
 	if resources.VPNTunnel != nil {
 		// 20. Create VPN Route under the tunnel (self-wait + GET inspection for #308 included).

--- a/examples/all-resources/orchestrator_create.go
+++ b/examples/all-resources/orchestrator_create.go
@@ -41,6 +41,7 @@ func createAllResources(ctx context.Context, arubaClient aruba.Client) *Resource
 	resources.CloudServerEIP = createElasticIP(ctx, arubaClient, resources.Project, resourceName(NameElasticIPCS))
 	resources.DBaaSEIP = createElasticIP(ctx, arubaClient, resources.Project, resourceName(NameElasticIPDBaaS))
 	resources.ContainerRegistryEIP = createElasticIP(ctx, arubaClient, resources.Project, resourceName(NameElasticIPCR))
+	resources.VPNTunnelEIP = createElasticIP(ctx, arubaClient, resources.Project, resourceName(NameElasticIPVPN))
 
 	// 3. Create Block Storage volumes — one per consumer.
 	resources.CloudServerBlockStorage = createBlockStorage(ctx, arubaClient, resources.Project, resourceName(NameBlockStorageCS))
@@ -131,7 +132,7 @@ func createAllResources(ctx context.Context, arubaClient aruba.Client) *Resource
 	printPhase(7, 8, "VPN stack")
 
 	// 19. Create VPN Tunnel (self-wait included).
-	resources.VPNTunnel = createVPNTunnel(ctx, arubaClient, resources.Project)
+	resources.VPNTunnel = createVPNTunnel(ctx, arubaClient, resources.Project, resources.VPC, resources.SubnetBasic, resources.VPNTunnelEIP)
 
 	if resources.VPNTunnel != nil {
 		// 20. Create VPN Route under the tunnel (self-wait + GET inspection for #308 included).

--- a/examples/all-resources/orchestrator_create.go
+++ b/examples/all-resources/orchestrator_create.go
@@ -136,7 +136,7 @@ func createAllResources(ctx context.Context, arubaClient aruba.Client) *Resource
 
 	if resources.VPNTunnel != nil {
 		// 20. Create VPN Route under the tunnel (self-wait + GET inspection for #308 included).
-		resources.VPNRoute = createVPNRoute(ctx, arubaClient, resources.VPNTunnel)
+		resources.VPNRoute = createVPNRoute(ctx, arubaClient, resources.VPNTunnel, resources.SubnetBasic)
 	}
 
 	printPhase(8, 8, "KMS stack")

--- a/examples/all-resources/orchestrator_create.go
+++ b/examples/all-resources/orchestrator_create.go
@@ -30,12 +30,12 @@ func runCreateExample(clientID, clientSecret string, debug bool) {
 func createAllResources(ctx context.Context, arubaClient aruba.Client) *ResourceCollection {
 	resources := &ResourceCollection{}
 
-	printPhase(1, 7, "Account & isolation")
+	printPhase(1, 8, "Account & isolation")
 
 	// 1. Create Project.
 	resources.Project = createProject(ctx, arubaClient)
 
-	printPhase(2, 7, "Independent network & storage primitives")
+	printPhase(2, 8, "Independent network & storage primitives")
 
 	// 2. Create Elastic IPs — one per consumer to avoid attach-state conflicts.
 	resources.CloudServerEIP = createElasticIP(ctx, arubaClient, resources.Project, resourceName(NameElasticIPCS))
@@ -52,7 +52,7 @@ func createAllResources(ctx context.Context, arubaClient aruba.Client) *Resource
 	// 5. Create VPC (self-wait included).
 	resources.VPC = createVPC(ctx, arubaClient, resources.Project)
 
-	printPhase(3, 7, "VPC-scoped network")
+	printPhase(3, 8, "VPC-scoped network")
 
 	// 6. Create Subnets in VPC (pre-dep VPC Active + self-wait included).
 	resources.SubnetAdvanced = createAdvancedSubnet(ctx, arubaClient, resources.VPC)
@@ -81,7 +81,7 @@ func createAllResources(ctx context.Context, arubaClient aruba.Client) *Resource
 	// 9. Create SSH Key Pair (self-wait included).
 	resources.KeyPair = createKeyPair(ctx, arubaClient, resources.Project)
 
-	printPhase(4, 7, "Database stack")
+	printPhase(4, 8, "Database stack")
 
 	// 10. Create DBaaS (pre-dep waits + self-wait + EIP post-dep all included).
 	resources.DBaaS = createDBaaS(ctx, arubaClient, resources.Project, resources.VPC, resources.SubnetBasic, resources.SecurityGroup, resources.DBaaSEIP)
@@ -95,7 +95,7 @@ func createAllResources(ctx context.Context, arubaClient aruba.Client) *Resource
 		}
 	}
 
-	printPhase(5, 7, "Compute & container platforms")
+	printPhase(5, 8, "Compute & container platforms")
 
 	// 12. Create KaaS (pre-dep waits + self-wait included).
 	resources.KaaS = createKaaS(ctx, arubaClient, resources.Project, resources.VPC, resources.SubnetBasic)
@@ -114,7 +114,7 @@ func createAllResources(ctx context.Context, arubaClient aruba.Client) *Resource
 	// 15. Create Container Registry (pre-dep waits + self-wait + EIP/BS post-deps all included).
 	resources.ContainerRegistry = createContainerRegistry(ctx, arubaClient, resources)
 
-	printPhase(6, 7, "Backup & restore")
+	printPhase(6, 8, "Backup & restore")
 
 	// 16. Create Storage Backup (pre-dep + self-wait included).
 	resources.Backup = createStorageBackup(ctx, arubaClient, resources.Project, resources.CloudServerBlockStorage)
@@ -128,7 +128,17 @@ func createAllResources(ctx context.Context, arubaClient aruba.Client) *Resource
 	// 18. Create Restore from Backup (pre-dep waits + self-wait included).
 	resources.Restore = createRestore(ctx, arubaClient, resources.Backup, resources.RestoreTargetStorage)
 
-	printPhase(7, 7, "KMS stack")
+	printPhase(7, 8, "VPN stack")
+
+	// 19. Create VPN Tunnel (self-wait included).
+	resources.VPNTunnel = createVPNTunnel(ctx, arubaClient, resources.Project)
+
+	if resources.VPNTunnel != nil {
+		// 20. Create VPN Route under the tunnel (self-wait + GET inspection for #308 included).
+		resources.VPNRoute = createVPNRoute(ctx, arubaClient, resources.VPNTunnel)
+	}
+
+	printPhase(8, 8, "KMS stack")
 
 	// 19. Create KMS Instance (self-wait included).
 	resources.KMS = createKMS(ctx, arubaClient, resources.Project)

--- a/examples/all-resources/orchestrator_delete.go
+++ b/examples/all-resources/orchestrator_delete.go
@@ -253,6 +253,27 @@ func fetchAllResources(ctx context.Context, arubaClient aruba.Client, proj *arub
 		}
 	}
 
+	// VPN tunnel + first route (the delete orchestrator deletes the route then the tunnel).
+	vpnTunnelList, err := arubaClient.FromNetwork().VPNTunnels().List(ctx, proj)
+	if err == nil && vpnTunnelList.Total() > 0 {
+		tunnelRef := vpnTunnelList.Items()[0]
+		tunnelResp, err := arubaClient.FromNetwork().VPNTunnels().Get(ctx, tunnelRef)
+		if err == nil {
+			resources.VPNTunnel = tunnelResp
+			fmt.Printf("✓ Found VPN Tunnel: %s\n", tunnelResp.Name())
+
+			routeList, err := arubaClient.FromNetwork().VPNRoutes().List(ctx, tunnelResp)
+			if err == nil && routeList.Total() > 0 {
+				routeResp, err := arubaClient.FromNetwork().VPNRoutes().Get(ctx, routeList.Items()[0])
+				if err == nil {
+					resources.VPNRoute = routeResp
+					fmt.Printf("✓ Found VPN Route: %s (cloudSubnet=%s)\n",
+						routeResp.Name(), routeResp.CloudSubnetCIDR())
+				}
+			}
+		}
+	}
+
 	return resources
 }
 
@@ -302,6 +323,9 @@ func printDeletionInventory(r *ResourceCollection) {
 
 	fmt.Printf("  Block Storages: %d  Elastic IPs: %d\n",
 		len(r.BlockStorages), len(r.ElasticIPs))
+
+	fmt.Printf("  VPN Tunnel: %d  VPN Route: %d\n",
+		count(r.VPNTunnel != nil), count(r.VPNRoute != nil))
 }
 
 // deleteAllResources deletes all resources in strict inverse of the creation order
@@ -311,8 +335,18 @@ func printDeletionInventory(r *ResourceCollection) {
 func deleteAllResources(ctx context.Context, arubaClient aruba.Client, resources *ResourceCollection) {
 	fmt.Println("\n=== Deleting Resources ===")
 
-	// Phase 1/7: KMS stack (inverse of create Phase 7: KMS → KMSKey → KMIP).
-	printPhase(1, 7, "KMS stack")
+	// Phase 1/8: VPN stack (inverse of create Phase 7: VPNRoute → VPNTunnel).
+	printPhase(1, 8, "VPN stack")
+
+	if resources.VPNRoute != nil && resources.VPNRoute.VPNRouteID() != "" {
+		withDeleteDeadline(ctx, func(c context.Context) { deleteVPNRoute(c, arubaClient, resources.VPNRoute) })
+	}
+	if resources.VPNTunnel != nil && resources.VPNTunnel.VPNTunnelID() != "" {
+		withDeleteDeadline(ctx, func(c context.Context) { deleteVPNTunnel(c, arubaClient, resources.VPNTunnel) })
+	}
+
+	// Phase 2/8: KMS stack (inverse of create Phase 8: KMS → KMSKey → KMIP).
+	printPhase(2, 8, "KMS stack")
 
 	if resources.Kmip != nil && resources.Kmip.KmipID() != "" {
 		withDeleteDeadline(ctx, func(c context.Context) { deleteKmip(c, arubaClient, resources.Kmip) })
@@ -324,9 +358,9 @@ func deleteAllResources(ctx context.Context, arubaClient aruba.Client, resources
 		withDeleteDeadline(ctx, func(c context.Context) { deleteKMS(c, arubaClient, resources.KMS) })
 	}
 
-	// Phase 2/7: Backup & restore (inverse of create Phase 6: Restore → Backup).
-	// RestoreTargetStorage is a BlockStorage; it falls into Phase 6 with all other volumes.
-	printPhase(2, 7, "Backup & restore")
+	// Phase 3/8: Backup & restore (inverse of create Phase 6: Restore → Backup).
+	// RestoreTargetStorage is a BlockStorage; it falls into Phase 7 with all other volumes.
+	printPhase(3, 8, "Backup & restore")
 
 	if resources.Restore != nil && resources.Restore.RestoreID() != "" {
 		withDeleteDeadline(ctx, func(c context.Context) { deleteRestore(c, arubaClient, resources.Restore) })
@@ -335,9 +369,9 @@ func deleteAllResources(ctx context.Context, arubaClient aruba.Client, resources
 		withDeleteDeadline(ctx, func(c context.Context) { deleteStorageBackup(c, arubaClient, resources.Backup) })
 	}
 
-	// Phase 3/7: Compute & container platforms (inverse of create Phase 5:
+	// Phase 4/8: Compute & container platforms (inverse of create Phase 5:
 	// ContainerRegistry → Jobs → CloudServer → KaaS).
-	printPhase(3, 7, "Compute & container platforms")
+	printPhase(4, 8, "Compute & container platforms")
 
 	if resources.ContainerRegistry != nil && resources.ContainerRegistry.ContainerRegistryID() != "" {
 		withDeleteDeadline(ctx, func(c context.Context) {
@@ -357,9 +391,9 @@ func deleteAllResources(ctx context.Context, arubaClient aruba.Client, resources
 		withDeleteDeadline(ctx, func(c context.Context) { deleteKaaS(c, arubaClient, resources.KaaS) })
 	}
 
-	// Phase 4/7: Database stack (inverse of create Phase 4:
+	// Phase 5/8: Database stack (inverse of create Phase 4:
 	// Grant → DBaaSUser → Database → DBaaS).
-	printPhase(4, 7, "Database stack")
+	printPhase(5, 8, "Database stack")
 
 	if resources.Grant != nil && resources.Grant.ID() != "" {
 		withDeleteDeadline(ctx, func(c context.Context) { deleteGrant(c, arubaClient, resources.Grant) })
@@ -374,9 +408,9 @@ func deleteAllResources(ctx context.Context, arubaClient aruba.Client, resources
 		withDeleteDeadline(ctx, func(c context.Context) { deleteDBaaS(c, arubaClient, resources.DBaaS) })
 	}
 
-	// Phase 5/7: VPC-scoped network (inverse of create Phase 3:
+	// Phase 6/8: VPC-scoped network (inverse of create Phase 3:
 	// KeyPair → Rules (egress, ingress) → SecurityGroup → Subnets (Basic, Advanced)).
-	printPhase(5, 7, "VPC-scoped network")
+	printPhase(6, 8, "VPC-scoped network")
 
 	if resources.KeyPair != nil && resources.KeyPair.KeyPairID() != "" {
 		withDeleteDeadline(ctx, func(c context.Context) { deleteKeyPair(c, arubaClient, resources.KeyPair) })
@@ -402,9 +436,9 @@ func deleteAllResources(ctx context.Context, arubaClient aruba.Client, resources
 		withDeleteDeadline(ctx, func(c context.Context) { deleteAdvancedSubnet(c, arubaClient, resources.SubnetAdvanced) })
 	}
 
-	// Phase 6/7: Independent network & storage primitives (inverse of create Phase 2:
+	// Phase 7/8: Independent network & storage primitives (inverse of create Phase 2:
 	// VPC → Snapshot → BlockStorages → ElasticIPs).
-	printPhase(6, 7, "Independent network & storage primitives")
+	printPhase(7, 8, "Independent network & storage primitives")
 
 	if resources.VPC != nil {
 		withDeleteDeadline(ctx, func(c context.Context) { deleteVPC(c, arubaClient, resources.VPC) })
@@ -421,8 +455,8 @@ func deleteAllResources(ctx context.Context, arubaClient aruba.Client, resources
 		withDeleteDeadline(ctx, func(c context.Context) { deleteElasticIP(c, arubaClient, eip) })
 	}
 
-	// Phase 7/7: Account & isolation (inverse of create Phase 1).
-	printPhase(7, 7, "Account & isolation")
+	// Phase 8/8: Account & isolation (inverse of create Phase 1).
+	printPhase(8, 8, "Account & isolation")
 
 	if resources.Project != nil {
 		withDeleteDeadline(ctx, func(c context.Context) { deleteProject(c, arubaClient, resources.Project) })

--- a/examples/all-resources/resource_container_registry.go
+++ b/examples/all-resources/resource_container_registry.go
@@ -3,7 +3,6 @@ package main
 import (
 	"context"
 	"fmt"
-	"os"
 
 	"github.com/Arubacloud/sdk-go/pkg/aruba"
 )
@@ -23,21 +22,12 @@ func createContainerRegistry(ctx context.Context, arubaClient aruba.Client, reso
 		return nil
 	}
 
-	// SDK_EXAMPLE_REGISTRY_PASSWORD sets the admin password for the container registry.
-	// The provisioner requires a password alongside the username; without it the resource
-	// is accepted (HTTP 201) but silently transitions to Failed during async provisioning.
-	registryPassword := os.Getenv("SDK_EXAMPLE_REGISTRY_PASSWORD")
-	if registryPassword == "" {
-		registryPassword = "Adm1n@Registry!" // fallback for local convenience only — override via env var
-	}
-
 	r := aruba.NewContainerRegistry().
 		OfSize(aruba.ContainerRegistrySizeFlavorSmall).
 		Named(resourceName(NameContainerRegistry)).
 		InProject(resources.Project).
 		InRegion(aruba.RegionITBGBergamo).
 		WithAdminUsername("adminuser").
-		WithAdminPassword(registryPassword).
 		WithVPC(resources.VPC).
 		WithSubnet(resources.SubnetBasic).
 		WithSecurityGroup(resources.SecurityGroup).

--- a/examples/all-resources/resource_container_registry.go
+++ b/examples/all-resources/resource_container_registry.go
@@ -3,6 +3,7 @@ package main
 import (
 	"context"
 	"fmt"
+	"os"
 
 	"github.com/Arubacloud/sdk-go/pkg/aruba"
 )
@@ -22,12 +23,21 @@ func createContainerRegistry(ctx context.Context, arubaClient aruba.Client, reso
 		return nil
 	}
 
+	// SDK_EXAMPLE_REGISTRY_PASSWORD sets the admin password for the container registry.
+	// The provisioner requires a password alongside the username; without it the resource
+	// is accepted (HTTP 201) but silently transitions to Failed during async provisioning.
+	registryPassword := os.Getenv("SDK_EXAMPLE_REGISTRY_PASSWORD")
+	if registryPassword == "" {
+		registryPassword = "Adm1n@Registry!" // fallback for local convenience only — override via env var
+	}
+
 	r := aruba.NewContainerRegistry().
 		OfSize(aruba.ContainerRegistrySizeFlavorSmall).
 		Named(resourceName(NameContainerRegistry)).
 		InProject(resources.Project).
 		InRegion(aruba.RegionITBGBergamo).
 		WithAdminUsername("adminuser").
+		WithAdminPassword(registryPassword).
 		WithVPC(resources.VPC).
 		WithSubnet(resources.SubnetBasic).
 		WithSecurityGroup(resources.SecurityGroup).

--- a/examples/all-resources/resource_grant.go
+++ b/examples/all-resources/resource_grant.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/Arubacloud/sdk-go/pkg/aruba"
 )
@@ -20,7 +21,7 @@ func createGrant(ctx context.Context, arubaClient aruba.Client, db *aruba.Databa
 		printCreateError("DBaaS Grant", err)
 		return nil
 	}
-	printCreated("DBaaS Grant", res.Username(), res.ID())
+	fmt.Printf("✓ Created DBaaS Grant: %s on %s (%s)\n", res.Username(), res.DatabaseName(), res.RoleName())
 	return res
 }
 

--- a/examples/all-resources/resource_job.go
+++ b/examples/all-resources/resource_job.go
@@ -20,7 +20,6 @@ func createRecurringJob(ctx context.Context, arubaClient aruba.Client, proj arub
 		RecurringUntil(time.Now().AddDate(0, 2, 0)).
 		WithSteps(aruba.NewJobStep().
 			Named("poweroff-step").
-			OfTypology(aruba.JobStepTypologyCloudServer).
 			Targeting(target).
 			WithAction("poweroff").
 			WithVerb(aruba.HTTPVerbPOST)).
@@ -47,7 +46,6 @@ func createOneShotJob(ctx context.Context, arubaClient aruba.Client, proj aruba.
 		OneShotAt(time.Now().Add(24 * time.Hour)).
 		WithSteps(aruba.NewJobStep().
 			Named("poweroff-step").
-			OfTypology(aruba.JobStepTypologyCloudServer).
 			Targeting(target).
 			WithAction("poweroff").
 			WithVerb(aruba.HTTPVerbPOST)).

--- a/examples/all-resources/resource_job.go
+++ b/examples/all-resources/resource_job.go
@@ -16,7 +16,9 @@ func createRecurringJob(ctx context.Context, arubaClient aruba.Client, proj arub
 		Tagged("schedule", "recurring").
 		InProject(proj).
 		InRegion(aruba.RegionITBGBergamo).
+		OfType(aruba.JobTypeRecurring).
 		WithCron("0 10 * * *").
+		StartingAt(time.Now()).
 		RecurringUntil(time.Now().AddDate(0, 2, 0)).
 		WithSteps(aruba.NewJobStep().
 			Named("poweroff-step").
@@ -43,7 +45,8 @@ func createOneShotJob(ctx context.Context, arubaClient aruba.Client, proj aruba.
 		Tagged("schedule", "oneshot").
 		InProject(proj).
 		InRegion(aruba.RegionITBGBergamo).
-		OneShotAt(time.Now().Add(24 * time.Hour)).
+		OfType(aruba.JobTypeOneShot).
+		StartingAt(time.Now().Add(24 * time.Hour)).
 		WithSteps(aruba.NewJobStep().
 			Named("poweroff-step").
 			Targeting(target).

--- a/examples/all-resources/resource_job.go
+++ b/examples/all-resources/resource_job.go
@@ -20,6 +20,7 @@ func createRecurringJob(ctx context.Context, arubaClient aruba.Client, proj arub
 		RecurringUntil(time.Now().AddDate(0, 2, 0)).
 		WithSteps(aruba.NewJobStep().
 			Named("poweroff-step").
+			OfTypology(aruba.JobStepTypologyCloudServer).
 			Targeting(target).
 			WithAction("poweroff").
 			WithVerb(aruba.HTTPVerbPOST)).
@@ -46,6 +47,7 @@ func createOneShotJob(ctx context.Context, arubaClient aruba.Client, proj aruba.
 		OneShotAt(time.Now().Add(24 * time.Hour)).
 		WithSteps(aruba.NewJobStep().
 			Named("poweroff-step").
+			OfTypology(aruba.JobStepTypologyCloudServer).
 			Targeting(target).
 			WithAction("poweroff").
 			WithVerb(aruba.HTTPVerbPOST)).

--- a/examples/all-resources/resource_vpn_route.go
+++ b/examples/all-resources/resource_vpn_route.go
@@ -1,0 +1,57 @@
+package main
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/Arubacloud/sdk-go/pkg/aruba"
+)
+
+// createVPNRoute creates a VPN route under the given tunnel, routing the cloud subnet
+// 10.0.0.0/24 to the on-premises subnet 192.168.1.0/24.
+func createVPNRoute(ctx context.Context, arubaClient aruba.Client, tunnel *aruba.VPNTunnel) *aruba.VPNRoute {
+	name := resourceName(NameVPNRoute)
+	fmt.Printf("--- VPN Route (%s) ---\n", name)
+
+	route := aruba.NewVPNRoute().
+		Named(name).
+		Tagged("vpn", "route").
+		InVPNTunnel(tunnel).
+		InRegion(aruba.RegionITBGBergamo).
+		WithCloudSubnet("10.0.0.0/24").
+		WithOnPremSubnet("192.168.1.0/24")
+
+	created, err := arubaClient.FromNetwork().VPNRoutes().Create(ctx, route)
+	if err != nil {
+		printCreateError("VPN Route", err)
+		return nil
+	}
+	printCreated("VPN Route", created.Name(), created.ID(),
+		"cloudSubnet="+created.CloudSubnetCIDR(),
+		"onPremSubnet="+created.OnPremSubnet())
+
+	waitUntilSelfReady(ctx, "VPN Route", created.Name(), created, created.WaitUntilReady)
+
+	// GET the route back and print the raw JSON — used to inspect the CloudSubnet
+	// wire shape that the API returns on GET (for issue #308 diagnosis).
+	got, err := arubaClient.FromNetwork().VPNRoutes().Get(ctx, created)
+	if err != nil {
+		fmt.Printf("⚠ VPN Route GET failed (non-fatal): %v\n", err)
+	} else {
+		fmt.Printf("VPN Route GET CloudSubnetCIDR: %q\n", got.CloudSubnetCIDR())
+		fmt.Printf("VPN Route GET RawJSON:\n%s\n", string(got.RawJSON()))
+	}
+
+	return created
+}
+
+// deleteVPNRoute deletes a VPN route and waits for it to be fully removed.
+func deleteVPNRoute(ctx context.Context, arubaClient aruba.Client, route *aruba.VPNRoute) {
+	printDeleteBanner("VPN Route")
+	if err := arubaClient.FromNetwork().VPNRoutes().Delete(ctx, route); err != nil {
+		printDeleteError("VPN Route", err)
+		return
+	}
+	printDeleteSubmitted("VPN Route", route.Name())
+	waitUntilGone(ctx, "VPN Route "+route.Name(), route.WaitUntilGone)
+}

--- a/examples/all-resources/resource_vpn_route.go
+++ b/examples/all-resources/resource_vpn_route.go
@@ -7,18 +7,27 @@ import (
 	"github.com/Arubacloud/sdk-go/pkg/aruba"
 )
 
-// createVPNRoute creates a VPN route under the given tunnel, routing the cloud subnet
-// 10.0.0.0/24 to the on-premises subnet 192.168.1.0/24.
-func createVPNRoute(ctx context.Context, arubaClient aruba.Client, tunnel *aruba.VPNTunnel) *aruba.VPNRoute {
-	name := resourceName(NameVPNRoute)
-	fmt.Printf("--- VPN Route (%s) ---\n", name)
+// createVPNRoute creates a VPN route under the given tunnel, routing the Basic Subnet's
+// server-assigned CIDR to the on-premises subnet 192.168.1.0/24. The Basic Subnet must
+// reach Active so its CIDR is available before the route is created.
+func createVPNRoute(ctx context.Context, arubaClient aruba.Client, tunnel *aruba.VPNTunnel, subnet *aruba.Subnet) *aruba.VPNRoute {
+	printBanner("VPN Route", "")
 
+	if err := waitForDependencies(ctx, "VPN Route", map[string]depEntry{
+		"VPN Tunnel":     dep(tunnel, tunnel.WaitUntilActive),
+		"Subnet (Basic)": dep(subnet, subnet.WaitUntilActive),
+	}); err != nil {
+		printDepWaitError("VPN Route", err)
+		return nil
+	}
+
+	name := resourceName(NameVPNRoute)
 	route := aruba.NewVPNRoute().
 		Named(name).
 		Tagged("vpn-route", "route").
 		InVPNTunnel(tunnel).
 		InRegion(aruba.RegionITBGBergamo).
-		WithCloudSubnet("10.0.0.0/24").
+		WithCloudSubnet(subnet.CIDR()).
 		WithOnPremSubnet("192.168.1.0/24")
 
 	created, err := arubaClient.FromNetwork().VPNRoutes().Create(ctx, route)

--- a/examples/all-resources/resource_vpn_route.go
+++ b/examples/all-resources/resource_vpn_route.go
@@ -15,7 +15,7 @@ func createVPNRoute(ctx context.Context, arubaClient aruba.Client, tunnel *aruba
 
 	route := aruba.NewVPNRoute().
 		Named(name).
-		Tagged("vpn", "route").
+		Tagged("vpn-route", "route").
 		InVPNTunnel(tunnel).
 		InRegion(aruba.RegionITBGBergamo).
 		WithCloudSubnet("10.0.0.0/24").

--- a/examples/all-resources/resource_vpn_tunnel.go
+++ b/examples/all-resources/resource_vpn_tunnel.go
@@ -10,13 +10,13 @@ import (
 // createVPNTunnel creates a Site-to-Site VPN tunnel with IKEv2/AES-256/SHA-256 settings.
 // The peer IP and PSK use placeholder values suitable for a dry-run; replace them with
 // real values when running against a live peer.
-func createVPNTunnel(ctx context.Context, arubaClient aruba.Client, proj aruba.Ref, vpc *aruba.VPC, subnet *aruba.Subnet, eip *aruba.ElasticIP) *aruba.VPNTunnel {
+func createVPNTunnel(ctx context.Context, arubaClient aruba.Client, proj aruba.Ref, vpc *aruba.VPC, eip *aruba.ElasticIP) *aruba.VPNTunnel {
 	name := resourceName(NameVPNTunnel)
 	fmt.Printf("--- VPN Tunnel (%s) ---\n", name)
 
 	ipcfg := aruba.NewVPNIPConfig().
 		WithVPC(vpc).
-		WithSubnet(subnet.Name(), subnet.CIDR()).
+		WithSubnet(resourceName(NameVPNTunnel+"-subnet"), "192.168.10.0/24").
 		WithElasticIP(eip)
 
 	tunnel := aruba.NewVPNTunnel().

--- a/examples/all-resources/resource_vpn_tunnel.go
+++ b/examples/all-resources/resource_vpn_tunnel.go
@@ -1,0 +1,65 @@
+package main
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/Arubacloud/sdk-go/pkg/aruba"
+)
+
+// createVPNTunnel creates a Site-to-Site VPN tunnel with IKEv2/AES-256/SHA-256 settings.
+// The peer IP and PSK use placeholder values suitable for a dry-run; replace them with
+// real values when running against a live peer.
+func createVPNTunnel(ctx context.Context, arubaClient aruba.Client, proj aruba.Ref) *aruba.VPNTunnel {
+	name := resourceName(NameVPNTunnel)
+	fmt.Printf("--- VPN Tunnel (%s) ---\n", name)
+
+	tunnel := aruba.NewVPNTunnel().
+		OfType(aruba.VPNTypeSiteToSite).
+		Named(name).
+		Tagged("vpn", "network").
+		InProject(proj).
+		InRegion(aruba.RegionITBGBergamo).
+		WithVPNClientProtocol(aruba.VPNClientProtocolIKEv2).
+		WithPeerClientPublicIP("203.0.113.1"). // TEST-NET-3, replace with real peer IP
+		WithIKESettings(aruba.NewVPNIKE().
+			WithEncryption(aruba.IKEEncryptionAES256).
+			WithHash(aruba.IKEHashSHA256).
+			WithDHGroup(aruba.IKEDHGroup14).
+			WithLifetimeSeconds(86400).
+			WithDPDAction(aruba.IKEDPDActionRestart).
+			WithDPDIntervalSeconds(30).
+			WithDPDTimeoutSeconds(120)).
+		WithESPSettings(aruba.NewVPNESP().
+			WithEncryption(aruba.ESPEncryptionAES256).
+			WithHash(aruba.ESPHashSHA256).
+			WithPFS(aruba.ESPPFSGroupDHGroup14).
+			WithLifetimeSeconds(3600)).
+		WithPSKSettings(aruba.NewVPNPSK().
+			WithCloudSite("cloud-side").
+			WithOnPremSite("onprem-side").
+			WithKey("example-psk-replace-in-production")).
+		BilledBy(aruba.BillingPeriodHour)
+
+	created, err := arubaClient.FromNetwork().VPNTunnels().Create(ctx, tunnel)
+	if err != nil {
+		printCreateError("VPN Tunnel", err)
+		return nil
+	}
+	printCreated("VPN Tunnel", created.Name(), created.ID())
+
+	waitUntilSelfReady(ctx, "VPN Tunnel", created.Name(), created, created.WaitUntilReady)
+
+	return created
+}
+
+// deleteVPNTunnel deletes a VPN Tunnel and waits for it to be fully removed.
+func deleteVPNTunnel(ctx context.Context, arubaClient aruba.Client, tunnel *aruba.VPNTunnel) {
+	printDeleteBanner("VPN Tunnel")
+	if err := arubaClient.FromNetwork().VPNTunnels().Delete(ctx, tunnel); err != nil {
+		printDeleteError("VPN Tunnel", err)
+		return
+	}
+	printDeleteSubmitted("VPN Tunnel", tunnel.Name())
+	waitUntilGone(ctx, "VPN Tunnel "+tunnel.Name(), tunnel.WaitUntilGone)
+}

--- a/examples/all-resources/resource_vpn_tunnel.go
+++ b/examples/all-resources/resource_vpn_tunnel.go
@@ -10,16 +10,22 @@ import (
 // createVPNTunnel creates a Site-to-Site VPN tunnel with IKEv2/AES-256/SHA-256 settings.
 // The peer IP and PSK use placeholder values suitable for a dry-run; replace them with
 // real values when running against a live peer.
-func createVPNTunnel(ctx context.Context, arubaClient aruba.Client, proj aruba.Ref) *aruba.VPNTunnel {
+func createVPNTunnel(ctx context.Context, arubaClient aruba.Client, proj aruba.Ref, vpc *aruba.VPC, subnet *aruba.Subnet, eip *aruba.ElasticIP) *aruba.VPNTunnel {
 	name := resourceName(NameVPNTunnel)
 	fmt.Printf("--- VPN Tunnel (%s) ---\n", name)
+
+	ipcfg := aruba.NewVPNIPConfig().
+		WithVPC(vpc).
+		WithSubnet(subnet.Name(), subnet.CIDR()).
+		WithElasticIP(eip)
 
 	tunnel := aruba.NewVPNTunnel().
 		OfType(aruba.VPNTypeSiteToSite).
 		Named(name).
-		Tagged("vpn", "network").
+		Tagged("vpn-tunnel", "network").
 		InProject(proj).
 		InRegion(aruba.RegionITBGBergamo).
+		WithIPConfig(ipcfg).
 		WithVPNClientProtocol(aruba.VPNClientProtocolIKEv2).
 		WithPeerClientPublicIP("203.0.113.1"). // TEST-NET-3, replace with real peer IP
 		WithIKESettings(aruba.NewVPNIKE().

--- a/internal/clients/audit/event_test.go
+++ b/internal/clients/audit/event_test.go
@@ -20,35 +20,35 @@ func TestListEvents(t *testing.T) {
 				w.WriteHeader(http.StatusOK)
 				resp := types.AuditEventListResponse{
 					ListResponse: types.ListResponse{Total: 1},
-					Values: []types.AuditEvent{
+					Values: []types.AuditEventResponse{
 						{
 							SeverityLevel: "Information",
-							LogFormat: types.LogFormatVersion{
+							LogFormat: types.EventLogFormatVersionResponse{
 								Version: "1.0",
 							},
 							Timestamp: time.Now(),
-							Operation: types.Operation{
+							Operation: types.EventOperationResponse{
 								ID:    "Microsoft.Compute/virtualMachines/start/action",
 								Value: ptr.To("Start Virtual Machine"),
 							},
-							Event: types.EventInfo{
+							Event: types.EventInfoResponse{
 								ID:    "event-123",
 								Value: ptr.To("Virtual Machine Started"),
 								Type:  "operational",
 							},
-							Category: types.EventCategory{
+							Category: types.EventCategoryResponse{
 								Value:       "Administrative",
 								Description: ptr.To("Administrative operations"),
 							},
 							Origin:  "user",
 							Channel: "Operation",
-							Status: types.Status{
+							Status: types.EventStatusResponse{
 								Value:       "Succeeded",
 								Description: ptr.To("Operation completed successfully"),
 								Code:        ptr.To(int32(200)),
 							},
-							Identity: types.Identity{
-								Caller: types.Caller{
+							Identity: types.EventIdentityResponse{
+								Caller: types.EventCallerResponse{
 									Subject:  "user@example.com",
 									Username: ptr.To("testuser"),
 									Company:  ptr.To("TestCompany"),
@@ -87,7 +87,7 @@ func TestListEvents(t *testing.T) {
 				w.WriteHeader(http.StatusOK)
 				resp := types.AuditEventListResponse{
 					ListResponse: types.ListResponse{Total: 0},
-					Values:       []types.AuditEvent{},
+					Values:       []types.AuditEventResponse{},
 				}
 				json.NewEncoder(w).Encode(resp)
 				return
@@ -117,18 +117,18 @@ func TestListEvents(t *testing.T) {
 				w.WriteHeader(http.StatusOK)
 				resp := types.AuditEventListResponse{
 					ListResponse: types.ListResponse{Total: 100},
-					Values: []types.AuditEvent{
+					Values: []types.AuditEventResponse{
 						{
 							SeverityLevel: "Warning",
-							LogFormat:     types.LogFormatVersion{Version: "1.0"},
+							LogFormat:     types.EventLogFormatVersionResponse{Version: "1.0"},
 							Timestamp:     time.Now(),
-							Operation:     types.Operation{ID: "test-operation"},
-							Event:         types.EventInfo{ID: "event-456", Type: "operational"},
-							Category:      types.EventCategory{Value: "Security"},
+							Operation:     types.EventOperationResponse{ID: "test-operation"},
+							Event:         types.EventInfoResponse{ID: "event-456", Type: "operational"},
+							Category:      types.EventCategoryResponse{Value: "Security"},
 							Origin:        "system",
 							Channel:       "Security",
-							Status:        types.Status{Value: "Failed", Code: ptr.To(int32(403))},
-							Identity:      types.Identity{Caller: types.Caller{Subject: "system"}},
+							Status:        types.EventStatusResponse{Value: "Failed", Code: ptr.To(int32(403))},
+							Identity:      types.EventIdentityResponse{Caller: types.EventCallerResponse{Subject: "system"}},
 						},
 					},
 				}

--- a/internal/clients/compute/cloudserver.go
+++ b/internal/clients/compute/cloudserver.go
@@ -23,7 +23,7 @@ func NewCloudServersClientImpl(client *restclient.Client) *cloudServersClientImp
 }
 
 // List retrieves all cloud servers for a project
-func (c *cloudServersClientImpl) List(ctx context.Context, projectID string, params *types.RequestParameters) (*types.Response[types.CloudServerList], error) {
+func (c *cloudServersClientImpl) List(ctx context.Context, projectID string, params *types.RequestParameters) (*types.Response[types.CloudServerListResponse], error) {
 	c.client.Logger().Debugf("Listing cloud servers for project: %s", projectID)
 
 	if err := types.ValidateProject(projectID); err != nil {
@@ -49,7 +49,7 @@ func (c *cloudServersClientImpl) List(ctx context.Context, projectID string, par
 	}
 	defer httpResp.Body.Close()
 
-	return types.ParseResponseBody[types.CloudServerList](httpResp, c.client.Logger())
+	return types.ParseResponseBody[types.CloudServerListResponse](httpResp, c.client.Logger())
 }
 
 // Get retrieves a specific cloud server by ID

--- a/internal/clients/compute/cloudserver_test.go
+++ b/internal/clients/compute/cloudserver_test.go
@@ -234,8 +234,8 @@ func TestCloudServerRequestOmitsOptionalFields(t *testing.T) {
 			},
 			Properties: types.CloudServerPropertiesRequest{
 				Zone: "ITBG-1",
-				VPC:  types.ReferenceResource{URI: "/vpcs/123"},
-				BootVolume: types.ReferenceResource{
+				VPC:  types.ReferenceResourceCommon{URI: "/vpcs/123"},
+				BootVolume: types.ReferenceResourceCommon{
 					URI: "/blockStorages/456",
 				},
 			},
@@ -532,7 +532,7 @@ func TestPowerOnCloudServer(t *testing.T) {
 			resp := types.CloudServerResponse{
 				Metadata:   types.ResourceMetadataResponse{Name: ptr.To("my-server")},
 				Properties: types.CloudServerPropertiesResponse{Zone: "ITBG-1"},
-				Status:     types.ResourceStatus{State: statePtr(types.State("active"))},
+				Status:     types.ResourceStatusResponse{State: statePtr(types.State("active"))},
 			}
 			json.NewEncoder(w).Encode(resp)
 		})
@@ -637,7 +637,7 @@ func TestPowerOffCloudServer(t *testing.T) {
 			resp := types.CloudServerResponse{
 				Metadata:   types.ResourceMetadataResponse{Name: ptr.To("my-server")},
 				Properties: types.CloudServerPropertiesResponse{Zone: "ITBG-1"},
-				Status:     types.ResourceStatus{State: statePtr(types.State("stopped"))},
+				Status:     types.ResourceStatusResponse{State: statePtr(types.State("stopped"))},
 			}
 			json.NewEncoder(w).Encode(resp)
 		})

--- a/internal/clients/compute/cloudserver_test.go
+++ b/internal/clients/compute/cloudserver_test.go
@@ -22,7 +22,7 @@ func TestListCloudServers(t *testing.T) {
 		server := testutil.NewMockServer(t, func(w http.ResponseWriter, r *http.Request) {
 			apiCalled = true
 			w.WriteHeader(http.StatusOK)
-			resp := types.CloudServerList{
+			resp := types.CloudServerListResponse{
 				ListResponse: types.ListResponse{Total: 2},
 				Values: []types.CloudServerResponse{
 					{Metadata: types.ResourceMetadataResponse{Name: ptr.To("server-1")}},
@@ -130,7 +130,7 @@ func TestGetCloudServer(t *testing.T) {
 			w.WriteHeader(http.StatusOK)
 			resp := types.CloudServerResponse{
 				Metadata:   types.ResourceMetadataResponse{Name: ptr.To("my-server")},
-				Properties: types.CloudServerPropertiesResult{Zone: "ITBG-1"},
+				Properties: types.CloudServerPropertiesResponse{Zone: "ITBG-1"},
 			}
 			json.NewEncoder(w).Encode(resp)
 		})
@@ -531,7 +531,7 @@ func TestPowerOnCloudServer(t *testing.T) {
 			w.WriteHeader(http.StatusOK)
 			resp := types.CloudServerResponse{
 				Metadata:   types.ResourceMetadataResponse{Name: ptr.To("my-server")},
-				Properties: types.CloudServerPropertiesResult{Zone: "ITBG-1"},
+				Properties: types.CloudServerPropertiesResponse{Zone: "ITBG-1"},
 				Status:     types.ResourceStatus{State: statePtr(types.State("active"))},
 			}
 			json.NewEncoder(w).Encode(resp)
@@ -636,7 +636,7 @@ func TestPowerOffCloudServer(t *testing.T) {
 			w.WriteHeader(http.StatusOK)
 			resp := types.CloudServerResponse{
 				Metadata:   types.ResourceMetadataResponse{Name: ptr.To("my-server")},
-				Properties: types.CloudServerPropertiesResult{Zone: "ITBG-1"},
+				Properties: types.CloudServerPropertiesResponse{Zone: "ITBG-1"},
 				Status:     types.ResourceStatus{State: statePtr(types.State("stopped"))},
 			}
 			json.NewEncoder(w).Encode(resp)

--- a/internal/clients/compute/path.go
+++ b/internal/clients/compute/path.go
@@ -1,6 +1,11 @@
 package compute
 
-// API path constants for compute resources
+// Path constants follow the server-canonical lowerCamelCase rule:
+//   - Compound collections use lowerCamelCase: cloudServers, keyPairs.
+//
+// Do not flatten these to all-lowercase. Downstream provisioners store and re-emit
+// request URIs verbatim, so a casing change causes silent provisioning failures.
+// Verified via examples/all-resources/ create.log (2026-05-28, commit f548a4f alignment).
 const (
 	// CloudServer paths
 	CloudServersPath        = "/projects/%s/providers/Aruba.Compute/cloudServers"

--- a/internal/clients/container/containerregistry.go
+++ b/internal/clients/container/containerregistry.go
@@ -25,7 +25,7 @@ func NewContainerRegistryClientImpl(client *restclient.Client) *containerRegistr
 }
 
 // List retrieves all Container Registries for a project
-func (c *containerRegistryClientImpl) List(ctx context.Context, projectID string, params *types.RequestParameters) (*types.Response[types.ContainerRegistryList], error) {
+func (c *containerRegistryClientImpl) List(ctx context.Context, projectID string, params *types.RequestParameters) (*types.Response[types.ContainerRegistryListResponse], error) {
 	c.client.Logger().Debugf("Listing Container Registries for project: %s", projectID)
 
 	if err := types.ValidateProject(projectID); err != nil {
@@ -51,7 +51,7 @@ func (c *containerRegistryClientImpl) List(ctx context.Context, projectID string
 	}
 	defer httpResp.Body.Close()
 
-	return types.ParseResponseBody[types.ContainerRegistryList](httpResp, c.client.Logger())
+	return types.ParseResponseBody[types.ContainerRegistryListResponse](httpResp, c.client.Logger())
 }
 
 // Get retrieves a specific Container Registry by ID

--- a/internal/clients/container/containerregistry_test.go
+++ b/internal/clients/container/containerregistry_test.go
@@ -26,31 +26,31 @@ func TestListContainerRegistry(t *testing.T) {
 								Name: ptr.To("test-registry"),
 							},
 							Properties: types.ContainerRegistryPropertiesResponse{
-								VPC: types.ReferenceResource{
+								VPC: types.ReferenceResourceCommon{
 									URI: *ptr.To("/projects/test-project/providers/Aruba.Network/vpcs/vpc-1"),
 								},
-								Subnet: types.ReferenceResource{
+								Subnet: types.ReferenceResourceCommon{
 									URI: *ptr.To("/projects/test-project/providers/Aruba.Network/vpcs/vpc-1/subnets/subnet-124"),
 								},
-								SecurityGroup: types.ReferenceResource{
+								SecurityGroup: types.ReferenceResourceCommon{
 									URI: *ptr.To("/projects/test-project/providers/Aruba.Network/vpcs/vpc-1/securityGroups/sg-67890"),
 								},
-								PublicIp: types.ReferenceResource{
+								PublicIp: types.ReferenceResourceCommon{
 									URI: *ptr.To("/projects/test-project/providers/Aruba.Network/elasticips/eip-12345"),
 								},
-								BlockStorage: types.ReferenceResource{
+								BlockStorage: types.ReferenceResourceCommon{
 									URI: *ptr.To("/projects/test-project/providers/Aruba.Storage/blockStorages/bs-54321"),
 								},
-								BillingPlan: func() *types.BillingPlan {
+								BillingPlanCommon: func() *types.BillingPlanCommon {
 									v := types.BillingPeriodHour
-									return &types.BillingPlan{BillingPeriod: &v}
+									return &types.BillingPlanCommon{BillingPeriod: &v}
 								}(),
 								AdminUser: &types.UserCredentialCommon{
 									Username: "admin",
 								},
 								ConcurrentUsers: ptr.To("100"),
 							},
-							Status: types.ResourceStatus{
+							Status: types.ResourceStatusResponse{
 								State: ptr.To(types.State("active")),
 							},
 						},
@@ -98,8 +98,8 @@ func TestListContainerRegistry(t *testing.T) {
 		if resp.Data.Values[0].Properties.BlockStorage.URI != "/projects/test-project/providers/Aruba.Storage/blockStorages/bs-54321" {
 			t.Errorf("expected BlockStorage URI")
 		}
-		if resp.Data.Values[0].Properties.BillingPlan == nil || resp.Data.Values[0].Properties.BillingPlan.BillingPeriod == nil || *resp.Data.Values[0].Properties.BillingPlan.BillingPeriod != "Hour" {
-			t.Errorf("expected BillingPlan.BillingPeriod Hour")
+		if resp.Data.Values[0].Properties.BillingPlanCommon == nil || resp.Data.Values[0].Properties.BillingPlanCommon.BillingPeriod == nil || *resp.Data.Values[0].Properties.BillingPlanCommon.BillingPeriod != "Hour" {
+			t.Errorf("expected BillingPlanCommon.BillingPeriod Hour")
 		}
 		if resp.Data.Values[0].Properties.AdminUser == nil || resp.Data.Values[0].Properties.AdminUser.Username != "admin" {
 			t.Errorf("expected AdminUser username")
@@ -194,31 +194,31 @@ func TestGetContainerRegistry(t *testing.T) {
 						ID:   ptr.To("registry-123"),
 					},
 					Properties: types.ContainerRegistryPropertiesResponse{
-						VPC: types.ReferenceResource{
+						VPC: types.ReferenceResourceCommon{
 							URI: *ptr.To("/projects/test-project/providers/Aruba.Network/vpcs/vpc-1"),
 						},
-						Subnet: types.ReferenceResource{
+						Subnet: types.ReferenceResourceCommon{
 							URI: *ptr.To("/projects/test-project/providers/Aruba.Network/vpcs/vpc-1/subnets/subnet-124"),
 						},
-						SecurityGroup: types.ReferenceResource{
+						SecurityGroup: types.ReferenceResourceCommon{
 							URI: *ptr.To("/projects/test-project/providers/Aruba.Network/vpcs/vpc-1/securityGroups/sg-67890"),
 						},
-						PublicIp: types.ReferenceResource{
+						PublicIp: types.ReferenceResourceCommon{
 							URI: *ptr.To("/projects/test-project/providers/Aruba.Network/elasticips/eip-12345"),
 						},
-						BlockStorage: types.ReferenceResource{
+						BlockStorage: types.ReferenceResourceCommon{
 							URI: *ptr.To("/projects/test-project/providers/Aruba.Storage/blockStorages/bs-54321"),
 						},
-						BillingPlan: func() *types.BillingPlan {
+						BillingPlanCommon: func() *types.BillingPlanCommon {
 							v := types.BillingPeriodHour
-							return &types.BillingPlan{BillingPeriod: &v}
+							return &types.BillingPlanCommon{BillingPeriod: &v}
 						}(),
 						AdminUser: &types.UserCredentialCommon{
 							Username: "admin",
 						},
 						ConcurrentUsers: ptr.To("100"),
 					},
-					Status: types.ResourceStatus{
+					Status: types.ResourceStatusResponse{
 						State: ptr.To(types.State("active")),
 					},
 				}
@@ -255,8 +255,8 @@ func TestGetContainerRegistry(t *testing.T) {
 		if resp.Data.Properties.BlockStorage.URI != "/projects/test-project/providers/Aruba.Storage/blockStorages/bs-54321" {
 			t.Errorf("expected BlockStorage URI")
 		}
-		if resp.Data.Properties.BillingPlan == nil || resp.Data.Properties.BillingPlan.BillingPeriod == nil || *resp.Data.Properties.BillingPlan.BillingPeriod != "Hour" {
-			t.Errorf("expected BillingPlan.BillingPeriod Hour")
+		if resp.Data.Properties.BillingPlanCommon == nil || resp.Data.Properties.BillingPlanCommon.BillingPeriod == nil || *resp.Data.Properties.BillingPlanCommon.BillingPeriod != "Hour" {
+			t.Errorf("expected BillingPlanCommon.BillingPeriod Hour")
 		}
 		if resp.Data.Properties.AdminUser == nil || resp.Data.Properties.AdminUser.Username != "admin" {
 			t.Errorf("expected AdminUser username")
@@ -353,31 +353,31 @@ func TestCreateContainerRegistry(t *testing.T) {
 						URI:  ptr.To("/projects/test-project/providers/Aruba.Container/registries/registry-456"),
 					},
 					Properties: types.ContainerRegistryPropertiesResponse{
-						VPC: types.ReferenceResource{
+						VPC: types.ReferenceResourceCommon{
 							URI: *ptr.To("/projects/test-project/providers/Aruba.Network/vpcs/vpc-1"),
 						},
-						Subnet: types.ReferenceResource{
+						Subnet: types.ReferenceResourceCommon{
 							URI: *ptr.To("/projects/test-project/providers/Aruba.Network/vpcs/vpc-1/subnets/subnet-124"),
 						},
-						SecurityGroup: types.ReferenceResource{
+						SecurityGroup: types.ReferenceResourceCommon{
 							URI: *ptr.To("/projects/test-project/providers/Aruba.Network/vpcs/vpc-1/securityGroups/sg-67890"),
 						},
-						PublicIp: types.ReferenceResource{
+						PublicIp: types.ReferenceResourceCommon{
 							URI: *ptr.To("/projects/test-project/providers/Aruba.Network/elasticips/eip-12345"),
 						},
-						BlockStorage: types.ReferenceResource{
+						BlockStorage: types.ReferenceResourceCommon{
 							URI: *ptr.To("/projects/test-project/providers/Aruba.Storage/blockStorages/bs-54321"),
 						},
-						BillingPlan: func() *types.BillingPlan {
+						BillingPlanCommon: func() *types.BillingPlanCommon {
 							v := types.BillingPeriodHour
-							return &types.BillingPlan{BillingPeriod: &v}
+							return &types.BillingPlanCommon{BillingPeriod: &v}
 						}(),
 						AdminUser: &types.UserCredentialCommon{
 							Username: "admin",
 						},
 						ConcurrentUsers: ptr.To("100"),
 					},
-					Status: types.ResourceStatus{
+					Status: types.ResourceStatusResponse{
 						State: ptr.To(types.State("creating")),
 					},
 				}
@@ -396,14 +396,14 @@ func TestCreateContainerRegistry(t *testing.T) {
 				},
 			},
 			Properties: types.ContainerRegistryPropertiesRequest{
-				PublicIp:      types.ReferenceResource{URI: "/projects/test-project/providers/Aruba.Network/elasticips/eip-12345"},
-				VPC:           types.ReferenceResource{URI: "/projects/test-project/providers/Aruba.Network/vpcs/vpc-1"},
-				Subnet:        types.ReferenceResource{URI: "/projects/test-project/providers/Aruba.Network/vpcs/vpc-1/subnets/subnet-124"},
-				SecurityGroup: types.ReferenceResource{URI: "/projects/test-project/providers/Aruba.Network/vpcs/vpc-1/securityGroups/sg-67890"},
-				BlockStorage:  types.ReferenceResource{URI: "/projects/test-project/providers/Aruba.Storage/blockStorages/bs-54321"},
-				BillingPlan: func() *types.BillingPlan {
+				PublicIp:      types.ReferenceResourceCommon{URI: "/projects/test-project/providers/Aruba.Network/elasticips/eip-12345"},
+				VPC:           types.ReferenceResourceCommon{URI: "/projects/test-project/providers/Aruba.Network/vpcs/vpc-1"},
+				Subnet:        types.ReferenceResourceCommon{URI: "/projects/test-project/providers/Aruba.Network/vpcs/vpc-1/subnets/subnet-124"},
+				SecurityGroup: types.ReferenceResourceCommon{URI: "/projects/test-project/providers/Aruba.Network/vpcs/vpc-1/securityGroups/sg-67890"},
+				BlockStorage:  types.ReferenceResourceCommon{URI: "/projects/test-project/providers/Aruba.Storage/blockStorages/bs-54321"},
+				BillingPlanCommon: func() *types.BillingPlanCommon {
 					v := types.BillingPeriod("Hour")
-					return &types.BillingPlan{BillingPeriod: &v}
+					return &types.BillingPlanCommon{BillingPeriod: &v}
 				}(),
 				AdminUser:       &types.UserCredentialCommon{Username: "admin"},
 				ConcurrentUsers: ptr.To("100"),
@@ -435,8 +435,8 @@ func TestCreateContainerRegistry(t *testing.T) {
 		if resp.Data.Properties.BlockStorage.URI != "/projects/test-project/providers/Aruba.Storage/blockStorages/bs-54321" {
 			t.Errorf("expected BlockStorage URI")
 		}
-		if resp.Data.Properties.BillingPlan == nil || resp.Data.Properties.BillingPlan.BillingPeriod == nil || *resp.Data.Properties.BillingPlan.BillingPeriod != "Hour" {
-			t.Errorf("expected BillingPlan.BillingPeriod Hour")
+		if resp.Data.Properties.BillingPlanCommon == nil || resp.Data.Properties.BillingPlanCommon.BillingPeriod == nil || *resp.Data.Properties.BillingPlanCommon.BillingPeriod != "Hour" {
+			t.Errorf("expected BillingPlanCommon.BillingPeriod Hour")
 		}
 		if resp.Data.Properties.AdminUser == nil || resp.Data.Properties.AdminUser.Username != "admin" {
 			t.Errorf("expected AdminUser username")
@@ -594,31 +594,31 @@ func TestUpdateContainerRegistry(t *testing.T) {
 						ID:   ptr.To("registry-123"),
 					},
 					Properties: types.ContainerRegistryPropertiesResponse{
-						VPC: types.ReferenceResource{
+						VPC: types.ReferenceResourceCommon{
 							URI: *ptr.To("/projects/test-project/providers/Aruba.Network/vpcs/vpc-1"),
 						},
-						Subnet: types.ReferenceResource{
+						Subnet: types.ReferenceResourceCommon{
 							URI: *ptr.To("/projects/test-project/providers/Aruba.Network/vpcs/vpc-1/subnets/subnet-124"),
 						},
-						SecurityGroup: types.ReferenceResource{
+						SecurityGroup: types.ReferenceResourceCommon{
 							URI: *ptr.To("/projects/test-project/providers/Aruba.Network/vpcs/vpc-1/securityGroups/sg-67890"),
 						},
-						PublicIp: types.ReferenceResource{
+						PublicIp: types.ReferenceResourceCommon{
 							URI: *ptr.To("/projects/test-project/providers/Aruba.Network/elasticips/eip-12345"),
 						},
-						BlockStorage: types.ReferenceResource{
+						BlockStorage: types.ReferenceResourceCommon{
 							URI: *ptr.To("/projects/test-project/providers/Aruba.Storage/blockStorages/bs-54321"),
 						},
-						BillingPlan: func() *types.BillingPlan {
+						BillingPlanCommon: func() *types.BillingPlanCommon {
 							v := types.BillingPeriodHour
-							return &types.BillingPlan{BillingPeriod: &v}
+							return &types.BillingPlanCommon{BillingPeriod: &v}
 						}(),
 						AdminUser: &types.UserCredentialCommon{
 							Username: "admin",
 						},
 						ConcurrentUsers: ptr.To("100"),
 					},
-					Status: types.ResourceStatus{
+					Status: types.ResourceStatusResponse{
 						State: ptr.To(types.State("updating")),
 					},
 				}
@@ -637,14 +637,14 @@ func TestUpdateContainerRegistry(t *testing.T) {
 				},
 			},
 			Properties: types.ContainerRegistryPropertiesRequest{
-				PublicIp:      types.ReferenceResource{URI: "/projects/test-project/providers/Aruba.Network/elasticips/eip-12345"},
-				VPC:           types.ReferenceResource{URI: "/projects/test-project/providers/Aruba.Network/vpcs/vpc-1"},
-				Subnet:        types.ReferenceResource{URI: "/projects/test-project/providers/Aruba.Network/vpcs/vpc-1/subnets/subnet-124"},
-				SecurityGroup: types.ReferenceResource{URI: "/projects/test-project/providers/Aruba.Network/vpcs/vpc-1/securityGroups/sg-67890"},
-				BlockStorage:  types.ReferenceResource{URI: "/projects/test-project/providers/Aruba.Storage/blockStorages/bs-54321"},
-				BillingPlan: func() *types.BillingPlan {
+				PublicIp:      types.ReferenceResourceCommon{URI: "/projects/test-project/providers/Aruba.Network/elasticips/eip-12345"},
+				VPC:           types.ReferenceResourceCommon{URI: "/projects/test-project/providers/Aruba.Network/vpcs/vpc-1"},
+				Subnet:        types.ReferenceResourceCommon{URI: "/projects/test-project/providers/Aruba.Network/vpcs/vpc-1/subnets/subnet-124"},
+				SecurityGroup: types.ReferenceResourceCommon{URI: "/projects/test-project/providers/Aruba.Network/vpcs/vpc-1/securityGroups/sg-67890"},
+				BlockStorage:  types.ReferenceResourceCommon{URI: "/projects/test-project/providers/Aruba.Storage/blockStorages/bs-54321"},
+				BillingPlanCommon: func() *types.BillingPlanCommon {
 					v := types.BillingPeriod("Hour")
-					return &types.BillingPlan{BillingPeriod: &v}
+					return &types.BillingPlanCommon{BillingPeriod: &v}
 				}(),
 				AdminUser:       &types.UserCredentialCommon{Username: "admin"},
 				ConcurrentUsers: ptr.To("100"),
@@ -676,8 +676,8 @@ func TestUpdateContainerRegistry(t *testing.T) {
 		if resp.Data.Properties.BlockStorage.URI != "/projects/test-project/providers/Aruba.Storage/blockStorages/bs-54321" {
 			t.Errorf("expected BlockStorage URI")
 		}
-		if resp.Data.Properties.BillingPlan == nil || resp.Data.Properties.BillingPlan.BillingPeriod == nil || *resp.Data.Properties.BillingPlan.BillingPeriod != "Hour" {
-			t.Errorf("expected BillingPlan.BillingPeriod Hour")
+		if resp.Data.Properties.BillingPlanCommon == nil || resp.Data.Properties.BillingPlanCommon.BillingPeriod == nil || *resp.Data.Properties.BillingPlanCommon.BillingPeriod != "Hour" {
+			t.Errorf("expected BillingPlanCommon.BillingPeriod Hour")
 		}
 		if resp.Data.Properties.AdminUser == nil || resp.Data.Properties.AdminUser.Username != "admin" {
 			t.Errorf("expected AdminUser username")

--- a/internal/clients/container/containerregistry_test.go
+++ b/internal/clients/container/containerregistry_test.go
@@ -18,7 +18,7 @@ func TestListContainerRegistry(t *testing.T) {
 		server := testutil.NewMockServer(t, func(w http.ResponseWriter, r *http.Request) {
 			if r.Method == "GET" && r.URL.Path == "/projects/test-project/providers/Aruba.Container/registries" {
 				w.WriteHeader(http.StatusOK)
-				resp := types.ContainerRegistryList{
+				resp := types.ContainerRegistryListResponse{
 					ListResponse: types.ListResponse{Total: 1},
 					Values: []types.ContainerRegistryResponse{
 						{
@@ -45,7 +45,7 @@ func TestListContainerRegistry(t *testing.T) {
 									v := types.BillingPeriodHour
 									return &types.BillingPlan{BillingPeriod: &v}
 								}(),
-								AdminUser: &types.UserCredential{
+								AdminUser: &types.UserCredentialCommon{
 									Username: "admin",
 								},
 								ConcurrentUsers: ptr.To("100"),
@@ -213,7 +213,7 @@ func TestGetContainerRegistry(t *testing.T) {
 							v := types.BillingPeriodHour
 							return &types.BillingPlan{BillingPeriod: &v}
 						}(),
-						AdminUser: &types.UserCredential{
+						AdminUser: &types.UserCredentialCommon{
 							Username: "admin",
 						},
 						ConcurrentUsers: ptr.To("100"),
@@ -372,7 +372,7 @@ func TestCreateContainerRegistry(t *testing.T) {
 							v := types.BillingPeriodHour
 							return &types.BillingPlan{BillingPeriod: &v}
 						}(),
-						AdminUser: &types.UserCredential{
+						AdminUser: &types.UserCredentialCommon{
 							Username: "admin",
 						},
 						ConcurrentUsers: ptr.To("100"),
@@ -405,7 +405,7 @@ func TestCreateContainerRegistry(t *testing.T) {
 					v := types.BillingPeriod("Hour")
 					return &types.BillingPlan{BillingPeriod: &v}
 				}(),
-				AdminUser:       &types.UserCredential{Username: "admin"},
+				AdminUser:       &types.UserCredentialCommon{Username: "admin"},
 				ConcurrentUsers: ptr.To("100"),
 			},
 		}
@@ -613,7 +613,7 @@ func TestUpdateContainerRegistry(t *testing.T) {
 							v := types.BillingPeriodHour
 							return &types.BillingPlan{BillingPeriod: &v}
 						}(),
-						AdminUser: &types.UserCredential{
+						AdminUser: &types.UserCredentialCommon{
 							Username: "admin",
 						},
 						ConcurrentUsers: ptr.To("100"),
@@ -646,7 +646,7 @@ func TestUpdateContainerRegistry(t *testing.T) {
 					v := types.BillingPeriod("Hour")
 					return &types.BillingPlan{BillingPeriod: &v}
 				}(),
-				AdminUser:       &types.UserCredential{Username: "admin"},
+				AdminUser:       &types.UserCredentialCommon{Username: "admin"},
 				ConcurrentUsers: ptr.To("100"),
 			},
 		}

--- a/internal/clients/container/containerregistry_test.go
+++ b/internal/clients/container/containerregistry_test.go
@@ -25,7 +25,7 @@ func TestListContainerRegistry(t *testing.T) {
 							Metadata: types.ResourceMetadataResponse{
 								Name: ptr.To("test-registry"),
 							},
-							Properties: types.ContainerRegistryPropertiesResult{
+							Properties: types.ContainerRegistryPropertiesResponse{
 								VPC: types.ReferenceResource{
 									URI: *ptr.To("/projects/test-project/providers/Aruba.Network/vpcs/vpc-1"),
 								},
@@ -193,7 +193,7 @@ func TestGetContainerRegistry(t *testing.T) {
 						Name: ptr.To("test-registry"),
 						ID:   ptr.To("registry-123"),
 					},
-					Properties: types.ContainerRegistryPropertiesResult{
+					Properties: types.ContainerRegistryPropertiesResponse{
 						VPC: types.ReferenceResource{
 							URI: *ptr.To("/projects/test-project/providers/Aruba.Network/vpcs/vpc-1"),
 						},
@@ -352,7 +352,7 @@ func TestCreateContainerRegistry(t *testing.T) {
 						ID:   ptr.To("registry-456"),
 						URI:  ptr.To("/projects/test-project/providers/Aruba.Container/registries/registry-456"),
 					},
-					Properties: types.ContainerRegistryPropertiesResult{
+					Properties: types.ContainerRegistryPropertiesResponse{
 						VPC: types.ReferenceResource{
 							URI: *ptr.To("/projects/test-project/providers/Aruba.Network/vpcs/vpc-1"),
 						},
@@ -593,7 +593,7 @@ func TestUpdateContainerRegistry(t *testing.T) {
 						Name: ptr.To("updated-registry"),
 						ID:   ptr.To("registry-123"),
 					},
-					Properties: types.ContainerRegistryPropertiesResult{
+					Properties: types.ContainerRegistryPropertiesResponse{
 						VPC: types.ReferenceResource{
 							URI: *ptr.To("/projects/test-project/providers/Aruba.Network/vpcs/vpc-1"),
 						},

--- a/internal/clients/container/kaas.go
+++ b/internal/clients/container/kaas.go
@@ -25,7 +25,7 @@ func NewKaaSClientImpl(client *restclient.Client) *kaasClientImpl {
 }
 
 // List retrieves all KaaS clusters for a project
-func (c *kaasClientImpl) List(ctx context.Context, projectID string, params *types.RequestParameters) (*types.Response[types.KaaSList], error) {
+func (c *kaasClientImpl) List(ctx context.Context, projectID string, params *types.RequestParameters) (*types.Response[types.KaaSListResponse], error) {
 	c.client.Logger().Debugf("Listing KaaS clusters for project: %s", projectID)
 
 	if err := types.ValidateProject(projectID); err != nil {
@@ -51,7 +51,7 @@ func (c *kaasClientImpl) List(ctx context.Context, projectID string, params *typ
 	}
 	defer httpResp.Body.Close()
 
-	return types.ParseResponseBody[types.KaaSList](httpResp, c.client.Logger())
+	return types.ParseResponseBody[types.KaaSListResponse](httpResp, c.client.Logger())
 }
 
 // Get retrieves a specific KaaS cluster by ID

--- a/internal/clients/container/kaas_test.go
+++ b/internal/clients/container/kaas_test.go
@@ -33,7 +33,7 @@ func TestListKaaS(t *testing.T) {
 									Recommended: true,
 								},
 							},
-							Status: types.ResourceStatus{
+							Status: types.ResourceStatusResponse{
 								State: ptr.To(types.State("active")),
 							},
 						},
@@ -167,7 +167,7 @@ func TestGetKaaS(t *testing.T) {
 						}(),
 						ManagementIP: ptr.To("10.0.0.100"),
 					},
-					Status: types.ResourceStatus{
+					Status: types.ResourceStatusResponse{
 						State: ptr.To(types.State("active")),
 					},
 				}
@@ -297,7 +297,7 @@ func TestCreateKaaS(t *testing.T) {
 							Value: ptr.To("1.28.0"),
 						},
 					},
-					Status: types.ResourceStatus{
+					Status: types.ResourceStatusResponse{
 						State: ptr.To(types.State("creating")),
 					},
 				}
@@ -490,7 +490,7 @@ func TestUpdateKaaS(t *testing.T) {
 							Value: ptr.To("1.29.0"),
 						},
 					},
-					Status: types.ResourceStatus{
+					Status: types.ResourceStatusResponse{
 						State: ptr.To(types.State("updating")),
 					},
 				}

--- a/internal/clients/container/kaas_test.go
+++ b/internal/clients/container/kaas_test.go
@@ -18,7 +18,7 @@ func TestListKaaS(t *testing.T) {
 		server := testutil.NewMockServer(t, func(w http.ResponseWriter, r *http.Request) {
 			if r.Method == "GET" && r.URL.Path == "/projects/test-project/providers/Aruba.Container/kaas" {
 				w.WriteHeader(http.StatusOK)
-				resp := types.KaaSList{
+				resp := types.KaaSListResponse{
 					ListResponse: types.ListResponse{Total: 1},
 					Values: []types.KaaSResponse{
 						{
@@ -158,8 +158,8 @@ func TestGetKaaS(t *testing.T) {
 								{
 									Name:        ptr.To("default-pool"),
 									Nodes:       ptr.To(int32(3)),
-									Instance:    &types.InstanceResponse{Name: ptr.To("small")},
-									DataCenter:  &types.DataCenterResponse{Code: ptr.To("dc-01")},
+									Instance:    &types.KaaSNodePoolInstanceResponse{Name: ptr.To("small")},
+									DataCenter:  &types.KaaSNodePoolDataCenterResponse{Code: ptr.To("dc-01")},
 									Autoscaling: false,
 								},
 							}
@@ -318,7 +318,7 @@ func TestCreateKaaS(t *testing.T) {
 			Properties: types.KaaSPropertiesRequest{
 				Preset: ptr.To(false),
 				HA:     ptr.To(true),
-				KubernetesVersion: types.KubernetesVersionInfo{
+				KubernetesVersion: types.KubernetesVersionInfoRequest{
 					Value: "1.28.0",
 				},
 			},
@@ -509,10 +509,10 @@ func TestUpdateKaaS(t *testing.T) {
 				},
 			},
 			Properties: types.KaaSPropertiesUpdateRequest{
-				KubernetesVersion: types.KubernetesVersionInfoUpdate{
+				KubernetesVersion: types.KubernetesVersionInfoUpdateRequest{
 					Value: "1.29.0",
 				},
-				NodePools: []types.NodePoolProperties{
+				NodePools: []types.NodePoolPropertiesRequest{
 					{
 						Name:     "default-pool",
 						Nodes:    3,

--- a/internal/clients/container/path.go
+++ b/internal/clients/container/path.go
@@ -1,5 +1,11 @@
 package container
 
+// Path constants follow the server-canonical lowerCamelCase rule:
+//   - Single-word / acronym collections stay lowercase: kaas, registries.
+//
+// Do not flatten these to all-lowercase. Downstream provisioners store and re-emit
+// request URIs verbatim, so a casing change causes silent provisioning failures.
+// Verified via examples/all-resources/ create.log (2026-05-28, commit f548a4f alignment).
 const (
 	// KaaSPath is the base path for KaaS operations
 	KaaSPath = "/projects/%s/providers/Aruba.Container/kaas"

--- a/internal/clients/database/backup.go
+++ b/internal/clients/database/backup.go
@@ -23,7 +23,7 @@ func NewBackupsClientImpl(client *restclient.Client) *backupsClientImpl {
 }
 
 // List retrieves all backups for a project
-func (c *backupsClientImpl) List(ctx context.Context, projectID string, params *types.RequestParameters) (*types.Response[types.BackupList], error) {
+func (c *backupsClientImpl) List(ctx context.Context, projectID string, params *types.RequestParameters) (*types.Response[types.DBaaSBackupListResponse], error) {
 	c.client.Logger().Debugf("Listing backups for project: %s", projectID)
 
 	if err := types.ValidateProject(projectID); err != nil {
@@ -49,7 +49,7 @@ func (c *backupsClientImpl) List(ctx context.Context, projectID string, params *
 	}
 	defer httpResp.Body.Close()
 
-	return types.ParseResponseBody[types.BackupList](httpResp, c.client.Logger())
+	return types.ParseResponseBody[types.DBaaSBackupListResponse](httpResp, c.client.Logger())
 }
 
 // Get retrieves a specific backup by ID

--- a/internal/clients/database/backup_test.go
+++ b/internal/clients/database/backup_test.go
@@ -28,15 +28,15 @@ func TestListBackups(t *testing.T) {
 							},
 							Properties: types.BackupPropertiesResponse{
 								Zone:     "ITBG-1",
-								DBaaS:    types.ReferenceResource{URI: "/projects/test-project/providers/Aruba.Database/dbaas/dbaas-1"},
-								Database: types.ReferenceResource{URI: "/projects/test-project/providers/Aruba.Database/dbaas/dbaas-1/databases/db-1"},
-								BillingPlan: func() *types.BillingPlan {
+								DBaaS:    types.ReferenceResourceCommon{URI: "/projects/test-project/providers/Aruba.Database/dbaas/dbaas-1"},
+								Database: types.ReferenceResourceCommon{URI: "/projects/test-project/providers/Aruba.Database/dbaas/dbaas-1/databases/db-1"},
+								BillingPlanCommon: func() *types.BillingPlanCommon {
 									v := types.BillingPeriod("Hour")
-									return &types.BillingPlan{BillingPeriod: &v}
+									return &types.BillingPlanCommon{BillingPeriod: &v}
 								}(),
 								Storage: types.BackupStorageResponse{Size: 10},
 							},
-							Status: types.ResourceStatus{State: statePtr(types.State("active"))},
+							Status: types.ResourceStatusResponse{State: statePtr(types.State("active"))},
 						},
 					},
 				}
@@ -156,15 +156,15 @@ func TestGetBackup(t *testing.T) {
 					},
 					Properties: types.BackupPropertiesResponse{
 						Zone:     "ITBG-1",
-						DBaaS:    types.ReferenceResource{URI: "/projects/test-project/providers/Aruba.Database/dbaas/dbaas-1"},
-						Database: types.ReferenceResource{URI: "/projects/test-project/providers/Aruba.Database/dbaas/dbaas-1/databases/db-1"},
-						BillingPlan: func() *types.BillingPlan {
+						DBaaS:    types.ReferenceResourceCommon{URI: "/projects/test-project/providers/Aruba.Database/dbaas/dbaas-1"},
+						Database: types.ReferenceResourceCommon{URI: "/projects/test-project/providers/Aruba.Database/dbaas/dbaas-1/databases/db-1"},
+						BillingPlanCommon: func() *types.BillingPlanCommon {
 							v := types.BillingPeriod("Hour")
-							return &types.BillingPlan{BillingPeriod: &v}
+							return &types.BillingPlanCommon{BillingPeriod: &v}
 						}(),
 						Storage: types.BackupStorageResponse{Size: 10},
 					},
-					Status: types.ResourceStatus{State: statePtr(types.State("active"))},
+					Status: types.ResourceStatusResponse{State: statePtr(types.State("active"))},
 				}
 				json.NewEncoder(w).Encode(resp)
 				return
@@ -293,14 +293,14 @@ func TestCreateBackup(t *testing.T) {
 					},
 					Properties: types.BackupPropertiesResponse{
 						Zone:     "ITBG-1",
-						DBaaS:    types.ReferenceResource{URI: "/projects/test-project/providers/Aruba.Database/dbaas/dbaas-1"},
-						Database: types.ReferenceResource{URI: "/projects/test-project/providers/Aruba.Database/dbaas/dbaas-1/databases/db-1"},
-						BillingPlan: func() *types.BillingPlan {
+						DBaaS:    types.ReferenceResourceCommon{URI: "/projects/test-project/providers/Aruba.Database/dbaas/dbaas-1"},
+						Database: types.ReferenceResourceCommon{URI: "/projects/test-project/providers/Aruba.Database/dbaas/dbaas-1/databases/db-1"},
+						BillingPlanCommon: func() *types.BillingPlanCommon {
 							v := types.BillingPeriod("Hour")
-							return &types.BillingPlan{BillingPeriod: &v}
+							return &types.BillingPlanCommon{BillingPeriod: &v}
 						}(),
 					},
-					Status: types.ResourceStatus{State: statePtr(types.State("creating"))},
+					Status: types.ResourceStatusResponse{State: statePtr(types.State("creating"))},
 				}
 				json.NewEncoder(w).Encode(resp)
 				return
@@ -316,11 +316,11 @@ func TestCreateBackup(t *testing.T) {
 			},
 			Properties: types.BackupPropertiesRequest{
 				Zone:     "ITBG-1",
-				DBaaS:    types.ReferenceResource{URI: "/projects/test-project/providers/Aruba.Database/dbaas/dbaas-1"},
-				Database: types.ReferenceResource{URI: "/projects/test-project/providers/Aruba.Database/dbaas/dbaas-1/databases/db-1"},
-				BillingPlan: func() *types.BillingPlan {
+				DBaaS:    types.ReferenceResourceCommon{URI: "/projects/test-project/providers/Aruba.Database/dbaas/dbaas-1"},
+				Database: types.ReferenceResourceCommon{URI: "/projects/test-project/providers/Aruba.Database/dbaas/dbaas-1/databases/db-1"},
+				BillingPlanCommon: func() *types.BillingPlanCommon {
 					v := types.BillingPeriod("Hour")
-					return &types.BillingPlan{BillingPeriod: &v}
+					return &types.BillingPlanCommon{BillingPeriod: &v}
 				}(),
 			},
 		}

--- a/internal/clients/database/backup_test.go
+++ b/internal/clients/database/backup_test.go
@@ -18,7 +18,7 @@ func TestListBackups(t *testing.T) {
 		server := testutil.NewMockServer(t, func(w http.ResponseWriter, r *http.Request) {
 			if r.Method == "GET" && r.URL.Path == "/projects/test-project/providers/Aruba.Database/backups" {
 				w.WriteHeader(http.StatusOK)
-				resp := types.BackupList{
+				resp := types.DBaaSBackupListResponse{
 					ListResponse: types.ListResponse{Total: 1},
 					Values: []types.BackupResponse{
 						{

--- a/internal/clients/database/database.go
+++ b/internal/clients/database/database.go
@@ -24,7 +24,7 @@ func NewDatabasesClientImpl(client *restclient.Client) *databasesClientImpl {
 }
 
 // List retrieves all databases for a DBaaS instance
-func (c *databasesClientImpl) List(ctx context.Context, projectID string, dbaasID string, params *types.RequestParameters) (*types.Response[types.DatabaseList], error) {
+func (c *databasesClientImpl) List(ctx context.Context, projectID string, dbaasID string, params *types.RequestParameters) (*types.Response[types.DatabaseListResponse], error) {
 	c.client.Logger().Debugf("Listing databases for DBaaS: %s in project: %s", dbaasID, projectID)
 
 	if err := types.ValidateProjectAndResource(projectID, dbaasID, "DBaaS ID"); err != nil {
@@ -50,7 +50,7 @@ func (c *databasesClientImpl) List(ctx context.Context, projectID string, dbaasI
 	}
 	defer httpResp.Body.Close()
 
-	return types.ParseResponseBody[types.DatabaseList](httpResp, c.client.Logger())
+	return types.ParseResponseBody[types.DatabaseListResponse](httpResp, c.client.Logger())
 }
 
 // Get retrieves a specific database by ID

--- a/internal/clients/database/database_test.go
+++ b/internal/clients/database/database_test.go
@@ -16,7 +16,7 @@ func TestListDatabases(t *testing.T) {
 		server := testutil.NewMockServer(t, func(w http.ResponseWriter, r *http.Request) {
 			if r.Method == "GET" && r.URL.Path == "/projects/test-project/providers/Aruba.Database/dbaas/dbaas-123/databases" {
 				w.WriteHeader(http.StatusOK)
-				resp := types.DatabaseList{
+				resp := types.DatabaseListResponse{
 					ListResponse: types.ListResponse{Total: 1},
 					Values: []types.DatabaseResponse{
 						{Name: "my-db"},

--- a/internal/clients/database/dbaas.go
+++ b/internal/clients/database/dbaas.go
@@ -24,7 +24,7 @@ func NewDBaaSClientImpl(client *restclient.Client) *dbaasClientImpl {
 }
 
 // List retrieves all DBaaS instances for a project
-func (c *dbaasClientImpl) List(ctx context.Context, projectID string, params *types.RequestParameters) (*types.Response[types.DBaaSList], error) {
+func (c *dbaasClientImpl) List(ctx context.Context, projectID string, params *types.RequestParameters) (*types.Response[types.DBaaSListResponse], error) {
 	c.client.Logger().Debugf("Listing DBaaS instances for project: %s", projectID)
 
 	if err := types.ValidateProject(projectID); err != nil {
@@ -49,7 +49,7 @@ func (c *dbaasClientImpl) List(ctx context.Context, projectID string, params *ty
 	}
 	defer httpResp.Body.Close()
 
-	return types.ParseResponseBody[types.DBaaSList](httpResp, c.client.Logger())
+	return types.ParseResponseBody[types.DBaaSListResponse](httpResp, c.client.Logger())
 }
 
 // Get retrieves a specific DBaaS instance by ID

--- a/internal/clients/database/dbaas_test.go
+++ b/internal/clients/database/dbaas_test.go
@@ -20,7 +20,7 @@ func TestListDBaaS(t *testing.T) {
 		server := testutil.NewMockServer(t, func(w http.ResponseWriter, r *http.Request) {
 			if r.Method == "GET" && r.URL.Path == "/projects/test-project/providers/Aruba.Database/dbaas" {
 				w.WriteHeader(http.StatusOK)
-				resp := types.DBaaSList{
+				resp := types.DBaaSListResponse{
 					ListResponse: types.ListResponse{Total: 1},
 					Values: []types.DBaaSResponse{
 						{

--- a/internal/clients/database/dbaas_test.go
+++ b/internal/clients/database/dbaas_test.go
@@ -34,7 +34,7 @@ func TestListDBaaS(t *testing.T) {
 									Version: ptr.To("8.0"),
 								},
 							},
-							Status: types.ResourceStatus{State: statePtr(types.State("active"))},
+							Status: types.ResourceStatusResponse{State: statePtr(types.State("active"))},
 						},
 					},
 				}
@@ -158,7 +158,7 @@ func TestGetDBaaS(t *testing.T) {
 							Name: ptr.To("M4-8"),
 						},
 					},
-					Status: types.ResourceStatus{State: statePtr(types.State("active"))},
+					Status: types.ResourceStatusResponse{State: statePtr(types.State("active"))},
 				}
 				json.NewEncoder(w).Encode(resp)
 				return
@@ -288,7 +288,7 @@ func TestCreateDBaaS(t *testing.T) {
 					Properties: types.DBaaSPropertiesResponse{
 						Engine: &types.DBaaSEngineResponse{Type: ptr.To("MySQL")},
 					},
-					Status: types.ResourceStatus{State: statePtr(types.State("creating"))},
+					Status: types.ResourceStatusResponse{State: statePtr(types.State("creating"))},
 				}
 				json.NewEncoder(w).Encode(resp)
 				return
@@ -470,7 +470,7 @@ func TestUpdateDBaaS(t *testing.T) {
 					Properties: types.DBaaSPropertiesResponse{
 						Engine: &types.DBaaSEngineResponse{Type: ptr.To("MySQL")},
 					},
-					Status: types.ResourceStatus{State: statePtr(types.State("updating"))},
+					Status: types.ResourceStatusResponse{State: statePtr(types.State("updating"))},
 				}
 				json.NewEncoder(w).Encode(resp)
 				return

--- a/internal/clients/database/grant.go
+++ b/internal/clients/database/grant.go
@@ -24,7 +24,7 @@ func NewGrantsClientImpl(client *restclient.Client) *grantsClientImpl {
 }
 
 // List retrieves all grants for a database
-func (c *grantsClientImpl) List(ctx context.Context, projectID string, dbaasID string, databaseID string, params *types.RequestParameters) (*types.Response[types.GrantList], error) {
+func (c *grantsClientImpl) List(ctx context.Context, projectID string, dbaasID string, databaseID string, params *types.RequestParameters) (*types.Response[types.GrantListResponse], error) {
 	c.client.Logger().Debugf("Listing grants for database: %s in DBaaS: %s in project: %s", databaseID, dbaasID, projectID)
 
 	if err := types.ValidateDBaaSResource(projectID, dbaasID, databaseID, "database ID"); err != nil {
@@ -50,7 +50,7 @@ func (c *grantsClientImpl) List(ctx context.Context, projectID string, dbaasID s
 	}
 	defer httpResp.Body.Close()
 
-	return types.ParseResponseBody[types.GrantList](httpResp, c.client.Logger())
+	return types.ParseResponseBody[types.GrantListResponse](httpResp, c.client.Logger())
 }
 
 // Get retrieves a specific grant by ID

--- a/internal/clients/database/grant_test.go
+++ b/internal/clients/database/grant_test.go
@@ -16,12 +16,12 @@ func TestListGrants(t *testing.T) {
 		server := testutil.NewMockServer(t, func(w http.ResponseWriter, r *http.Request) {
 			if r.Method == "GET" && r.URL.Path == "/projects/test-project/providers/Aruba.Database/dbaas/dbaas-123/databases/db-456/grants" {
 				w.WriteHeader(http.StatusOK)
-				resp := types.GrantList{
+				resp := types.GrantListResponse{
 					ListResponse: types.ListResponse{Total: 1},
 					Values: []types.GrantResponse{
 						{
-							User:     types.GrantUser{Username: "alice"},
-							Role:     types.GrantRole{Name: "read"},
+							User:     types.GrantUserCommon{Username: "alice"},
+							Role:     types.GrantRoleCommon{Name: "read"},
 							Database: types.GrantDatabaseResponse{Name: "my-db"},
 						},
 					},
@@ -154,8 +154,8 @@ func TestGetGrant(t *testing.T) {
 			if r.Method == "GET" && r.URL.Path == "/projects/test-project/providers/Aruba.Database/dbaas/dbaas-123/databases/db-456/grants/grant-789" {
 				w.WriteHeader(http.StatusOK)
 				resp := types.GrantResponse{
-					User:     types.GrantUser{Username: "alice"},
-					Role:     types.GrantRole{Name: "read"},
+					User:     types.GrantUserCommon{Username: "alice"},
+					Role:     types.GrantRoleCommon{Name: "read"},
 					Database: types.GrantDatabaseResponse{Name: "my-db"},
 				}
 				json.NewEncoder(w).Encode(resp)
@@ -295,8 +295,8 @@ func TestCreateGrant(t *testing.T) {
 			if r.Method == "POST" && r.URL.Path == "/projects/test-project/providers/Aruba.Database/dbaas/dbaas-123/databases/db-456/grants" {
 				w.WriteHeader(http.StatusCreated)
 				resp := types.GrantResponse{
-					User:     types.GrantUser{Username: "alice"},
-					Role:     types.GrantRole{Name: "read"},
+					User:     types.GrantUserCommon{Username: "alice"},
+					Role:     types.GrantRoleCommon{Name: "read"},
 					Database: types.GrantDatabaseResponse{Name: "my-db"},
 				}
 				json.NewEncoder(w).Encode(resp)
@@ -308,8 +308,8 @@ func TestCreateGrant(t *testing.T) {
 		svc := NewGrantsClientImpl(c)
 
 		body := types.GrantRequest{
-			User: types.GrantUser{Username: "alice"},
-			Role: types.GrantRole{Name: "read"},
+			User: types.GrantUserCommon{Username: "alice"},
+			Role: types.GrantRoleCommon{Name: "read"},
 		}
 
 		resp, err := svc.Create(context.Background(), "test-project", "dbaas-123", "db-456", body, nil)
@@ -434,8 +434,8 @@ func TestUpdateGrant(t *testing.T) {
 			if r.Method == "PUT" && r.URL.Path == "/projects/test-project/providers/Aruba.Database/dbaas/dbaas-123/databases/db-456/grants/grant-789" {
 				w.WriteHeader(http.StatusOK)
 				resp := types.GrantResponse{
-					User:     types.GrantUser{Username: "alice"},
-					Role:     types.GrantRole{Name: "write"},
+					User:     types.GrantUserCommon{Username: "alice"},
+					Role:     types.GrantRoleCommon{Name: "write"},
 					Database: types.GrantDatabaseResponse{Name: "my-db"},
 				}
 				json.NewEncoder(w).Encode(resp)
@@ -447,8 +447,8 @@ func TestUpdateGrant(t *testing.T) {
 		svc := NewGrantsClientImpl(c)
 
 		body := types.GrantRequest{
-			User: types.GrantUser{Username: "alice"},
-			Role: types.GrantRole{Name: "write"},
+			User: types.GrantUserCommon{Username: "alice"},
+			Role: types.GrantRoleCommon{Name: "write"},
 		}
 
 		resp, err := svc.Update(context.Background(), "test-project", "dbaas-123", "db-456", "grant-789", body, nil)

--- a/internal/clients/database/path.go
+++ b/internal/clients/database/path.go
@@ -1,6 +1,12 @@
 package database
 
-// API path constants for database resources
+// Path constants follow the server-canonical lowerCamelCase rule:
+//   - Single-word / acronym collections stay lowercase: dbaas, databases, backups,
+//     grants, users.
+//
+// Do not flatten these to all-lowercase. Downstream provisioners store and re-emit
+// request URIs verbatim, so a casing change causes silent provisioning failures.
+// Verified via examples/all-resources/ create.log (2026-05-28, commit f548a4f alignment).
 const (
 	// DBaaS paths
 	DBaaSPath     = "/projects/%s/providers/Aruba.Database/dbaas"

--- a/internal/clients/database/user.go
+++ b/internal/clients/database/user.go
@@ -24,7 +24,7 @@ func NewUsersClientImpl(client *restclient.Client) *usersClientImpl {
 }
 
 // List retrieves all users for a DBaaS instance
-func (c *usersClientImpl) List(ctx context.Context, projectID string, dbaasID string, params *types.RequestParameters) (*types.Response[types.UserList], error) {
+func (c *usersClientImpl) List(ctx context.Context, projectID string, dbaasID string, params *types.RequestParameters) (*types.Response[types.DatabaseUserListResponse], error) {
 	c.client.Logger().Debugf("Listing users for DBaaS: %s in project: %s", dbaasID, projectID)
 
 	if err := types.ValidateProjectAndResource(projectID, dbaasID, "DBaaS ID"); err != nil {
@@ -50,7 +50,7 @@ func (c *usersClientImpl) List(ctx context.Context, projectID string, dbaasID st
 	}
 	defer httpResp.Body.Close()
 
-	return types.ParseResponseBody[types.UserList](httpResp, c.client.Logger())
+	return types.ParseResponseBody[types.DatabaseUserListResponse](httpResp, c.client.Logger())
 }
 
 // Get retrieves a specific user by ID

--- a/internal/clients/database/user_test.go
+++ b/internal/clients/database/user_test.go
@@ -16,7 +16,7 @@ func TestListUsers(t *testing.T) {
 		server := testutil.NewMockServer(t, func(w http.ResponseWriter, r *http.Request) {
 			if r.Method == "GET" && r.URL.Path == "/projects/test-project/providers/Aruba.Database/dbaas/dbaas-123/users" {
 				w.WriteHeader(http.StatusOK)
-				resp := types.UserList{
+				resp := types.DatabaseUserListResponse{
 					ListResponse: types.ListResponse{Total: 1},
 					Values:       []types.UserResponse{{Username: "alice"}},
 				}

--- a/internal/clients/network/elastic-ip.go
+++ b/internal/clients/network/elastic-ip.go
@@ -23,7 +23,7 @@ func NewElasticIPsClientImpl(client *restclient.Client) *elasticIPsClientImpl {
 }
 
 // List retrieves all elastic IPs for a project
-func (c *elasticIPsClientImpl) List(ctx context.Context, projectID string, params *types.RequestParameters) (*types.Response[types.ElasticList], error) {
+func (c *elasticIPsClientImpl) List(ctx context.Context, projectID string, params *types.RequestParameters) (*types.Response[types.ElasticIPListResponse], error) {
 	c.client.Logger().Debugf("Listing elastic IPs for project: %s", projectID)
 
 	if err := types.ValidateProject(projectID); err != nil {
@@ -49,7 +49,7 @@ func (c *elasticIPsClientImpl) List(ctx context.Context, projectID string, param
 	}
 	defer httpResp.Body.Close()
 
-	return types.ParseResponseBody[types.ElasticList](httpResp, c.client.Logger())
+	return types.ParseResponseBody[types.ElasticIPListResponse](httpResp, c.client.Logger())
 }
 
 // Get retrieves a specific elastic IP by ID

--- a/internal/clients/network/elastic-ip_test.go
+++ b/internal/clients/network/elastic-ip_test.go
@@ -233,7 +233,10 @@ func TestCreateElasticIP(t *testing.T) {
 				Location:                types.LocationRequest{Value: "ITBG-Bergamo"},
 			},
 			Properties: types.ElasticIPPropertiesRequest{
-				BillingPlan: func() *types.BillingPlan { v := types.BillingPeriodMonth; return &types.BillingPlan{BillingPeriod: &v} }(),
+				BillingPlanCommon: func() *types.BillingPlanCommon {
+					v := types.BillingPeriodMonth
+					return &types.BillingPlanCommon{BillingPeriod: &v}
+				}(),
 			},
 		}
 		resp, err := svc.Create(context.Background(), "test-project", req, nil)

--- a/internal/clients/network/load-balancer.go
+++ b/internal/clients/network/load-balancer.go
@@ -21,7 +21,7 @@ func NewLoadBalancersClientImpl(client *restclient.Client) *loadBalancersClientI
 }
 
 // List retrieves all load balancers for a project
-func (c *loadBalancersClientImpl) List(ctx context.Context, projectID string, params *types.RequestParameters) (*types.Response[types.LoadBalancerList], error) {
+func (c *loadBalancersClientImpl) List(ctx context.Context, projectID string, params *types.RequestParameters) (*types.Response[types.LoadBalancerListResponse], error) {
 	if err := types.ValidateProject(projectID); err != nil {
 		return nil, err
 	}
@@ -45,7 +45,7 @@ func (c *loadBalancersClientImpl) List(ctx context.Context, projectID string, pa
 	}
 	defer httpResp.Body.Close()
 
-	return types.ParseResponseBody[types.LoadBalancerList](httpResp, c.client.Logger())
+	return types.ParseResponseBody[types.LoadBalancerListResponse](httpResp, c.client.Logger())
 }
 
 // Get retrieves a specific load balancer by ID

--- a/internal/clients/network/path.go
+++ b/internal/clients/network/path.go
@@ -1,6 +1,13 @@
 package network
 
-// API path constants for network resources
+// Path constants follow the server-canonical lowerCamelCase rule:
+//   - Single-word / acronym collections stay lowercase: vpcs, subnets.
+//   - Compound collections use lowerCamelCase: securityGroups, securityRules,
+//     elasticIps, loadBalancers, vpcPeerings, vpcPeeringRoutes, vpnTunnels, vpnRoutes.
+//
+// Do not flatten these to all-lowercase. Downstream provisioners store and re-emit
+// request URIs verbatim, so a casing change causes silent provisioning failures.
+// Verified via examples/all-resources/ create.log (2026-05-28, commit f548a4f alignment).
 const (
 	// VPC Network paths
 	VPCNetworksPath = "/projects/%s/providers/Aruba.Network/vpcs"

--- a/internal/clients/network/security-group-rule.go
+++ b/internal/clients/network/security-group-rule.go
@@ -29,7 +29,7 @@ func NewSecurityGroupRulesClientImpl(client *restclient.Client, securityGroupsCl
 }
 
 // List retrieves all security group rules for a security group
-func (c *securityGroupRulesClientImpl) List(ctx context.Context, projectID string, vpcID string, securityGroupID string, params *types.RequestParameters) (*types.Response[types.SecurityRuleList], error) {
+func (c *securityGroupRulesClientImpl) List(ctx context.Context, projectID string, vpcID string, securityGroupID string, params *types.RequestParameters) (*types.Response[types.SecurityRuleListResponse], error) {
 	c.client.Logger().Debugf("Listing security group rules for security group: %s in VPC: %s in project: %s", securityGroupID, vpcID, projectID)
 
 	if err := types.ValidateVPCResource(projectID, vpcID, securityGroupID, "security group ID"); err != nil {
@@ -55,7 +55,7 @@ func (c *securityGroupRulesClientImpl) List(ctx context.Context, projectID strin
 	}
 	defer httpResp.Body.Close()
 
-	return types.ParseResponseBody[types.SecurityRuleList](httpResp, c.client.Logger())
+	return types.ParseResponseBody[types.SecurityRuleListResponse](httpResp, c.client.Logger())
 }
 
 // Get retrieves a specific security group rule by ID

--- a/internal/clients/network/security-group.go
+++ b/internal/clients/network/security-group.go
@@ -29,7 +29,7 @@ func NewSecurityGroupsClientImpl(client *restclient.Client, vpcClient *vpcsClien
 }
 
 // List retrieves all security groups for a VPC
-func (c *securityGroupsClientImpl) List(ctx context.Context, projectID string, vpcID string, params *types.RequestParameters) (*types.Response[types.SecurityGroupList], error) {
+func (c *securityGroupsClientImpl) List(ctx context.Context, projectID string, vpcID string, params *types.RequestParameters) (*types.Response[types.SecurityGroupListResponse], error) {
 	c.client.Logger().Debugf("Listing security groups for VPC: %s in project: %s", vpcID, projectID)
 
 	if err := types.ValidateProjectAndResource(projectID, vpcID, "VPC ID"); err != nil {
@@ -55,7 +55,7 @@ func (c *securityGroupsClientImpl) List(ctx context.Context, projectID string, v
 	}
 	defer httpResp.Body.Close()
 
-	return types.ParseResponseBody[types.SecurityGroupList](httpResp, c.client.Logger())
+	return types.ParseResponseBody[types.SecurityGroupListResponse](httpResp, c.client.Logger())
 }
 
 // Get retrieves a specific security group by ID

--- a/internal/clients/network/subnet.go
+++ b/internal/clients/network/subnet.go
@@ -29,7 +29,7 @@ func NewSubnetsClientImpl(client *restclient.Client, vpcClient *vpcsClientImpl) 
 }
 
 // List retrieves all subnets for a VPC
-func (c *subnetsClientImpl) List(ctx context.Context, projectID string, vpcID string, params *types.RequestParameters) (*types.Response[types.SubnetList], error) {
+func (c *subnetsClientImpl) List(ctx context.Context, projectID string, vpcID string, params *types.RequestParameters) (*types.Response[types.SubnetListResponse], error) {
 	c.client.Logger().Debugf("Listing subnets for VPC: %s in project: %s", vpcID, projectID)
 
 	if err := types.ValidateProjectAndResource(projectID, vpcID, "VPC ID"); err != nil {
@@ -55,7 +55,7 @@ func (c *subnetsClientImpl) List(ctx context.Context, projectID string, vpcID st
 	}
 	defer httpResp.Body.Close()
 
-	return types.ParseResponseBody[types.SubnetList](httpResp, c.client.Logger())
+	return types.ParseResponseBody[types.SubnetListResponse](httpResp, c.client.Logger())
 }
 
 // Get retrieves a specific subnet by ID

--- a/internal/clients/network/vpc-peering-route.go
+++ b/internal/clients/network/vpc-peering-route.go
@@ -24,7 +24,7 @@ func NewVPCPeeringRoutesClientImpl(client *restclient.Client) *vpcPeeringRoutesC
 }
 
 // List retrieves all VPC peering routes for a VPC peering connection
-func (c *vpcPeeringRoutesClientImpl) List(ctx context.Context, projectID string, vpcID string, vpcPeeringID string, params *types.RequestParameters) (*types.Response[types.VPCPeeringRouteList], error) {
+func (c *vpcPeeringRoutesClientImpl) List(ctx context.Context, projectID string, vpcID string, vpcPeeringID string, params *types.RequestParameters) (*types.Response[types.VPCPeeringRouteListResponse], error) {
 	c.client.Logger().Debugf("Listing VPC peering routes for VPC peering: %s in VPC: %s in project: %s", vpcPeeringID, vpcID, projectID)
 
 	if err := types.ValidateVPCResource(projectID, vpcID, vpcPeeringID, "VPC peering ID"); err != nil {
@@ -50,7 +50,7 @@ func (c *vpcPeeringRoutesClientImpl) List(ctx context.Context, projectID string,
 	}
 	defer httpResp.Body.Close()
 
-	return types.ParseResponseBody[types.VPCPeeringRouteList](httpResp, c.client.Logger())
+	return types.ParseResponseBody[types.VPCPeeringRouteListResponse](httpResp, c.client.Logger())
 }
 
 // Get retrieves a specific VPC peering route by ID

--- a/internal/clients/network/vpc-peering.go
+++ b/internal/clients/network/vpc-peering.go
@@ -24,7 +24,7 @@ func NewVPCPeeringsClientImpl(client *restclient.Client) *vpcPeeringsClientImpl 
 }
 
 // List retrieves all VPC peerings for a VPC
-func (c *vpcPeeringsClientImpl) List(ctx context.Context, projectID string, vpcID string, params *types.RequestParameters) (*types.Response[types.VPCPeeringList], error) {
+func (c *vpcPeeringsClientImpl) List(ctx context.Context, projectID string, vpcID string, params *types.RequestParameters) (*types.Response[types.VPCPeeringListResponse], error) {
 	c.client.Logger().Debugf("Listing VPC peerings for VPC: %s in project: %s", vpcID, projectID)
 
 	if err := types.ValidateProjectAndResource(projectID, vpcID, "VPC ID"); err != nil {
@@ -50,7 +50,7 @@ func (c *vpcPeeringsClientImpl) List(ctx context.Context, projectID string, vpcI
 	}
 	defer httpResp.Body.Close()
 
-	return types.ParseResponseBody[types.VPCPeeringList](httpResp, c.client.Logger())
+	return types.ParseResponseBody[types.VPCPeeringListResponse](httpResp, c.client.Logger())
 }
 
 // Get retrieves a specific VPC peering by ID

--- a/internal/clients/network/vpc.go
+++ b/internal/clients/network/vpc.go
@@ -24,7 +24,7 @@ func NewVPCsClientImpl(client *restclient.Client) *vpcsClientImpl {
 }
 
 // List retrieves all VPCs for a project
-func (c *vpcsClientImpl) List(ctx context.Context, projectID string, params *types.RequestParameters) (*types.Response[types.VPCList], error) {
+func (c *vpcsClientImpl) List(ctx context.Context, projectID string, params *types.RequestParameters) (*types.Response[types.VPCListResponse], error) {
 	c.client.Logger().Debugf("Listing VPCs for project: %s", projectID)
 
 	if err := types.ValidateProject(projectID); err != nil {
@@ -50,7 +50,7 @@ func (c *vpcsClientImpl) List(ctx context.Context, projectID string, params *typ
 	}
 	defer httpResp.Body.Close()
 
-	return types.ParseResponseBody[types.VPCList](httpResp, c.client.Logger())
+	return types.ParseResponseBody[types.VPCListResponse](httpResp, c.client.Logger())
 }
 
 // Get retrieves a specific VPC by ID

--- a/internal/clients/network/vpn-route.go
+++ b/internal/clients/network/vpn-route.go
@@ -24,7 +24,7 @@ func NewVPNRoutesClientImpl(client *restclient.Client) *vpnRoutesClientImpl {
 }
 
 // List retrieves all VPN routes for a VPN tunnel
-func (c *vpnRoutesClientImpl) List(ctx context.Context, projectID string, vpnTunnelID string, params *types.RequestParameters) (*types.Response[types.VPNRouteList], error) {
+func (c *vpnRoutesClientImpl) List(ctx context.Context, projectID string, vpnTunnelID string, params *types.RequestParameters) (*types.Response[types.VPNRouteListResponse], error) {
 	c.client.Logger().Debugf("Listing VPN routes for VPN tunnel: %s in project: %s", vpnTunnelID, projectID)
 
 	if err := types.ValidateProjectAndResource(projectID, vpnTunnelID, "VPN tunnel ID"); err != nil {
@@ -50,7 +50,7 @@ func (c *vpnRoutesClientImpl) List(ctx context.Context, projectID string, vpnTun
 	}
 	defer httpResp.Body.Close()
 
-	return types.ParseResponseBody[types.VPNRouteList](httpResp, c.client.Logger())
+	return types.ParseResponseBody[types.VPNRouteListResponse](httpResp, c.client.Logger())
 }
 
 // Get retrieves a specific VPN route by ID

--- a/internal/clients/network/vpn-tunnel.go
+++ b/internal/clients/network/vpn-tunnel.go
@@ -24,7 +24,7 @@ func NewVPNTunnelsClientImpl(client *restclient.Client) *vpnTunnelsClientImpl {
 }
 
 // List retrieves all VPN tunnels for a project
-func (c *vpnTunnelsClientImpl) List(ctx context.Context, projectID string, params *types.RequestParameters) (*types.Response[types.VPNTunnelList], error) {
+func (c *vpnTunnelsClientImpl) List(ctx context.Context, projectID string, params *types.RequestParameters) (*types.Response[types.VPNTunnelListResponse], error) {
 	c.client.Logger().Debugf("Listing VPN tunnels for project: %s", projectID)
 
 	if err := types.ValidateProject(projectID); err != nil {
@@ -50,7 +50,7 @@ func (c *vpnTunnelsClientImpl) List(ctx context.Context, projectID string, param
 	}
 	defer httpResp.Body.Close()
 
-	return types.ParseResponseBody[types.VPNTunnelList](httpResp, c.client.Logger())
+	return types.ParseResponseBody[types.VPNTunnelListResponse](httpResp, c.client.Logger())
 }
 
 // Get retrieves a specific VPN tunnel by ID

--- a/internal/clients/project/project.go
+++ b/internal/clients/project/project.go
@@ -25,7 +25,7 @@ func NewProjectsClientImpl(client *restclient.Client) *projectsClientImpl {
 }
 
 // List retrieves all projects
-func (c *projectsClientImpl) List(ctx context.Context, params *types.RequestParameters) (*types.Response[types.ProjectList], error) {
+func (c *projectsClientImpl) List(ctx context.Context, params *types.RequestParameters) (*types.Response[types.ProjectListResponse], error) {
 	c.client.Logger().Debugf("Listing projects")
 
 	path := ProjectsPath
@@ -47,7 +47,7 @@ func (c *projectsClientImpl) List(ctx context.Context, params *types.RequestPara
 	}
 	defer httpResp.Body.Close()
 
-	return types.ParseResponseBody[types.ProjectList](httpResp, c.client.Logger())
+	return types.ParseResponseBody[types.ProjectListResponse](httpResp, c.client.Logger())
 }
 
 // Get retrieves a specific project by ID

--- a/internal/clients/schedule/job.go
+++ b/internal/clients/schedule/job.go
@@ -24,7 +24,7 @@ func NewJobsClientImpl(client *restclient.Client) *jobsClientImpl {
 }
 
 // List retrieves all schedule jobs for a project
-func (c *jobsClientImpl) List(ctx context.Context, projectID string, params *types.RequestParameters) (*types.Response[types.JobList], error) {
+func (c *jobsClientImpl) List(ctx context.Context, projectID string, params *types.RequestParameters) (*types.Response[types.JobListResponse], error) {
 	c.client.Logger().Debugf("Listing schedule jobs for project: %s", projectID)
 
 	if err := types.ValidateProject(projectID); err != nil {
@@ -50,7 +50,7 @@ func (c *jobsClientImpl) List(ctx context.Context, projectID string, params *typ
 	}
 	defer httpResp.Body.Close()
 
-	return types.ParseResponseBody[types.JobList](httpResp, c.client.Logger())
+	return types.ParseResponseBody[types.JobListResponse](httpResp, c.client.Logger())
 }
 
 // Get retrieves a specific schedule job by ID

--- a/internal/clients/schedule/job_test.go
+++ b/internal/clients/schedule/job_test.go
@@ -267,7 +267,7 @@ func TestCreateScheduleJob(t *testing.T) {
 				JobType:      types.JobTypeRecurring,
 				Cron:         ptr.To("0 3 * * 0"),
 				ExecuteUntil: ptr.To("2026-01-01T00:00:00Z"),
-				Steps: []types.JobStep{
+				Steps: []types.JobStepRequest{
 					{
 						Name:        ptr.To("cleanup-old-snapshots"),
 						ResourceURI: "/projects/test-project/providers/Aruba.Storage/snapshots",
@@ -312,7 +312,7 @@ func TestCreateScheduleJob(t *testing.T) {
 				Enabled:    ptr.To(true),
 				JobType:    types.JobTypeOneShot,
 				ScheduleAt: ptr.To("2025-11-20T22:00:00Z"),
-				Steps: []types.JobStep{
+				Steps: []types.JobStepRequest{
 					{
 						Name:        ptr.To("stop-servers"),
 						ResourceURI: "/projects/test-project/providers/Aruba.Compute/cloudservers/vm-123",
@@ -493,7 +493,7 @@ func TestUpdateScheduleJob(t *testing.T) {
 				JobType:      types.JobTypeRecurring,
 				Cron:         ptr.To("0 4 * * *"),
 				ExecuteUntil: ptr.To("2025-12-31T23:59:59Z"),
-				Steps: []types.JobStep{
+				Steps: []types.JobStepRequest{
 					{
 						Name:        ptr.To("updated-backup-step"),
 						ResourceURI: "/projects/test-project/providers/Aruba.Storage/block-storages/vol-456",

--- a/internal/clients/schedule/path.go
+++ b/internal/clients/schedule/path.go
@@ -1,6 +1,11 @@
 package schedule
 
-// API path constants for schedule resources
+// Path constants follow the server-canonical lowerCamelCase rule:
+//   - Single-word collections stay lowercase: jobs.
+//
+// Do not flatten these to all-lowercase. Downstream provisioners store and re-emit
+// request URIs verbatim, so a casing change causes silent provisioning failures.
+// Verified via examples/all-resources/ create.log (2026-05-28, commit f548a4f alignment).
 const (
 	// Schedule Jobs paths
 	JobsPath = "/projects/%s/providers/Aruba.Schedule/jobs"

--- a/internal/clients/security/key.go
+++ b/internal/clients/security/key.go
@@ -25,7 +25,7 @@ func NewKeyClientImpl(client *restclient.Client) *KeyClientImpl {
 }
 
 // List retrieves all Keys for a specific KMS instance
-func (c *KeyClientImpl) List(ctx context.Context, projectID string, kmsID string, params *types.RequestParameters) (*types.Response[types.KeyList], error) {
+func (c *KeyClientImpl) List(ctx context.Context, projectID string, kmsID string, params *types.RequestParameters) (*types.Response[types.KeyListResponse], error) {
 	c.client.Logger().Debugf("Listing Keys for KMS: %s in project: %s", kmsID, projectID)
 
 	if err := types.ValidateProjectAndResource(projectID, kmsID, "KMS ID"); err != nil {
@@ -51,7 +51,7 @@ func (c *KeyClientImpl) List(ctx context.Context, projectID string, kmsID string
 	}
 	defer httpResp.Body.Close()
 
-	return types.ParseResponseBody[types.KeyList](httpResp, c.client.Logger())
+	return types.ParseResponseBody[types.KeyListResponse](httpResp, c.client.Logger())
 }
 
 // Get retrieves a specific Key by ID

--- a/internal/clients/security/kmip.go
+++ b/internal/clients/security/kmip.go
@@ -25,7 +25,7 @@ func NewKmipClientImpl(client *restclient.Client) *KmipClientImpl {
 }
 
 // List retrieves all KMIP services for a specific KMS instance
-func (c *KmipClientImpl) List(ctx context.Context, projectID string, kmsID string, params *types.RequestParameters) (*types.Response[types.KmipList], error) {
+func (c *KmipClientImpl) List(ctx context.Context, projectID string, kmsID string, params *types.RequestParameters) (*types.Response[types.KmipListResponse], error) {
 	c.client.Logger().Debugf("Listing KMIP services for KMS: %s in project: %s", kmsID, projectID)
 
 	if err := types.ValidateProjectAndResource(projectID, kmsID, "KMS ID"); err != nil {
@@ -51,7 +51,7 @@ func (c *KmipClientImpl) List(ctx context.Context, projectID string, kmsID strin
 	}
 	defer httpResp.Body.Close()
 
-	return types.ParseResponseBody[types.KmipList](httpResp, c.client.Logger())
+	return types.ParseResponseBody[types.KmipListResponse](httpResp, c.client.Logger())
 }
 
 // Get retrieves a specific KMIP service by ID

--- a/internal/clients/security/kms.go
+++ b/internal/clients/security/kms.go
@@ -25,7 +25,7 @@ func NewKMSClientImpl(client *restclient.Client) *kmsClientImpl {
 }
 
 // List retrieves all KMS instances for a project
-func (c *kmsClientImpl) List(ctx context.Context, projectID string, params *types.RequestParameters) (*types.Response[types.KmsList], error) {
+func (c *kmsClientImpl) List(ctx context.Context, projectID string, params *types.RequestParameters) (*types.Response[types.KmsListResponse], error) {
 	c.client.Logger().Debugf("Listing KMS instances for project: %s", projectID)
 
 	if err := types.ValidateProject(projectID); err != nil {
@@ -51,7 +51,7 @@ func (c *kmsClientImpl) List(ctx context.Context, projectID string, params *type
 	}
 	defer httpResp.Body.Close()
 
-	return types.ParseResponseBody[types.KmsList](httpResp, c.client.Logger())
+	return types.ParseResponseBody[types.KmsListResponse](httpResp, c.client.Logger())
 }
 
 // Get retrieves a specific KMS instance by ID

--- a/internal/clients/security/path.go
+++ b/internal/clients/security/path.go
@@ -1,6 +1,11 @@
 package security
 
-// API path constants for security resources
+// Path constants follow the server-canonical lowerCamelCase rule:
+//   - Single-word / acronym collections stay lowercase: kms, kmip, keys.
+//
+// Do not flatten these to all-lowercase. Downstream provisioners store and re-emit
+// request URIs verbatim, so a casing change causes silent provisioning failures.
+// Verified via examples/all-resources/ create.log (2026-05-28, commit f548a4f alignment).
 const (
 	// KMS paths
 	KMSsPath = "/projects/%s/providers/Aruba.Security/kms"

--- a/internal/clients/storage/backup.go
+++ b/internal/clients/storage/backup.go
@@ -25,7 +25,7 @@ func NewBackupClientImpl(client *restclient.Client) *backupClientImpl {
 }
 
 // List retrieves all Storage Backups for a project
-func (c *backupClientImpl) List(ctx context.Context, projectID string, params *types.RequestParameters) (*types.Response[types.StorageBackupList], error) {
+func (c *backupClientImpl) List(ctx context.Context, projectID string, params *types.RequestParameters) (*types.Response[types.StorageBackupListResponse], error) {
 	c.client.Logger().Debugf("Listing Storage Backups for project: %s", projectID)
 
 	if err := types.ValidateProject(projectID); err != nil {
@@ -51,7 +51,7 @@ func (c *backupClientImpl) List(ctx context.Context, projectID string, params *t
 	}
 	defer httpResp.Body.Close()
 
-	return types.ParseResponseBody[types.StorageBackupList](httpResp, c.client.Logger())
+	return types.ParseResponseBody[types.StorageBackupListResponse](httpResp, c.client.Logger())
 }
 
 // Get retrieves a specific Storage Backup by ID

--- a/internal/clients/storage/backup_test.go
+++ b/internal/clients/storage/backup_test.go
@@ -246,7 +246,7 @@ func TestCreateBackup(t *testing.T) {
 			},
 			Properties: types.StorageBackupPropertiesRequest{
 				StorageBackupType: types.StorageBackupTypeFull,
-				Origin:            types.ReferenceResource{URI: "/projects/test-project/providers/Aruba.Storage/blockStorages/volume-456"},
+				Origin:            types.ReferenceResourceCommon{URI: "/projects/test-project/providers/Aruba.Storage/blockStorages/volume-456"},
 				RetentionDays:     ptr.To(20),
 				BillingPeriod:     (*types.BillingPeriod)(ptr.To("Yearly")),
 			},
@@ -412,7 +412,7 @@ func TestUpdateBackup(t *testing.T) {
 			},
 			Properties: types.StorageBackupPropertiesRequest{
 				StorageBackupType: types.StorageBackupTypeIncremental,
-				Origin:            types.ReferenceResource{URI: "/projects/test-project/providers/Aruba.Storage/blockStorages/volume-123"},
+				Origin:            types.ReferenceResourceCommon{URI: "/projects/test-project/providers/Aruba.Storage/blockStorages/volume-123"},
 				RetentionDays:     ptr.To(30),
 				BillingPeriod:     (*types.BillingPeriod)(ptr.To("Monthly")),
 			},

--- a/internal/clients/storage/block-storage.go
+++ b/internal/clients/storage/block-storage.go
@@ -59,7 +59,7 @@ func NewVolumesClientImpl(client *restclient.Client) *volumesClientImpl {
 }
 
 // List retrieves all block storage volumes for a project
-func (c *volumesClientImpl) List(ctx context.Context, projectID string, params *types.RequestParameters) (*types.Response[types.BlockStorageList], error) {
+func (c *volumesClientImpl) List(ctx context.Context, projectID string, params *types.RequestParameters) (*types.Response[types.BlockStorageListResponse], error) {
 	c.client.Logger().Debugf("Listing block storage volumes for project: %s", projectID)
 
 	if err := types.ValidateProject(projectID); err != nil {
@@ -85,7 +85,7 @@ func (c *volumesClientImpl) List(ctx context.Context, projectID string, params *
 	}
 	defer httpResp.Body.Close()
 
-	return types.ParseResponseBody[types.BlockStorageList](httpResp, c.client.Logger())
+	return types.ParseResponseBody[types.BlockStorageListResponse](httpResp, c.client.Logger())
 }
 
 // Get retrieves a specific block storage volume by ID

--- a/internal/clients/storage/path.go
+++ b/internal/clients/storage/path.go
@@ -1,6 +1,12 @@
 package storage
 
-// API path constants for storage resources
+// Path constants follow the server-canonical lowerCamelCase rule:
+//   - Single-word collections stay lowercase: snapshots, backups, restores.
+//   - Compound collections use lowerCamelCase: blockStorages.
+//
+// Do not flatten these to all-lowercase. Downstream provisioners store and re-emit
+// request URIs verbatim, so a casing change causes silent provisioning failures.
+// Verified via examples/all-resources/ create.log (2026-05-28, commit f548a4f alignment).
 const (
 
 	// Storage Bucket paths

--- a/internal/clients/storage/restore.go
+++ b/internal/clients/storage/restore.go
@@ -30,7 +30,7 @@ func NewRestoreClientImpl(client *restclient.Client, backupClient *backupClientI
 }
 
 // List retrieves all Restores for a backup in a project
-func (c *restoreClientImpl) List(ctx context.Context, projectID string, backupID string, params *types.RequestParameters) (*types.Response[types.StorageRestoreList], error) {
+func (c *restoreClientImpl) List(ctx context.Context, projectID string, backupID string, params *types.RequestParameters) (*types.Response[types.StorageRestoreListResponse], error) {
 	c.client.Logger().Debugf("Listing Restores for project: %s, backup: %s", projectID, backupID)
 
 	if err := types.ValidateProjectAndResource(projectID, backupID, "Backup ID"); err != nil {
@@ -55,7 +55,7 @@ func (c *restoreClientImpl) List(ctx context.Context, projectID string, backupID
 	}
 	defer httpResp.Body.Close()
 
-	return types.ParseResponseBody[types.StorageRestoreList](httpResp, c.client.Logger())
+	return types.ParseResponseBody[types.StorageRestoreListResponse](httpResp, c.client.Logger())
 }
 
 // Get retrieves a specific Restore by ID

--- a/internal/clients/storage/restore_test.go
+++ b/internal/clients/storage/restore_test.go
@@ -253,7 +253,7 @@ func TestCreateRestore(t *testing.T) {
 				ResourceMetadataRequest: types.ResourceMetadataRequest{Name: "new-restore"},
 			},
 			Properties: types.StorageRestorePropertiesRequest{
-				Target: types.ReferenceResource{URI: "/projects/test-project/providers/Aruba.Storage/blockStorages/vol-789"},
+				Target: types.ReferenceResourceCommon{URI: "/projects/test-project/providers/Aruba.Storage/blockStorages/vol-789"},
 			},
 		}
 		resp, err := svc.Create(context.Background(), "test-project", "backup-123", body, nil)
@@ -297,7 +297,7 @@ func TestCreateRestore(t *testing.T) {
 			fmt.Fprint(w, testutil.ErrorBodyJSON("Not Found", "resource not found", 404))
 		})
 		svc := newRestoreSvc(t, server.URL)
-		body := types.StorageRestoreRequest{Properties: types.StorageRestorePropertiesRequest{Target: types.ReferenceResource{URI: "dummy"}}}
+		body := types.StorageRestoreRequest{Properties: types.StorageRestorePropertiesRequest{Target: types.ReferenceResourceCommon{URI: "dummy"}}}
 		resp, err := svc.Create(context.Background(), "test-project", "backup-123", body, nil)
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
@@ -318,7 +318,7 @@ func TestCreateRestore(t *testing.T) {
 			fmt.Fprint(w, "Bad Gateway")
 		})
 		svc := newRestoreSvc(t, server.URL)
-		body := types.StorageRestoreRequest{Properties: types.StorageRestorePropertiesRequest{Target: types.ReferenceResource{URI: "dummy"}}}
+		body := types.StorageRestoreRequest{Properties: types.StorageRestorePropertiesRequest{Target: types.ReferenceResourceCommon{URI: "dummy"}}}
 		resp, err := svc.Create(context.Background(), "test-project", "backup-123", body, nil)
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
@@ -334,7 +334,7 @@ func TestCreateRestore(t *testing.T) {
 	t.Run("network error", func(t *testing.T) {
 		c := testutil.NewBrokenClient(t, "http://unused.invalid")
 		svc := NewRestoreClientImpl(c, NewBackupClientImpl(c))
-		body := types.StorageRestoreRequest{Properties: types.StorageRestorePropertiesRequest{Target: types.ReferenceResource{URI: "dummy"}}}
+		body := types.StorageRestoreRequest{Properties: types.StorageRestorePropertiesRequest{Target: types.ReferenceResourceCommon{URI: "dummy"}}}
 		_, err := svc.Create(context.Background(), "test-project", "backup-123", body, nil)
 		if err == nil {
 			t.Fatal("expected transport error, got nil")
@@ -351,7 +351,7 @@ func TestCreateRestore(t *testing.T) {
 			fmt.Fprint(w, `{"metadata":{"id":"x","uri":"/x","name":"x"}}`)
 		})
 		svc := newRestoreSvc(t, server.URL)
-		body := types.StorageRestoreRequest{Properties: types.StorageRestorePropertiesRequest{Target: types.ReferenceResource{URI: "dummy"}}}
+		body := types.StorageRestoreRequest{Properties: types.StorageRestorePropertiesRequest{Target: types.ReferenceResourceCommon{URI: "dummy"}}}
 		resp, err := svc.Create(context.Background(), "test-project", "backup-123", body, nil)
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
@@ -368,7 +368,7 @@ func TestCreateRestore(t *testing.T) {
 			fmt.Fprint(w, `{"metadata":{"uri":"/projects/test-project/providers/Aruba.Storage/restores/res-123","name":"test-name"}}`)
 		})
 		svc := newRestoreSvc(t, server.URL)
-		body := types.StorageRestoreRequest{Properties: types.StorageRestorePropertiesRequest{Target: types.ReferenceResource{URI: "dummy"}}}
+		body := types.StorageRestoreRequest{Properties: types.StorageRestorePropertiesRequest{Target: types.ReferenceResourceCommon{URI: "dummy"}}}
 		resp, err := svc.Create(context.Background(), "test-project", "backup-123", body, nil)
 		if err == nil {
 			t.Fatal("expected metadata validation error, got nil")
@@ -392,7 +392,7 @@ func TestCreateRestore(t *testing.T) {
 			fmt.Fprint(w, `{"metadata":{"id":"res-123","uri":"/projects/test-project/providers/Aruba.Storage/restores/res-123"}}`)
 		})
 		svc := newRestoreSvc(t, server.URL)
-		body := types.StorageRestoreRequest{Properties: types.StorageRestorePropertiesRequest{Target: types.ReferenceResource{URI: "dummy"}}}
+		body := types.StorageRestoreRequest{Properties: types.StorageRestorePropertiesRequest{Target: types.ReferenceResourceCommon{URI: "dummy"}}}
 		resp, err := svc.Create(context.Background(), "test-project", "backup-123", body, nil)
 		if err == nil {
 			t.Fatal("expected metadata validation error, got nil")
@@ -423,7 +423,7 @@ func TestUpdateRestore(t *testing.T) {
 				ResourceMetadataRequest: types.ResourceMetadataRequest{Name: "updated-restore"},
 			},
 			Properties: types.StorageRestorePropertiesRequest{
-				Target: types.ReferenceResource{URI: "/projects/test-project/providers/Aruba.Storage/blockStorages/vol-789"},
+				Target: types.ReferenceResourceCommon{URI: "/projects/test-project/providers/Aruba.Storage/blockStorages/vol-789"},
 			},
 		}
 		resp, err := svc.Update(context.Background(), "test-project", "backup-123", "restore-123", body, nil)

--- a/internal/clients/storage/snapshot.go
+++ b/internal/clients/storage/snapshot.go
@@ -64,7 +64,7 @@ func NewSnapshotsClientImpl(client *restclient.Client, volumesClient *volumesCli
 }
 
 // List retrieves all snapshots for a project
-func (c *snapshotsClientImpl) List(ctx context.Context, projectID string, params *types.RequestParameters) (*types.Response[types.SnapshotList], error) {
+func (c *snapshotsClientImpl) List(ctx context.Context, projectID string, params *types.RequestParameters) (*types.Response[types.SnapshotListResponse], error) {
 	c.client.Logger().Debugf("Listing snapshots for project: %s", projectID)
 
 	if err := types.ValidateProject(projectID); err != nil {
@@ -90,7 +90,7 @@ func (c *snapshotsClientImpl) List(ctx context.Context, projectID string, params
 	}
 	defer httpResp.Body.Close()
 
-	return types.ParseResponseBody[types.SnapshotList](httpResp, c.client.Logger())
+	return types.ParseResponseBody[types.SnapshotListResponse](httpResp, c.client.Logger())
 }
 
 // Get retrieves a specific snapshot by ID

--- a/pkg/aruba/aliases.go
+++ b/pkg/aruba/aliases.go
@@ -416,7 +416,7 @@ type AcceptHeader = types.AcceptHeader
 // VPN IKE crypto
 // ---------------------------------------------------------------------------
 
-// IKEEncryption is the encryption algorithm for IKESettings.Encryption.
+// IKEEncryption is the encryption algorithm for IKESettingsCommon.Encryption.
 // Values are StrongSwan wire identifiers. The authoritative list is at:
 //
 //	GET /providers/Aruba.Network/vpnTunnels
@@ -479,7 +479,7 @@ const (
 	IKEEncryptionChaCha20Poly1305  = types.IKEEncryptionChaCha20Poly1305  // ChaCha20-Poly1305 AEAD
 )
 
-// IKEHash is the hash/PRF algorithm for IKESettings.Hash.
+// IKEHash is the hash/PRF algorithm for IKESettingsCommon.Hash.
 type IKEHash = types.IKEHash
 
 const (
@@ -498,7 +498,7 @@ const (
 	IKEHashAES256GMAC = types.IKEHashAES256GMAC // AES-256-GMAC
 )
 
-// IKEDHGroup is the Diffie-Hellman group for IKESettings.DHGroup.
+// IKEDHGroup is the Diffie-Hellman group for IKESettingsCommon.DHGroup.
 // Groups 3, 4, and 6–13 are not exposed by the platform.
 type IKEDHGroup = types.IKEDHGroup
 
@@ -527,7 +527,7 @@ const (
 	IKEDHGroup32 = types.IKEDHGroup32 // Curve448 (X448)
 )
 
-// IKEDPDAction is the Dead Peer Detection action for IKESettings.DPDAction.
+// IKEDPDAction is the Dead Peer Detection action for IKESettingsCommon.DPDAction.
 type IKEDPDAction = types.IKEDPDAction
 
 const (
@@ -540,7 +540,7 @@ const (
 // VPN ESP crypto
 // ---------------------------------------------------------------------------
 
-// ESPEncryption is the encryption algorithm for ESPSettings.Encryption.
+// ESPEncryption is the encryption algorithm for ESPSettingsCommon.Encryption.
 // Values are StrongSwan wire identifiers. The authoritative list is at:
 //
 //	GET /providers/Aruba.Network/vpnTunnels
@@ -603,7 +603,7 @@ const (
 	ESPEncryptionChaCha20Poly1305  = types.ESPEncryptionChaCha20Poly1305  // ChaCha20-Poly1305 AEAD
 )
 
-// ESPHash is the integrity/authentication algorithm for ESPSettings.Hash.
+// ESPHash is the integrity/authentication algorithm for ESPSettingsCommon.Hash.
 type ESPHash = types.ESPHash
 
 const (
@@ -622,7 +622,7 @@ const (
 	ESPHashAES256GMAC = types.ESPHashAES256GMAC // AES-256-GMAC
 )
 
-// ESPPFSGroup is the Perfect Forward Secrecy DH group for ESPSettings.PFS.
+// ESPPFSGroup is the Perfect Forward Secrecy DH group for ESPSettingsCommon.PFS.
 // Wire values use a "dh-group<N>" prefix (e.g., "dh-group14"), unlike the
 // bare numeric IDs used by IKEDHGroup. Groups 3, 4, and 6–13 are not exposed.
 type ESPPFSGroup = types.ESPPFSGroup

--- a/pkg/aruba/builder.go
+++ b/pkg/aruba/builder.go
@@ -23,6 +23,7 @@ import (
 	"github.com/Arubacloud/sdk-go/internal/ports/interceptor"
 	"github.com/Arubacloud/sdk-go/internal/ports/logger"
 	"github.com/Arubacloud/sdk-go/internal/restclient"
+	middleware_util "github.com/Arubacloud/sdk-go/pkg/util/middleware"
 )
 
 // Client
@@ -154,16 +155,31 @@ func buildMiddleware(options *Options) (interceptor.Interceptor, error) {
 		return nil, err // TODO: better error handling
 	}
 
+	ua := options.userAgent
+	if ua == "" {
+		ua = defaultUserAgent
+	}
+
 	if options.userDefinedDependencies.middleware != nil {
+		// Bind UA first so user middleware (and the token manager last) can still override it.
+		interceptable, ok := options.userDefinedDependencies.middleware.(interceptor.Interceptable)
+		if !ok {
+			return nil, errors.New("failed to bind the token manager to the user-defined middleware")
+		}
+		if err := interceptable.Bind(middleware_util.WithUserAgent(ua)); err != nil {
+			return nil, err
+		}
 		middleware, err := buildUserDefinedMiddleware(options.userDefinedDependencies.middleware, tokenManager)
 		if err != nil {
 			return nil, err // TODO: better error handling
 		}
-
 		return middleware, nil
 	}
 
 	middleware := std_interceptor.NewInterceptor()
+	if err := middleware.Bind(middleware_util.WithUserAgent(ua)); err != nil {
+		return nil, err
+	}
 	err = tokenManager.BindTo(middleware)
 	if err != nil {
 		return nil, err // TODO: better error handling

--- a/pkg/aruba/builder_test.go
+++ b/pkg/aruba/builder_test.go
@@ -1,6 +1,9 @@
 package aruba
 
 import (
+	"context"
+	"net/http"
+	"net/http/httptest"
 	"reflect"
 	"testing"
 )
@@ -110,6 +113,67 @@ func TestNewClient_RejectsInvalidOptions(t *testing.T) {
 				t.Errorf("expected nil client on error for %q", tc.name)
 			}
 		})
+	}
+}
+
+// --------------------------------------------------------------------------
+// User-Agent injection (#310)
+// --------------------------------------------------------------------------
+
+// captureUserAgent spins up an httptest.Server that records the User-Agent
+// of the first request it receives, returns 200, and closes.
+func captureUserAgent(t *testing.T) (serverURL string, getUA func() string) {
+	t.Helper()
+	var captured string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		captured = r.Header.Get("User-Agent")
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"total":0,"values":[]}`))
+	}))
+	t.Cleanup(srv.Close)
+	return srv.URL, func() string { return captured }
+}
+
+func TestClient_SendsDefaultUserAgent(t *testing.T) {
+	srvURL, getUA := captureUserAgent(t)
+
+	cli, err := NewClient(NewOptions().
+		WithBaseURL(srvURL).
+		WithToken("test-token").
+		WithNoLogs())
+	if err != nil {
+		t.Fatalf("NewClient: %v", err)
+	}
+	_, _ = cli.FromProject().List(context.Background())
+
+	want := defaultUserAgent
+	if got := getUA(); got != want {
+		t.Errorf("User-Agent = %q, want %q", got, want)
+	}
+}
+
+func TestOptions_WithUserAgent_Override(t *testing.T) {
+	// WithUserAgent + DeepCopy round-trip
+	o := NewOptions().WithUserAgent("acloud-cli@1.0.0")
+	cp := o.DeepCopy()
+	if cp.userAgent != "acloud-cli@1.0.0" {
+		t.Errorf("DeepCopy().userAgent = %q, want %q", cp.userAgent, "acloud-cli@1.0.0")
+	}
+}
+
+func TestOptions_WithUserAgent_DefaultWhenEmpty(t *testing.T) {
+	o := NewOptions()
+	if o.userAgent != "" {
+		t.Errorf("default userAgent = %q, want empty", o.userAgent)
+	}
+	// resolved UA should equal defaultUserAgent
+	ua := o.userAgent
+	if ua == "" {
+		ua = defaultUserAgent
+	}
+	if ua != defaultUserAgent {
+		t.Errorf("resolved UA = %q, want %q", ua, defaultUserAgent)
 	}
 }
 

--- a/pkg/aruba/client_root.go
+++ b/pkg/aruba/client_root.go
@@ -1,4 +1,3 @@
-// Package sdkgo provides the main entry point for the Aruba Cloud SDK
 package aruba
 
 type Client interface {

--- a/pkg/aruba/doc.go
+++ b/pkg/aruba/doc.go
@@ -1,0 +1,58 @@
+// Package aruba is the public entry point for the Aruba Cloud Go SDK.
+//
+// # Overview
+//
+// Importing only this package covers ~99.9% of real-world use cases:
+//
+//	import "github.com/Arubacloud/sdk-go/pkg/aruba"
+//
+// Construct a client with your OAuth2 credentials:
+//
+//	client, err := aruba.NewClient(aruba.DefaultOptions(clientID, clientSecret))
+//
+// Then reach any resource through the ten service-group accessors:
+// [Client.FromCompute], [Client.FromNetwork], [Client.FromStorage],
+// [Client.FromProject], [Client.FromDatabase], [Client.FromContainer],
+// [Client.FromAudit], [Client.FromMetric], [Client.FromSchedule],
+// [Client.FromSecurity].
+//
+// # Wrapper layer
+//
+// Every resource follows the triplet pattern defined in each resource_<name>.go:
+//   - Wrapper  — chainable fluent builder constructed via NewXxx().
+//   - Low-level client interface — contract the adapter depends on (testable in isolation).
+//   - Adapter  — bridges the wrapper to internal/clients/<domain>.
+//
+// Wrappers are divided into two wire-shape families:
+//   - Family A: Metadata{Properties{…}} envelope, regional, embeds statusMixin.
+//     Most resources (CloudServer, VPC, KaaS, DBaaS, BlockStorage, Job, KMS, …).
+//   - Family B: flat request body, no metadata envelope, no tags, no statusMixin.
+//     Resources: Database, Key, Kmip, User, Grant.
+//
+// # Single-import principle
+//
+// All typed enum constants (Region, Zone, BillingPeriod, CloudServerFlavor, …)
+// are re-exported from [pkg/aruba/aliases.go] so callers never need to import
+// pkg/types for day-to-day use. Wrappers expose Raw(), RawJSON(), and RawYAML()
+// for serialisation without a second import.
+//
+// The residual cases that require pkg/types or pkg/async — non-promoted wire
+// fields, structured validation errors, and concurrent background polling — are
+// documented in docs/website/docs/working-at-low-level.md.
+//
+// # Error accumulation
+//
+// Setter-time errors are deferred into an internal errMixin and surfaced as a
+// single joined error when Create or Update is called. This means a builder
+// chain never panics or short-circuits; call wrapper.Err() to inspect
+// accumulated errors before submitting.
+//
+// # Async polling
+//
+// Resources that embed statusMixin gain WaitUntilActive, WaitUntilReady, and
+// WaitUntilStates(ctx, targets, opts…) for free. The underlying polling is
+// driven by pkg/async.WaitFor with defaults DefaultRetries=60,
+// DefaultBaseDelay=10s, DefaultTimeout=600s (overridable via WaitOption helpers).
+//
+// See ai/ARCHITECTURE.md and ai/CONVENTIONS.md for the full design reference.
+package aruba

--- a/pkg/aruba/list.go
+++ b/pkg/aruba/list.go
@@ -33,7 +33,7 @@ type List[T Wrapper] struct {
 }
 
 // listPayload is the type constraint satisfied by every per-resource list type
-// (e.g. types.VPCList, types.AlertsListResponse). All such types embed
+// (e.g. types.VPCListResponse, types.AlertsListResponse). All such types embed
 // types.ListResponse, which carries a BaseList() method that is automatically
 // promoted, so no per-type implementation is required.
 type listPayload interface {

--- a/pkg/aruba/list_test.go
+++ b/pkg/aruba/list_test.go
@@ -170,20 +170,20 @@ func TestList_Raw(t *testing.T) {
 // is a non-serialisable func, breaking json.Marshal. Raw() now returns only
 // the JSON-safe wire payload (*types.XxxList).
 func TestList_Raw_JSONMarshalable(t *testing.T) {
-	resp := &types.Response[types.VPCList]{
-		Data: &types.VPCList{
+	resp := &types.Response[types.VPCListResponse]{
+		Data: &types.VPCListResponse{
 			ListResponse: types.ListResponse{Total: 2, Self: "/self", Next: "/next"},
 			Values:       []types.VPCResponse{},
 		},
 		StatusCode: 200,
 	}
-	l := newListFromResponse[testItem, types.VPCList](nil, resp, nil, nil)
+	l := newListFromResponse[testItem, types.VPCListResponse](nil, resp, nil, nil)
 
 	b, err := json.Marshal(l.Raw())
 	if err != nil {
 		t.Fatalf("json.Marshal(list.Raw()): %v", err)
 	}
-	var back types.VPCList
+	var back types.VPCListResponse
 	if err := json.Unmarshal(b, &back); err != nil {
 		t.Fatalf("json.Unmarshal: %v", err)
 	}
@@ -195,13 +195,13 @@ func TestList_Raw_JSONMarshalable(t *testing.T) {
 // TestList_HTTPEnvelopeAccessors verifies the accessors promoted from the
 // embedded httpEnvelopeMixin (parity with single-resource wrappers).
 func TestList_HTTPEnvelopeAccessors(t *testing.T) {
-	resp := &types.Response[types.VPCList]{
-		Data:       &types.VPCList{ListResponse: types.ListResponse{Total: 0}},
+	resp := &types.Response[types.VPCListResponse]{
+		Data:       &types.VPCListResponse{ListResponse: types.ListResponse{Total: 0}},
 		StatusCode: 200,
 		Headers:    http.Header{"X-Trace-Id": []string{"abc-123"}},
 		RawBody:    []byte(`{"total":0,"values":[]}`),
 	}
-	l := newListFromResponse[testItem, types.VPCList](nil, resp, nil, nil)
+	l := newListFromResponse[testItem, types.VPCListResponse](nil, resp, nil, nil)
 
 	if l.StatusCode() != 200 {
 		t.Errorf("StatusCode() = %d, want 200", l.StatusCode())
@@ -220,13 +220,13 @@ func TestList_HTTPEnvelopeAccessors(t *testing.T) {
 // TestList_NewListFromResponse_NilSafe ensures the helper tolerates a nil
 // response and a nil resp.Data.
 func TestList_NewListFromResponse_NilSafe(t *testing.T) {
-	l1 := newListFromResponse[testItem, types.VPCList](nil, nil, nil, nil)
+	l1 := newListFromResponse[testItem, types.VPCListResponse](nil, nil, nil, nil)
 	if l1 == nil || l1.Total() != 0 || l1.HasNext() || l1.HasPrev() {
 		t.Errorf("nil resp produced bad list: %+v", l1)
 	}
-	l2 := newListFromResponse[testItem, types.VPCList](
+	l2 := newListFromResponse[testItem, types.VPCListResponse](
 		nil,
-		&types.Response[types.VPCList]{StatusCode: 200},
+		&types.Response[types.VPCListResponse]{StatusCode: 200},
 		nil, nil,
 	)
 	if l2.Raw() != nil {
@@ -238,18 +238,18 @@ func TestList_NewListFromResponse_NilSafe(t *testing.T) {
 }
 
 func TestList_RawJSON_RoundTrip(t *testing.T) {
-	resp := &types.Response[types.VPCList]{
-		Data: &types.VPCList{
+	resp := &types.Response[types.VPCListResponse]{
+		Data: &types.VPCListResponse{
 			ListResponse: types.ListResponse{Total: 3, Self: "/self", Next: "/next"},
 			Values:       []types.VPCResponse{},
 		},
 	}
-	l := newListFromResponse[testItem, types.VPCList](nil, resp, nil, nil)
+	l := newListFromResponse[testItem, types.VPCListResponse](nil, resp, nil, nil)
 	b := l.RawJSON()
 	if len(b) == 0 {
 		t.Fatal("RawJSON() returned empty")
 	}
-	var back types.VPCList
+	var back types.VPCListResponse
 	if err := json.Unmarshal(b, &back); err != nil {
 		t.Fatalf("json.Unmarshal: %v", err)
 	}
@@ -259,18 +259,18 @@ func TestList_RawJSON_RoundTrip(t *testing.T) {
 }
 
 func TestList_RawYAML_RoundTrip(t *testing.T) {
-	resp := &types.Response[types.VPCList]{
-		Data: &types.VPCList{
+	resp := &types.Response[types.VPCListResponse]{
+		Data: &types.VPCListResponse{
 			ListResponse: types.ListResponse{Total: 5, Self: "/s", Next: "/n"},
 			Values:       []types.VPCResponse{},
 		},
 	}
-	l := newListFromResponse[testItem, types.VPCList](nil, resp, nil, nil)
+	l := newListFromResponse[testItem, types.VPCListResponse](nil, resp, nil, nil)
 	b := l.RawYAML()
 	if len(b) == 0 {
 		t.Fatal("RawYAML() returned empty")
 	}
-	var back types.VPCList
+	var back types.VPCListResponse
 	if err := yaml.Unmarshal(b, &back); err != nil {
 		t.Fatalf("yaml.Unmarshal: %v", err)
 	}
@@ -280,14 +280,14 @@ func TestList_RawYAML_RoundTrip(t *testing.T) {
 }
 
 func TestList_RawJSON_NilSafe(t *testing.T) {
-	l := newListFromResponse[testItem, types.VPCList](nil, nil, nil, nil)
+	l := newListFromResponse[testItem, types.VPCListResponse](nil, nil, nil, nil)
 	if b := l.RawJSON(); b != nil {
 		t.Errorf("RawJSON() = %q, want nil", b)
 	}
 }
 
 func TestList_RawYAML_NilSafe(t *testing.T) {
-	l := newListFromResponse[testItem, types.VPCList](nil, nil, nil, nil)
+	l := newListFromResponse[testItem, types.VPCListResponse](nil, nil, nil, nil)
 	if b := l.RawYAML(); b != nil {
 		t.Errorf("RawYAML() = %q, want nil", b)
 	}

--- a/pkg/aruba/mixin_common.go
+++ b/pkg/aruba/mixin_common.go
@@ -162,10 +162,10 @@ func (m *responseMetadataMixin) RespURI() string {
 
 // Project returns the owning project's ID from the response metadata, or "".
 func (m *responseMetadataMixin) Project() string {
-	if m.meta == nil || m.meta.ProjectResponseMetadata == nil {
+	if m.meta == nil || m.meta.ProjectMetadataResponse == nil {
 		return ""
 	}
-	return m.meta.ProjectResponseMetadata.ID
+	return m.meta.ProjectMetadataResponse.ID
 }
 
 // CreatedAt returns the resource creation time, or zero time.
@@ -202,13 +202,13 @@ func (m *responseMetadataMixin) Raw() *types.ResourceMetadataResponse {
 // --------------------------------------------------------------------------
 
 type linkedMixin struct {
-	linked []types.LinkedResource
+	linked []types.LinkedResourceCommon
 }
 
-func (m *linkedMixin) setLinked(l []types.LinkedResource) { m.linked = l }
+func (m *linkedMixin) setLinked(l []types.LinkedResourceCommon) { m.linked = l }
 
 // LinkedResources returns the slice of linked resources.
-func (m *linkedMixin) LinkedResources() []types.LinkedResource { return m.linked }
+func (m *linkedMixin) LinkedResources() []types.LinkedResourceCommon { return m.linked }
 
 // --------------------------------------------------------------------------
 // httpEnvelopeMixin — HTTP response metadata

--- a/pkg/aruba/mixin_common_test.go
+++ b/pkg/aruba/mixin_common_test.go
@@ -163,7 +163,7 @@ func TestResponseMetadataMixin_Populated(t *testing.T) {
 			ID:      &id,
 			URI:     &uri,
 			Version: &ver,
-			ProjectResponseMetadata: &types.ProjectResponseMetadata{
+			ProjectMetadataResponse: &types.ProjectMetadataResponse{
 				ID: proj,
 			},
 			CreationDate: &now,
@@ -197,7 +197,7 @@ func TestResponseMetadataMixin_Populated(t *testing.T) {
 
 func TestLinkedMixin(t *testing.T) {
 	var m linkedMixin
-	m.setLinked([]types.LinkedResource{{URI: "/foo", StrictCorrelation: true}})
+	m.setLinked([]types.LinkedResourceCommon{{URI: "/foo", StrictCorrelation: true}})
 	got := m.LinkedResources()
 	if len(got) != 1 || got[0].URI != "/foo" {
 		t.Errorf("LinkedResources() = %v", got)

--- a/pkg/aruba/mixin_status.go
+++ b/pkg/aruba/mixin_status.go
@@ -52,10 +52,10 @@ func applyWaitOptions(opts []WaitOption) waitOptions {
 
 type statusMixin struct {
 	refreshMixin
-	status *types.ResourceStatus
+	status *types.ResourceStatusResponse
 }
 
-func (m *statusMixin) setStatus(s *types.ResourceStatus) { m.status = s }
+func (m *statusMixin) setStatus(s *types.ResourceStatusResponse) { m.status = s }
 
 // State returns the current lifecycle state, or the zero State ("").
 func (m *statusMixin) State() types.State {
@@ -67,18 +67,18 @@ func (m *statusMixin) State() types.State {
 
 // IsDisabled returns true when the server has disabled this resource.
 func (m *statusMixin) IsDisabled() bool {
-	if m.status == nil || m.status.DisableStatusInfo == nil {
+	if m.status == nil || m.status.DisableStatusInfoResponse == nil {
 		return false
 	}
-	return m.status.DisableStatusInfo.IsDisabled
+	return m.status.DisableStatusInfoResponse.IsDisabled
 }
 
 // DisableReasons returns the reasons for disabling, or nil.
 func (m *statusMixin) DisableReasons() []string {
-	if m.status == nil || m.status.DisableStatusInfo == nil {
+	if m.status == nil || m.status.DisableStatusInfoResponse == nil {
 		return nil
 	}
-	return m.status.DisableStatusInfo.Reasons
+	return m.status.DisableStatusInfoResponse.Reasons
 }
 
 // FailureReason returns the failure reason string, or "".
@@ -91,10 +91,10 @@ func (m *statusMixin) FailureReason() string {
 
 // PreviousState returns the previous lifecycle state, or the zero State ("").
 func (m *statusMixin) PreviousState() types.State {
-	if m.status == nil || m.status.PreviousStatus == nil || m.status.PreviousStatus.State == nil {
+	if m.status == nil || m.status.PreviousStatusResponse == nil || m.status.PreviousStatusResponse.State == nil {
 		return ""
 	}
-	return *m.status.PreviousStatus.State
+	return *m.status.PreviousStatusResponse.State
 }
 
 // WaitUntilActive blocks until the resource reaches the "Active" state.

--- a/pkg/aruba/mixin_status_test.go
+++ b/pkg/aruba/mixin_status_test.go
@@ -18,7 +18,7 @@ import (
 func TestStatusMixin_SetStatus(t *testing.T) {
 	var m statusMixin
 	var state types.State = "Active"
-	m.setStatus(&types.ResourceStatus{State: &state})
+	m.setStatus(&types.ResourceStatusResponse{State: &state})
 	if m.State() != "Active" {
 		t.Errorf("State() after setStatus = %q", m.State())
 	}
@@ -63,14 +63,14 @@ func TestStatusMixin_Populated(t *testing.T) {
 	var prev types.State = "Pending"
 	reason := "disk full"
 	m := statusMixin{
-		status: &types.ResourceStatus{
+		status: &types.ResourceStatusResponse{
 			State:         &state,
 			FailureReason: &reason,
-			DisableStatusInfo: &types.DisableStatusInfo{
+			DisableStatusInfoResponse: &types.DisableStatusInfoResponse{
 				IsDisabled: true,
 				Reasons:    []string{"maintenance"},
 			},
-			PreviousStatus: &types.PreviousStatus{
+			PreviousStatusResponse: &types.PreviousStatusResponse{
 				State: &prev,
 			},
 		},
@@ -211,7 +211,7 @@ func TestWaitUntilActive_HappyPath(t *testing.T) {
 			state = types.StateActive
 		}
 		s := state
-		m.setStatus(&types.ResourceStatus{State: &s})
+		m.setStatus(&types.ResourceStatusResponse{State: &s})
 		return nil
 	})
 	if err := m.WaitUntilActive(context.Background(), fastOpts()...); err != nil {
@@ -235,7 +235,7 @@ func TestWaitUntilStates_CustomTarget(t *testing.T) {
 			state = "Available"
 		}
 		s := state
-		m.setStatus(&types.ResourceStatus{State: &s})
+		m.setStatus(&types.ResourceStatusResponse{State: &s})
 		return nil
 	})
 	if err := m.WaitUntilStates(context.Background(), []types.State{"Available"}, fastOpts()...); err != nil {
@@ -262,7 +262,7 @@ func TestWaitUntilReady_HappyPath(t *testing.T) {
 					state = target
 				}
 				s := state
-				m.setStatus(&types.ResourceStatus{State: &s})
+				m.setStatus(&types.ResourceStatusResponse{State: &s})
 				return nil
 			})
 			if err := m.WaitUntilReady(context.Background(), fastOpts()...); err != nil {
@@ -292,7 +292,7 @@ func TestWaitUntilActive_FailureState(t *testing.T) {
 					state = failState
 				}
 				s := state
-				m.setStatus(&types.ResourceStatus{State: &s})
+				m.setStatus(&types.ResourceStatusResponse{State: &s})
 				return nil
 			})
 			err := m.WaitUntilActive(context.Background(), fastOpts()...)
@@ -320,7 +320,7 @@ func TestWaitUntilActive_SettledNonTarget(t *testing.T) {
 			state = types.StateReserved // settled non-target for WaitUntilActive
 		}
 		s := state
-		m.setStatus(&types.ResourceStatus{State: &s})
+		m.setStatus(&types.ResourceStatusResponse{State: &s})
 		return nil
 	})
 	err := m.WaitUntilActive(context.Background(), fastOpts()...)
@@ -346,7 +346,7 @@ func TestWaitUntilStates_ReservedIsTarget(t *testing.T) {
 			state = types.StateReserved
 		}
 		s := state
-		m.setStatus(&types.ResourceStatus{State: &s})
+		m.setStatus(&types.ResourceStatusResponse{State: &s})
 		return nil
 	})
 	// Listing Reserved as a target (as WaitUntilUsed does) must succeed.
@@ -372,7 +372,7 @@ func TestWaitUntilStates_ReservedFailsFastWhenNotTarget(t *testing.T) {
 			state = types.StateReserved
 		}
 		s := state
-		m.setStatus(&types.ResourceStatus{State: &s})
+		m.setStatus(&types.ResourceStatusResponse{State: &s})
 		return nil
 	})
 	// NotUsed only — Reserved is not in the target list.
@@ -402,7 +402,7 @@ func TestWaitUntilActive_RefreshError_Retried(t *testing.T) {
 		}
 		state = types.StateActive
 		s := state
-		m.setStatus(&types.ResourceStatus{State: &s})
+		m.setStatus(&types.ResourceStatusResponse{State: &s})
 		return nil
 	})
 	if err := m.WaitUntilActive(context.Background(), fastOpts()...); err != nil {
@@ -417,7 +417,7 @@ func TestWaitUntilActive_RefreshError_Retried(t *testing.T) {
 func TestWaitUntilActive_RetriesExhausted(t *testing.T) {
 	var m statusMixin
 	s := types.StateInCreation
-	m.setStatus(&types.ResourceStatus{State: &s})
+	m.setStatus(&types.ResourceStatusResponse{State: &s})
 	m.setRefresh(func(_ context.Context) error { return nil }) // never advances state
 	err := m.WaitUntilActive(context.Background(),
 		WithRetries(2),
@@ -436,7 +436,7 @@ func TestWaitUntilActive_RetriesExhausted(t *testing.T) {
 func TestWaitUntilActive_Timeout(t *testing.T) {
 	var m statusMixin
 	s := types.StateInCreation
-	m.setStatus(&types.ResourceStatus{State: &s})
+	m.setStatus(&types.ResourceStatusResponse{State: &s})
 	m.setRefresh(func(_ context.Context) error { return nil }) // never advances
 	err := m.WaitUntilActive(context.Background(),
 		WithRetries(1000),
@@ -455,7 +455,7 @@ func TestWaitUntilActive_Timeout(t *testing.T) {
 func TestWaitUntilActive_ContextCancellation(t *testing.T) {
 	var m statusMixin
 	s := types.StateInCreation
-	m.setStatus(&types.ResourceStatus{State: &s})
+	m.setStatus(&types.ResourceStatusResponse{State: &s})
 	m.setRefresh(func(_ context.Context) error { return nil })
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel() // cancel immediately

--- a/pkg/aruba/options.go
+++ b/pkg/aruba/options.go
@@ -25,6 +25,10 @@ type Options struct {
 
 	// userDefinedDependencies contains injected components.
 	userDefinedDependencies userDefinedDependenciesOptions
+
+	// userAgent overrides the default User-Agent header value.
+	// When empty, defaultUserAgent is used.
+	userAgent string
 }
 
 func (o *Options) validate() error {
@@ -364,6 +368,7 @@ func (o *Options) DeepCopy() *Options {
 	cp := &Options{
 		baseURL:    o.baseURL,
 		loggerType: o.loggerType,
+		userAgent:  o.userAgent,
 		userDefinedDependencies: userDefinedDependenciesOptions{
 			httpClient: o.userDefinedDependencies.httpClient,
 			logger:     o.userDefinedDependencies.logger,
@@ -695,6 +700,14 @@ func (o *Options) WithCustomLogger(logger logger.Logger) *Options {
 // WithCustomMiddleware allows injecting a custom interceptor.Interceptor.
 func (o *Options) WithCustomMiddleware(middleware interceptor.Interceptor) *Options {
 	o.userDefinedDependencies.middleware = middleware
+	return o
+}
+
+// WithUserAgent overrides the default User-Agent header sent with every request.
+// The default is "sdk-go@<version>" (see pkg/aruba.Version). Pass an empty string
+// to restore the default.
+func (o *Options) WithUserAgent(ua string) *Options {
+	o.userAgent = ua
 	return o
 }
 

--- a/pkg/aruba/resource_alert.go
+++ b/pkg/aruba/resource_alert.go
@@ -235,7 +235,7 @@ func (a *Alert) Hidden() bool {
 }
 
 // ExecutedAlertActions returns the list of executed alert actions, or nil when absent.
-func (a *Alert) ExecutedAlertActions() []types.ExecutedAlertAction {
+func (a *Alert) ExecutedAlertActions() []types.ExecutedAlertActionResponse {
 	if a.response == nil {
 		return nil
 	}
@@ -243,7 +243,7 @@ func (a *Alert) ExecutedAlertActions() []types.ExecutedAlertAction {
 }
 
 // Actions returns the list of available alert actions, or nil when absent.
-func (a *Alert) Actions() []types.AlertAction {
+func (a *Alert) Actions() []types.AlertActionResponse {
 	if a.response == nil {
 		return nil
 	}

--- a/pkg/aruba/resource_alert_test.go
+++ b/pkg/aruba/resource_alert_test.go
@@ -53,8 +53,8 @@ func alertMakeFullResponse() types.AlertResponse {
 		Email:                true,
 		Panel:                false,
 		Hidden:               false,
-		ExecutedAlertActions: []types.ExecutedAlertAction{{ActionType: "email", Success: true}},
-		Actions:              []types.AlertAction{{Key: "retry"}},
+		ExecutedAlertActions: []types.ExecutedAlertActionResponse{{ActionType: "email", Success: true}},
+		Actions:              []types.AlertActionResponse{{Key: "retry"}},
 	}
 }
 

--- a/pkg/aruba/resource_audit_event.go
+++ b/pkg/aruba/resource_audit_event.go
@@ -185,6 +185,30 @@ func (e *AuditEvent) Title() string {
 	return *e.response.Title
 }
 
+// EventTypeName returns the event type string from Event.Type, or "" when absent.
+func (e *AuditEvent) EventTypeName() string {
+	if e.response == nil {
+		return ""
+	}
+	return e.response.Event.Type
+}
+
+// IdentityName returns the caller username, or "" when absent.
+func (e *AuditEvent) IdentityName() string {
+	if e.response == nil || e.response.Identity.Caller.Username == nil {
+		return ""
+	}
+	return *e.response.Identity.Caller.Username
+}
+
+// OperationName returns the operation value string, or "" when absent.
+func (e *AuditEvent) OperationName() string {
+	if e.response == nil || e.response.Operation.Value == nil {
+		return ""
+	}
+	return *e.response.Operation.Value
+}
+
 func (e *AuditEvent) fromResponse(resp *types.AuditEvent) {
 	if resp == nil {
 		return

--- a/pkg/aruba/resource_audit_event.go
+++ b/pkg/aruba/resource_audit_event.go
@@ -19,7 +19,7 @@ type AuditEvent struct {
 	responseMetadataMixin // shadowed: ID(), URI(), CreatedAt(), Raw()
 	httpEnvelopeMixin     // RawHTTP(), StatusCode(), Headers(), RawError()
 
-	response *types.AuditEvent // backs Raw() and all field accessors
+	response *types.AuditEventResponse // backs Raw() and all field accessors
 }
 
 // Getters — general → specific
@@ -45,9 +45,9 @@ func (e *AuditEvent) CreatedAt() time.Time {
 }
 
 // Raw returns the underlying wire payload. Shadows responseMetadataMixin.Raw().
-func (e *AuditEvent) Raw() *types.AuditEvent { return e.response }
-func (e *AuditEvent) RawJSON() []byte        { return marshalRawJSON(e.response) }
-func (e *AuditEvent) RawYAML() []byte        { return marshalRawYAML(e.response) }
+func (e *AuditEvent) Raw() *types.AuditEventResponse { return e.response }
+func (e *AuditEvent) RawJSON() []byte                { return marshalRawJSON(e.response) }
+func (e *AuditEvent) RawYAML() []byte                { return marshalRawYAML(e.response) }
 
 // SeverityLevel returns the event severity level, or "" when unset.
 func (e *AuditEvent) SeverityLevel() string {
@@ -74,33 +74,33 @@ func (e *AuditEvent) Channel() string {
 }
 
 // LogFormat returns the log format version.
-func (e *AuditEvent) LogFormat() types.LogFormatVersion {
+func (e *AuditEvent) LogFormat() types.EventLogFormatVersionResponse {
 	if e.response == nil {
-		return types.LogFormatVersion{}
+		return types.EventLogFormatVersionResponse{}
 	}
 	return e.response.LogFormat
 }
 
 // Operation returns the operation associated with this event.
-func (e *AuditEvent) Operation() types.Operation {
+func (e *AuditEvent) Operation() types.EventOperationResponse {
 	if e.response == nil {
-		return types.Operation{}
+		return types.EventOperationResponse{}
 	}
 	return e.response.Operation
 }
 
 // Event returns the event information (ID, type, value).
-func (e *AuditEvent) Event() types.EventInfo {
+func (e *AuditEvent) Event() types.EventInfoResponse {
 	if e.response == nil {
-		return types.EventInfo{}
+		return types.EventInfoResponse{}
 	}
 	return e.response.Event
 }
 
 // Category returns the event category.
-func (e *AuditEvent) Category() types.EventCategory {
+func (e *AuditEvent) Category() types.EventCategoryResponse {
 	if e.response == nil {
-		return types.EventCategory{}
+		return types.EventCategoryResponse{}
 	}
 	return e.response.Category
 }
@@ -122,15 +122,15 @@ func (e *AuditEvent) Zone() Zone {
 }
 
 // Status returns the event status.
-func (e *AuditEvent) Status() types.Status {
+func (e *AuditEvent) Status() types.EventStatusResponse {
 	if e.response == nil {
-		return types.Status{}
+		return types.EventStatusResponse{}
 	}
 	return e.response.Status
 }
 
 // SubStatus returns the optional sub-status, or nil when absent.
-func (e *AuditEvent) SubStatus() *types.SubStatus {
+func (e *AuditEvent) SubStatus() *types.EventSubStatusResponse {
 	if e.response == nil {
 		return nil
 	}
@@ -138,9 +138,9 @@ func (e *AuditEvent) SubStatus() *types.SubStatus {
 }
 
 // Identity returns the caller identity for this event.
-func (e *AuditEvent) Identity() types.Identity {
+func (e *AuditEvent) Identity() types.EventIdentityResponse {
 	if e.response == nil {
-		return types.Identity{}
+		return types.EventIdentityResponse{}
 	}
 	return e.response.Identity
 }
@@ -154,7 +154,7 @@ func (e *AuditEvent) Properties() map[string]interface{} {
 }
 
 // Actions returns the available actions for this event, or nil when absent.
-func (e *AuditEvent) Actions() []types.Action {
+func (e *AuditEvent) Actions() []types.EventActionResponse {
 	if e.response == nil {
 		return nil
 	}
@@ -209,7 +209,7 @@ func (e *AuditEvent) OperationName() string {
 	return *e.response.Operation.Value
 }
 
-func (e *AuditEvent) fromResponse(resp *types.AuditEvent) {
+func (e *AuditEvent) fromResponse(resp *types.AuditEventResponse) {
 	if resp == nil {
 		return
 	}

--- a/pkg/aruba/resource_audit_event_test.go
+++ b/pkg/aruba/resource_audit_event_test.go
@@ -27,8 +27,8 @@ func buildAuditEventTestAdapter(t *testing.T, handler http.HandlerFunc) *auditEv
 // auditTestTimestamp is a fixed time used across hydration tests.
 var auditTestTimestamp = time.Date(2025, 1, 15, 12, 0, 0, 0, time.UTC)
 
-// auditMakeFullEvent returns a fully-populated types.AuditEvent for hydration tests.
-func auditMakeFullEvent() types.AuditEvent {
+// auditMakeFullEvent returns a fully-populated types.AuditEventResponse for hydration tests.
+func auditMakeFullEvent() types.AuditEventResponse {
 	catID := "cat-42"
 	typID := "typ-99"
 	title := "Resource Created"
@@ -36,20 +36,20 @@ func auditMakeFullEvent() types.AuditEvent {
 	az := "az1"
 	subStatusVal := "sub-ok"
 	subStatusDesc := "sub-description"
-	return types.AuditEvent{
+	return types.AuditEventResponse{
 		SeverityLevel: "Info",
-		LogFormat:     types.LogFormatVersion{Version: "1.0"},
+		LogFormat:     types.EventLogFormatVersionResponse{Version: "1.0"},
 		Timestamp:     auditTestTimestamp,
-		Operation:     types.Operation{ID: "op-1", Value: strPtr("Create")},
-		Event:         types.EventInfo{ID: "evt-1", Value: strPtr("evt-value"), Type: "write"},
-		Category:      types.EventCategory{Value: "resource", Description: strPtr("Resource category")},
-		Region:        &types.RegionInfo{Name: &regionName, AvailabilityZone: &az},
+		Operation:     types.EventOperationResponse{ID: "op-1", Value: strPtr("Create")},
+		Event:         types.EventInfoResponse{ID: "evt-1", Value: strPtr("evt-value"), Type: "write"},
+		Category:      types.EventCategoryResponse{Value: "resource", Description: strPtr("Resource category")},
+		Region:        &types.EventRegionInfoResponse{Name: &regionName, AvailabilityZone: &az},
 		Origin:        "portal",
 		Channel:       "web",
-		Status:        types.Status{Value: "Success", Description: strPtr("ok"), Code: int32Ptr(200)},
-		SubStatus:     &types.SubStatus{Value: &subStatusVal, Description: &subStatusDesc},
-		Identity: types.Identity{
-			Caller: types.Caller{
+		Status:        types.EventStatusResponse{Value: "Success", Description: strPtr("ok"), Code: int32Ptr(200)},
+		SubStatus:     &types.EventSubStatusResponse{Value: &subStatusVal, Description: &subStatusDesc},
+		Identity: types.EventIdentityResponse{
+			Caller: types.EventCallerResponse{
 				Subject:  "user-sub",
 				Username: strPtr("alice"),
 				Company:  strPtr("ArubaCloud"),
@@ -57,7 +57,7 @@ func auditMakeFullEvent() types.AuditEvent {
 			},
 		},
 		Properties: map[string]interface{}{"key": "val"},
-		Actions:    []types.Action{{Key: strPtr("action-1")}},
+		Actions:    []types.EventActionResponse{{Key: strPtr("action-1")}},
 		CategoryID: &catID,
 		TypologyID: &typID,
 		Title:      &title,
@@ -171,16 +171,16 @@ func TestAuditEvent_Accessors_ZeroValue(t *testing.T) {
 	if ev.Channel() != "" {
 		t.Error("Channel() on zero should be empty")
 	}
-	if ev.LogFormat() != (types.LogFormatVersion{}) {
+	if ev.LogFormat() != (types.EventLogFormatVersionResponse{}) {
 		t.Error("LogFormat() on zero should be zero value")
 	}
-	if ev.Operation() != (types.Operation{}) {
+	if ev.Operation() != (types.EventOperationResponse{}) {
 		t.Error("Operation() on zero should be zero value")
 	}
-	if ev.Event() != (types.EventInfo{}) {
+	if ev.Event() != (types.EventInfoResponse{}) {
 		t.Error("Event() on zero should be zero value")
 	}
-	if ev.Category() != (types.EventCategory{}) {
+	if ev.Category() != (types.EventCategoryResponse{}) {
 		t.Error("Category() on zero should be zero value")
 	}
 	if ev.Region() != "" {
@@ -223,13 +223,13 @@ func TestAuditEvent_Accessors_ZeroValue(t *testing.T) {
 
 func TestAuditEvent_ID_FromEvent(t *testing.T) {
 	ev := &AuditEvent{}
-	ev.fromResponse(&types.AuditEvent{Event: types.EventInfo{ID: "evt-123"}})
+	ev.fromResponse(&types.AuditEventResponse{Event: types.EventInfoResponse{ID: "evt-123"}})
 	if ev.ID() != "evt-123" {
 		t.Errorf("ID() = %q, want evt-123", ev.ID())
 	}
 
 	ev2 := &AuditEvent{}
-	ev2.fromResponse(&types.AuditEvent{}) // Event.ID is ""
+	ev2.fromResponse(&types.AuditEventResponse{}) // Event.ID is ""
 	if ev2.ID() != "" {
 		t.Errorf("ID() = %q, want empty", ev2.ID())
 	}
@@ -248,7 +248,7 @@ func TestAuditEvent_URI_AlwaysEmpty(t *testing.T) {
 func TestAuditEvent_CreatedAt_FromTimestamp(t *testing.T) {
 	ts := time.Date(2024, 6, 1, 0, 0, 0, 0, time.UTC)
 	ev := &AuditEvent{}
-	ev.fromResponse(&types.AuditEvent{Timestamp: ts})
+	ev.fromResponse(&types.AuditEventResponse{Timestamp: ts})
 	if !ev.CreatedAt().Equal(ts) {
 		t.Errorf("CreatedAt() = %v, want %v", ev.CreatedAt(), ts)
 	}
@@ -256,7 +256,7 @@ func TestAuditEvent_CreatedAt_FromTimestamp(t *testing.T) {
 
 func TestAuditEvent_OptionalStringPointers_NilAndPresent(t *testing.T) {
 	ev := &AuditEvent{}
-	ev.fromResponse(&types.AuditEvent{})
+	ev.fromResponse(&types.AuditEventResponse{})
 
 	if ev.CategoryID() != "" {
 		t.Errorf("CategoryID() nil ptr = %q", ev.CategoryID())
@@ -272,7 +272,7 @@ func TestAuditEvent_OptionalStringPointers_NilAndPresent(t *testing.T) {
 	typID := "typ-2"
 	title := "My Title"
 	ev2 := &AuditEvent{}
-	ev2.fromResponse(&types.AuditEvent{CategoryID: &catID, TypologyID: &typID, Title: &title})
+	ev2.fromResponse(&types.AuditEventResponse{CategoryID: &catID, TypologyID: &typID, Title: &title})
 
 	if ev2.CategoryID() != "cat-1" {
 		t.Errorf("CategoryID() = %q", ev2.CategoryID())
@@ -481,7 +481,7 @@ func TestAuditEvent_IdentityName_NilResponse(t *testing.T) {
 }
 
 func TestAuditEvent_IdentityName_NoUsername(t *testing.T) {
-	ev := types.AuditEvent{Identity: types.Identity{Caller: types.Caller{Subject: "sub"}}}
+	ev := types.AuditEventResponse{Identity: types.EventIdentityResponse{Caller: types.EventCallerResponse{Subject: "sub"}}}
 	e := &AuditEvent{}
 	e.fromResponse(&ev)
 	if got := e.IdentityName(); got != "" {
@@ -510,7 +510,7 @@ func TestAuditEvent_OperationName_NilResponse(t *testing.T) {
 }
 
 func TestAuditEvent_OperationName_NoValue(t *testing.T) {
-	ev := types.AuditEvent{Operation: types.Operation{ID: "op-1"}}
+	ev := types.AuditEventResponse{Operation: types.EventOperationResponse{ID: "op-1"}}
 	e := &AuditEvent{}
 	e.fromResponse(&ev)
 	if got := e.OperationName(); got != "" {

--- a/pkg/aruba/resource_audit_event_test.go
+++ b/pkg/aruba/resource_audit_event_test.go
@@ -449,6 +449,84 @@ func TestEventsClient_OnlyHasList(t *testing.T) {
 // Refetch placeholder coverage
 // --------------------------------------------------------------------------
 
+// --------------------------------------------------------------------------
+// EventTypeName getter
+// --------------------------------------------------------------------------
+
+func TestAuditEvent_EventTypeName_NilResponse(t *testing.T) {
+	e := &AuditEvent{}
+	if got := e.EventTypeName(); got != "" {
+		t.Errorf("EventTypeName() = %q, want empty", got)
+	}
+}
+
+func TestAuditEvent_EventTypeName_FromResponse(t *testing.T) {
+	ev := auditMakeFullEvent()
+	e := &AuditEvent{}
+	e.fromResponse(&ev)
+	if got := e.EventTypeName(); got != "write" {
+		t.Errorf("EventTypeName() = %q, want write", got)
+	}
+}
+
+// --------------------------------------------------------------------------
+// IdentityName getter
+// --------------------------------------------------------------------------
+
+func TestAuditEvent_IdentityName_NilResponse(t *testing.T) {
+	e := &AuditEvent{}
+	if got := e.IdentityName(); got != "" {
+		t.Errorf("IdentityName() = %q, want empty", got)
+	}
+}
+
+func TestAuditEvent_IdentityName_NoUsername(t *testing.T) {
+	ev := types.AuditEvent{Identity: types.Identity{Caller: types.Caller{Subject: "sub"}}}
+	e := &AuditEvent{}
+	e.fromResponse(&ev)
+	if got := e.IdentityName(); got != "" {
+		t.Errorf("IdentityName() = %q, want empty when username nil", got)
+	}
+}
+
+func TestAuditEvent_IdentityName_FromResponse(t *testing.T) {
+	ev := auditMakeFullEvent()
+	e := &AuditEvent{}
+	e.fromResponse(&ev)
+	if got := e.IdentityName(); got != "alice" {
+		t.Errorf("IdentityName() = %q, want alice", got)
+	}
+}
+
+// --------------------------------------------------------------------------
+// OperationName getter
+// --------------------------------------------------------------------------
+
+func TestAuditEvent_OperationName_NilResponse(t *testing.T) {
+	e := &AuditEvent{}
+	if got := e.OperationName(); got != "" {
+		t.Errorf("OperationName() = %q, want empty", got)
+	}
+}
+
+func TestAuditEvent_OperationName_NoValue(t *testing.T) {
+	ev := types.AuditEvent{Operation: types.Operation{ID: "op-1"}}
+	e := &AuditEvent{}
+	e.fromResponse(&ev)
+	if got := e.OperationName(); got != "" {
+		t.Errorf("OperationName() = %q, want empty when Value nil", got)
+	}
+}
+
+func TestAuditEvent_OperationName_FromResponse(t *testing.T) {
+	ev := auditMakeFullEvent()
+	e := &AuditEvent{}
+	e.fromResponse(&ev)
+	if got := e.OperationName(); got != "Create" {
+		t.Errorf("OperationName() = %q, want Create", got)
+	}
+}
+
 func TestAuditEventsClientAdapter_List_RefetchReturnsError(t *testing.T) {
 	adapter := buildAuditEventTestAdapter(t, func(w http.ResponseWriter, _ *http.Request) {
 		w.Header().Set("Content-Type", "application/json")

--- a/pkg/aruba/resource_block_storage.go
+++ b/pkg/aruba/resource_block_storage.go
@@ -323,7 +323,7 @@ func (b *BlockStorage) WaitUntilUsed(ctx context.Context, opts ...WaitOption) er
 // *types.Response[T] preserves HTTP envelope details (status code, headers,
 // raw body) for the wrapper's diagnostics.
 type volumeLowLevelClient interface {
-	List(ctx context.Context, projectID string, params *types.RequestParameters) (*types.Response[types.BlockStorageList], error)
+	List(ctx context.Context, projectID string, params *types.RequestParameters) (*types.Response[types.BlockStorageListResponse], error)
 	Get(ctx context.Context, projectID, volumeID string, params *types.RequestParameters) (*types.Response[types.BlockStorageResponse], error)
 	Create(ctx context.Context, projectID string, body types.BlockStorageRequest, params *types.RequestParameters) (*types.Response[types.BlockStorageResponse], error)
 	Update(ctx context.Context, projectID, volumeID string, body types.BlockStorageRequest, params *types.RequestParameters) (*types.Response[types.BlockStorageResponse], error)
@@ -514,7 +514,7 @@ func (a *volumesClientAdapter) List(ctx context.Context, project Ref, opts ...Ca
 	}
 	var refetch func(ctx context.Context, pageURL string) (*List[*BlockStorage], error)
 	refetch = func(ctx context.Context, pageURL string) (*List[*BlockStorage], error) {
-		fetch := listPageFetch[types.BlockStorageList](a.rest, opts)
+		fetch := listPageFetch[types.BlockStorageListResponse](a.rest, opts)
 		pageResp, fetchErr := fetch(ctx, pageURL)
 		if fetchErr != nil {
 			return nil, fetchErr

--- a/pkg/aruba/resource_block_storage.go
+++ b/pkg/aruba/resource_block_storage.go
@@ -187,7 +187,7 @@ func (b *BlockStorage) toCreateRequest() types.BlockStorageRequest {
 		Image:         b.image,
 	}
 	if b.snapshotRef != nil {
-		props.Snapshot = &types.ReferenceResource{URI: *b.snapshotRef}
+		props.Snapshot = &types.ReferenceResourceCommon{URI: *b.snapshotRef}
 	}
 	return types.BlockStorageRequest{
 		Metadata: types.RegionalResourceMetadataRequest{
@@ -218,7 +218,7 @@ func (b *BlockStorage) toUpdateRequest() types.BlockStorageRequest {
 		Image:         b.image,
 	}
 	if b.snapshotRef != nil {
-		props.Snapshot = &types.ReferenceResource{URI: *b.snapshotRef}
+		props.Snapshot = &types.ReferenceResourceCommon{URI: *b.snapshotRef}
 	}
 	return types.BlockStorageRequest{
 		Metadata: types.RegionalResourceMetadataRequest{
@@ -276,8 +276,8 @@ func (b *BlockStorage) fromResponse(resp *types.BlockStorageResponse) {
 		b.snapshotRef = &v
 	}
 
-	if resp.Metadata.ProjectResponseMetadata != nil && resp.Metadata.ProjectResponseMetadata.ID != "" {
-		b.projectID = resp.Metadata.ProjectResponseMetadata.ID
+	if resp.Metadata.ProjectMetadataResponse != nil && resp.Metadata.ProjectMetadataResponse.ID != "" {
+		b.projectID = resp.Metadata.ProjectMetadataResponse.ID
 	}
 	if b.projectID == "" && b.RespURI() != "" {
 		if pid := parseURIIDs(b.RespURI())["projects"]; pid != "" {

--- a/pkg/aruba/resource_block_storage_test.go
+++ b/pkg/aruba/resource_block_storage_test.go
@@ -258,7 +258,7 @@ func blockStorageTestResponse(id, name, uri, projectID string) *types.BlockStora
 	img := VolumeImageLU22001
 	boot := true
 	zone := ZoneITBG1
-	snap := &types.ReferenceResource{URI: "/projects/p/providers/Aruba.Storage/snapshots/s1"}
+	snap := &types.ReferenceResourceCommon{URI: "/projects/p/providers/Aruba.Storage/snapshots/s1"}
 	return &types.BlockStorageResponse{
 		Metadata: types.ResourceMetadataResponse{
 			ID:               &id,
@@ -266,7 +266,7 @@ func blockStorageTestResponse(id, name, uri, projectID string) *types.BlockStora
 			Name:             &name,
 			Tags:             []string{"tag1"},
 			LocationResponse: loc,
-			ProjectResponseMetadata: &types.ProjectResponseMetadata{
+			ProjectMetadataResponse: &types.ProjectMetadataResponse{
 				ID: projectID,
 			},
 		},
@@ -278,13 +278,13 @@ func blockStorageTestResponse(id, name, uri, projectID string) *types.BlockStora
 			Image:         &img,
 			Bootable:      &boot,
 			Snapshot:      snap,
-			LinkedResources: []types.LinkedResource{
+			LinkedResources: []types.LinkedResourceCommon{
 				{URI: "/projects/p/providers/Aruba.Compute/cloudservers/cs1", StrictCorrelation: true},
 			},
 		},
-		Status: types.ResourceStatus{
+		Status: types.ResourceStatusResponse{
 			State: &state,
-			DisableStatusInfo: &types.DisableStatusInfo{
+			DisableStatusInfoResponse: &types.DisableStatusInfoResponse{
 				IsDisabled: false,
 			},
 		},
@@ -377,12 +377,12 @@ func TestBlockStorage_FromResponseURIBackfill(t *testing.T) {
 			ID:  &id,
 			URI: &uri,
 		},
-		Status: types.ResourceStatus{State: &state},
+		Status: types.ResourceStatusResponse{State: &state},
 	}
 	bs := &BlockStorage{}
 	bs.fromResponse(resp)
 
-	// ProjectResponseMetadata is nil → should backfill from URI.
+	// ProjectMetadataResponse is nil → should backfill from URI.
 	if bs.ProjectID() != "p-uri" {
 		t.Errorf("ProjectID() via URI backfill = %q", bs.ProjectID())
 	}
@@ -682,7 +682,7 @@ func TestVolumesClientAdapter_Update_NoProject(t *testing.T) {
 		Metadata: types.ResourceMetadataResponse{
 			ID: strPtr("bs-1"),
 		},
-		Status: types.ResourceStatus{},
+		Status: types.ResourceStatusResponse{},
 	})
 
 	_, err := adapter.Update(context.Background(), bs)
@@ -919,7 +919,7 @@ func TestBlockStorage_FromResponse_SetsStatus(t *testing.T) {
 	b := &BlockStorage{}
 	state := types.State("NotUsed")
 	b.fromResponse(&types.BlockStorageResponse{
-		Status: types.ResourceStatus{State: &state},
+		Status: types.ResourceStatusResponse{State: &state},
 	})
 	if b.State() != types.StateNotUsed {
 		t.Errorf("State() = %q after fromResponse, want NotUsed", b.State())
@@ -936,7 +936,7 @@ func TestBlockStorage_WaitUntilNotUsed_HappyPath(t *testing.T) {
 			state = "NotUsed"
 		}
 		s := state
-		b.setStatus(&types.ResourceStatus{State: &s})
+		b.setStatus(&types.ResourceStatusResponse{State: &s})
 		return nil
 	})
 	if err := b.WaitUntilNotUsed(context.Background(), fastOpts()...); err != nil {
@@ -959,7 +959,7 @@ func TestBlockStorage_WaitUntilUsed_HappyPath(t *testing.T) {
 					state = attachedState
 				}
 				s := state
-				b.setStatus(&types.ResourceStatus{State: &s})
+				b.setStatus(&types.ResourceStatusResponse{State: &s})
 				return nil
 			})
 			if err := b.WaitUntilUsed(context.Background(), fastOpts()...); err != nil {

--- a/pkg/aruba/resource_cloud_server.go
+++ b/pkg/aruba/resource_cloud_server.go
@@ -299,7 +299,7 @@ func (cs *CloudServer) SecurityGroups() []string {
 func (cs *CloudServer) UserData() string { return cloudServerDerefString(cs.userData) }
 
 // NetworkInterfaces returns the list of network interface details from the last response, or nil.
-func (cs *CloudServer) NetworkInterfaces() []types.CloudServerNetworkInterfaceDetails {
+func (cs *CloudServer) NetworkInterfaces() []types.CloudServerNetworkInterfaceResponse {
 	if cs.response == nil {
 		return nil
 	}
@@ -528,7 +528,7 @@ type cloudServerActions interface {
 // *types.Response[T] preserves HTTP envelope details (status code, headers,
 // raw body) for the wrapper's diagnostics.
 type cloudServerLowLevelClient interface {
-	List(ctx context.Context, projectID string, params *types.RequestParameters) (*types.Response[types.CloudServerList], error)
+	List(ctx context.Context, projectID string, params *types.RequestParameters) (*types.Response[types.CloudServerListResponse], error)
 	Get(ctx context.Context, projectID, cloudServerID string, params *types.RequestParameters) (*types.Response[types.CloudServerResponse], error)
 	Create(ctx context.Context, projectID string, body types.CloudServerRequest, params *types.RequestParameters) (*types.Response[types.CloudServerResponse], error)
 	Update(ctx context.Context, projectID, cloudServerID string, body types.CloudServerRequest, params *types.RequestParameters) (*types.Response[types.CloudServerResponse], error)
@@ -727,7 +727,7 @@ func (a *cloudServersClientAdapter) List(ctx context.Context, project Ref, opts 
 	}
 	var refetch func(ctx context.Context, pageURL string) (*List[*CloudServer], error)
 	refetch = func(ctx context.Context, pageURL string) (*List[*CloudServer], error) {
-		fetch := listPageFetch[types.CloudServerList](a.rest, opts)
+		fetch := listPageFetch[types.CloudServerListResponse](a.rest, opts)
 		pageResp, fetchErr := fetch(ctx, pageURL)
 		if fetchErr != nil {
 			return nil, fetchErr

--- a/pkg/aruba/resource_cloud_server.go
+++ b/pkg/aruba/resource_cloud_server.go
@@ -253,6 +253,51 @@ func (cs *CloudServer) KeyPair() string {
 	return cloudServerDerefString(cs.keyPairRef)
 }
 
+// ElasticIP returns the elastic IP URI set via WithElasticIP, or "" if unset.
+// The API does not return the elastic IP in the response body; this getter
+// returns the locally-cached setter value only.
+func (cs *CloudServer) ElasticIP() string { return cloudServerDerefString(cs.elasticIPRef) }
+
+// Subnets returns the subnet URIs. After a Get/Create/Update the values come from
+// the server response (NetworkInterfaces[].Subnet); before hydration they reflect
+// what was passed to OnSubnets.
+func (cs *CloudServer) Subnets() []string {
+	if cs.response != nil && len(cs.response.Properties.NetworkInterfaces) > 0 {
+		out := make([]string, 0, len(cs.response.Properties.NetworkInterfaces))
+		for _, ni := range cs.response.Properties.NetworkInterfaces {
+			if ni.Subnet != nil && *ni.Subnet != "" {
+				out = append(out, *ni.Subnet)
+			}
+		}
+		if len(out) > 0 {
+			return out
+		}
+	}
+	if len(cs.subnetRefs) == 0 {
+		return nil
+	}
+	out := make([]string, len(cs.subnetRefs))
+	copy(out, cs.subnetRefs)
+	return out
+}
+
+// SecurityGroups returns the security group URIs set via WithSecurityGroups.
+// The API does not return security groups in a distinguishable form in the
+// response body; this getter returns the locally-cached setter values only.
+func (cs *CloudServer) SecurityGroups() []string {
+	if len(cs.securityGroupRefs) == 0 {
+		return nil
+	}
+	out := make([]string, len(cs.securityGroupRefs))
+	copy(out, cs.securityGroupRefs)
+	return out
+}
+
+// UserData returns the base64-encoded cloud-init user data set via WithUserData.
+// The API does not return user data in the response body; this getter returns
+// the locally-cached setter value only.
+func (cs *CloudServer) UserData() string { return cloudServerDerefString(cs.userData) }
+
 // NetworkInterfaces returns the list of network interface details from the last response, or nil.
 func (cs *CloudServer) NetworkInterfaces() []types.CloudServerNetworkInterfaceDetails {
 	if cs.response == nil {
@@ -442,6 +487,14 @@ func (cs *CloudServer) fromResponse(resp *types.CloudServerResponse) {
 	}
 	if resp.Properties.BillingPlan != nil && resp.Properties.BillingPlan.BillingPeriod != nil {
 		cs.billingPeriod = resp.Properties.BillingPlan.BillingPeriod
+	}
+	if len(resp.Properties.NetworkInterfaces) > 0 {
+		cs.subnetRefs = cs.subnetRefs[:0]
+		for _, ni := range resp.Properties.NetworkInterfaces {
+			if ni.Subnet != nil && *ni.Subnet != "" {
+				cs.subnetRefs = append(cs.subnetRefs, *ni.Subnet)
+			}
+		}
 	}
 
 	if resp.Metadata.ProjectResponseMetadata != nil && resp.Metadata.ProjectResponseMetadata.ID != "" {

--- a/pkg/aruba/resource_cloud_server.go
+++ b/pkg/aruba/resource_cloud_server.go
@@ -20,7 +20,7 @@ import (
 // This wrapper exposes OfFlavor(flavor) for the request leg and Flavor() / FlavorRaw()
 // for the response leg.
 //
-// The response also carries Template ReferenceResource (no request equivalent); this
+// The response also carries Template ReferenceResourceCommon (no request equivalent); this
 // wrapper exposes Template() as a read-only getter.
 type CloudServer struct {
 	errMixin
@@ -415,30 +415,30 @@ func (cs *CloudServer) toRequest() types.CloudServerRequest {
 		props.UserData = &v
 	}
 	if cs.vpcRef != nil {
-		props.VPC = types.ReferenceResource{URI: *cs.vpcRef}
+		props.VPC = types.ReferenceResourceCommon{URI: *cs.vpcRef}
 	}
 	if cs.bootVolumeRef != nil {
-		props.BootVolume = types.ReferenceResource{URI: *cs.bootVolumeRef}
+		props.BootVolume = types.ReferenceResourceCommon{URI: *cs.bootVolumeRef}
 	}
 	if cs.keyPairRef != nil {
-		props.KeyPair = &types.ReferenceResource{URI: *cs.keyPairRef}
+		props.KeyPair = &types.ReferenceResourceCommon{URI: *cs.keyPairRef}
 	}
 	if cs.elasticIPRef != nil {
-		props.ElasticIP = &types.ReferenceResource{URI: *cs.elasticIPRef}
+		props.ElasticIP = &types.ReferenceResourceCommon{URI: *cs.elasticIPRef}
 	}
 	if len(cs.subnetRefs) > 0 {
-		props.Subnets = make([]types.ReferenceResource, 0, len(cs.subnetRefs))
+		props.Subnets = make([]types.ReferenceResourceCommon, 0, len(cs.subnetRefs))
 		for _, u := range cs.subnetRefs {
-			props.Subnets = append(props.Subnets, types.ReferenceResource{URI: u})
+			props.Subnets = append(props.Subnets, types.ReferenceResourceCommon{URI: u})
 		}
 	}
 	if len(cs.securityGroupRefs) > 0 {
-		props.SecurityGroups = make([]types.ReferenceResource, 0, len(cs.securityGroupRefs))
+		props.SecurityGroups = make([]types.ReferenceResourceCommon, 0, len(cs.securityGroupRefs))
 		for _, u := range cs.securityGroupRefs {
-			props.SecurityGroups = append(props.SecurityGroups, types.ReferenceResource{URI: u})
+			props.SecurityGroups = append(props.SecurityGroups, types.ReferenceResourceCommon{URI: u})
 		}
 	}
-	props.BillingPlan = &types.BillingPlan{BillingPeriod: defaultBillingPeriod(cs.billingPeriod)}
+	props.BillingPlanCommon = &types.BillingPlanCommon{BillingPeriod: defaultBillingPeriod(cs.billingPeriod)}
 	return types.CloudServerRequest{
 		Metadata: types.RegionalResourceMetadataRequest{
 			ResourceMetadataRequest: cs.toMetadata(),
@@ -485,8 +485,8 @@ func (cs *CloudServer) fromResponse(resp *types.CloudServerResponse) {
 		v := resp.Properties.KeyPair.URI
 		cs.keyPairRef = &v
 	}
-	if resp.Properties.BillingPlan != nil && resp.Properties.BillingPlan.BillingPeriod != nil {
-		cs.billingPeriod = resp.Properties.BillingPlan.BillingPeriod
+	if resp.Properties.BillingPlanCommon != nil && resp.Properties.BillingPlanCommon.BillingPeriod != nil {
+		cs.billingPeriod = resp.Properties.BillingPlanCommon.BillingPeriod
 	}
 	if len(resp.Properties.NetworkInterfaces) > 0 {
 		cs.subnetRefs = cs.subnetRefs[:0]
@@ -497,8 +497,8 @@ func (cs *CloudServer) fromResponse(resp *types.CloudServerResponse) {
 		}
 	}
 
-	if resp.Metadata.ProjectResponseMetadata != nil && resp.Metadata.ProjectResponseMetadata.ID != "" {
-		cs.projectID = resp.Metadata.ProjectResponseMetadata.ID
+	if resp.Metadata.ProjectMetadataResponse != nil && resp.Metadata.ProjectMetadataResponse.ID != "" {
+		cs.projectID = resp.Metadata.ProjectMetadataResponse.ID
 	}
 	if cs.projectID == "" && cs.RespURI() != "" {
 		ids := parseURIIDs(cs.RespURI())

--- a/pkg/aruba/resource_cloud_server_test.go
+++ b/pkg/aruba/resource_cloud_server_test.go
@@ -453,6 +453,87 @@ func TestCloudServer_FromResponse_NilSafe(t *testing.T) {
 }
 
 // --------------------------------------------------------------------------
+// New getters: ElasticIP, Subnets, SecurityGroups, UserData
+// --------------------------------------------------------------------------
+
+func TestCloudServer_ElasticIP_Getter(t *testing.T) {
+	cs := NewCloudServer().WithElasticIP(URI("/eips/eip-1"))
+	if cs.ElasticIP() != "/eips/eip-1" {
+		t.Errorf("ElasticIP() = %q", cs.ElasticIP())
+	}
+	// not set
+	cs2 := NewCloudServer()
+	if cs2.ElasticIP() != "" {
+		t.Errorf("ElasticIP() unset = %q", cs2.ElasticIP())
+	}
+}
+
+func TestCloudServer_UserData_Getter(t *testing.T) {
+	cs := NewCloudServer().WithUserData("dGVzdA==")
+	if cs.UserData() != "dGVzdA==" {
+		t.Errorf("UserData() = %q", cs.UserData())
+	}
+	cs2 := NewCloudServer()
+	if cs2.UserData() != "" {
+		t.Errorf("UserData() unset = %q", cs2.UserData())
+	}
+}
+
+func TestCloudServer_SecurityGroups_Getter(t *testing.T) {
+	cs := NewCloudServer().
+		WithSecurityGroups(URI("/sgs/sg-1")).
+		WithSecurityGroups(URI("/sgs/sg-2"))
+	sgs := cs.SecurityGroups()
+	if len(sgs) != 2 || sgs[0] != "/sgs/sg-1" || sgs[1] != "/sgs/sg-2" {
+		t.Errorf("SecurityGroups() = %v", sgs)
+	}
+	cs2 := NewCloudServer()
+	if cs2.SecurityGroups() != nil {
+		t.Errorf("SecurityGroups() unset = %v", cs2.SecurityGroups())
+	}
+}
+
+func TestCloudServer_FromResponse_RehydratesSubnetRefs(t *testing.T) {
+	sub1 := "/subnets/s-1"
+	sub2 := "/subnets/s-2"
+	resp := &types.CloudServerResponse{
+		Properties: types.CloudServerPropertiesResult{
+			NetworkInterfaces: []types.CloudServerNetworkInterfaceDetails{
+				{Subnet: &sub1},
+				{Subnet: &sub2},
+			},
+		},
+	}
+	cs := &CloudServer{}
+	cs.fromResponse(resp)
+
+	subnets := cs.Subnets()
+	if len(subnets) != 2 {
+		t.Fatalf("Subnets() after fromResponse = %v (want 2)", subnets)
+	}
+	if subnets[0] != sub1 || subnets[1] != sub2 {
+		t.Errorf("Subnets() = %v", subnets)
+	}
+
+	// toRequest should include the rehydrated subnets
+	req := cs.toRequest()
+	if len(req.Properties.Subnets) != 2 {
+		t.Fatalf("toRequest().Subnets len = %d (want 2)", len(req.Properties.Subnets))
+	}
+	if req.Properties.Subnets[0].URI != sub1 || req.Properties.Subnets[1].URI != sub2 {
+		t.Errorf("toRequest().Subnets = %v", req.Properties.Subnets)
+	}
+}
+
+func TestCloudServer_Subnets_FallbackToLocal(t *testing.T) {
+	cs := NewCloudServer().OnSubnets(URI("/subnets/local"))
+	subnets := cs.Subnets()
+	if len(subnets) != 1 || subnets[0] != "/subnets/local" {
+		t.Errorf("Subnets() fallback = %v", subnets)
+	}
+}
+
+// --------------------------------------------------------------------------
 // Flavor asymmetry (request vs response)
 // --------------------------------------------------------------------------
 

--- a/pkg/aruba/resource_cloud_server_test.go
+++ b/pkg/aruba/resource_cloud_server_test.go
@@ -356,7 +356,7 @@ func cloudServerTestResponse(id, name, uri string) *types.CloudServerResponse {
 			Tags:             []string{"tag1"},
 			LocationResponse: loc,
 		},
-		Properties: types.CloudServerPropertiesResult{
+		Properties: types.CloudServerPropertiesResponse{
 			Zone:       ZoneITBG1,
 			Flavor:     types.CloudServerFlavorResponse{Name: CloudServerFlavorCSO2A4, CPU: 2, RAM: 4096},
 			VPC:        types.ReferenceResource{URI: "/vpcs/v"},
@@ -497,8 +497,8 @@ func TestCloudServer_FromResponse_RehydratesSubnetRefs(t *testing.T) {
 	sub1 := "/subnets/s-1"
 	sub2 := "/subnets/s-2"
 	resp := &types.CloudServerResponse{
-		Properties: types.CloudServerPropertiesResult{
-			NetworkInterfaces: []types.CloudServerNetworkInterfaceDetails{
+		Properties: types.CloudServerPropertiesResponse{
+			NetworkInterfaces: []types.CloudServerNetworkInterfaceResponse{
 				{Subnet: &sub1},
 				{Subnet: &sub2},
 			},
@@ -549,7 +549,7 @@ func TestCloudServer_Flavor_Asymmetry(t *testing.T) {
 
 	// After fromResponse: Flavor() returns the response Flavor.Name (response wins).
 	cs.fromResponse(&types.CloudServerResponse{
-		Properties: types.CloudServerPropertiesResult{
+		Properties: types.CloudServerPropertiesResponse{
 			Flavor: types.CloudServerFlavorResponse{Name: CloudServerFlavorCSO4A8, CPU: 4, RAM: 8192},
 		},
 	})
@@ -1137,13 +1137,13 @@ func TestCloudServer_Template_AndNetworkInterfaces_AfterHydration(t *testing.T) 
 	// Hydrate with a response that carries template and network-interface data.
 	templateURI := "/templates/tmpl-1"
 	mac := "aa:bb:cc:dd:ee:ff"
-	iface := types.CloudServerNetworkInterfaceDetails{
+	iface := types.CloudServerNetworkInterfaceResponse{
 		MacAddress: &mac,
 		IPs:        []string{"10.0.0.1"},
 	}
 	resp := cloudServerTestResponse("cs-1", "srv", "/projects/p/providers/Aruba.Compute/cloudServers/cs-1")
 	resp.Properties.Template = types.ReferenceResource{URI: templateURI}
-	resp.Properties.NetworkInterfaces = []types.CloudServerNetworkInterfaceDetails{iface}
+	resp.Properties.NetworkInterfaces = []types.CloudServerNetworkInterfaceResponse{iface}
 	cs.fromResponse(resp)
 
 	if cs.Template() != templateURI {

--- a/pkg/aruba/resource_cloud_server_test.go
+++ b/pkg/aruba/resource_cloud_server_test.go
@@ -359,11 +359,11 @@ func cloudServerTestResponse(id, name, uri string) *types.CloudServerResponse {
 		Properties: types.CloudServerPropertiesResponse{
 			Zone:       ZoneITBG1,
 			Flavor:     types.CloudServerFlavorResponse{Name: CloudServerFlavorCSO2A4, CPU: 2, RAM: 4096},
-			VPC:        types.ReferenceResource{URI: "/vpcs/v"},
-			BootVolume: types.ReferenceResource{URI: "/vols/bv"},
-			KeyPair:    types.ReferenceResource{URI: "/kps/kp"},
+			VPC:        types.ReferenceResourceCommon{URI: "/vpcs/v"},
+			BootVolume: types.ReferenceResourceCommon{URI: "/vols/bv"},
+			KeyPair:    types.ReferenceResourceCommon{URI: "/kps/kp"},
 		},
-		Status: types.ResourceStatus{State: &state},
+		Status: types.ResourceStatusResponse{State: &state},
 	}
 }
 
@@ -415,7 +415,7 @@ func TestCloudServer_FromResponseHydration(t *testing.T) {
 	if cs.Raw() != resp {
 		t.Error("Raw() should return the hydrated response pointer")
 	}
-	// ProjectID backfilled from URI when ProjectResponseMetadata is nil
+	// ProjectID backfilled from URI when ProjectMetadataResponse is nil
 	if cs.ProjectID() != "p" {
 		t.Errorf("ProjectID() = %q", cs.ProjectID())
 	}
@@ -1142,7 +1142,7 @@ func TestCloudServer_Template_AndNetworkInterfaces_AfterHydration(t *testing.T) 
 		IPs:        []string{"10.0.0.1"},
 	}
 	resp := cloudServerTestResponse("cs-1", "srv", "/projects/p/providers/Aruba.Compute/cloudServers/cs-1")
-	resp.Properties.Template = types.ReferenceResource{URI: templateURI}
+	resp.Properties.Template = types.ReferenceResourceCommon{URI: templateURI}
 	resp.Properties.NetworkInterfaces = []types.CloudServerNetworkInterfaceResponse{iface}
 	cs.fromResponse(resp)
 
@@ -1403,7 +1403,7 @@ func TestCloudServer_FromResponse_SetsStatus(t *testing.T) {
 	cs := &CloudServer{}
 	state := types.State("Active")
 	cs.fromResponse(&types.CloudServerResponse{
-		Status: types.ResourceStatus{State: &state},
+		Status: types.ResourceStatusResponse{State: &state},
 	})
 	if cs.State() != types.StateActive {
 		t.Errorf("State() = %q after fromResponse, want Active", cs.State())
@@ -1440,15 +1440,15 @@ func TestCloudServer_WithBillingPeriod_SetsField(t *testing.T) {
 func TestCloudServer_WithBillingPeriod_InRequest(t *testing.T) {
 	cs := NewCloudServer().BilledBy(BillingPeriodMonth)
 	req := cs.RawRequest()
-	if req.Properties.BillingPlan == nil || req.Properties.BillingPlan.BillingPeriod == nil || *req.Properties.BillingPlan.BillingPeriod != BillingPeriodMonth {
-		t.Errorf("request BillingPlan.BillingPeriod = %v, want %q", req.Properties.BillingPlan, BillingPeriodMonth)
+	if req.Properties.BillingPlanCommon == nil || req.Properties.BillingPlanCommon.BillingPeriod == nil || *req.Properties.BillingPlanCommon.BillingPeriod != BillingPeriodMonth {
+		t.Errorf("request BillingPlanCommon.BillingPeriod = %v, want %q", req.Properties.BillingPlanCommon, BillingPeriodMonth)
 	}
 }
 
 func TestCloudServer_BillingPeriod_DefaultHour(t *testing.T) {
 	cs := NewCloudServer()
 	req := cs.RawRequest()
-	if req.Properties.BillingPlan == nil || req.Properties.BillingPlan.BillingPeriod == nil || *req.Properties.BillingPlan.BillingPeriod != BillingPeriodHour {
-		t.Errorf("default BillingPlan.BillingPeriod = %v, want %q", req.Properties.BillingPlan, BillingPeriodHour)
+	if req.Properties.BillingPlanCommon == nil || req.Properties.BillingPlanCommon.BillingPeriod == nil || *req.Properties.BillingPlanCommon.BillingPeriod != BillingPeriodHour {
+		t.Errorf("default BillingPlanCommon.BillingPeriod = %v, want %q", req.Properties.BillingPlanCommon, BillingPeriodHour)
 	}
 }

--- a/pkg/aruba/resource_container_registry.go
+++ b/pkg/aruba/resource_container_registry.go
@@ -3,6 +3,7 @@ package aruba
 import (
 	"context"
 	"fmt"
+	"time"
 
 	"github.com/Arubacloud/sdk-go/internal/clients/container"
 	"github.com/Arubacloud/sdk-go/internal/restclient"
@@ -38,7 +39,6 @@ type ContainerRegistry struct {
 
 	// Registry-specific scalars.
 	adminUsername   *string
-	adminPassword   *string
 	concurrentUsers *string // wire "size" — flavor enum string ("Small", "Medium", "HighPerf")
 	billingPeriod   *BillingPeriod
 
@@ -137,13 +137,6 @@ func (r *ContainerRegistry) WithAdminUsername(u string) *ContainerRegistry {
 	return r
 }
 
-// WithAdminPassword sets the admin password for the registry.
-// The provisioner requires a password when a username is supplied.
-func (r *ContainerRegistry) WithAdminPassword(p string) *ContainerRegistry {
-	r.adminPassword = &p
-	return r
-}
-
 // OfSize sets the concurrent-users tier for the registry.
 // Accepted values per the platform: "Small", "Medium", "HighPerf".
 // Use the ContainerRegistrySizeFlavor* constants.
@@ -222,6 +215,56 @@ func (r *ContainerRegistry) AdminUsername() string {
 	return containerRegistryDeref(r.adminUsername)
 }
 
+// IsPasswordSet reports whether the Aruba provisioner has generated the admin
+// password for the registry. The password itself is never returned over the wire.
+func (r *ContainerRegistry) IsPasswordSet() bool {
+	if r.response != nil && r.response.Data != nil && r.response.Data.Private != nil && r.response.Data.Private.PasswordSet != nil {
+		return *r.response.Data.Private.PasswordSet
+	}
+	return false
+}
+
+// AdminPasswordLastSetAt returns when the Aruba provisioner last generated the
+// admin password, or the zero time if that information is unavailable.
+func (r *ContainerRegistry) AdminPasswordLastSetAt() time.Time {
+	if r.response != nil && r.response.Data != nil && r.response.Data.Private != nil && r.response.Data.Private.PasswordLastSetAt != nil {
+		return *r.response.Data.Private.PasswordLastSetAt
+	}
+	return time.Time{}
+}
+
+// FQDN returns the fully-qualified domain name for the registry, or "" if unset.
+func (r *ContainerRegistry) FQDN() string {
+	if r.response != nil && r.response.Data != nil && r.response.Data.Info != nil {
+		return containerRegistryDeref(r.response.Data.Info.FQDN)
+	}
+	return ""
+}
+
+// PublicBaseURL returns the public base URL for the registry, or "" if unset.
+func (r *ContainerRegistry) PublicBaseURL() string {
+	if r.response != nil && r.response.Data != nil && r.response.Data.Info != nil {
+		return containerRegistryDeref(r.response.Data.Info.PublicBaseURL)
+	}
+	return ""
+}
+
+// PrivateBaseURL returns the private (VPC-internal) base URL for the registry, or "" if unset.
+func (r *ContainerRegistry) PrivateBaseURL() string {
+	if r.response != nil && r.response.Data != nil && r.response.Data.Info != nil {
+		return containerRegistryDeref(r.response.Data.Info.PrivateBaseURL)
+	}
+	return ""
+}
+
+// Version returns the registry software version, or "" if unset.
+func (r *ContainerRegistry) Version() string {
+	if r.response != nil && r.response.Data != nil && r.response.Data.Info != nil {
+		return containerRegistryDeref(r.response.Data.Info.Version)
+	}
+	return ""
+}
+
 // SizeFlavor returns the registry's concurrent-users tier as the typed enum.
 // Returns "" if the wire field has not been populated.
 func (r *ContainerRegistry) SizeFlavor() types.ContainerRegistrySizeFlavor {
@@ -265,15 +308,8 @@ func (r *ContainerRegistry) toRequest() types.ContainerRegistryRequest {
 	if r.blockStorageRef != nil {
 		props.BlockStorage = types.ReferenceResource{URI: *r.blockStorageRef}
 	}
-	if r.adminUsername != nil || r.adminPassword != nil {
-		cred := &types.UserCredential{}
-		if r.adminUsername != nil {
-			cred.Username = *r.adminUsername
-		}
-		if r.adminPassword != nil {
-			cred.Password = r.adminPassword
-		}
-		props.AdminUser = cred
+	if r.adminUsername != nil {
+		props.AdminUser = &types.UserCredential{Username: *r.adminUsername}
 	}
 	if r.concurrentUsers != nil {
 		props.ConcurrentUsers = r.concurrentUsers

--- a/pkg/aruba/resource_container_registry.go
+++ b/pkg/aruba/resource_container_registry.go
@@ -279,8 +279,8 @@ func (r *ContainerRegistry) SizeFlavor() types.ContainerRegistrySizeFlavor {
 
 // BillingPeriod returns the billing period for the registry, or "" if unset.
 func (r *ContainerRegistry) BillingPeriod() BillingPeriod {
-	if r.response != nil && r.response.Properties.BillingPlan != nil && r.response.Properties.BillingPlan.BillingPeriod != nil {
-		return *r.response.Properties.BillingPlan.BillingPeriod
+	if r.response != nil && r.response.Properties.BillingPlanCommon != nil && r.response.Properties.BillingPlanCommon.BillingPeriod != nil {
+		return *r.response.Properties.BillingPlanCommon.BillingPeriod
 	}
 	if r.billingPeriod == nil {
 		return ""
@@ -294,19 +294,19 @@ func (r *ContainerRegistry) BillingPeriod() BillingPeriod {
 func (r *ContainerRegistry) toRequest() types.ContainerRegistryRequest {
 	props := types.ContainerRegistryPropertiesRequest{}
 	if r.elasticIPRef != nil {
-		props.PublicIp = types.ReferenceResource{URI: *r.elasticIPRef}
+		props.PublicIp = types.ReferenceResourceCommon{URI: *r.elasticIPRef}
 	}
 	if r.vpcRef != nil {
-		props.VPC = types.ReferenceResource{URI: *r.vpcRef}
+		props.VPC = types.ReferenceResourceCommon{URI: *r.vpcRef}
 	}
 	if r.subnetRef != nil {
-		props.Subnet = types.ReferenceResource{URI: *r.subnetRef}
+		props.Subnet = types.ReferenceResourceCommon{URI: *r.subnetRef}
 	}
 	if r.securityGroupRef != nil {
-		props.SecurityGroup = types.ReferenceResource{URI: *r.securityGroupRef}
+		props.SecurityGroup = types.ReferenceResourceCommon{URI: *r.securityGroupRef}
 	}
 	if r.blockStorageRef != nil {
-		props.BlockStorage = types.ReferenceResource{URI: *r.blockStorageRef}
+		props.BlockStorage = types.ReferenceResourceCommon{URI: *r.blockStorageRef}
 	}
 	if r.adminUsername != nil {
 		props.AdminUser = &types.UserCredentialCommon{Username: *r.adminUsername}
@@ -314,7 +314,7 @@ func (r *ContainerRegistry) toRequest() types.ContainerRegistryRequest {
 	if r.concurrentUsers != nil {
 		props.ConcurrentUsers = r.concurrentUsers
 	}
-	props.BillingPlan = &types.BillingPlan{BillingPeriod: defaultBillingPeriod(r.billingPeriod)}
+	props.BillingPlanCommon = &types.BillingPlanCommon{BillingPeriod: defaultBillingPeriod(r.billingPeriod)}
 	return types.ContainerRegistryRequest{
 		Metadata: types.RegionalResourceMetadataRequest{
 			ResourceMetadataRequest: r.toMetadata(),
@@ -368,12 +368,12 @@ func (r *ContainerRegistry) fromResponse(resp *types.ContainerRegistryResponse) 
 		v := *resp.Properties.ConcurrentUsers
 		r.concurrentUsers = &v
 	}
-	if resp.Properties.BillingPlan != nil && resp.Properties.BillingPlan.BillingPeriod != nil {
-		r.billingPeriod = resp.Properties.BillingPlan.BillingPeriod
+	if resp.Properties.BillingPlanCommon != nil && resp.Properties.BillingPlanCommon.BillingPeriod != nil {
+		r.billingPeriod = resp.Properties.BillingPlanCommon.BillingPeriod
 	}
 
-	if resp.Metadata.ProjectResponseMetadata != nil && resp.Metadata.ProjectResponseMetadata.ID != "" {
-		r.projectID = resp.Metadata.ProjectResponseMetadata.ID
+	if resp.Metadata.ProjectMetadataResponse != nil && resp.Metadata.ProjectMetadataResponse.ID != "" {
+		r.projectID = resp.Metadata.ProjectMetadataResponse.ID
 	}
 	if r.projectID == "" && r.RespURI() != "" {
 		if pid := parseURIIDs(r.RespURI())["projects"]; pid != "" {

--- a/pkg/aruba/resource_container_registry.go
+++ b/pkg/aruba/resource_container_registry.go
@@ -38,6 +38,7 @@ type ContainerRegistry struct {
 
 	// Registry-specific scalars.
 	adminUsername   *string
+	adminPassword   *string
 	concurrentUsers *string // wire "size" — flavor enum string ("Small", "Medium", "HighPerf")
 	billingPeriod   *BillingPeriod
 
@@ -133,6 +134,13 @@ func (r *ContainerRegistry) setSingleRef(label string, ref Ref, dst **string) *C
 // WithAdminUsername sets the admin username for the registry.
 func (r *ContainerRegistry) WithAdminUsername(u string) *ContainerRegistry {
 	r.adminUsername = &u
+	return r
+}
+
+// WithAdminPassword sets the admin password for the registry.
+// The provisioner requires a password when a username is supplied.
+func (r *ContainerRegistry) WithAdminPassword(p string) *ContainerRegistry {
+	r.adminPassword = &p
 	return r
 }
 
@@ -257,8 +265,15 @@ func (r *ContainerRegistry) toRequest() types.ContainerRegistryRequest {
 	if r.blockStorageRef != nil {
 		props.BlockStorage = types.ReferenceResource{URI: *r.blockStorageRef}
 	}
-	if r.adminUsername != nil {
-		props.AdminUser = &types.UserCredential{Username: *r.adminUsername}
+	if r.adminUsername != nil || r.adminPassword != nil {
+		cred := &types.UserCredential{}
+		if r.adminUsername != nil {
+			cred.Username = *r.adminUsername
+		}
+		if r.adminPassword != nil {
+			cred.Password = r.adminPassword
+		}
+		props.AdminUser = cred
 	}
 	if r.concurrentUsers != nil {
 		props.ConcurrentUsers = r.concurrentUsers

--- a/pkg/aruba/resource_container_registry.go
+++ b/pkg/aruba/resource_container_registry.go
@@ -309,7 +309,7 @@ func (r *ContainerRegistry) toRequest() types.ContainerRegistryRequest {
 		props.BlockStorage = types.ReferenceResource{URI: *r.blockStorageRef}
 	}
 	if r.adminUsername != nil {
-		props.AdminUser = &types.UserCredential{Username: *r.adminUsername}
+		props.AdminUser = &types.UserCredentialCommon{Username: *r.adminUsername}
 	}
 	if r.concurrentUsers != nil {
 		props.ConcurrentUsers = r.concurrentUsers
@@ -417,7 +417,7 @@ func containerRegistryIDsFromRef(ref Ref) (projectID, registryID string, err err
 // *types.Response[T] preserves HTTP envelope details (status code, headers,
 // raw body) for the wrapper's diagnostics.
 type containerRegistriesLowLevelClient interface {
-	List(ctx context.Context, projectID string, params *types.RequestParameters) (*types.Response[types.ContainerRegistryList], error)
+	List(ctx context.Context, projectID string, params *types.RequestParameters) (*types.Response[types.ContainerRegistryListResponse], error)
 	Get(ctx context.Context, projectID, registryID string, params *types.RequestParameters) (*types.Response[types.ContainerRegistryResponse], error)
 	Create(ctx context.Context, projectID string, body types.ContainerRegistryRequest, params *types.RequestParameters) (*types.Response[types.ContainerRegistryResponse], error)
 	Update(ctx context.Context, projectID, registryID string, body types.ContainerRegistryRequest, params *types.RequestParameters) (*types.Response[types.ContainerRegistryResponse], error)
@@ -608,7 +608,7 @@ func (a *containerRegistriesClientAdapter) List(ctx context.Context, parent Ref,
 	}
 	var refetch func(ctx context.Context, pageURL string) (*List[*ContainerRegistry], error)
 	refetch = func(ctx context.Context, pageURL string) (*List[*ContainerRegistry], error) {
-		fetch := listPageFetch[types.ContainerRegistryList](a.rest, opts)
+		fetch := listPageFetch[types.ContainerRegistryListResponse](a.rest, opts)
 		pageResp, fetchErr := fetch(ctx, pageURL)
 		if fetchErr != nil {
 			return nil, fetchErr

--- a/pkg/aruba/resource_container_registry_test.go
+++ b/pkg/aruba/resource_container_registry_test.go
@@ -477,7 +477,7 @@ func containerRegistryTestResponse(name string) *types.ContainerRegistryResponse
 			SecurityGroup:   types.ReferenceResource{URI: sgURI},
 			PublicIp:        types.ReferenceResource{URI: eipURI},
 			BlockStorage:    types.ReferenceResource{URI: bsURI},
-			AdminUser:       &types.UserCredential{Username: "admin"},
+			AdminUser:       &types.UserCredentialCommon{Username: "admin"},
 			ConcurrentUsers: &size,
 			BillingPlan: func() *types.BillingPlan {
 				v := BillingPeriodHour
@@ -621,7 +621,7 @@ type fakeContainerRegistryLowLevel struct {
 	updateFunc func(ctx context.Context, projectID, registryID string, body types.ContainerRegistryRequest, params *types.RequestParameters) (*types.Response[types.ContainerRegistryResponse], error)
 	getFunc    func(ctx context.Context, projectID, registryID string, params *types.RequestParameters) (*types.Response[types.ContainerRegistryResponse], error)
 	deleteFunc func(ctx context.Context, projectID, registryID string, params *types.RequestParameters) (*types.Response[any], error)
-	listFunc   func(ctx context.Context, projectID string, params *types.RequestParameters) (*types.Response[types.ContainerRegistryList], error)
+	listFunc   func(ctx context.Context, projectID string, params *types.RequestParameters) (*types.Response[types.ContainerRegistryListResponse], error)
 }
 
 func (f *fakeContainerRegistryLowLevel) Create(ctx context.Context, projectID string, body types.ContainerRegistryRequest, params *types.RequestParameters) (*types.Response[types.ContainerRegistryResponse], error) {
@@ -636,7 +636,7 @@ func (f *fakeContainerRegistryLowLevel) Get(ctx context.Context, projectID, regi
 func (f *fakeContainerRegistryLowLevel) Delete(ctx context.Context, projectID, registryID string, params *types.RequestParameters) (*types.Response[any], error) {
 	return f.deleteFunc(ctx, projectID, registryID, params)
 }
-func (f *fakeContainerRegistryLowLevel) List(ctx context.Context, projectID string, params *types.RequestParameters) (*types.Response[types.ContainerRegistryList], error) {
+func (f *fakeContainerRegistryLowLevel) List(ctx context.Context, projectID string, params *types.RequestParameters) (*types.Response[types.ContainerRegistryListResponse], error) {
 	return f.listFunc(ctx, projectID, params)
 }
 
@@ -1339,7 +1339,7 @@ func TestContainerRegistriesClientAdapter_Delete_LowLevelError(t *testing.T) {
 // List_LowLevelError: low-level List returns error → propagate.
 func TestContainerRegistriesClientAdapter_List_LowLevelError(t *testing.T) {
 	fake := &fakeContainerRegistryLowLevel{
-		listFunc: func(_ context.Context, _ string, _ *types.RequestParameters) (*types.Response[types.ContainerRegistryList], error) {
+		listFunc: func(_ context.Context, _ string, _ *types.RequestParameters) (*types.Response[types.ContainerRegistryListResponse], error) {
 			return nil, fmt.Errorf("upstream unavailable")
 		},
 	}
@@ -1399,12 +1399,12 @@ func TestContainerRegistry_FromResponse_HydratesData(t *testing.T) {
 			ID:  func() *string { s := "cr-1"; return &s }(),
 			URI: func() *string { s := "/projects/p/providers/Aruba.Container/registries/cr-1"; return &s }(),
 		},
-		Data: &types.ContainerRegistryData{
-			Private: &types.ContainerRegistryDataPrivate{
+		Data: &types.ContainerRegistryDataResponse{
+			Private: &types.ContainerRegistryDataPrivateResponse{
 				PasswordSet:       &passwordSet,
 				PasswordLastSetAt: &lastSet,
 			},
-			Info: &types.ContainerRegistryDataInfo{
+			Info: &types.ContainerRegistryDataInfoResponse{
 				FQDN:           &fqdn,
 				PublicBaseURL:  &pub,
 				PrivateBaseURL: &priv,

--- a/pkg/aruba/resource_container_registry_test.go
+++ b/pkg/aruba/resource_container_registry_test.go
@@ -394,8 +394,8 @@ func TestContainerRegistry_ToRequest(t *testing.T) {
 	if req.Properties.ConcurrentUsers == nil || *req.Properties.ConcurrentUsers != "HighPerf" {
 		t.Errorf("Properties.ConcurrentUsers = %v", req.Properties.ConcurrentUsers)
 	}
-	if req.Properties.BillingPlan == nil || req.Properties.BillingPlan.BillingPeriod == nil || *req.Properties.BillingPlan.BillingPeriod != BillingPeriodHour {
-		t.Errorf("Properties.BillingPlan.BillingPeriod = %v", req.Properties.BillingPlan)
+	if req.Properties.BillingPlanCommon == nil || req.Properties.BillingPlanCommon.BillingPeriod == nil || *req.Properties.BillingPlanCommon.BillingPeriod != BillingPeriodHour {
+		t.Errorf("Properties.BillingPlanCommon.BillingPeriod = %v", req.Properties.BillingPlanCommon)
 	}
 }
 
@@ -410,10 +410,10 @@ func TestContainerRegistry_ToRequest_Empty(t *testing.T) {
 	if req.Properties.ConcurrentUsers != nil {
 		t.Errorf("ConcurrentUsers should be nil, got %v", req.Properties.ConcurrentUsers)
 	}
-	if req.Properties.BillingPlan == nil || req.Properties.BillingPlan.BillingPeriod == nil || *req.Properties.BillingPlan.BillingPeriod != BillingPeriodHour {
-		t.Errorf("BillingPlan.BillingPeriod should default to Hour, got %v", req.Properties.BillingPlan)
+	if req.Properties.BillingPlanCommon == nil || req.Properties.BillingPlanCommon.BillingPeriod == nil || *req.Properties.BillingPlanCommon.BillingPeriod != BillingPeriodHour {
+		t.Errorf("BillingPlanCommon.BillingPeriod should default to Hour, got %v", req.Properties.BillingPlanCommon)
 	}
-	// Body-ref ReferenceResource fields should have empty URIs.
+	// Body-ref ReferenceResourceCommon fields should have empty URIs.
 	if req.Properties.VPC.URI != "" {
 		t.Errorf("VPC.URI should be empty, got %q", req.Properties.VPC.URI)
 	}
@@ -467,24 +467,24 @@ func containerRegistryTestResponse(name string) *types.ContainerRegistryResponse
 			Name:             func() *string { s := name; return &s }(),
 			Tags:             []string{"tag1"},
 			LocationResponse: &types.LocationResponse{Value: RegionITBGBergamo},
-			ProjectResponseMetadata: &types.ProjectResponseMetadata{
+			ProjectMetadataResponse: &types.ProjectMetadataResponse{
 				ID: "p",
 			},
 		},
 		Properties: types.ContainerRegistryPropertiesResponse{
-			VPC:             types.ReferenceResource{URI: vpcURI},
-			Subnet:          types.ReferenceResource{URI: subnetURI},
-			SecurityGroup:   types.ReferenceResource{URI: sgURI},
-			PublicIp:        types.ReferenceResource{URI: eipURI},
-			BlockStorage:    types.ReferenceResource{URI: bsURI},
+			VPC:             types.ReferenceResourceCommon{URI: vpcURI},
+			Subnet:          types.ReferenceResourceCommon{URI: subnetURI},
+			SecurityGroup:   types.ReferenceResourceCommon{URI: sgURI},
+			PublicIp:        types.ReferenceResourceCommon{URI: eipURI},
+			BlockStorage:    types.ReferenceResourceCommon{URI: bsURI},
 			AdminUser:       &types.UserCredentialCommon{Username: "admin"},
 			ConcurrentUsers: &size,
-			BillingPlan: func() *types.BillingPlan {
+			BillingPlanCommon: func() *types.BillingPlanCommon {
 				v := BillingPeriodHour
-				return &types.BillingPlan{BillingPeriod: &v}
+				return &types.BillingPlanCommon{BillingPeriod: &v}
 			}(),
 		},
-		Status: types.ResourceStatus{
+		Status: types.ResourceStatusResponse{
 			State: &state,
 		},
 	}
@@ -576,7 +576,7 @@ func TestContainerRegistry_FromResponse_BackfillsProjectID_FromURI(t *testing.T)
 		Metadata: types.ResourceMetadataResponse{
 			ID:  &id,
 			URI: &uri,
-			// No ProjectResponseMetadata — should backfill from URI.
+			// No ProjectMetadataResponse — should backfill from URI.
 		},
 	}
 	cr := &ContainerRegistry{}
@@ -1358,7 +1358,7 @@ func TestContainerRegistry_FromResponse_SetsStatus(t *testing.T) {
 	r := &ContainerRegistry{}
 	state := types.State("Active")
 	r.fromResponse(&types.ContainerRegistryResponse{
-		Status: types.ResourceStatus{State: &state},
+		Status: types.ResourceStatusResponse{State: &state},
 	})
 	if r.State() != types.StateActive {
 		t.Errorf("State() = %q after fromResponse, want Active", r.State())

--- a/pkg/aruba/resource_container_registry_test.go
+++ b/pkg/aruba/resource_container_registry_test.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"net/http"
 	"reflect"
+	"strings"
 	"testing"
 
 	"github.com/Arubacloud/sdk-go/internal/testutil"
@@ -414,6 +415,41 @@ func TestContainerRegistry_ToRequest_Empty(t *testing.T) {
 	// Body-ref ReferenceResource fields should have empty URIs.
 	if req.Properties.VPC.URI != "" {
 		t.Errorf("VPC.URI should be empty, got %q", req.Properties.VPC.URI)
+	}
+}
+
+func TestContainerRegistry_ToRequest_IncludesAdminPassword(t *testing.T) {
+	cr := NewContainerRegistry().
+		WithAdminUsername("admin").
+		WithAdminPassword("s3cr3t")
+
+	req := cr.RawRequest()
+	if req.Properties.AdminUser == nil {
+		t.Fatal("AdminUser should not be nil")
+	}
+	if req.Properties.AdminUser.Username != "admin" {
+		t.Errorf("Username = %q", req.Properties.AdminUser.Username)
+	}
+	if req.Properties.AdminUser.Password == nil || *req.Properties.AdminUser.Password != "s3cr3t" {
+		t.Errorf("Password = %v", req.Properties.AdminUser.Password)
+	}
+
+	// JSON must carry "password" key.
+	b, _ := json.Marshal(req.Properties.AdminUser)
+	if !strings.Contains(string(b), `"password"`) {
+		t.Errorf("marshalled AdminUser does not contain password field: %s", b)
+	}
+}
+
+func TestContainerRegistry_ToRequest_OmitsAdminUserWhenNeither(t *testing.T) {
+	cr := NewContainerRegistry()
+	req := cr.RawRequest()
+	if req.Properties.AdminUser != nil {
+		t.Errorf("AdminUser should be nil when neither username nor password is set, got %+v", req.Properties.AdminUser)
+	}
+	b, _ := json.Marshal(req.Properties)
+	if strings.Contains(string(b), `"adminUser"`) {
+		t.Errorf("marshalled properties should not contain adminUser key: %s", b)
 	}
 }
 

--- a/pkg/aruba/resource_container_registry_test.go
+++ b/pkg/aruba/resource_container_registry_test.go
@@ -9,6 +9,7 @@ import (
 	"reflect"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/Arubacloud/sdk-go/internal/testutil"
 	"github.com/Arubacloud/sdk-go/pkg/types"
@@ -418,11 +419,8 @@ func TestContainerRegistry_ToRequest_Empty(t *testing.T) {
 	}
 }
 
-func TestContainerRegistry_ToRequest_IncludesAdminPassword(t *testing.T) {
-	cr := NewContainerRegistry().
-		WithAdminUsername("admin").
-		WithAdminPassword("s3cr3t")
-
+func TestContainerRegistry_ToRequest_OmitsPassword(t *testing.T) {
+	cr := NewContainerRegistry().WithAdminUsername("admin")
 	req := cr.RawRequest()
 	if req.Properties.AdminUser == nil {
 		t.Fatal("AdminUser should not be nil")
@@ -430,14 +428,9 @@ func TestContainerRegistry_ToRequest_IncludesAdminPassword(t *testing.T) {
 	if req.Properties.AdminUser.Username != "admin" {
 		t.Errorf("Username = %q", req.Properties.AdminUser.Username)
 	}
-	if req.Properties.AdminUser.Password == nil || *req.Properties.AdminUser.Password != "s3cr3t" {
-		t.Errorf("Password = %v", req.Properties.AdminUser.Password)
-	}
-
-	// JSON must carry "password" key.
 	b, _ := json.Marshal(req.Properties.AdminUser)
-	if !strings.Contains(string(b), `"password"`) {
-		t.Errorf("marshalled AdminUser does not contain password field: %s", b)
+	if strings.Contains(string(b), `"password"`) {
+		t.Errorf("marshalled AdminUser must not contain password field: %s", b)
 	}
 }
 
@@ -478,7 +471,7 @@ func containerRegistryTestResponse(name string) *types.ContainerRegistryResponse
 				ID: "p",
 			},
 		},
-		Properties: types.ContainerRegistryPropertiesResult{
+		Properties: types.ContainerRegistryPropertiesResponse{
 			VPC:             types.ReferenceResource{URI: vpcURI},
 			Subnet:          types.ReferenceResource{URI: subnetURI},
 			SecurityGroup:   types.ReferenceResource{URI: sgURI},
@@ -1108,7 +1101,7 @@ func TestContainerRegistry_SizeFlavor_UnknownResponseString(t *testing.T) {
 	cr := &ContainerRegistry{}
 	unknown := "not-a-flavor"
 	cr.response = &types.ContainerRegistryResponse{
-		Properties: types.ContainerRegistryPropertiesResult{
+		Properties: types.ContainerRegistryPropertiesResponse{
 			ConcurrentUsers: &unknown,
 		},
 	}
@@ -1385,5 +1378,87 @@ func TestContainerRegistriesClientAdapter_Get_InjectsRefresh(t *testing.T) {
 	}
 	if !refreshIsSet(&cr.statusMixin) {
 		t.Error("Get should inject a refresh callback into the returned ContainerRegistry")
+	}
+}
+
+// --------------------------------------------------------------------------
+// Data block — getters
+// --------------------------------------------------------------------------
+
+func TestContainerRegistry_FromResponse_HydratesData(t *testing.T) {
+	passwordSet := true
+	lastSet := time.Date(2026, 5, 29, 10, 0, 0, 0, time.UTC)
+	fqdn := "registry.example.com"
+	pub := "https://registry.example.com"
+	priv := "https://private.registry.example.com"
+	ver := "2.8"
+
+	cr := &ContainerRegistry{}
+	cr.fromResponse(&types.ContainerRegistryResponse{
+		Metadata: types.ResourceMetadataResponse{
+			ID:  func() *string { s := "cr-1"; return &s }(),
+			URI: func() *string { s := "/projects/p/providers/Aruba.Container/registries/cr-1"; return &s }(),
+		},
+		Data: &types.ContainerRegistryData{
+			Private: &types.ContainerRegistryDataPrivate{
+				PasswordSet:       &passwordSet,
+				PasswordLastSetAt: &lastSet,
+			},
+			Info: &types.ContainerRegistryDataInfo{
+				FQDN:           &fqdn,
+				PublicBaseURL:  &pub,
+				PrivateBaseURL: &priv,
+				Version:        &ver,
+			},
+		},
+	})
+
+	if !cr.IsPasswordSet() {
+		t.Error("IsPasswordSet() = false, want true")
+	}
+	if cr.AdminPasswordLastSetAt() != lastSet {
+		t.Errorf("AdminPasswordLastSetAt() = %v, want %v", cr.AdminPasswordLastSetAt(), lastSet)
+	}
+	if cr.FQDN() != fqdn {
+		t.Errorf("FQDN() = %q, want %q", cr.FQDN(), fqdn)
+	}
+	if cr.PublicBaseURL() != pub {
+		t.Errorf("PublicBaseURL() = %q, want %q", cr.PublicBaseURL(), pub)
+	}
+	if cr.PrivateBaseURL() != priv {
+		t.Errorf("PrivateBaseURL() = %q, want %q", cr.PrivateBaseURL(), priv)
+	}
+	if cr.Version() != ver {
+		t.Errorf("Version() = %q, want %q", cr.Version(), ver)
+	}
+}
+
+func TestContainerRegistry_DataGetters_NilSafe(t *testing.T) {
+	cr := &ContainerRegistry{}
+	cr.fromResponse(&types.ContainerRegistryResponse{
+		Metadata: types.ResourceMetadataResponse{
+			ID:  func() *string { s := "cr-1"; return &s }(),
+			URI: func() *string { s := "/projects/p/providers/Aruba.Container/registries/cr-1"; return &s }(),
+		},
+		// Data intentionally nil
+	})
+
+	if cr.IsPasswordSet() {
+		t.Error("IsPasswordSet() = true, want false for nil Data")
+	}
+	if !cr.AdminPasswordLastSetAt().IsZero() {
+		t.Errorf("AdminPasswordLastSetAt() = %v, want zero", cr.AdminPasswordLastSetAt())
+	}
+	if cr.FQDN() != "" {
+		t.Errorf("FQDN() = %q, want empty", cr.FQDN())
+	}
+	if cr.PublicBaseURL() != "" {
+		t.Errorf("PublicBaseURL() = %q, want empty", cr.PublicBaseURL())
+	}
+	if cr.PrivateBaseURL() != "" {
+		t.Errorf("PrivateBaseURL() = %q, want empty", cr.PrivateBaseURL())
+	}
+	if cr.Version() != "" {
+		t.Errorf("Version() = %q, want empty", cr.Version())
 	}
 }

--- a/pkg/aruba/resource_database.go
+++ b/pkg/aruba/resource_database.go
@@ -136,7 +136,7 @@ func dbDerefString(p *string) string {
 // *types.Response[T] preserves HTTP envelope details (status code, headers,
 // raw body) for the wrapper's diagnostics.
 type databasesLowLevelClient interface {
-	List(ctx context.Context, projectID, dbaasID string, params *types.RequestParameters) (*types.Response[types.DatabaseList], error)
+	List(ctx context.Context, projectID, dbaasID string, params *types.RequestParameters) (*types.Response[types.DatabaseListResponse], error)
 	Get(ctx context.Context, projectID, dbaasID, databaseID string, params *types.RequestParameters) (*types.Response[types.DatabaseResponse], error)
 	Create(ctx context.Context, projectID, dbaasID string, body types.DatabaseRequest, params *types.RequestParameters) (*types.Response[types.DatabaseResponse], error)
 	Update(ctx context.Context, projectID, dbaasID, databaseID string, body types.DatabaseRequest, params *types.RequestParameters) (*types.Response[types.DatabaseResponse], error)
@@ -334,7 +334,7 @@ func (a *databasesClientAdapter) List(ctx context.Context, dbaas Ref, opts ...Ca
 	}
 	var refetch func(ctx context.Context, pageURL string) (*List[*Database], error)
 	refetch = func(ctx context.Context, pageURL string) (*List[*Database], error) {
-		fetch := listPageFetch[types.DatabaseList](a.rest, opts)
+		fetch := listPageFetch[types.DatabaseListResponse](a.rest, opts)
 		pageResp, fetchErr := fetch(ctx, pageURL)
 		if fetchErr != nil {
 			return nil, fetchErr

--- a/pkg/aruba/resource_dbaas.go
+++ b/pkg/aruba/resource_dbaas.go
@@ -314,6 +314,44 @@ func (d *DBaaS) AutoscalingRaw() *types.DBaaSAutoscalingResponse {
 	return d.response.Properties.Autoscaling
 }
 
+// EngineVersion returns the database engine version string from the response, or "" before hydration.
+func (d *DBaaS) EngineVersion() string {
+	if d.response != nil && d.response.Properties.Engine != nil && d.response.Properties.Engine.Version != nil {
+		return *d.response.Properties.Engine.Version
+	}
+	return ""
+}
+
+// EngineType returns the database engine type string from the response.
+// On a hydrated response it reads Engine.Type; before hydration it returns what was passed to OfEngine.
+func (d *DBaaS) EngineType() string {
+	return string(d.Engine())
+}
+
+// PrivateIPAddress returns the private IP address from the engine response, or "" before hydration.
+func (d *DBaaS) PrivateIPAddress() string {
+	if d.response != nil && d.response.Properties.Engine != nil && d.response.Properties.Engine.PrivateIPAddress != nil {
+		return *d.response.Properties.Engine.PrivateIPAddress
+	}
+	return ""
+}
+
+// FlavorCPU returns the number of CPUs from the flavor response, or 0 before hydration.
+func (d *DBaaS) FlavorCPU() int32 {
+	if d.response != nil && d.response.Properties.Flavor != nil && d.response.Properties.Flavor.CPU != nil {
+		return *d.response.Properties.Flavor.CPU
+	}
+	return 0
+}
+
+// FlavorRAMMB returns the amount of RAM in MB from the flavor response, or 0 before hydration.
+func (d *DBaaS) FlavorRAMMB() int32 {
+	if d.response != nil && d.response.Properties.Flavor != nil && d.response.Properties.Flavor.RAM != nil {
+		return *d.response.Properties.Flavor.RAM
+	}
+	return 0
+}
+
 // VPC returns the VPC URI for this DBaaS instance, or "" if unset.
 func (d *DBaaS) VPC() string {
 	return dbaasNetworkingURI(d.response, func(n *types.DBaaSNetworkingResponse) *types.ReferenceResource { return n.VPC }, d.vpcRef)

--- a/pkg/aruba/resource_dbaas.go
+++ b/pkg/aruba/resource_dbaas.go
@@ -379,17 +379,17 @@ func (d *DBaaS) toRequest() types.DBaaSRequest {
 	props := types.DBaaSPropertiesRequest{}
 	props.Zone = d.zonePtr()
 	if d.engine != nil {
-		props.Engine = &types.DBaaSEngine{ID: d.engine}
+		props.Engine = &types.DBaaSEngineRequest{ID: d.engine}
 	}
 	if d.flavor != nil {
-		props.Flavor = &types.DBaaSFlavorSpec{Name: d.flavor}
+		props.Flavor = &types.DBaaSFlavorRequest{Name: d.flavor}
 	}
 	if d.sizeGB != nil {
 		v := *d.sizeGB
-		props.Storage = &types.DBaaSStorage{SizeGB: &v}
+		props.Storage = &types.DBaaSStorageRequest{SizeGB: &v}
 	}
 	if d.autoscalingEnabled != nil || d.autoscalingAvailableSpace != nil || d.autoscalingStepSize != nil {
-		a := &types.DBaaSAutoscaling{}
+		a := &types.DBaaSAutoscalingRequest{}
 		if d.autoscalingEnabled != nil {
 			v := *d.autoscalingEnabled
 			a.Enabled = &v
@@ -406,7 +406,7 @@ func (d *DBaaS) toRequest() types.DBaaSRequest {
 	}
 	props.BillingPlan = &types.BillingPlan{BillingPeriod: defaultBillingPeriod(d.billingPeriod)}
 	if d.vpcRef != nil || d.subnetRef != nil || d.securityGroupRef != nil || d.elasticIPRef != nil {
-		net := &types.DBaaSNetworking{}
+		net := &types.DBaaSNetworkingRequest{}
 		if d.vpcRef != nil {
 			net.VPCURI = d.vpcRef
 		}
@@ -540,7 +540,7 @@ func dbaasNetworkingURI(resp *types.DBaaSResponse, pick func(*types.DBaaSNetwork
 // *types.Response[T] preserves HTTP envelope details (status code, headers,
 // raw body) for the wrapper's diagnostics.
 type dbaasLowLevelClient interface {
-	List(ctx context.Context, projectID string, params *types.RequestParameters) (*types.Response[types.DBaaSList], error)
+	List(ctx context.Context, projectID string, params *types.RequestParameters) (*types.Response[types.DBaaSListResponse], error)
 	Get(ctx context.Context, projectID, dbaasID string, params *types.RequestParameters) (*types.Response[types.DBaaSResponse], error)
 	Create(ctx context.Context, projectID string, body types.DBaaSRequest, params *types.RequestParameters) (*types.Response[types.DBaaSResponse], error)
 	Update(ctx context.Context, projectID, dbaasID string, body types.DBaaSRequest, params *types.RequestParameters) (*types.Response[types.DBaaSResponse], error)
@@ -731,7 +731,7 @@ func (a *dbaasClientAdapter) List(ctx context.Context, project Ref, opts ...Call
 	}
 	var refetch func(ctx context.Context, pageURL string) (*List[*DBaaS], error)
 	refetch = func(ctx context.Context, pageURL string) (*List[*DBaaS], error) {
-		fetch := listPageFetch[types.DBaaSList](a.rest, opts)
+		fetch := listPageFetch[types.DBaaSListResponse](a.rest, opts)
 		pageResp, fetchErr := fetch(ctx, pageURL)
 		if fetchErr != nil {
 			return nil, fetchErr

--- a/pkg/aruba/resource_dbaas.go
+++ b/pkg/aruba/resource_dbaas.go
@@ -23,7 +23,7 @@ import (
 //   - Flavor: request emits Flavor.Name; response returns the full
 //     DBaaSFlavorResponse struct.
 //   - Networking: request emits 4 raw URI strings (VPCURI/SubnetURI/
-//     SecurityGroupURI/ElasticIPURI); response returns 4 *ReferenceResource
+//     SecurityGroupURI/ElasticIPURI); response returns 4 *ReferenceResourceCommon
 //     objects. Read-back getters (VPC/Subnet/SecurityGroup/ElasticIP)
 //     prefer the response side, falling back to the locally-set URI.
 //   - Zone: Go field is "Zone" but the wire JSON tag is "dataCenter".
@@ -53,7 +53,7 @@ type DBaaS struct {
 	autoscalingEnabled        *bool           // wire: Autoscaling.Enabled
 	autoscalingAvailableSpace *int32          // wire: Autoscaling.AvailableSpace
 	autoscalingStepSize       *int32          // wire: Autoscaling.StepSize
-	billingPeriod             *BillingPeriod  // wire: BillingPlan.BillingPeriod
+	billingPeriod             *BillingPeriod  // wire: BillingPlanCommon.BillingPeriod
 
 	// Networking refs.
 	vpcRef           *string
@@ -238,11 +238,11 @@ func (d *DBaaS) SizeGB() int {
 }
 
 // BillingPeriod returns the billing period. On a hydrated response the value comes
-// from BillingPlan.BillingPeriod; before hydration it returns what was passed to
+// from BillingPlanCommon.BillingPeriod; before hydration it returns what was passed to
 // WithBillingPeriod.
 func (d *DBaaS) BillingPeriod() BillingPeriod {
-	if d.response != nil && d.response.Properties.BillingPlan != nil && d.response.Properties.BillingPlan.BillingPeriod != nil {
-		return *d.response.Properties.BillingPlan.BillingPeriod
+	if d.response != nil && d.response.Properties.BillingPlanCommon != nil && d.response.Properties.BillingPlanCommon.BillingPeriod != nil {
+		return *d.response.Properties.BillingPlanCommon.BillingPeriod
 	}
 	if d.billingPeriod == nil {
 		return ""
@@ -354,22 +354,22 @@ func (d *DBaaS) FlavorRAMMB() int32 {
 
 // VPC returns the VPC URI for this DBaaS instance, or "" if unset.
 func (d *DBaaS) VPC() string {
-	return dbaasNetworkingURI(d.response, func(n *types.DBaaSNetworkingResponse) *types.ReferenceResource { return n.VPC }, d.vpcRef)
+	return dbaasNetworkingURI(d.response, func(n *types.DBaaSNetworkingResponse) *types.ReferenceResourceCommon { return n.VPC }, d.vpcRef)
 }
 
 // Subnet returns the subnet URI for this DBaaS instance, or "" if unset.
 func (d *DBaaS) Subnet() string {
-	return dbaasNetworkingURI(d.response, func(n *types.DBaaSNetworkingResponse) *types.ReferenceResource { return n.Subnet }, d.subnetRef)
+	return dbaasNetworkingURI(d.response, func(n *types.DBaaSNetworkingResponse) *types.ReferenceResourceCommon { return n.Subnet }, d.subnetRef)
 }
 
 // SecurityGroup returns the security group URI for this DBaaS instance, or "" if unset.
 func (d *DBaaS) SecurityGroup() string {
-	return dbaasNetworkingURI(d.response, func(n *types.DBaaSNetworkingResponse) *types.ReferenceResource { return n.SecurityGroup }, d.securityGroupRef)
+	return dbaasNetworkingURI(d.response, func(n *types.DBaaSNetworkingResponse) *types.ReferenceResourceCommon { return n.SecurityGroup }, d.securityGroupRef)
 }
 
 // ElasticIP returns the elastic IP URI for this DBaaS instance, or "" if unset.
 func (d *DBaaS) ElasticIP() string {
-	return dbaasNetworkingURI(d.response, func(n *types.DBaaSNetworkingResponse) *types.ReferenceResource { return n.ElasticIP }, d.elasticIPRef)
+	return dbaasNetworkingURI(d.response, func(n *types.DBaaSNetworkingResponse) *types.ReferenceResourceCommon { return n.ElasticIP }, d.elasticIPRef)
 }
 
 // Wire converters
@@ -404,7 +404,7 @@ func (d *DBaaS) toRequest() types.DBaaSRequest {
 		}
 		props.Autoscaling = a
 	}
-	props.BillingPlan = &types.BillingPlan{BillingPeriod: defaultBillingPeriod(d.billingPeriod)}
+	props.BillingPlanCommon = &types.BillingPlanCommon{BillingPeriod: defaultBillingPeriod(d.billingPeriod)}
 	if d.vpcRef != nil || d.subnetRef != nil || d.securityGroupRef != nil || d.elasticIPRef != nil {
 		net := &types.DBaaSNetworkingRequest{}
 		if d.vpcRef != nil {
@@ -468,8 +468,8 @@ func (d *DBaaS) fromResponse(resp *types.DBaaSResponse) {
 		v := *resp.Properties.Storage.SizeGB
 		d.sizeGB = &v
 	}
-	if resp.Properties.BillingPlan != nil && resp.Properties.BillingPlan.BillingPeriod != nil {
-		d.billingPeriod = resp.Properties.BillingPlan.BillingPeriod
+	if resp.Properties.BillingPlanCommon != nil && resp.Properties.BillingPlanCommon.BillingPeriod != nil {
+		d.billingPeriod = resp.Properties.BillingPlanCommon.BillingPeriod
 	}
 	if resp.Properties.Networking != nil {
 		if resp.Properties.Networking.VPC != nil && resp.Properties.Networking.VPC.URI != "" {
@@ -509,8 +509,8 @@ func (d *DBaaS) fromResponse(resp *types.DBaaSResponse) {
 		}
 	}
 
-	if resp.Metadata.ProjectResponseMetadata != nil && resp.Metadata.ProjectResponseMetadata.ID != "" {
-		d.projectID = resp.Metadata.ProjectResponseMetadata.ID
+	if resp.Metadata.ProjectMetadataResponse != nil && resp.Metadata.ProjectMetadataResponse.ID != "" {
+		d.projectID = resp.Metadata.ProjectMetadataResponse.ID
 	}
 	if d.projectID == "" && d.RespURI() != "" {
 		ids := parseURIIDs(d.RespURI())
@@ -525,7 +525,7 @@ func dbaasDerefString(p *string) string {
 	return *p
 }
 
-func dbaasNetworkingURI(resp *types.DBaaSResponse, pick func(*types.DBaaSNetworkingResponse) *types.ReferenceResource, fallback *string) string {
+func dbaasNetworkingURI(resp *types.DBaaSResponse, pick func(*types.DBaaSNetworkingResponse) *types.ReferenceResourceCommon, fallback *string) string {
 	if resp != nil && resp.Properties.Networking != nil {
 		if r := pick(resp.Properties.Networking); r != nil && r.URI != "" {
 			return r.URI

--- a/pkg/aruba/resource_dbaas_backup.go
+++ b/pkg/aruba/resource_dbaas_backup.go
@@ -168,12 +168,12 @@ func (b *DBaaSBackup) toRequest() types.BackupRequest {
 		Zone: zone,
 	}
 	if b.dbaasRef != nil {
-		props.DBaaS = types.ReferenceResource{URI: *b.dbaasRef}
+		props.DBaaS = types.ReferenceResourceCommon{URI: *b.dbaasRef}
 	}
 	if b.databaseRef != nil {
-		props.Database = types.ReferenceResource{URI: *b.databaseRef}
+		props.Database = types.ReferenceResourceCommon{URI: *b.databaseRef}
 	}
-	props.BillingPlan = &types.BillingPlan{BillingPeriod: defaultBillingPeriod(b.billingPeriod)}
+	props.BillingPlanCommon = &types.BillingPlanCommon{BillingPeriod: defaultBillingPeriod(b.billingPeriod)}
 	return types.BackupRequest{
 		Metadata: types.RegionalResourceMetadataRequest{
 			ResourceMetadataRequest: b.toMetadata(),
@@ -207,12 +207,12 @@ func (b *DBaaSBackup) fromResponse(resp *types.BackupResponse) {
 		v := resp.Properties.Database.URI
 		b.databaseRef = &v
 	}
-	if resp.Properties.BillingPlan != nil && resp.Properties.BillingPlan.BillingPeriod != nil {
-		b.billingPeriod = resp.Properties.BillingPlan.BillingPeriod
+	if resp.Properties.BillingPlanCommon != nil && resp.Properties.BillingPlanCommon.BillingPeriod != nil {
+		b.billingPeriod = resp.Properties.BillingPlanCommon.BillingPeriod
 	}
 
-	if resp.Metadata.ProjectResponseMetadata != nil && resp.Metadata.ProjectResponseMetadata.ID != "" {
-		b.projectID = resp.Metadata.ProjectResponseMetadata.ID
+	if resp.Metadata.ProjectMetadataResponse != nil && resp.Metadata.ProjectMetadataResponse.ID != "" {
+		b.projectID = resp.Metadata.ProjectMetadataResponse.ID
 	}
 	if b.projectID == "" && b.RespURI() != "" {
 		if pid := parseURIIDs(b.RespURI())["projects"]; pid != "" {

--- a/pkg/aruba/resource_dbaas_backup.go
+++ b/pkg/aruba/resource_dbaas_backup.go
@@ -261,7 +261,7 @@ func dbaasBackupIDsFromRef(ref Ref) (projectID, backupID string, err error) {
 // *types.Response[T] preserves HTTP envelope details (status code, headers,
 // raw body) for the wrapper's diagnostics.
 type dbaasBackupsLowLevelClient interface {
-	List(ctx context.Context, projectID string, params *types.RequestParameters) (*types.Response[types.BackupList], error)
+	List(ctx context.Context, projectID string, params *types.RequestParameters) (*types.Response[types.DBaaSBackupListResponse], error)
 	Get(ctx context.Context, projectID, backupID string, params *types.RequestParameters) (*types.Response[types.BackupResponse], error)
 	Create(ctx context.Context, projectID string, body types.BackupRequest, params *types.RequestParameters) (*types.Response[types.BackupResponse], error)
 	Delete(ctx context.Context, projectID, backupID string, params *types.RequestParameters) (*types.Response[any], error)
@@ -416,7 +416,7 @@ func (a *dbaasBackupsClientAdapter) List(ctx context.Context, parent Ref, opts .
 	}
 	var refetch func(ctx context.Context, pageURL string) (*List[*DBaaSBackup], error)
 	refetch = func(ctx context.Context, pageURL string) (*List[*DBaaSBackup], error) {
-		fetch := listPageFetch[types.BackupList](a.rest, opts)
+		fetch := listPageFetch[types.DBaaSBackupListResponse](a.rest, opts)
 		pageResp, fetchErr := fetch(ctx, pageURL)
 		if fetchErr != nil {
 			return nil, fetchErr

--- a/pkg/aruba/resource_dbaas_backup_test.go
+++ b/pkg/aruba/resource_dbaas_backup_test.go
@@ -421,7 +421,7 @@ type fakeDBaaSBackupLowLevel struct {
 	createFunc func(ctx context.Context, projectID string, body types.BackupRequest, params *types.RequestParameters) (*types.Response[types.BackupResponse], error)
 	getFunc    func(ctx context.Context, projectID, backupID string, params *types.RequestParameters) (*types.Response[types.BackupResponse], error)
 	deleteFunc func(ctx context.Context, projectID, backupID string, params *types.RequestParameters) (*types.Response[any], error)
-	listFunc   func(ctx context.Context, projectID string, params *types.RequestParameters) (*types.Response[types.BackupList], error)
+	listFunc   func(ctx context.Context, projectID string, params *types.RequestParameters) (*types.Response[types.DBaaSBackupListResponse], error)
 }
 
 func (f *fakeDBaaSBackupLowLevel) Create(ctx context.Context, projectID string, body types.BackupRequest, params *types.RequestParameters) (*types.Response[types.BackupResponse], error) {
@@ -433,7 +433,7 @@ func (f *fakeDBaaSBackupLowLevel) Get(ctx context.Context, projectID, backupID s
 func (f *fakeDBaaSBackupLowLevel) Delete(ctx context.Context, projectID, backupID string, params *types.RequestParameters) (*types.Response[any], error) {
 	return f.deleteFunc(ctx, projectID, backupID, params)
 }
-func (f *fakeDBaaSBackupLowLevel) List(ctx context.Context, projectID string, params *types.RequestParameters) (*types.Response[types.BackupList], error) {
+func (f *fakeDBaaSBackupLowLevel) List(ctx context.Context, projectID string, params *types.RequestParameters) (*types.Response[types.DBaaSBackupListResponse], error) {
 	return f.listFunc(ctx, projectID, params)
 }
 

--- a/pkg/aruba/resource_dbaas_backup_test.go
+++ b/pkg/aruba/resource_dbaas_backup_test.go
@@ -224,8 +224,8 @@ func TestDBaaSBackup_ToRequest(t *testing.T) {
 	if req.Properties.Database.URI != dbURI {
 		t.Errorf("Properties.Database.URI = %q", req.Properties.Database.URI)
 	}
-	if req.Properties.BillingPlan == nil || req.Properties.BillingPlan.BillingPeriod == nil || *req.Properties.BillingPlan.BillingPeriod != BillingPeriodHour {
-		t.Errorf("Properties.BillingPlan.BillingPeriod = %v", req.Properties.BillingPlan)
+	if req.Properties.BillingPlanCommon == nil || req.Properties.BillingPlanCommon.BillingPeriod == nil || *req.Properties.BillingPlanCommon.BillingPeriod != BillingPeriodHour {
+		t.Errorf("Properties.BillingPlanCommon.BillingPeriod = %v", req.Properties.BillingPlanCommon)
 	}
 }
 
@@ -268,21 +268,21 @@ func dbaasBackupTestResponse(name string) *types.BackupResponse {
 			Name:             func() *string { s := name; return &s }(),
 			Tags:             []string{"tag1"},
 			LocationResponse: &types.LocationResponse{Value: RegionITBGBergamo},
-			ProjectResponseMetadata: &types.ProjectResponseMetadata{
+			ProjectMetadataResponse: &types.ProjectMetadataResponse{
 				ID: "p",
 			},
 		},
 		Properties: types.BackupPropertiesResponse{
 			Zone:     ZoneITBG1,
-			DBaaS:    types.ReferenceResource{URI: dbaasURI},
-			Database: types.ReferenceResource{URI: dbURI},
-			BillingPlan: func() *types.BillingPlan {
+			DBaaS:    types.ReferenceResourceCommon{URI: dbaasURI},
+			Database: types.ReferenceResourceCommon{URI: dbURI},
+			BillingPlanCommon: func() *types.BillingPlanCommon {
 				v := BillingPeriodHour
-				return &types.BillingPlan{BillingPeriod: &v}
+				return &types.BillingPlanCommon{BillingPeriod: &v}
 			}(),
 			Storage: types.BackupStorageResponse{Size: 50},
 		},
-		Status: types.ResourceStatus{
+		Status: types.ResourceStatusResponse{
 			State: &state,
 		},
 	}
@@ -351,7 +351,7 @@ func TestDBaaSBackup_FromResponse_NilSafe(t *testing.T) {
 
 func TestDBaaSBackup_FromResponse_BackfillsProjectID_FromMetadata(t *testing.T) {
 	resp := dbaasBackupTestResponse("n")
-	// ProjectResponseMetadata.ID is "p" — should be backfilled directly.
+	// ProjectMetadataResponse.ID is "p" — should be backfilled directly.
 	bkp := &DBaaSBackup{}
 	bkp.fromResponse(resp)
 	if bkp.ProjectID() != "p" {
@@ -366,7 +366,7 @@ func TestDBaaSBackup_FromResponse_BackfillsProjectID_FromURI(t *testing.T) {
 		Metadata: types.ResourceMetadataResponse{
 			ID:  &id,
 			URI: &uri,
-			// No ProjectResponseMetadata — should backfill from URI.
+			// No ProjectMetadataResponse — should backfill from URI.
 		},
 	}
 	bkp := &DBaaSBackup{}
@@ -507,8 +507,8 @@ func TestDBaaSBackupsClientAdapter_Create_Success(t *testing.T) {
 	if gotBody.Properties.Database.URI != "/projects/p/providers/Aruba.Database/dbaas/d-1/databases/mydb" {
 		t.Errorf("request Properties.Database.URI = %q", gotBody.Properties.Database.URI)
 	}
-	if gotBody.Properties.BillingPlan == nil || gotBody.Properties.BillingPlan.BillingPeriod == nil || *gotBody.Properties.BillingPlan.BillingPeriod != BillingPeriodHour {
-		t.Errorf("request Properties.BillingPlan.BillingPeriod = %v", gotBody.Properties.BillingPlan)
+	if gotBody.Properties.BillingPlanCommon == nil || gotBody.Properties.BillingPlanCommon.BillingPeriod == nil || *gotBody.Properties.BillingPlanCommon.BillingPeriod != BillingPeriodHour {
+		t.Errorf("request Properties.BillingPlanCommon.BillingPeriod = %v", gotBody.Properties.BillingPlanCommon)
 	}
 }
 
@@ -613,8 +613,8 @@ func TestDBaaSBackupsClientAdapter_Create_WithBodyRefs_ViaFake(t *testing.T) {
 	if captured.Properties.Zone != Zone(RegionITBGBergamo) {
 		t.Errorf("captured Zone = %q", captured.Properties.Zone)
 	}
-	if captured.Properties.BillingPlan == nil || captured.Properties.BillingPlan.BillingPeriod == nil || *captured.Properties.BillingPlan.BillingPeriod != BillingPeriodHour {
-		t.Errorf("captured BillingPlan.BillingPeriod = %v", captured.Properties.BillingPlan)
+	if captured.Properties.BillingPlanCommon == nil || captured.Properties.BillingPlanCommon.BillingPeriod == nil || *captured.Properties.BillingPlanCommon.BillingPeriod != BillingPeriodHour {
+		t.Errorf("captured BillingPlanCommon.BillingPeriod = %v", captured.Properties.BillingPlanCommon)
 	}
 }
 
@@ -883,7 +883,7 @@ func TestDBaaSBackup_FromResponse_SetsStatus(t *testing.T) {
 	b := &DBaaSBackup{}
 	state := types.State("Active")
 	b.fromResponse(&types.BackupResponse{
-		Status: types.ResourceStatus{State: &state},
+		Status: types.ResourceStatusResponse{State: &state},
 	})
 	if b.State() != types.StateActive {
 		t.Errorf("State() = %q after fromResponse, want Active", b.State())

--- a/pkg/aruba/resource_dbaas_test.go
+++ b/pkg/aruba/resource_dbaas_test.go
@@ -306,8 +306,8 @@ func TestDBaaS_ToRequestRoundTrip(t *testing.T) {
 	if req.Properties.Storage == nil || req.Properties.Storage.SizeGB == nil || *req.Properties.Storage.SizeGB != 20 {
 		t.Errorf("Storage.SizeGB = %v", req.Properties.Storage)
 	}
-	if req.Properties.BillingPlan == nil || req.Properties.BillingPlan.BillingPeriod == nil || *req.Properties.BillingPlan.BillingPeriod != BillingPeriodHour {
-		t.Errorf("BillingPlan.BillingPeriod = %v", req.Properties.BillingPlan)
+	if req.Properties.BillingPlanCommon == nil || req.Properties.BillingPlanCommon.BillingPeriod == nil || *req.Properties.BillingPlanCommon.BillingPeriod != BillingPeriodHour {
+		t.Errorf("BillingPlanCommon.BillingPeriod = %v", req.Properties.BillingPlanCommon)
 	}
 	if req.Properties.Autoscaling == nil || req.Properties.Autoscaling.Enabled == nil || !*req.Properties.Autoscaling.Enabled {
 		t.Errorf("Autoscaling.Enabled = %v", req.Properties.Autoscaling)
@@ -376,18 +376,18 @@ func dbaasTestResponse(id, name, uri string) *types.DBaaSResponse {
 			LocationResponse: loc,
 		},
 		Properties: types.DBaaSPropertiesResponse{
-			Engine:      &types.DBaaSEngineResponse{Type: &engineType},
-			Flavor:      &types.DBaaSFlavorResponse{Name: &flavorName},
-			Storage:     &types.DBaaSStorageResponse{SizeGB: &sizeGB},
-			BillingPlan: &types.BillingPlan{BillingPeriod: &billingPeriod},
+			Engine:            &types.DBaaSEngineResponse{Type: &engineType},
+			Flavor:            &types.DBaaSFlavorResponse{Name: &flavorName},
+			Storage:           &types.DBaaSStorageResponse{SizeGB: &sizeGB},
+			BillingPlanCommon: &types.BillingPlanCommon{BillingPeriod: &billingPeriod},
 			Networking: &types.DBaaSNetworkingResponse{
-				VPC:           &types.ReferenceResource{URI: vpcURI},
-				Subnet:        &types.ReferenceResource{URI: subnetURI},
-				SecurityGroup: &types.ReferenceResource{URI: sgURI},
-				ElasticIP:     &types.ReferenceResource{URI: eipURI},
+				VPC:           &types.ReferenceResourceCommon{URI: vpcURI},
+				Subnet:        &types.ReferenceResourceCommon{URI: subnetURI},
+				SecurityGroup: &types.ReferenceResourceCommon{URI: sgURI},
+				ElasticIP:     &types.ReferenceResourceCommon{URI: eipURI},
 			},
 		},
-		Status: types.ResourceStatus{State: &state},
+		Status: types.ResourceStatusResponse{State: &state},
 	}
 }
 
@@ -1179,7 +1179,7 @@ func TestDBaaS_FromResponse_SetsStatus(t *testing.T) {
 	d := &DBaaS{}
 	state := types.State("Active")
 	d.fromResponse(&types.DBaaSResponse{
-		Status: types.ResourceStatus{State: &state},
+		Status: types.ResourceStatusResponse{State: &state},
 	})
 	if d.State() != types.StateActive {
 		t.Errorf("State() = %q after fromResponse, want Active", d.State())

--- a/pkg/aruba/resource_dbaas_test.go
+++ b/pkg/aruba/resource_dbaas_test.go
@@ -1245,3 +1245,107 @@ func TestDBaaS_FromResponse_AutoscalingDisabledStatus(t *testing.T) {
 		t.Error("AutoscalingEnabled() should be false when Status=Disabled")
 	}
 }
+
+// --------------------------------------------------------------------------
+// EngineVersion / EngineType / PrivateIPAddress / FlavorCPU / FlavorRAMMB getters
+// --------------------------------------------------------------------------
+
+func TestDBaaS_EngineVersion_NilResponse(t *testing.T) {
+	d := &DBaaS{}
+	if got := d.EngineVersion(); got != "" {
+		t.Errorf("EngineVersion() on nil response = %q, want \"\"", got)
+	}
+}
+
+func TestDBaaS_EngineVersion_Populated(t *testing.T) {
+	ver := "8.0"
+	d := &DBaaS{}
+	d.fromResponse(&types.DBaaSResponse{
+		Properties: types.DBaaSPropertiesResponse{
+			Engine: &types.DBaaSEngineResponse{Version: &ver},
+		},
+	})
+	if got := d.EngineVersion(); got != "8.0" {
+		t.Errorf("EngineVersion() = %q, want %q", got, "8.0")
+	}
+}
+
+func TestDBaaS_EngineType_FromResponse(t *testing.T) {
+	eng := "mysql-8.0"
+	d := &DBaaS{}
+	d.fromResponse(&types.DBaaSResponse{
+		Properties: types.DBaaSPropertiesResponse{
+			Engine: &types.DBaaSEngineResponse{Type: &eng},
+		},
+	})
+	if got := d.EngineType(); got != "mysql-8.0" {
+		t.Errorf("EngineType() = %q, want %q", got, "mysql-8.0")
+	}
+}
+
+func TestDBaaS_EngineType_FromLocalField(t *testing.T) {
+	d := NewDBaaS().OfEngine(types.DatabaseEngineMySQL80)
+	if got := d.EngineType(); got != "mysql-8.0" {
+		t.Errorf("EngineType() from local field = %q, want %q", got, "mysql-8.0")
+	}
+}
+
+func TestDBaaS_PrivateIPAddress_NilResponse(t *testing.T) {
+	d := &DBaaS{}
+	if got := d.PrivateIPAddress(); got != "" {
+		t.Errorf("PrivateIPAddress() on nil response = %q, want \"\"", got)
+	}
+}
+
+func TestDBaaS_PrivateIPAddress_Populated(t *testing.T) {
+	ip := "10.0.0.5"
+	d := &DBaaS{}
+	d.fromResponse(&types.DBaaSResponse{
+		Properties: types.DBaaSPropertiesResponse{
+			Engine: &types.DBaaSEngineResponse{PrivateIPAddress: &ip},
+		},
+	})
+	if got := d.PrivateIPAddress(); got != ip {
+		t.Errorf("PrivateIPAddress() = %q, want %q", got, ip)
+	}
+}
+
+func TestDBaaS_FlavorCPU_NilResponse(t *testing.T) {
+	d := &DBaaS{}
+	if got := d.FlavorCPU(); got != 0 {
+		t.Errorf("FlavorCPU() on nil response = %d, want 0", got)
+	}
+}
+
+func TestDBaaS_FlavorCPU_Populated(t *testing.T) {
+	cpu := int32(4)
+	d := &DBaaS{}
+	d.fromResponse(&types.DBaaSResponse{
+		Properties: types.DBaaSPropertiesResponse{
+			Flavor: &types.DBaaSFlavorResponse{CPU: &cpu},
+		},
+	})
+	if got := d.FlavorCPU(); got != 4 {
+		t.Errorf("FlavorCPU() = %d, want 4", got)
+	}
+}
+
+func TestDBaaS_FlavorRAMMB_NilResponse(t *testing.T) {
+	d := &DBaaS{}
+	if got := d.FlavorRAMMB(); got != 0 {
+		t.Errorf("FlavorRAMMB() on nil response = %d, want 0", got)
+	}
+}
+
+func TestDBaaS_FlavorRAMMB_Populated(t *testing.T) {
+	ram := int32(8192)
+	d := &DBaaS{}
+	d.fromResponse(&types.DBaaSResponse{
+		Properties: types.DBaaSPropertiesResponse{
+			Flavor: &types.DBaaSFlavorResponse{RAM: &ram},
+		},
+	})
+	if got := d.FlavorRAMMB(); got != 8192 {
+		t.Errorf("FlavorRAMMB() = %d, want 8192", got)
+	}
+}

--- a/pkg/aruba/resource_elastic_ip.go
+++ b/pkg/aruba/resource_elastic_ip.go
@@ -32,7 +32,7 @@ type ElasticIP struct {
 	linkedMixin
 	httpEnvelopeMixin
 
-	billingPeriod *BillingPeriod           // Properties.BillingPlan.BillingPeriod
+	billingPeriod *BillingPeriod           // Properties.BillingPlanCommon.BillingPeriod
 	address       *string                  // Properties.Address (read-only from response)
 	response      *types.ElasticIPResponse // backs Raw()
 }
@@ -130,7 +130,7 @@ func (e *ElasticIP) toRequest() types.ElasticIPRequest {
 			Location:                e.toLocation(),
 		},
 		Properties: types.ElasticIPPropertiesRequest{
-			BillingPlan: &types.BillingPlan{BillingPeriod: defaultBillingPeriod(e.billingPeriod)},
+			BillingPlanCommon: &types.BillingPlanCommon{BillingPeriod: defaultBillingPeriod(e.billingPeriod)},
 		},
 	}
 }
@@ -153,16 +153,16 @@ func (e *ElasticIP) fromResponse(resp *types.ElasticIPResponse) {
 
 	e.setLinked(resp.Properties.LinkedResources)
 
-	if resp.Properties.BillingPlan != nil && resp.Properties.BillingPlan.BillingPeriod != nil {
-		e.billingPeriod = resp.Properties.BillingPlan.BillingPeriod
+	if resp.Properties.BillingPlanCommon != nil && resp.Properties.BillingPlanCommon.BillingPeriod != nil {
+		e.billingPeriod = resp.Properties.BillingPlanCommon.BillingPeriod
 	}
 	if resp.Properties.Address != nil && *resp.Properties.Address != "" {
 		addr := *resp.Properties.Address
 		e.address = &addr
 	}
 
-	if resp.Metadata.ProjectResponseMetadata != nil && resp.Metadata.ProjectResponseMetadata.ID != "" {
-		e.projectID = resp.Metadata.ProjectResponseMetadata.ID
+	if resp.Metadata.ProjectMetadataResponse != nil && resp.Metadata.ProjectMetadataResponse.ID != "" {
+		e.projectID = resp.Metadata.ProjectMetadataResponse.ID
 	}
 	if e.projectID == "" && e.RespURI() != "" {
 		if pid := parseURIIDs(e.RespURI())["projects"]; pid != "" {

--- a/pkg/aruba/resource_elastic_ip.go
+++ b/pkg/aruba/resource_elastic_ip.go
@@ -110,6 +110,16 @@ func (e *ElasticIP) Address() string {
 	return *e.address
 }
 
+// AssociatedResourceURI returns the URI of the first linked resource ("" if none).
+// This is the resource the elastic IP is currently attached to (e.g. a cloud server).
+func (e *ElasticIP) AssociatedResourceURI() string {
+	linked := e.LinkedResources()
+	if len(linked) == 0 {
+		return ""
+	}
+	return linked[0].URI
+}
+
 // Wire converters
 
 // toRequest assembles the Create/Update body from current setter state. Defaults are applied at the wire boundary.

--- a/pkg/aruba/resource_elastic_ip.go
+++ b/pkg/aruba/resource_elastic_ip.go
@@ -198,7 +198,7 @@ func (e *ElasticIP) WaitUntilUsed(ctx context.Context, opts ...WaitOption) error
 // *types.Response[T] preserves HTTP envelope details (status code, headers,
 // raw body) for the wrapper's diagnostics.
 type elasticIPLowLevelClient interface {
-	List(ctx context.Context, projectID string, params *types.RequestParameters) (*types.Response[types.ElasticList], error)
+	List(ctx context.Context, projectID string, params *types.RequestParameters) (*types.Response[types.ElasticIPListResponse], error)
 	Get(ctx context.Context, projectID, elasticIPID string, params *types.RequestParameters) (*types.Response[types.ElasticIPResponse], error)
 	Create(ctx context.Context, projectID string, body types.ElasticIPRequest, params *types.RequestParameters) (*types.Response[types.ElasticIPResponse], error)
 	Update(ctx context.Context, projectID, elasticIPID string, body types.ElasticIPRequest, params *types.RequestParameters) (*types.Response[types.ElasticIPResponse], error)
@@ -387,7 +387,7 @@ func (a *elasticIPsClientAdapter) List(ctx context.Context, project Ref, opts ..
 	}
 	var refetch func(ctx context.Context, pageURL string) (*List[*ElasticIP], error)
 	refetch = func(ctx context.Context, pageURL string) (*List[*ElasticIP], error) {
-		fetch := listPageFetch[types.ElasticList](a.rest, opts)
+		fetch := listPageFetch[types.ElasticIPListResponse](a.rest, opts)
 		pageResp, fetchErr := fetch(ctx, pageURL)
 		if fetchErr != nil {
 			return nil, fetchErr

--- a/pkg/aruba/resource_elastic_ip_test.go
+++ b/pkg/aruba/resource_elastic_ip_test.go
@@ -99,21 +99,21 @@ func TestElasticIP_ToRequestRoundTrip(t *testing.T) {
 	if req.Metadata.Location.Value != RegionITBGBergamo {
 		t.Errorf("Location.Value = %q", req.Metadata.Location.Value)
 	}
-	if req.Properties.BillingPlan == nil || req.Properties.BillingPlan.BillingPeriod == nil || *req.Properties.BillingPlan.BillingPeriod != BillingPeriodHour {
-		t.Errorf("BillingPlan.BillingPeriod (wire) = %v", req.Properties.BillingPlan)
+	if req.Properties.BillingPlanCommon == nil || req.Properties.BillingPlanCommon.BillingPeriod == nil || *req.Properties.BillingPlanCommon.BillingPeriod != BillingPeriodHour {
+		t.Errorf("BillingPlanCommon.BillingPeriod (wire) = %v", req.Properties.BillingPlanCommon)
 	}
 
 	// No billing period set → defaults to Hour on the wire.
 	e2 := NewElasticIP().
 		Named("bare")
 	req2 := e2.RawRequest()
-	if req2.Properties.BillingPlan == nil || req2.Properties.BillingPlan.BillingPeriod == nil || *req2.Properties.BillingPlan.BillingPeriod != BillingPeriodHour {
-		t.Errorf("unset BillingPeriod should default to Hour in billingPlan on wire, got %v", req2.Properties.BillingPlan)
+	if req2.Properties.BillingPlanCommon == nil || req2.Properties.BillingPlanCommon.BillingPeriod == nil || *req2.Properties.BillingPlanCommon.BillingPeriod != BillingPeriodHour {
+		t.Errorf("unset BillingPeriod should default to Hour in billingPlan on wire, got %v", req2.Properties.BillingPlanCommon)
 	}
 }
 
 // --------------------------------------------------------------------------
-// BillingPlan wire round-trip
+// BillingPlanCommon wire round-trip
 // --------------------------------------------------------------------------
 
 func TestElasticIP_BillingPeriod_WireBillingPlan(t *testing.T) {
@@ -121,17 +121,17 @@ func TestElasticIP_BillingPeriod_WireBillingPlan(t *testing.T) {
 		tc := period
 		t.Run(string(tc), func(t *testing.T) {
 			req := NewElasticIP().Named("x").InRegion(RegionITBGBergamo).BilledBy(tc).RawRequest()
-			if req.Properties.BillingPlan == nil || req.Properties.BillingPlan.BillingPeriod == nil {
-				t.Fatal("BillingPlan or BillingPlan.BillingPeriod is nil")
+			if req.Properties.BillingPlanCommon == nil || req.Properties.BillingPlanCommon.BillingPeriod == nil {
+				t.Fatal("BillingPlanCommon or BillingPlanCommon.BillingPeriod is nil")
 			}
-			if got := *req.Properties.BillingPlan.BillingPeriod; got != tc {
+			if got := *req.Properties.BillingPlanCommon.BillingPeriod; got != tc {
 				t.Errorf("toRequest wire = %q, want %q", got, tc)
 			}
 			std := tc
 			e := &ElasticIP{}
 			e.fromResponse(&types.ElasticIPResponse{
 				Properties: types.ElasticIPPropertiesResponse{
-					BillingPlan: &types.BillingPlan{BillingPeriod: &std},
+					BillingPlanCommon: &types.BillingPlanCommon{BillingPeriod: &std},
 				},
 			})
 			if e.BillingPeriod() != tc {
@@ -156,20 +156,20 @@ func elasticIPTestResponse(id, name, uri, projectID string) *types.ElasticIPResp
 			Name:             &name,
 			Tags:             []string{"tag1"},
 			LocationResponse: loc,
-			ProjectResponseMetadata: &types.ProjectResponseMetadata{
+			ProjectMetadataResponse: &types.ProjectMetadataResponse{
 				ID: projectID,
 			},
 		},
 		Properties: types.ElasticIPPropertiesResponse{
-			BillingPlan: &types.BillingPlan{BillingPeriod: func() *BillingPeriod { v := BillingPeriodHour; return &v }()},
-			Address:     &addr,
-			LinkedResources: []types.LinkedResource{
+			BillingPlanCommon: &types.BillingPlanCommon{BillingPeriod: func() *BillingPeriod { v := BillingPeriodHour; return &v }()},
+			Address:           &addr,
+			LinkedResources: []types.LinkedResourceCommon{
 				{URI: "/projects/p/providers/Aruba.Compute/cloudservers/cs1", StrictCorrelation: true},
 			},
 		},
-		Status: types.ResourceStatus{
+		Status: types.ResourceStatusResponse{
 			State: &state,
-			DisableStatusInfo: &types.DisableStatusInfo{
+			DisableStatusInfoResponse: &types.DisableStatusInfoResponse{
 				IsDisabled: false,
 			},
 		},
@@ -345,8 +345,8 @@ func TestElasticIPsClientAdapter_Create_Success(t *testing.T) {
 	if gotBody.Metadata.Name != "my-eip" {
 		t.Errorf("request Name = %q", gotBody.Metadata.Name)
 	}
-	if gotBody.Properties.BillingPlan == nil || gotBody.Properties.BillingPlan.BillingPeriod == nil || *gotBody.Properties.BillingPlan.BillingPeriod != BillingPeriodHour {
-		t.Errorf("request BillingPlan.BillingPeriod (wire) = %v", gotBody.Properties.BillingPlan)
+	if gotBody.Properties.BillingPlanCommon == nil || gotBody.Properties.BillingPlanCommon.BillingPeriod == nil || *gotBody.Properties.BillingPlanCommon.BillingPeriod != BillingPeriodHour {
+		t.Errorf("request BillingPlanCommon.BillingPeriod (wire) = %v", gotBody.Properties.BillingPlanCommon)
 	}
 }
 
@@ -820,7 +820,7 @@ func TestElasticIP_FromResponse_URIBackfillProjectID(t *testing.T) {
 			ID:   &id,
 			URI:  &uri,
 			Name: &name,
-			// ProjectResponseMetadata intentionally nil
+			// ProjectMetadataResponse intentionally nil
 		},
 	}
 	e := &ElasticIP{}
@@ -834,7 +834,7 @@ func TestElasticIP_FromResponse_SetsStatus(t *testing.T) {
 	e := &ElasticIP{}
 	state := types.State("NotUsed")
 	e.fromResponse(&types.ElasticIPResponse{
-		Status: types.ResourceStatus{State: &state},
+		Status: types.ResourceStatusResponse{State: &state},
 	})
 	if e.State() != types.StateNotUsed {
 		t.Errorf("State() = %q after fromResponse, want NotUsed", e.State())
@@ -851,7 +851,7 @@ func TestElasticIP_WaitUntilNotUsed_HappyPath(t *testing.T) {
 			state = "NotUsed"
 		}
 		s := state
-		e.setStatus(&types.ResourceStatus{State: &s})
+		e.setStatus(&types.ResourceStatusResponse{State: &s})
 		return nil
 	})
 	if err := e.WaitUntilNotUsed(context.Background(), fastOpts()...); err != nil {
@@ -874,7 +874,7 @@ func TestElasticIP_WaitUntilUsed_HappyPath(t *testing.T) {
 					state = attachedState
 				}
 				s := state
-				e.setStatus(&types.ResourceStatus{State: &s})
+				e.setStatus(&types.ResourceStatusResponse{State: &s})
 				return nil
 			})
 			if err := e.WaitUntilUsed(context.Background(), fastOpts()...); err != nil {
@@ -929,7 +929,7 @@ func TestElasticIP_AssociatedResourceURI_NoLinked(t *testing.T) {
 func TestElasticIP_AssociatedResourceURI_WithLinked(t *testing.T) {
 	e := &ElasticIP{}
 	linkedURI := "/projects/p/providers/Aruba.Compute/cloudServers/cs-1"
-	e.setLinked([]types.LinkedResource{{URI: linkedURI}})
+	e.setLinked([]types.LinkedResourceCommon{{URI: linkedURI}})
 	if got := e.AssociatedResourceURI(); got != linkedURI {
 		t.Errorf("AssociatedResourceURI() = %q, want %q", got, linkedURI)
 	}
@@ -939,7 +939,7 @@ func TestElasticIP_AssociatedResourceURI_FirstLinked(t *testing.T) {
 	e := &ElasticIP{}
 	first := "/projects/p/providers/Aruba.Compute/cloudServers/cs-1"
 	second := "/projects/p/providers/Aruba.Network/loadBalancers/lb-1"
-	e.setLinked([]types.LinkedResource{{URI: first}, {URI: second}})
+	e.setLinked([]types.LinkedResourceCommon{{URI: first}, {URI: second}})
 	if got := e.AssociatedResourceURI(); got != first {
 		t.Errorf("AssociatedResourceURI() = %q, want first = %q", got, first)
 	}

--- a/pkg/aruba/resource_elastic_ip_test.go
+++ b/pkg/aruba/resource_elastic_ip_test.go
@@ -914,3 +914,33 @@ func TestElasticIPRef(t *testing.T) {
 		t.Errorf("parseURIIDs = %v", ids)
 	}
 }
+
+// --------------------------------------------------------------------------
+// AssociatedResourceURI getter
+// --------------------------------------------------------------------------
+
+func TestElasticIP_AssociatedResourceURI_NoLinked(t *testing.T) {
+	e := &ElasticIP{}
+	if got := e.AssociatedResourceURI(); got != "" {
+		t.Errorf("AssociatedResourceURI() with no linked = %q, want \"\"", got)
+	}
+}
+
+func TestElasticIP_AssociatedResourceURI_WithLinked(t *testing.T) {
+	e := &ElasticIP{}
+	linkedURI := "/projects/p/providers/Aruba.Compute/cloudServers/cs-1"
+	e.setLinked([]types.LinkedResource{{URI: linkedURI}})
+	if got := e.AssociatedResourceURI(); got != linkedURI {
+		t.Errorf("AssociatedResourceURI() = %q, want %q", got, linkedURI)
+	}
+}
+
+func TestElasticIP_AssociatedResourceURI_FirstLinked(t *testing.T) {
+	e := &ElasticIP{}
+	first := "/projects/p/providers/Aruba.Compute/cloudServers/cs-1"
+	second := "/projects/p/providers/Aruba.Network/loadBalancers/lb-1"
+	e.setLinked([]types.LinkedResource{{URI: first}, {URI: second}})
+	if got := e.AssociatedResourceURI(); got != first {
+		t.Errorf("AssociatedResourceURI() = %q, want first = %q", got, first)
+	}
+}

--- a/pkg/aruba/resource_grant.go
+++ b/pkg/aruba/resource_grant.go
@@ -137,8 +137,8 @@ func (g *Grant) RawRequest() types.GrantRequest { return g.toRequest() }
 // toRequest assembles the Create/Update body from current setter state. Defaults are applied at the wire boundary.
 func (g *Grant) toRequest() types.GrantRequest {
 	return types.GrantRequest{
-		User: types.GrantUser{Username: grantDerefString(g.username)},
-		Role: types.GrantRole{Name: grantDerefString(g.roleName)},
+		User: types.GrantUserCommon{Username: grantDerefString(g.username)},
+		Role: types.GrantRoleCommon{Name: grantDerefString(g.roleName)},
 	}
 }
 
@@ -211,7 +211,7 @@ func grantIDsFromRef(ref Ref) (projectID, dbaasID, databaseID, grantID string, e
 // *types.Response[T] preserves HTTP envelope details (status code, headers,
 // raw body) for the wrapper's diagnostics.
 type grantsLowLevelClient interface {
-	List(ctx context.Context, projectID, dbaasID, databaseID string, params *types.RequestParameters) (*types.Response[types.GrantList], error)
+	List(ctx context.Context, projectID, dbaasID, databaseID string, params *types.RequestParameters) (*types.Response[types.GrantListResponse], error)
 	Get(ctx context.Context, projectID, dbaasID, databaseID, grantID string, params *types.RequestParameters) (*types.Response[types.GrantResponse], error)
 	Create(ctx context.Context, projectID, dbaasID, databaseID string, body types.GrantRequest, params *types.RequestParameters) (*types.Response[types.GrantResponse], error)
 	Update(ctx context.Context, projectID, dbaasID, databaseID, grantID string, body types.GrantRequest, params *types.RequestParameters) (*types.Response[types.GrantResponse], error)
@@ -427,7 +427,7 @@ func (a *grantsClientAdapter) List(ctx context.Context, parent Ref, opts ...Call
 	}
 	var refetch func(ctx context.Context, pageURL string) (*List[*Grant], error)
 	refetch = func(ctx context.Context, pageURL string) (*List[*Grant], error) {
-		fetch := listPageFetch[types.GrantList](a.rest, opts)
+		fetch := listPageFetch[types.GrantListResponse](a.rest, opts)
 		pageResp, fetchErr := fetch(ctx, pageURL)
 		if fetchErr != nil {
 			return nil, fetchErr

--- a/pkg/aruba/resource_grant_test.go
+++ b/pkg/aruba/resource_grant_test.go
@@ -196,8 +196,8 @@ func grantTestResponse(userName, roleName, dbName string) *types.GrantResponse {
 	ts := time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC)
 	creator := "admin@example.com"
 	return &types.GrantResponse{
-		User:         types.GrantUser{Username: userName},
-		Role:         types.GrantRole{Name: roleName},
+		User:         types.GrantUserCommon{Username: userName},
+		Role:         types.GrantRoleCommon{Name: roleName},
 		Database:     types.GrantDatabaseResponse{Name: dbName},
 		CreationDate: &ts,
 		CreatedBy:    &creator,

--- a/pkg/aruba/resource_job.go
+++ b/pkg/aruba/resource_job.go
@@ -340,8 +340,8 @@ func (j *Job) fromResponse(resp *types.JobResponse) {
 	}
 	j.steps = jobRebuildSteps(resp.Properties.Steps)
 
-	if resp.Metadata.ProjectResponseMetadata != nil && resp.Metadata.ProjectResponseMetadata.ID != "" {
-		j.projectID = resp.Metadata.ProjectResponseMetadata.ID
+	if resp.Metadata.ProjectMetadataResponse != nil && resp.Metadata.ProjectMetadataResponse.ID != "" {
+		j.projectID = resp.Metadata.ProjectMetadataResponse.ID
 	}
 	if j.projectID == "" && j.RespURI() != "" {
 		if pid := parseURIIDs(j.RespURI())["projects"]; pid != "" {

--- a/pkg/aruba/resource_job.go
+++ b/pkg/aruba/resource_job.go
@@ -418,7 +418,7 @@ func jobIDsFromRef(ref Ref) (projectID, jobID string, err error) {
 // *types.Response[T] preserves HTTP envelope details (status code, headers,
 // raw body) for the wrapper's diagnostics.
 type jobsLowLevelClient interface {
-	List(ctx context.Context, projectID string, params *types.RequestParameters) (*types.Response[types.JobList], error)
+	List(ctx context.Context, projectID string, params *types.RequestParameters) (*types.Response[types.JobListResponse], error)
 	Get(ctx context.Context, projectID, jobID string, params *types.RequestParameters) (*types.Response[types.JobResponse], error)
 	Create(ctx context.Context, projectID string, body types.JobRequest, params *types.RequestParameters) (*types.Response[types.JobResponse], error)
 	Update(ctx context.Context, projectID, jobID string, body types.JobRequest, params *types.RequestParameters) (*types.Response[types.JobResponse], error)
@@ -611,7 +611,7 @@ func (a *jobsClientAdapter) List(ctx context.Context, parent Ref, opts ...CallOp
 	}
 	var refetch func(ctx context.Context, pageURL string) (*List[*Job], error)
 	refetch = func(ctx context.Context, pageURL string) (*List[*Job], error) {
-		fetch := listPageFetch[types.JobList](a.rest, opts)
+		fetch := listPageFetch[types.JobListResponse](a.rest, opts)
 		pageResp, fetchErr := fetch(ctx, pageURL)
 		if fetchErr != nil {
 			return nil, fetchErr

--- a/pkg/aruba/resource_job.go
+++ b/pkg/aruba/resource_job.go
@@ -23,6 +23,7 @@ import (
 //   - One-shot:  OneShotAt(t)                → JobType=OneShot, ScheduleAt=RFC3339
 //   - Recurring: WithCron(expr) [+ RecurringUntil(t)] → JobType=Recurring
 //
+// OfType(JobType) is also available when the mode must be stated explicitly.
 // Setter-time error if you mix the two modes.
 //
 // Path: /projects/{projectID}/providers/Aruba.Schedule/jobs[/{jobID}]
@@ -91,6 +92,17 @@ func (j *Job) Enabled() *Job { v := true; j.enabled = &v; return j }
 
 // Disabled deactivates the job.
 func (j *Job) Disabled() *Job { v := false; j.enabled = &v; return j }
+
+// OfType explicitly sets the job's schedule type. Useful when the type is
+// chosen at runtime or when callers want to make the mode self-documenting at
+// the call site. When omitted, the mode is implied by which schedule setter
+// you call: OneShotAt → JobTypeOneShot, WithCron / RecurringUntil → JobTypeRecurring.
+// Returns the receiver with an accumulated error if the requested type
+// conflicts with a previously-set mode.
+func (j *Job) OfType(t types.JobType) *Job {
+	j.requireMode(t, "OfType")
+	return j
+}
 
 // OneShotAt schedules a one-time execution at t (UTC, RFC3339).
 // Returns an error if a Recurring schedule has already been configured.

--- a/pkg/aruba/resource_job.go
+++ b/pkg/aruba/resource_job.go
@@ -327,8 +327,7 @@ func (j *Job) fromResponse(resp *types.JobResponse) {
 	}
 }
 
-// jobRebuildSteps converts response-side steps back to sub-builders, round-tripping
-// Typology so that a Get → Update flow preserves the field.
+// jobRebuildSteps converts response-side steps back to sub-builders.
 func jobRebuildSteps(steps []types.JobStepResponse) []*JobStep {
 	if steps == nil {
 		return nil
@@ -339,10 +338,6 @@ func jobRebuildSteps(steps []types.JobStepResponse) []*JobStep {
 		if rs.Name != nil {
 			v := *rs.Name
 			s.name = &v
-		}
-		if rs.Typology != nil {
-			v := *rs.Typology
-			s.typology = &v
 		}
 		if rs.ResourceURI != nil {
 			v := *rs.ResourceURI

--- a/pkg/aruba/resource_job.go
+++ b/pkg/aruba/resource_job.go
@@ -266,7 +266,7 @@ func (j *Job) toRequest() types.JobRequest {
 		props.JobType = *j.jobType
 	}
 	if len(j.steps) > 0 {
-		props.Steps = make([]types.JobStep, 0, len(j.steps))
+		props.Steps = make([]types.JobStepRequest, 0, len(j.steps))
 		for _, s := range j.steps {
 			props.Steps = append(props.Steps, s.build())
 		}
@@ -327,8 +327,8 @@ func (j *Job) fromResponse(resp *types.JobResponse) {
 	}
 }
 
-// jobRebuildSteps converts response-side steps (all *string) back to sub-builders,
-// dropping response-only enrichments (ActionName, Typology, TypologyName).
+// jobRebuildSteps converts response-side steps back to sub-builders, round-tripping
+// Typology so that a Get → Update flow preserves the field.
 func jobRebuildSteps(steps []types.JobStepResponse) []*JobStep {
 	if steps == nil {
 		return nil
@@ -339,6 +339,10 @@ func jobRebuildSteps(steps []types.JobStepResponse) []*JobStep {
 		if rs.Name != nil {
 			v := *rs.Name
 			s.name = &v
+		}
+		if rs.Typology != nil {
+			v := *rs.Typology
+			s.typology = &v
 		}
 		if rs.ResourceURI != nil {
 			v := *rs.ResourceURI

--- a/pkg/aruba/resource_job.go
+++ b/pkg/aruba/resource_job.go
@@ -197,6 +197,61 @@ func (j *Job) Cron() string {
 	return ""
 }
 
+// ScheduleAt returns the one-shot execution time parsed from the response or local state.
+// Returns zero time.Time if absent or not parseable.
+func (j *Job) ScheduleAt() time.Time {
+	var raw *string
+	if j.response != nil {
+		raw = j.response.Properties.ScheduleAt
+	} else {
+		raw = j.scheduleAt
+	}
+	if raw == nil {
+		return time.Time{}
+	}
+	t, err := time.Parse(time.RFC3339, *raw)
+	if err != nil {
+		return time.Time{}
+	}
+	return t
+}
+
+// ExecuteUntil returns the recurring-job end time parsed from the response or local state.
+// Returns zero time.Time if absent or not parseable.
+func (j *Job) ExecuteUntil() time.Time {
+	var raw *string
+	if j.response != nil {
+		raw = j.response.Properties.ExecuteUntil
+	} else {
+		raw = j.executeUntil
+	}
+	if raw == nil {
+		return time.Time{}
+	}
+	t, err := time.Parse(time.RFC3339, *raw)
+	if err != nil {
+		return time.Time{}
+	}
+	return t
+}
+
+// NextExecutionAt returns the next scheduled execution time from the response, or zero if absent.
+func (j *Job) NextExecutionAt() time.Time {
+	if j.response == nil || j.response.Properties.NextExecution == nil {
+		return time.Time{}
+	}
+	t, err := time.Parse(time.RFC3339, *j.response.Properties.NextExecution)
+	if err != nil {
+		return time.Time{}
+	}
+	return t
+}
+
+// Steps returns the job step sub-builders, or nil if none have been configured.
+func (j *Job) Steps() []*JobStep {
+	return j.steps
+}
+
 // Wire converters
 
 // toRequest assembles the Create/Update body from current setter state. Defaults are applied at the wire boundary.

--- a/pkg/aruba/resource_job.go
+++ b/pkg/aruba/resource_job.go
@@ -20,10 +20,11 @@ import (
 // there is no narrower JobUpdateRequest.
 //
 // Schedule modes:
-//   - One-shot:  OneShotAt(t)                → JobType=OneShot, ScheduleAt=RFC3339
-//   - Recurring: WithCron(expr) [+ RecurringUntil(t)] → JobType=Recurring
+//   - One-shot:  OneShotAt(t)                                         → JobType=OneShot, ScheduleAt=t
+//   - Recurring: WithCron(expr) [+ StartingAt(t)] [+ RecurringUntil(t)] → JobType=Recurring
 //
-// OfType(JobType) is also available when the mode must be stated explicitly.
+// StartingAt(t) is mode-neutral: usable on either mode. OfType(JobType) is
+// also available when the mode must be stated explicitly.
 // Setter-time error if you mix the two modes.
 //
 // Path: /projects/{projectID}/providers/Aruba.Schedule/jobs[/{jobID}]
@@ -104,15 +105,25 @@ func (j *Job) OfType(t types.JobType) *Job {
 	return j
 }
 
+// StartingAt sets the job's start time (wire field "scheduleAt"). For OneShot
+// jobs this is the fire time; for Recurring jobs it is the start of the
+// recurrence window. Unlike OneShotAt(t), this setter is mode-neutral — it
+// can be combined with WithCron / RecurringUntil to build a Recurring job
+// that carries scheduleAt as the window start (mirroring the Aruba Terraform
+// reference HCL).
+func (j *Job) StartingAt(t time.Time) *Job {
+	s := t.UTC().Format(time.RFC3339)
+	j.scheduleAt = &s
+	return j
+}
+
 // OneShotAt schedules a one-time execution at t (UTC, RFC3339).
 // Returns an error if a Recurring schedule has already been configured.
 func (j *Job) OneShotAt(t time.Time) *Job {
 	if !j.requireMode(types.JobTypeOneShot, "OneShotAt") {
 		return j
 	}
-	s := t.UTC().Format(time.RFC3339)
-	j.scheduleAt = &s
-	return j
+	return j.StartingAt(t)
 }
 
 // WithCron sets the cron expression for a recurring job.

--- a/pkg/aruba/resource_job_step.go
+++ b/pkg/aruba/resource_job_step.go
@@ -10,14 +10,9 @@ import (
 
 // JobStep is a fluent builder for a single step within a Job.
 // Construct with NewJobStep() and attach via Job.WithSteps.
-//
-// Typology is required by the API for step dispatch. Use OfTypology with one of
-// the JobStepTypology* constants (e.g. JobStepTypologyCloudServer). The value
-// must match category.typology.id on any GET response for the target resource.
 type JobStep struct {
 	errMixin
 	name        *string
-	typology    *string
 	resourceURI *string
 	actionURI   *string
 	httpVerb    *HTTPVerb
@@ -29,9 +24,6 @@ func NewJobStep() *JobStep { return &JobStep{} }
 
 // Named sets the step name.
 func (s *JobStep) Named(name string) *JobStep { s.name = &name; return s }
-
-// OfTypology sets the typology for this step. Use JobStepTypology* constants.
-func (s *JobStep) OfTypology(t string) *JobStep { s.typology = &t; return s }
 
 // WithAction sets the action URI to invoke for this step.
 func (s *JobStep) WithAction(action string) *JobStep { s.actionURI = &action; return s }
@@ -53,22 +45,10 @@ func (s *JobStep) Targeting(res Ref) *JobStep {
 	return s
 }
 
-// JobStepTypology* constants map to the server-side category.typology.id vocabulary.
-// Extend this list as new resource types are exercised in steps.
-const (
-	JobStepTypologyCloudServer       = "cloudServer"
-	JobStepTypologyKeyPair           = "keyPair"
-	JobStepTypologyElasticIP         = "elasticIp"
-	JobStepTypologyContainerRegistry = "containerRegistry"
-)
-
 func (s *JobStep) build() types.JobStepRequest {
 	out := types.JobStepRequest{}
 	if s.name != nil {
 		out.Name = s.name
-	}
-	if s.typology != nil {
-		out.Typology = s.typology
 	}
 	if s.resourceURI != nil {
 		out.ResourceURI = *s.resourceURI

--- a/pkg/aruba/resource_job_step.go
+++ b/pkg/aruba/resource_job_step.go
@@ -9,15 +9,15 @@ import (
 // ---- Sub-builder ----
 
 // JobStep is a fluent builder for a single step within a Job.
-// Construct with NewJobStep() and attach via Job.AddStep.
+// Construct with NewJobStep() and attach via Job.WithSteps.
 //
-// Schema note: ResourceURI and ActionURI are required plain strings in the wire
-// request (types.JobStep); the response side uses *string for all fields plus
-// additional read-only enrichments (ActionName, Typology, TypologyName) that
-// are not round-tripped on Update.
+// Typology is required by the API for step dispatch. Use OfTypology with one of
+// the JobStepTypology* constants (e.g. JobStepTypologyCloudServer). The value
+// must match category.typology.id on any GET response for the target resource.
 type JobStep struct {
 	errMixin
 	name        *string
+	typology    *string
 	resourceURI *string
 	actionURI   *string
 	httpVerb    *HTTPVerb
@@ -29,6 +29,9 @@ func NewJobStep() *JobStep { return &JobStep{} }
 
 // Named sets the step name.
 func (s *JobStep) Named(name string) *JobStep { s.name = &name; return s }
+
+// OfTypology sets the typology for this step. Use JobStepTypology* constants.
+func (s *JobStep) OfTypology(t string) *JobStep { s.typology = &t; return s }
 
 // WithAction sets the action URI to invoke for this step.
 func (s *JobStep) WithAction(action string) *JobStep { s.actionURI = &action; return s }
@@ -50,10 +53,22 @@ func (s *JobStep) Targeting(res Ref) *JobStep {
 	return s
 }
 
-func (s *JobStep) build() types.JobStep {
-	out := types.JobStep{}
+// JobStepTypology* constants map to the server-side category.typology.id vocabulary.
+// Extend this list as new resource types are exercised in steps.
+const (
+	JobStepTypologyCloudServer       = "cloudServer"
+	JobStepTypologyKeyPair           = "keyPair"
+	JobStepTypologyElasticIP         = "elasticIp"
+	JobStepTypologyContainerRegistry = "containerRegistry"
+)
+
+func (s *JobStep) build() types.JobStepRequest {
+	out := types.JobStepRequest{}
 	if s.name != nil {
 		out.Name = s.name
+	}
+	if s.typology != nil {
+		out.Typology = s.typology
 	}
 	if s.resourceURI != nil {
 		out.ResourceURI = *s.resourceURI

--- a/pkg/aruba/resource_job_test.go
+++ b/pkg/aruba/resource_job_test.go
@@ -429,7 +429,7 @@ func jobTestResponse(name string) *types.JobResponse {
 			Name:             func() *string { s := name; return &s }(),
 			Tags:             []string{"tag1"},
 			LocationResponse: &types.LocationResponse{Value: RegionITBGBergamo},
-			ProjectResponseMetadata: &types.ProjectResponseMetadata{
+			ProjectMetadataResponse: &types.ProjectMetadataResponse{
 				ID: "p",
 			},
 		},
@@ -448,7 +448,7 @@ func jobTestResponse(name string) *types.JobResponse {
 				},
 			},
 		},
-		Status: types.ResourceStatus{State: &state},
+		Status: types.ResourceStatusResponse{State: &state},
 	}
 }
 
@@ -1137,7 +1137,7 @@ func TestJob_FromResponse_SetsStatus(t *testing.T) {
 	j := &Job{}
 	state := types.State("Active")
 	j.fromResponse(&types.JobResponse{
-		Status: types.ResourceStatus{State: &state},
+		Status: types.ResourceStatusResponse{State: &state},
 	})
 	if j.State() != types.StateActive {
 		t.Errorf("State() = %q after fromResponse, want Active", j.State())

--- a/pkg/aruba/resource_job_test.go
+++ b/pkg/aruba/resource_job_test.go
@@ -200,6 +200,54 @@ func TestJob_WithCron_Then_OneShotAt_Errors(t *testing.T) {
 	}
 }
 
+func TestJob_StartingAt_NeutralOnEmpty(t *testing.T) {
+	ts := time.Date(2026, 5, 1, 12, 0, 0, 0, time.UTC)
+	j := NewJob().StartingAt(ts)
+	if j.Err() != nil {
+		t.Fatalf("unexpected error: %v", j.Err())
+	}
+	if j.JobType() != "" {
+		t.Errorf("JobType() = %q; want empty (mode-neutral)", j.JobType())
+	}
+	req := j.RawRequest()
+	if req.Properties.ScheduleAt == nil {
+		t.Fatal("ScheduleAt should be set")
+	}
+	if got, want := *req.Properties.ScheduleAt, "2026-05-01T12:00:00Z"; got != want {
+		t.Errorf("ScheduleAt = %q; want %q", got, want)
+	}
+}
+
+func TestJob_StartingAt_CompatibleWithRecurring(t *testing.T) {
+	start := time.Date(2026, 5, 1, 10, 0, 0, 0, time.UTC)
+	end := time.Date(2026, 7, 1, 10, 0, 0, 0, time.UTC)
+	j := NewJob().WithCron("0 10 * * *").StartingAt(start).RecurringUntil(end)
+	if j.Err() != nil {
+		t.Fatalf("unexpected error: %v", j.Err())
+	}
+	if j.JobType() != JobTypeRecurring {
+		t.Errorf("JobType() = %q; want %q", j.JobType(), JobTypeRecurring)
+	}
+	req := j.RawRequest()
+	if req.Properties.Cron == nil || *req.Properties.Cron != "0 10 * * *" {
+		t.Errorf("Cron = %v; want %q", req.Properties.Cron, "0 10 * * *")
+	}
+	if req.Properties.ScheduleAt == nil {
+		t.Error("ScheduleAt should be set")
+	}
+	if req.Properties.ExecuteUntil == nil {
+		t.Error("ExecuteUntil should be set")
+	}
+}
+
+func TestJob_OneShotAt_StillForcesOneShotMode(t *testing.T) {
+	ts := time.Date(2026, 5, 1, 12, 0, 0, 0, time.UTC)
+	j := NewJob().OneShotAt(ts).WithCron("0 8 * * 1-5")
+	if j.Err() == nil {
+		t.Error("expected error mixing OneShot (OneShotAt) and Recurring (WithCron)")
+	}
+}
+
 func TestJob_OfType_PopulatesScheduleJobType(t *testing.T) {
 	j := NewJob().OfType(JobTypeOneShot)
 	if j.Err() != nil {

--- a/pkg/aruba/resource_job_test.go
+++ b/pkg/aruba/resource_job_test.go
@@ -200,6 +200,56 @@ func TestJob_WithCron_Then_OneShotAt_Errors(t *testing.T) {
 	}
 }
 
+func TestJob_OfType_PopulatesScheduleJobType(t *testing.T) {
+	j := NewJob().OfType(JobTypeOneShot)
+	if j.Err() != nil {
+		t.Fatalf("unexpected error: %v", j.Err())
+	}
+	if j.JobType() != JobTypeOneShot {
+		t.Errorf("JobType() = %q; want %q", j.JobType(), JobTypeOneShot)
+	}
+	if got := j.RawRequest().Properties.JobType; got != JobTypeOneShot {
+		t.Errorf("wire JobType = %q; want %q", got, JobTypeOneShot)
+	}
+}
+
+func TestJob_OfType_CompatibleWithMatchingOneShotAt(t *testing.T) {
+	ts := time.Date(2026, 5, 1, 12, 0, 0, 0, time.UTC)
+	j := NewJob().OfType(JobTypeOneShot).OneShotAt(ts)
+	if j.Err() != nil {
+		t.Fatalf("unexpected error: %v", j.Err())
+	}
+	req := j.RawRequest()
+	if req.Properties.JobType != JobTypeOneShot {
+		t.Errorf("JobType = %q; want %q", req.Properties.JobType, JobTypeOneShot)
+	}
+	if req.Properties.ScheduleAt == nil {
+		t.Error("ScheduleAt should be set")
+	}
+}
+
+func TestJob_OfType_CompatibleWithMatchingWithCron(t *testing.T) {
+	j := NewJob().OfType(JobTypeRecurring).WithCron("0 10 * * *")
+	if j.Err() != nil {
+		t.Fatalf("unexpected error: %v", j.Err())
+	}
+	if j.JobType() != JobTypeRecurring {
+		t.Errorf("JobType() = %q; want %q", j.JobType(), JobTypeRecurring)
+	}
+}
+
+func TestJob_OfType_ConflictsWithOppositeMode(t *testing.T) {
+	ts := time.Date(2026, 5, 1, 12, 0, 0, 0, time.UTC)
+	j := NewJob().OfType(JobTypeRecurring).OneShotAt(ts)
+	if j.Err() == nil {
+		t.Error("expected error mixing Recurring (OfType) and OneShot (OneShotAt)")
+	}
+	j2 := NewJob().OfType(JobTypeOneShot).WithCron("0 8 * * 1-5")
+	if j2.Err() == nil {
+		t.Error("expected error mixing OneShot (OfType) and Recurring (WithCron)")
+	}
+}
+
 // --------------------------------------------------------------------------
 // JobStep sub-builder
 // --------------------------------------------------------------------------

--- a/pkg/aruba/resource_job_test.go
+++ b/pkg/aruba/resource_job_test.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"net/http"
 	"reflect"
+	"strings"
 	"testing"
 	"time"
 
@@ -227,6 +228,36 @@ func TestJobStep_Build_Basic(t *testing.T) {
 	}
 }
 
+func TestJobStep_Build_IncludesTypology(t *testing.T) {
+	s := NewJobStep().
+		Targeting(URI("/projects/p/providers/Aruba.Compute/cloudServers/srv-1")).
+		OfTypology(JobStepTypologyCloudServer).
+		WithAction("poweroff").
+		WithVerb(HTTPVerbPOST)
+
+	out := s.build()
+	if out.Typology == nil || *out.Typology != JobStepTypologyCloudServer {
+		t.Errorf("Typology = %v, want %q", out.Typology, JobStepTypologyCloudServer)
+	}
+}
+
+func TestJobStep_Build_OmitsTypologyWhenUnset(t *testing.T) {
+	s := NewJobStep().
+		Targeting(URI("/projects/p/providers/Aruba.Compute/cloudServers/srv-1")).
+		WithAction("poweroff").
+		WithVerb(HTTPVerbPOST)
+
+	out := s.build()
+	if out.Typology != nil {
+		t.Errorf("Typology should be nil when OfTypology not called, got %q", *out.Typology)
+	}
+
+	b, _ := json.Marshal(out)
+	if strings.Contains(string(b), `"typology"`) {
+		t.Errorf("marshalled step should not contain typology key: %s", b)
+	}
+}
+
 func TestJobStep_OfResource_EmptyURI_Errors(t *testing.T) {
 	s := NewJobStep().Targeting(URI(""))
 	if s.Err() == nil {
@@ -288,6 +319,32 @@ func TestJob_ToRequest_OneShot(t *testing.T) {
 	}
 }
 
+func TestJob_ToRequest_OneShot_WithTypology(t *testing.T) {
+	ts := time.Date(2026, 5, 1, 12, 0, 0, 0, time.UTC)
+	j := NewJob().
+		InProject(URI("/projects/p")).
+		Named("typed-step-job").
+		OneShotAt(ts).
+		WithSteps(NewJobStep().
+			OfTypology(JobStepTypologyCloudServer).
+			Targeting(URI("/projects/p/providers/Aruba.Compute/cloudServers/s-1")).
+			WithAction("poweroff").
+			WithVerb(HTTPVerbPOST))
+
+	req := j.RawRequest()
+	if len(req.Properties.Steps) != 1 {
+		t.Fatalf("Steps len = %d", len(req.Properties.Steps))
+	}
+	step := req.Properties.Steps[0]
+	if step.Typology == nil || *step.Typology != JobStepTypologyCloudServer {
+		t.Errorf("Typology = %v, want %q", step.Typology, JobStepTypologyCloudServer)
+	}
+	b, _ := json.Marshal(req.Properties)
+	if !strings.Contains(string(b), `"typology":"cloudServer"`) {
+		t.Errorf("marshalled properties missing typology: %s", b)
+	}
+}
+
 func TestJob_ToRequest_Recurring(t *testing.T) {
 	until := time.Date(2026, 12, 31, 0, 0, 0, 0, time.UTC)
 	j := NewJob().
@@ -324,6 +381,7 @@ func jobTestResponse(name string) *types.JobResponse {
 	actionURI := "/projects/p/providers/Aruba.Compute/cloudServers/s-1/actions/start"
 	verb := string(HTTPVerbPOST)
 	stepName := "step-1"
+	typology := JobStepTypologyCloudServer
 	return &types.JobResponse{
 		Metadata: types.ResourceMetadataResponse{
 			ID:               &id,
@@ -344,6 +402,7 @@ func jobTestResponse(name string) *types.JobResponse {
 			Steps: []types.JobStepResponse{
 				{
 					Name:        &stepName,
+					Typology:    &typology,
 					ResourceURI: &resURI,
 					ActionURI:   &actionURI,
 					HttpVerb:    &verb,
@@ -391,6 +450,9 @@ func TestJob_FromResponseHydration(t *testing.T) {
 	step := j.steps[0]
 	if step.name == nil || *step.name != "step-1" {
 		t.Errorf("steps[0].name = %v", step.name)
+	}
+	if step.typology == nil || *step.typology != JobStepTypologyCloudServer {
+		t.Errorf("steps[0].typology = %v, want %q", step.typology, JobStepTypologyCloudServer)
 	}
 	if step.resourceURI == nil || *step.resourceURI != "/projects/p/providers/Aruba.Compute/cloudServers/s-1" {
 		t.Errorf("steps[0].resourceURI = %v", step.resourceURI)

--- a/pkg/aruba/resource_job_test.go
+++ b/pkg/aruba/resource_job_test.go
@@ -1061,3 +1061,140 @@ func TestJobsClientAdapter_Get_InjectsRefresh(t *testing.T) {
 		t.Error("Get should inject a refresh callback into the returned Job")
 	}
 }
+
+// --------------------------------------------------------------------------
+// ScheduleAt getter
+// --------------------------------------------------------------------------
+
+func TestJob_ScheduleAt_NilResponse(t *testing.T) {
+	j := &Job{}
+	if got := j.ScheduleAt(); !got.IsZero() {
+		t.Errorf("ScheduleAt() = %v, want zero", got)
+	}
+}
+
+func TestJob_ScheduleAt_NoScheduleAt(t *testing.T) {
+	j := &Job{}
+	j.fromResponse(&types.JobResponse{})
+	if got := j.ScheduleAt(); !got.IsZero() {
+		t.Errorf("ScheduleAt() = %v, want zero", got)
+	}
+}
+
+func TestJob_ScheduleAt_FromResponse(t *testing.T) {
+	ts := "2025-06-01T10:00:00Z"
+	j := &Job{}
+	j.fromResponse(&types.JobResponse{
+		Properties: types.JobPropertiesResponse{ScheduleAt: &ts},
+	})
+	want := time.Date(2025, 6, 1, 10, 0, 0, 0, time.UTC)
+	if got := j.ScheduleAt(); !got.Equal(want) {
+		t.Errorf("ScheduleAt() = %v, want %v", got, want)
+	}
+}
+
+func TestJob_ScheduleAt_LocalSetter(t *testing.T) {
+	want := time.Date(2025, 6, 1, 10, 0, 0, 0, time.UTC)
+	j := NewJob().OneShotAt(want)
+	if got := j.ScheduleAt(); !got.Equal(want) {
+		t.Errorf("ScheduleAt() = %v, want %v", got, want)
+	}
+}
+
+// --------------------------------------------------------------------------
+// ExecuteUntil getter
+// --------------------------------------------------------------------------
+
+func TestJob_ExecuteUntil_NilResponse(t *testing.T) {
+	j := &Job{}
+	if got := j.ExecuteUntil(); !got.IsZero() {
+		t.Errorf("ExecuteUntil() = %v, want zero", got)
+	}
+}
+
+func TestJob_ExecuteUntil_FromResponse(t *testing.T) {
+	ts := "2025-12-31T23:59:59Z"
+	j := &Job{}
+	j.fromResponse(&types.JobResponse{
+		Properties: types.JobPropertiesResponse{ExecuteUntil: &ts},
+	})
+	want := time.Date(2025, 12, 31, 23, 59, 59, 0, time.UTC)
+	if got := j.ExecuteUntil(); !got.Equal(want) {
+		t.Errorf("ExecuteUntil() = %v, want %v", got, want)
+	}
+}
+
+func TestJob_ExecuteUntil_LocalSetter(t *testing.T) {
+	want := time.Date(2025, 12, 31, 0, 0, 0, 0, time.UTC)
+	j := NewJob().WithCron("0 * * * *").RecurringUntil(want)
+	if got := j.ExecuteUntil(); !got.Equal(want) {
+		t.Errorf("ExecuteUntil() = %v, want %v", got, want)
+	}
+}
+
+// --------------------------------------------------------------------------
+// NextExecutionAt getter
+// --------------------------------------------------------------------------
+
+func TestJob_NextExecutionAt_NilResponse(t *testing.T) {
+	j := &Job{}
+	if got := j.NextExecutionAt(); !got.IsZero() {
+		t.Errorf("NextExecutionAt() = %v, want zero", got)
+	}
+}
+
+func TestJob_NextExecutionAt_NoNextExecution(t *testing.T) {
+	j := &Job{}
+	j.fromResponse(&types.JobResponse{})
+	if got := j.NextExecutionAt(); !got.IsZero() {
+		t.Errorf("NextExecutionAt() = %v, want zero", got)
+	}
+}
+
+func TestJob_NextExecutionAt_FromResponse(t *testing.T) {
+	ts := "2025-06-15T08:00:00Z"
+	j := &Job{}
+	j.fromResponse(&types.JobResponse{
+		Properties: types.JobPropertiesResponse{NextExecution: &ts},
+	})
+	want := time.Date(2025, 6, 15, 8, 0, 0, 0, time.UTC)
+	if got := j.NextExecutionAt(); !got.Equal(want) {
+		t.Errorf("NextExecutionAt() = %v, want %v", got, want)
+	}
+}
+
+// --------------------------------------------------------------------------
+// Steps getter
+// --------------------------------------------------------------------------
+
+func TestJob_Steps_NilWhenEmpty(t *testing.T) {
+	j := &Job{}
+	if steps := j.Steps(); steps != nil {
+		t.Errorf("Steps() = %v, want nil", steps)
+	}
+}
+
+func TestJob_Steps_ReturnsConfigured(t *testing.T) {
+	step := NewJobStep().Named("step-1").WithAction("/actions/start").WithVerb(HTTPVerbPOST)
+	j := NewJob().WithSteps(step)
+	steps := j.Steps()
+	if len(steps) != 1 {
+		t.Fatalf("Steps() len = %d, want 1", len(steps))
+	}
+}
+
+func TestJob_Steps_FromResponse(t *testing.T) {
+	stepName := "step-from-resp"
+	j := &Job{}
+	j.fromResponse(&types.JobResponse{
+		Properties: types.JobPropertiesResponse{
+			Steps: []types.JobStepResponse{
+				{Name: &stepName},
+			},
+		},
+	})
+	steps := j.Steps()
+	if len(steps) != 1 {
+		t.Fatalf("Steps() len = %d, want 1", len(steps))
+	}
+}

--- a/pkg/aruba/resource_job_test.go
+++ b/pkg/aruba/resource_job_test.go
@@ -7,7 +7,6 @@ import (
 	"fmt"
 	"net/http"
 	"reflect"
-	"strings"
 	"testing"
 	"time"
 
@@ -228,36 +227,6 @@ func TestJobStep_Build_Basic(t *testing.T) {
 	}
 }
 
-func TestJobStep_Build_IncludesTypology(t *testing.T) {
-	s := NewJobStep().
-		Targeting(URI("/projects/p/providers/Aruba.Compute/cloudServers/srv-1")).
-		OfTypology(JobStepTypologyCloudServer).
-		WithAction("poweroff").
-		WithVerb(HTTPVerbPOST)
-
-	out := s.build()
-	if out.Typology == nil || *out.Typology != JobStepTypologyCloudServer {
-		t.Errorf("Typology = %v, want %q", out.Typology, JobStepTypologyCloudServer)
-	}
-}
-
-func TestJobStep_Build_OmitsTypologyWhenUnset(t *testing.T) {
-	s := NewJobStep().
-		Targeting(URI("/projects/p/providers/Aruba.Compute/cloudServers/srv-1")).
-		WithAction("poweroff").
-		WithVerb(HTTPVerbPOST)
-
-	out := s.build()
-	if out.Typology != nil {
-		t.Errorf("Typology should be nil when OfTypology not called, got %q", *out.Typology)
-	}
-
-	b, _ := json.Marshal(out)
-	if strings.Contains(string(b), `"typology"`) {
-		t.Errorf("marshalled step should not contain typology key: %s", b)
-	}
-}
-
 func TestJobStep_OfResource_EmptyURI_Errors(t *testing.T) {
 	s := NewJobStep().Targeting(URI(""))
 	if s.Err() == nil {
@@ -319,32 +288,6 @@ func TestJob_ToRequest_OneShot(t *testing.T) {
 	}
 }
 
-func TestJob_ToRequest_OneShot_WithTypology(t *testing.T) {
-	ts := time.Date(2026, 5, 1, 12, 0, 0, 0, time.UTC)
-	j := NewJob().
-		InProject(URI("/projects/p")).
-		Named("typed-step-job").
-		OneShotAt(ts).
-		WithSteps(NewJobStep().
-			OfTypology(JobStepTypologyCloudServer).
-			Targeting(URI("/projects/p/providers/Aruba.Compute/cloudServers/s-1")).
-			WithAction("poweroff").
-			WithVerb(HTTPVerbPOST))
-
-	req := j.RawRequest()
-	if len(req.Properties.Steps) != 1 {
-		t.Fatalf("Steps len = %d", len(req.Properties.Steps))
-	}
-	step := req.Properties.Steps[0]
-	if step.Typology == nil || *step.Typology != JobStepTypologyCloudServer {
-		t.Errorf("Typology = %v, want %q", step.Typology, JobStepTypologyCloudServer)
-	}
-	b, _ := json.Marshal(req.Properties)
-	if !strings.Contains(string(b), `"typology":"cloudServer"`) {
-		t.Errorf("marshalled properties missing typology: %s", b)
-	}
-}
-
 func TestJob_ToRequest_Recurring(t *testing.T) {
 	until := time.Date(2026, 12, 31, 0, 0, 0, 0, time.UTC)
 	j := NewJob().
@@ -381,7 +324,6 @@ func jobTestResponse(name string) *types.JobResponse {
 	actionURI := "/projects/p/providers/Aruba.Compute/cloudServers/s-1/actions/start"
 	verb := string(HTTPVerbPOST)
 	stepName := "step-1"
-	typology := JobStepTypologyCloudServer
 	return &types.JobResponse{
 		Metadata: types.ResourceMetadataResponse{
 			ID:               &id,
@@ -402,7 +344,6 @@ func jobTestResponse(name string) *types.JobResponse {
 			Steps: []types.JobStepResponse{
 				{
 					Name:        &stepName,
-					Typology:    &typology,
 					ResourceURI: &resURI,
 					ActionURI:   &actionURI,
 					HttpVerb:    &verb,
@@ -450,9 +391,6 @@ func TestJob_FromResponseHydration(t *testing.T) {
 	step := j.steps[0]
 	if step.name == nil || *step.name != "step-1" {
 		t.Errorf("steps[0].name = %v", step.name)
-	}
-	if step.typology == nil || *step.typology != JobStepTypologyCloudServer {
-		t.Errorf("steps[0].typology = %v, want %q", step.typology, JobStepTypologyCloudServer)
 	}
 	if step.resourceURI == nil || *step.resourceURI != "/projects/p/providers/Aruba.Compute/cloudServers/s-1" {
 		t.Errorf("steps[0].resourceURI = %v", step.resourceURI)

--- a/pkg/aruba/resource_kaas.go
+++ b/pkg/aruba/resource_kaas.go
@@ -17,7 +17,7 @@ import (
 //
 // Family A: regional, Metadata/Properties envelope, location-aware.
 // Supports full CRUD. Update emits KaaSUpdateRequest (narrower than KaaSRequest):
-// only KubernetesVersion, NodePools, HA, Storage, and BillingPlan are mutable.
+// only KubernetesVersion, NodePools, HA, Storage, and BillingPlanCommon are mutable.
 //
 // Schema asymmetry (request vs. response):
 //   - "nodePools" (request) vs. "nodesPool" (response)
@@ -319,8 +319,8 @@ func (k *KaaS) KubernetesVersion() KubernetesVersion {
 
 // BillingPeriod returns the billing period for this cluster, or "" if unset.
 func (k *KaaS) BillingPeriod() BillingPeriod {
-	if k.response != nil && k.response.Properties.BillingPlan != nil && k.response.Properties.BillingPlan.BillingPeriod != nil {
-		return *k.response.Properties.BillingPlan.BillingPeriod
+	if k.response != nil && k.response.Properties.BillingPlanCommon != nil && k.response.Properties.BillingPlanCommon.BillingPeriod != nil {
+		return *k.response.Properties.BillingPlanCommon.BillingPeriod
 	}
 	if k.billingPeriod == nil {
 		return ""
@@ -369,8 +369,8 @@ func (k *KaaS) NodePools() []*NodePool {
 // toRequest assembles the Create/Update body from current setter state. Defaults are applied at the wire boundary.
 func (k *KaaS) toRequest() types.KaaSRequest {
 	props := types.KaaSPropertiesRequest{
-		VPC:    types.ReferenceResource{URI: kaasDeref(k.vpcRef)},
-		Subnet: types.ReferenceResource{URI: kaasDeref(k.subnetRef)},
+		VPC:    types.ReferenceResourceCommon{URI: kaasDeref(k.vpcRef)},
+		Subnet: types.ReferenceResourceCommon{URI: kaasDeref(k.subnetRef)},
 		SecurityGroup: types.KaaSSecurityGroupPropertiesRequest{
 			Name: kaasDeref(k.securityGroupName),
 		},
@@ -385,8 +385,8 @@ func (k *KaaS) toRequest() types.KaaSRequest {
 			}
 			return ""
 		}()},
-		HA:          k.ha,
-		BillingPlan: &types.BillingPlan{BillingPeriod: defaultBillingPeriod(k.billingPeriod)},
+		HA:                k.ha,
+		BillingPlanCommon: &types.BillingPlanCommon{BillingPeriod: defaultBillingPeriod(k.billingPeriod)},
 	}
 	if k.storageMaxCumulative != nil {
 		props.Storage = types.StorageKubernetesCommon{MaxCumulativeVolumeSize: k.storageMaxCumulative}
@@ -416,7 +416,7 @@ func (k *KaaS) toRequest() types.KaaSRequest {
 }
 
 // toUpdateRequest emits KaaSUpdateRequest, which exposes only the mutable
-// fields (KubernetesVersion, NodePools, HA, Storage, BillingPlan).
+// fields (KubernetesVersion, NodePools, HA, Storage, BillingPlanCommon).
 // VPC, Subnet, SecurityGroup, and CIDRs are immutable after creation.
 func (k *KaaS) toUpdateRequest() types.KaaSUpdateRequest {
 	props := types.KaaSPropertiesUpdateRequest{
@@ -440,7 +440,7 @@ func (k *KaaS) toUpdateRequest() types.KaaSUpdateRequest {
 		props.Storage = &types.StorageKubernetesCommon{MaxCumulativeVolumeSize: k.storageMaxCumulative}
 	}
 	if k.billingPeriod != nil {
-		props.BillingPlan = &types.BillingPlan{BillingPeriod: k.billingPeriod}
+		props.BillingPlanCommon = &types.BillingPlanCommon{BillingPeriod: k.billingPeriod}
 	}
 	return types.KaaSUpdateRequest{
 		Metadata: types.RegionalResourceMetadataRequest{
@@ -470,8 +470,8 @@ func (k *KaaS) fromResponse(resp *types.KaaSResponse) {
 	k.setLinked(resp.Properties.LinkedResources)
 	k.kaasHydrateCacheFromProps(resp.Properties)
 	k.nodePools = kaasRebuildNodePools(resp.Properties.NodePools)
-	if resp.Metadata.ProjectResponseMetadata != nil && resp.Metadata.ProjectResponseMetadata.ID != "" {
-		k.projectID = resp.Metadata.ProjectResponseMetadata.ID
+	if resp.Metadata.ProjectMetadataResponse != nil && resp.Metadata.ProjectMetadataResponse.ID != "" {
+		k.projectID = resp.Metadata.ProjectMetadataResponse.ID
 	}
 	if k.projectID == "" && k.RespURI() != "" {
 		if pid := parseURIIDs(k.RespURI())["projects"]; pid != "" {
@@ -514,8 +514,8 @@ func (k *KaaS) kaasHydrateCacheFromProps(props types.KaaSPropertiesResponse) {
 		v := *props.Storage.MaxCumulativeVolumeSize
 		k.storageMaxCumulative = &v
 	}
-	if props.BillingPlan != nil && props.BillingPlan.BillingPeriod != nil {
-		k.billingPeriod = props.BillingPlan.BillingPeriod
+	if props.BillingPlanCommon != nil && props.BillingPlanCommon.BillingPeriod != nil {
+		k.billingPeriod = props.BillingPlanCommon.BillingPeriod
 	}
 	if props.Identity != nil && props.Identity.ClientID != nil {
 		v := *props.Identity.ClientID

--- a/pkg/aruba/resource_kaas.go
+++ b/pkg/aruba/resource_kaas.go
@@ -23,8 +23,8 @@ import (
 //   - "nodePools" (request) vs. "nodesPool" (response)
 //   - "nodeCidr" (request) vs. "nodecidr" (response)
 //   - "podCidr" (request) vs. "podcidr" (response)
-//   - NodePoolProperties.Instance string (request) vs. InstanceResponse{ID,Name} (response)
-//   - NodePoolProperties.Zone string (request JSON "dataCenter") vs. DataCenterResponse{Code,Name} (response)
+//   - NodePoolPropertiesRequest.Instance string (request) vs. KaaSNodePoolInstanceResponse{ID,Name} (response)
+//   - NodePoolPropertiesRequest.Zone string (request JSON "dataCenter") vs. KaaSNodePoolDataCenterResponse{Code,Name} (response)
 //
 // Path: /projects/{projectID}/providers/Aruba.Container/kaas[/{kaasID}]
 type KaaS struct {
@@ -52,7 +52,7 @@ type KaaS struct {
 	billingPeriod        *BillingPeriod
 	identityClientID     *string
 	identityClientSecret *string
-	apiServerProfile     *types.APIServerAccessProfileProperties // structural pass-through
+	apiServerProfile     *types.KaaSAPIServerAccessProfilePropertiesRequest // structural pass-through
 
 	// Sub-builders.
 	nodePools []*NodePool
@@ -155,7 +155,7 @@ func (k *KaaS) WithSecurityGroupName(name string) *KaaS {
 }
 
 // WithNodeCIDR sets the node CIDR block (address and name).
-// The wire type is NodeCIDRProperties{Address, Name}.
+// The wire type is NodeCIDRPropertiesRequest{Address, Name}.
 func (k *KaaS) WithNodeCIDR(address, name string) *KaaS {
 	k.nodeCIDRAddress = &address
 	k.nodeCIDRName = &name
@@ -177,7 +177,7 @@ func (k *KaaS) WithIdentity(clientID, clientSecret string) *KaaS {
 }
 
 // WithAPIServerAccessProfile sets the API server access profile.
-func (k *KaaS) WithAPIServerAccessProfile(p *types.APIServerAccessProfileProperties) *KaaS {
+func (k *KaaS) WithAPIServerAccessProfile(p *types.KaaSAPIServerAccessProfilePropertiesRequest) *KaaS {
 	k.apiServerProfile = p
 	return k
 }
@@ -371,15 +371,15 @@ func (k *KaaS) toRequest() types.KaaSRequest {
 	props := types.KaaSPropertiesRequest{
 		VPC:    types.ReferenceResource{URI: kaasDeref(k.vpcRef)},
 		Subnet: types.ReferenceResource{URI: kaasDeref(k.subnetRef)},
-		SecurityGroup: types.SecurityGroupProperties{
+		SecurityGroup: types.KaaSSecurityGroupPropertiesRequest{
 			Name: kaasDeref(k.securityGroupName),
 		},
-		NodeCIDR: types.NodeCIDRProperties{
+		NodeCIDR: types.NodeCIDRPropertiesRequest{
 			Address: kaasDeref(k.nodeCIDRAddress),
 			Name:    kaasDeref(k.nodeCIDRName),
 		},
 		PodCIDR: k.podCIDR,
-		KubernetesVersion: types.KubernetesVersionInfo{Value: func() KubernetesVersion {
+		KubernetesVersion: types.KubernetesVersionInfoRequest{Value: func() KubernetesVersion {
 			if k.kubernetesVersion != nil {
 				return *k.kubernetesVersion
 			}
@@ -389,10 +389,10 @@ func (k *KaaS) toRequest() types.KaaSRequest {
 		BillingPlan: &types.BillingPlan{BillingPeriod: defaultBillingPeriod(k.billingPeriod)},
 	}
 	if k.storageMaxCumulative != nil {
-		props.Storage = types.StorageKubernetes{MaxCumulativeVolumeSize: k.storageMaxCumulative}
+		props.Storage = types.StorageKubernetesCommon{MaxCumulativeVolumeSize: k.storageMaxCumulative}
 	}
 	if k.identityClientID != nil || k.identityClientSecret != nil {
-		props.Identity = &types.IdentityProperties{
+		props.Identity = &types.KaaSIdentityPropertiesRequest{
 			ClientID:     k.identityClientID,
 			ClientSecret: k.identityClientSecret,
 		}
@@ -401,7 +401,7 @@ func (k *KaaS) toRequest() types.KaaSRequest {
 		props.APIServerAccessProfile = k.apiServerProfile
 	}
 	if len(k.nodePools) > 0 {
-		props.NodePools = make([]types.NodePoolProperties, 0, len(k.nodePools))
+		props.NodePools = make([]types.NodePoolPropertiesRequest, 0, len(k.nodePools))
 		for _, np := range k.nodePools {
 			props.NodePools = append(props.NodePools, np.build())
 		}
@@ -420,7 +420,7 @@ func (k *KaaS) toRequest() types.KaaSRequest {
 // VPC, Subnet, SecurityGroup, and CIDRs are immutable after creation.
 func (k *KaaS) toUpdateRequest() types.KaaSUpdateRequest {
 	props := types.KaaSPropertiesUpdateRequest{
-		KubernetesVersion: types.KubernetesVersionInfoUpdate{
+		KubernetesVersion: types.KubernetesVersionInfoUpdateRequest{
 			Value: func() KubernetesVersion {
 				if k.kubernetesVersion != nil {
 					return *k.kubernetesVersion
@@ -431,13 +431,13 @@ func (k *KaaS) toUpdateRequest() types.KaaSUpdateRequest {
 		HA: k.ha,
 	}
 	if len(k.nodePools) > 0 {
-		props.NodePools = make([]types.NodePoolProperties, 0, len(k.nodePools))
+		props.NodePools = make([]types.NodePoolPropertiesRequest, 0, len(k.nodePools))
 		for _, np := range k.nodePools {
 			props.NodePools = append(props.NodePools, np.build())
 		}
 	}
 	if k.storageMaxCumulative != nil {
-		props.Storage = &types.StorageKubernetes{MaxCumulativeVolumeSize: k.storageMaxCumulative}
+		props.Storage = &types.StorageKubernetesCommon{MaxCumulativeVolumeSize: k.storageMaxCumulative}
 	}
 	if k.billingPeriod != nil {
 		props.BillingPlan = &types.BillingPlan{BillingPeriod: k.billingPeriod}
@@ -524,8 +524,8 @@ func (k *KaaS) kaasHydrateCacheFromProps(props types.KaaSPropertiesResponse) {
 	}
 }
 
-// kaasRebuildNodePools flattens response-side object types (InstanceResponse,
-// DataCenterResponse) back to plain strings so toUpdateRequest() round-trips correctly.
+// kaasRebuildNodePools flattens response-side object types (KaaSNodePoolInstanceResponse,
+// KaaSNodePoolDataCenterResponse) back to plain strings so toUpdateRequest() round-trips correctly.
 func kaasRebuildNodePools(pools *[]types.NodePoolPropertiesResponse) []*NodePool {
 	if pools == nil {
 		return nil
@@ -604,7 +604,7 @@ type kaasActions interface {
 // *types.Response[T] preserves HTTP envelope details (status code, headers,
 // raw body) for the wrapper's diagnostics.
 type kaasLowLevelClient interface {
-	List(ctx context.Context, projectID string, params *types.RequestParameters) (*types.Response[types.KaaSList], error)
+	List(ctx context.Context, projectID string, params *types.RequestParameters) (*types.Response[types.KaaSListResponse], error)
 	Get(ctx context.Context, projectID, kaasID string, params *types.RequestParameters) (*types.Response[types.KaaSResponse], error)
 	Create(ctx context.Context, projectID string, body types.KaaSRequest, params *types.RequestParameters) (*types.Response[types.KaaSResponse], error)
 	Update(ctx context.Context, projectID, kaasID string, body types.KaaSUpdateRequest, params *types.RequestParameters) (*types.Response[types.KaaSResponse], error)
@@ -802,7 +802,7 @@ func (a *kaasClientAdapter) List(ctx context.Context, parent Ref, opts ...CallOp
 	}
 	var refetch func(ctx context.Context, pageURL string) (*List[*KaaS], error)
 	refetch = func(ctx context.Context, pageURL string) (*List[*KaaS], error) {
-		fetch := listPageFetch[types.KaaSList](a.rest, opts)
+		fetch := listPageFetch[types.KaaSListResponse](a.rest, opts)
 		pageResp, fetchErr := fetch(ctx, pageURL)
 		if fetchErr != nil {
 			return nil, fetchErr

--- a/pkg/aruba/resource_kaas.go
+++ b/pkg/aruba/resource_kaas.go
@@ -340,6 +340,30 @@ func (k *KaaS) MaxStorageQuotaGB() int {
 	return int(*k.storageMaxCumulative)
 }
 
+// PodCIDR returns the pod CIDR block for the cluster, or "" if unset.
+// On a hydrated response the value comes from the response; otherwise returns what was passed to WithPodCIDR.
+func (k *KaaS) PodCIDR() string {
+	return kaasDeref(k.podCIDR)
+}
+
+// NodeCIDR returns the node CIDR block address for the cluster, or "" if unset.
+// On a hydrated response the value comes from the response; otherwise returns what was passed to WithNodeCIDR.
+func (k *KaaS) NodeCIDR() string {
+	return kaasDeref(k.nodeCIDRAddress)
+}
+
+// IdentityClientID returns the managed identity client ID, or "" if unset.
+// On a hydrated response the value comes from the response; otherwise returns what was passed to WithIdentity.
+func (k *KaaS) IdentityClientID() string {
+	return kaasDeref(k.identityClientID)
+}
+
+// NodePools returns the node pools attached to this cluster.
+// Returns nil if no node pools have been configured.
+func (k *KaaS) NodePools() []*NodePool {
+	return k.nodePools
+}
+
 // Wire converters
 
 // toRequest assembles the Create/Update body from current setter state. Defaults are applied at the wire boundary.

--- a/pkg/aruba/resource_kaas_nodepool.go
+++ b/pkg/aruba/resource_kaas_nodepool.go
@@ -9,7 +9,7 @@ import "github.com/Arubacloud/sdk-go/pkg/types"
 //
 // Schema note: Instance and Zone are plain strings in the Create/Update request
 // (wire fields "instance" and "dataCenter"); the response side uses object types
-// (InstanceResponse, DataCenterResponse). AddNodePool flattens the response
+// (KaaSNodePoolInstanceResponse, KaaSNodePoolDataCenterResponse). AddNodePool flattens the response
 // representation back to strings so Update round-trips correctly.
 type NodePool struct {
 	errMixin
@@ -58,8 +58,8 @@ func (n *NodePool) WithAutoscaling(min, max int) *NodePool {
 	return n
 }
 
-func (n *NodePool) build() types.NodePoolProperties {
-	out := types.NodePoolProperties{}
+func (n *NodePool) build() types.NodePoolPropertiesRequest {
+	out := types.NodePoolPropertiesRequest{}
 	if n.name != nil {
 		out.Name = *n.name
 	}

--- a/pkg/aruba/resource_kaas_nodepool.go
+++ b/pkg/aruba/resource_kaas_nodepool.go
@@ -28,6 +28,14 @@ func NewNodePool() *NodePool { return &NodePool{} }
 // Named sets the node pool name.
 func (n *NodePool) Named(name string) *NodePool { n.name = &name; return n }
 
+// Name returns the node pool name, or "" if unset.
+func (n *NodePool) Name() string {
+	if n.name == nil {
+		return ""
+	}
+	return *n.name
+}
+
 // OfInstance sets the machine instance type for this node pool.
 func (n *NodePool) OfInstance(instance NodePoolInstance) *NodePool {
 	n.instance = &instance

--- a/pkg/aruba/resource_kaas_test.go
+++ b/pkg/aruba/resource_kaas_test.go
@@ -1728,3 +1728,119 @@ func TestKaaS_SetNodePools_AliasForReplace(t *testing.T) {
 		t.Errorf("expected pool-2, got %q", req.Properties.NodePools[0].Name)
 	}
 }
+
+// --------------------------------------------------------------------------
+// PodCIDR getter
+// --------------------------------------------------------------------------
+
+func TestKaaS_PodCIDR_Unset(t *testing.T) {
+	k := &KaaS{}
+	if got := k.PodCIDR(); got != "" {
+		t.Errorf("PodCIDR() = %q, want empty", got)
+	}
+}
+
+func TestKaaS_PodCIDR_WithPodCIDR(t *testing.T) {
+	k := NewKaaS().WithPodCIDR("10.200.0.0/16")
+	if got := k.PodCIDR(); got != "10.200.0.0/16" {
+		t.Errorf("PodCIDR() = %q, want 10.200.0.0/16", got)
+	}
+}
+
+func TestKaaS_PodCIDR_FromResponse(t *testing.T) {
+	k := &KaaS{}
+	k.fromResponse(kaasTestResponse("cluster"))
+	if got := k.PodCIDR(); got != "10.200.0.0/16" {
+		t.Errorf("PodCIDR() = %q, want 10.200.0.0/16", got)
+	}
+}
+
+// --------------------------------------------------------------------------
+// NodeCIDR getter
+// --------------------------------------------------------------------------
+
+func TestKaaS_NodeCIDR_Unset(t *testing.T) {
+	k := &KaaS{}
+	if got := k.NodeCIDR(); got != "" {
+		t.Errorf("NodeCIDR() = %q, want empty", got)
+	}
+}
+
+func TestKaaS_NodeCIDR_WithNodeCIDR(t *testing.T) {
+	k := NewKaaS().WithNodeCIDR("10.100.0.0/16", "node-cidr")
+	if got := k.NodeCIDR(); got != "10.100.0.0/16" {
+		t.Errorf("NodeCIDR() = %q, want 10.100.0.0/16", got)
+	}
+}
+
+func TestKaaS_NodeCIDR_FromResponse(t *testing.T) {
+	k := &KaaS{}
+	k.fromResponse(kaasTestResponse("cluster"))
+	if got := k.NodeCIDR(); got != "10.100.0.0/16" {
+		t.Errorf("NodeCIDR() = %q, want 10.100.0.0/16", got)
+	}
+}
+
+// --------------------------------------------------------------------------
+// IdentityClientID getter
+// --------------------------------------------------------------------------
+
+func TestKaaS_IdentityClientID_Unset(t *testing.T) {
+	k := &KaaS{}
+	if got := k.IdentityClientID(); got != "" {
+		t.Errorf("IdentityClientID() = %q, want empty", got)
+	}
+}
+
+func TestKaaS_IdentityClientID_WithIdentity(t *testing.T) {
+	k := NewKaaS().WithIdentity("client-abc", "secret-xyz")
+	if got := k.IdentityClientID(); got != "client-abc" {
+		t.Errorf("IdentityClientID() = %q, want client-abc", got)
+	}
+}
+
+func TestKaaS_IdentityClientID_FromResponse(t *testing.T) {
+	clientID := "resp-client-id"
+	resp := kaasTestResponse("cluster")
+	resp.Properties.Identity = &types.IdentityPropertiesResponse{ClientID: &clientID}
+	k := &KaaS{}
+	k.fromResponse(resp)
+	if got := k.IdentityClientID(); got != "resp-client-id" {
+		t.Errorf("IdentityClientID() = %q, want resp-client-id", got)
+	}
+}
+
+// --------------------------------------------------------------------------
+// NodePools getter
+// --------------------------------------------------------------------------
+
+func TestKaaS_NodePools_NilWhenEmpty(t *testing.T) {
+	k := &KaaS{}
+	if pools := k.NodePools(); pools != nil {
+		t.Errorf("NodePools() = %v, want nil", pools)
+	}
+}
+
+func TestKaaS_NodePools_ReturnsConfigured(t *testing.T) {
+	np := NewNodePool().Named("pool-1").OfInstance("inst-1").WithAutoscaling(1, 3)
+	k := NewKaaS().WithNodePools(np)
+	pools := k.NodePools()
+	if len(pools) != 1 {
+		t.Fatalf("NodePools() len = %d, want 1", len(pools))
+	}
+	if pools[0].Name() != "pool-1" {
+		t.Errorf("NodePools()[0].Name() = %q, want pool-1", pools[0].Name())
+	}
+}
+
+func TestKaaS_NodePools_FromResponse(t *testing.T) {
+	k := &KaaS{}
+	k.fromResponse(kaasTestResponse("cluster"))
+	pools := k.NodePools()
+	if len(pools) != 1 {
+		t.Fatalf("NodePools() len = %d, want 1", len(pools))
+	}
+	if pools[0].Name() != "pool-1" {
+		t.Errorf("NodePools()[0].Name() = %q, want pool-1", pools[0].Name())
+	}
+}

--- a/pkg/aruba/resource_kaas_test.go
+++ b/pkg/aruba/resource_kaas_test.go
@@ -392,8 +392,8 @@ func TestKaaS_ToRequest(t *testing.T) {
 	if req.Properties.Storage.MaxCumulativeVolumeSize == nil || *req.Properties.Storage.MaxCumulativeVolumeSize != 100 {
 		t.Errorf("Storage = %+v", req.Properties.Storage)
 	}
-	if req.Properties.BillingPlan == nil || req.Properties.BillingPlan.BillingPeriod == nil || *req.Properties.BillingPlan.BillingPeriod != BillingPeriodHour {
-		t.Errorf("BillingPlan.BillingPeriod = %v", req.Properties.BillingPlan)
+	if req.Properties.BillingPlanCommon == nil || req.Properties.BillingPlanCommon.BillingPeriod == nil || *req.Properties.BillingPlanCommon.BillingPeriod != BillingPeriodHour {
+		t.Errorf("BillingPlanCommon.BillingPeriod = %v", req.Properties.BillingPlanCommon)
 	}
 	if req.Properties.Identity == nil {
 		t.Fatal("Identity is nil")
@@ -440,8 +440,8 @@ func TestKaaS_ToUpdateRequest_MutableOnly(t *testing.T) {
 	if upd.Properties.Storage == nil || upd.Properties.Storage.MaxCumulativeVolumeSize == nil || *upd.Properties.Storage.MaxCumulativeVolumeSize != 200 {
 		t.Errorf("Storage = %v", upd.Properties.Storage)
 	}
-	if upd.Properties.BillingPlan == nil || upd.Properties.BillingPlan.BillingPeriod == nil || *upd.Properties.BillingPlan.BillingPeriod != BillingPeriodHour {
-		t.Errorf("BillingPlan.BillingPeriod = %v", upd.Properties.BillingPlan)
+	if upd.Properties.BillingPlanCommon == nil || upd.Properties.BillingPlanCommon.BillingPeriod == nil || *upd.Properties.BillingPlanCommon.BillingPeriod != BillingPeriodHour {
+		t.Errorf("BillingPlanCommon.BillingPeriod = %v", upd.Properties.BillingPlanCommon)
 	}
 	if len(upd.Properties.NodePools) != 1 || upd.Properties.NodePools[0].Nodes != 5 {
 		t.Errorf("NodePools = %+v", upd.Properties.NodePools)
@@ -456,8 +456,8 @@ func TestKaaS_ToUpdateRequest_Empty(t *testing.T) {
 	if upd.Properties.Storage != nil {
 		t.Errorf("Storage should be nil when not set, got %v", upd.Properties.Storage)
 	}
-	if upd.Properties.BillingPlan != nil {
-		t.Errorf("BillingPlan should be nil when not set, got %v", upd.Properties.BillingPlan)
+	if upd.Properties.BillingPlanCommon != nil {
+		t.Errorf("BillingPlanCommon should be nil when not set, got %v", upd.Properties.BillingPlanCommon)
 	}
 }
 
@@ -492,7 +492,7 @@ func kaasTestResponse(name string) *types.KaaSResponse {
 			Name:             func() *string { s := name; return &s }(),
 			Tags:             []string{"tag1"},
 			LocationResponse: &types.LocationResponse{Value: RegionITBGBergamo},
-			ProjectResponseMetadata: &types.ProjectResponseMetadata{
+			ProjectMetadataResponse: &types.ProjectMetadataResponse{
 				ID: "p",
 			},
 		},
@@ -517,7 +517,7 @@ func kaasTestResponse(name string) *types.KaaSResponse {
 			Storage: &types.StorageKubernetesCommon{
 				MaxCumulativeVolumeSize: &maxVol,
 			},
-			BillingPlan: &types.BillingPlan{BillingPeriod: &billingPeriod},
+			BillingPlanCommon: &types.BillingPlanCommon{BillingPeriod: &billingPeriod},
 			NodePools: &[]types.NodePoolPropertiesResponse{
 				{
 					Name:        &poolName,
@@ -528,7 +528,7 @@ func kaasTestResponse(name string) *types.KaaSResponse {
 				},
 			},
 		},
-		Status: types.ResourceStatus{
+		Status: types.ResourceStatusResponse{
 			State: &state,
 		},
 	}
@@ -635,7 +635,7 @@ func TestKaaSIDsFromRef_TypedRef(t *testing.T) {
 		Metadata: types.ResourceMetadataResponse{
 			ID:                      &id,
 			URI:                     &uri,
-			ProjectResponseMetadata: &types.ProjectResponseMetadata{ID: "p2"},
+			ProjectMetadataResponse: &types.ProjectMetadataResponse{ID: "p2"},
 		},
 	}
 	k.fromResponse(resp)
@@ -853,7 +853,7 @@ func TestKaaSClientAdapter_Create_WithBodyRefs_ViaFake(t *testing.T) {
 					Metadata: types.ResourceMetadataResponse{
 						ID:                      &id,
 						URI:                     &uri,
-						ProjectResponseMetadata: &types.ProjectResponseMetadata{ID: "p"},
+						ProjectMetadataResponse: &types.ProjectMetadataResponse{ID: "p"},
 					},
 				},
 			}, nil
@@ -906,7 +906,7 @@ func TestKaaSClientAdapter_Update_Success(t *testing.T) {
 		Metadata: types.ResourceMetadataResponse{
 			ID:                      &id,
 			URI:                     &uri,
-			ProjectResponseMetadata: &types.ProjectResponseMetadata{ID: "p"},
+			ProjectMetadataResponse: &types.ProjectMetadataResponse{ID: "p"},
 		},
 	})
 	k.WithKubernetesVersion("1.33.0").
@@ -967,7 +967,7 @@ func TestKaaSClientAdapter_Update_NonTwoXX(t *testing.T) {
 		Metadata: types.ResourceMetadataResponse{
 			ID:                      &id,
 			URI:                     &uri,
-			ProjectResponseMetadata: &types.ProjectResponseMetadata{ID: "p"},
+			ProjectMetadataResponse: &types.ProjectMetadataResponse{ID: "p"},
 		},
 	})
 	_, err := adapter.Update(context.Background(), k)
@@ -1021,7 +1021,7 @@ func TestKaaSClientAdapter_Get_TypedRef(t *testing.T) {
 		Metadata: types.ResourceMetadataResponse{
 			ID:                      &id,
 			URI:                     &uri,
-			ProjectResponseMetadata: &types.ProjectResponseMetadata{ID: "p"},
+			ProjectMetadataResponse: &types.ProjectMetadataResponse{ID: "p"},
 		},
 	})
 
@@ -1140,7 +1140,7 @@ func TestKaaS_DownloadKubeconfig_Success(t *testing.T) {
 		Metadata: types.ResourceMetadataResponse{
 			ID:                      &id,
 			URI:                     &uri,
-			ProjectResponseMetadata: &types.ProjectResponseMetadata{ID: "p"},
+			ProjectMetadataResponse: &types.ProjectMetadataResponse{ID: "p"},
 		},
 	})
 	k.actions = adapter
@@ -1162,7 +1162,7 @@ func TestKaaS_DownloadKubeconfig_NoActionExecutor(t *testing.T) {
 		Metadata: types.ResourceMetadataResponse{
 			ID:                      &id,
 			URI:                     &uri,
-			ProjectResponseMetadata: &types.ProjectResponseMetadata{ID: "p"},
+			ProjectMetadataResponse: &types.ProjectMetadataResponse{ID: "p"},
 		},
 	})
 	// k.actions is nil — locally-built wrapper
@@ -1193,7 +1193,7 @@ func TestKaaS_DownloadKubeconfig_NonTwoXX(t *testing.T) {
 		Metadata: types.ResourceMetadataResponse{
 			ID:                      &id,
 			URI:                     &uri,
-			ProjectResponseMetadata: &types.ProjectResponseMetadata{ID: "p"},
+			ProjectMetadataResponse: &types.ProjectMetadataResponse{ID: "p"},
 		},
 	})
 	k.actions = adapter
@@ -1415,7 +1415,7 @@ func TestKaaS_DownloadKubeconfig_NilData(t *testing.T) {
 		Metadata: types.ResourceMetadataResponse{
 			ID:                      &id,
 			URI:                     &uri,
-			ProjectResponseMetadata: &types.ProjectResponseMetadata{ID: "p"},
+			ProjectMetadataResponse: &types.ProjectMetadataResponse{ID: "p"},
 		},
 	})
 	k.actions = adapter
@@ -1575,7 +1575,7 @@ func TestKaaS_DownloadKubeconfig_LowLevelError(t *testing.T) {
 		Metadata: types.ResourceMetadataResponse{
 			ID:                      &id,
 			URI:                     &uri,
-			ProjectResponseMetadata: &types.ProjectResponseMetadata{ID: "p"},
+			ProjectMetadataResponse: &types.ProjectMetadataResponse{ID: "p"},
 		},
 	})
 	k.actions = adapter
@@ -1613,7 +1613,7 @@ func TestKaaSClientAdapter_Update_WithErr(t *testing.T) {
 		Metadata: types.ResourceMetadataResponse{
 			ID:                      &id,
 			URI:                     &uri,
-			ProjectResponseMetadata: &types.ProjectResponseMetadata{ID: "p"},
+			ProjectMetadataResponse: &types.ProjectMetadataResponse{ID: "p"},
 		},
 	})
 	k.addErr(fmt.Errorf("pre-existing error after hydration"))
@@ -1649,7 +1649,7 @@ func TestKaaS_FromResponse_SetsStatus(t *testing.T) {
 	k := &KaaS{}
 	state := types.State("Active")
 	k.fromResponse(&types.KaaSResponse{
-		Status: types.ResourceStatus{State: &state},
+		Status: types.ResourceStatusResponse{State: &state},
 	})
 	if k.State() != types.StateActive {
 		t.Errorf("State() = %q after fromResponse, want Active", k.State())

--- a/pkg/aruba/resource_kaas_test.go
+++ b/pkg/aruba/resource_kaas_test.go
@@ -514,7 +514,7 @@ func kaasTestResponse(name string) *types.KaaSResponse {
 				Value: &k8sVersion,
 			},
 			HA: &haTrue,
-			Storage: &types.StorageKubernetes{
+			Storage: &types.StorageKubernetesCommon{
 				MaxCumulativeVolumeSize: &maxVol,
 			},
 			BillingPlan: &types.BillingPlan{BillingPeriod: &billingPeriod},
@@ -522,8 +522,8 @@ func kaasTestResponse(name string) *types.KaaSResponse {
 				{
 					Name:        &poolName,
 					Nodes:       &poolNodes,
-					Instance:    &types.InstanceResponse{Name: &instanceName},
-					DataCenter:  &types.DataCenterResponse{Code: &dcCode},
+					Instance:    &types.KaaSNodePoolInstanceResponse{Name: &instanceName},
+					DataCenter:  &types.KaaSNodePoolDataCenterResponse{Code: &dcCode},
 					Autoscaling: autoFalse,
 				},
 			},
@@ -668,7 +668,7 @@ type fakeKaaSLowLevel struct {
 	updateFunc             func(ctx context.Context, projectID, kaasID string, body types.KaaSUpdateRequest, params *types.RequestParameters) (*types.Response[types.KaaSResponse], error)
 	getFunc                func(ctx context.Context, projectID, kaasID string, params *types.RequestParameters) (*types.Response[types.KaaSResponse], error)
 	deleteFunc             func(ctx context.Context, projectID, kaasID string, params *types.RequestParameters) (*types.Response[any], error)
-	listFunc               func(ctx context.Context, projectID string, params *types.RequestParameters) (*types.Response[types.KaaSList], error)
+	listFunc               func(ctx context.Context, projectID string, params *types.RequestParameters) (*types.Response[types.KaaSListResponse], error)
 	downloadKubeconfigFunc func(ctx context.Context, projectID, kaasID string, params *types.RequestParameters) (*types.Response[types.KaaSKubeconfigResponse], error)
 }
 
@@ -684,7 +684,7 @@ func (f *fakeKaaSLowLevel) Get(ctx context.Context, projectID, kaasID string, pa
 func (f *fakeKaaSLowLevel) Delete(ctx context.Context, projectID, kaasID string, params *types.RequestParameters) (*types.Response[any], error) {
 	return f.deleteFunc(ctx, projectID, kaasID, params)
 }
-func (f *fakeKaaSLowLevel) List(ctx context.Context, projectID string, params *types.RequestParameters) (*types.Response[types.KaaSList], error) {
+func (f *fakeKaaSLowLevel) List(ctx context.Context, projectID string, params *types.RequestParameters) (*types.Response[types.KaaSListResponse], error) {
 	return f.listFunc(ctx, projectID, params)
 }
 func (f *fakeKaaSLowLevel) DownloadKubeconfig(ctx context.Context, projectID, kaasID string, params *types.RequestParameters) (*types.Response[types.KaaSKubeconfigResponse], error) {
@@ -920,7 +920,7 @@ func TestKaaSClientAdapter_Update_Success(t *testing.T) {
 	if result.ID() != "kaas-1" {
 		t.Errorf("ID() = %q", result.ID())
 	}
-	// The update request should use KubernetesVersionInfoUpdate
+	// The update request should use KubernetesVersionInfoUpdateRequest
 	if gotBody.Properties.KubernetesVersion.Value != "1.33.0" {
 		t.Errorf("update KubernetesVersion.Value = %q", gotBody.Properties.KubernetesVersion.Value)
 	}
@@ -1269,7 +1269,7 @@ func TestKaaS_Raw_AfterFromResponse(t *testing.T) {
 
 func TestKaaS_WithAPIServerAccessProfile_RoundTrip(t *testing.T) {
 	ranges := []string{"10.0.0.0/8", "192.168.0.0/16"}
-	profile := &types.APIServerAccessProfileProperties{
+	profile := &types.KaaSAPIServerAccessProfilePropertiesRequest{
 		AuthorizedIPRanges:   &ranges,
 		EnablePrivateCluster: true,
 	}

--- a/pkg/aruba/resource_key.go
+++ b/pkg/aruba/resource_key.go
@@ -208,7 +208,7 @@ func keyIDsFromRef(ref Ref) (projectID, kmsID, keyID string, err error) {
 // *types.Response[T] preserves HTTP envelope details (status code, headers,
 // raw body) for the wrapper's diagnostics.
 type keysLowLevelClient interface {
-	List(ctx context.Context, projectID, kmsID string, params *types.RequestParameters) (*types.Response[types.KeyList], error)
+	List(ctx context.Context, projectID, kmsID string, params *types.RequestParameters) (*types.Response[types.KeyListResponse], error)
 	Get(ctx context.Context, projectID, kmsID, keyID string, params *types.RequestParameters) (*types.Response[types.KeyResponse], error)
 	Create(ctx context.Context, projectID, kmsID string, body types.KeyRequest, params *types.RequestParameters) (*types.Response[types.KeyResponse], error)
 	Delete(ctx context.Context, projectID, kmsID, keyID string, params *types.RequestParameters) (*types.Response[any], error)
@@ -362,7 +362,7 @@ func (a *keysClientAdapter) List(ctx context.Context, parent Ref, opts ...CallOp
 	}
 	var refetch func(ctx context.Context, pageURL string) (*List[*Key], error)
 	refetch = func(ctx context.Context, pageURL string) (*List[*Key], error) {
-		fetch := listPageFetch[types.KeyList](a.rest, opts)
+		fetch := listPageFetch[types.KeyListResponse](a.rest, opts)
 		pageResp, fetchErr := fetch(ctx, pageURL)
 		if fetchErr != nil {
 			return nil, fetchErr

--- a/pkg/aruba/resource_key_pair.go
+++ b/pkg/aruba/resource_key_pair.go
@@ -132,8 +132,8 @@ func (k *KeyPair) fromResponse(resp *types.KeyPairResponse) {
 		k.publicKey = &v
 	}
 
-	if resp.Metadata.ProjectResponseMetadata != nil && resp.Metadata.ProjectResponseMetadata.ID != "" {
-		k.projectID = resp.Metadata.ProjectResponseMetadata.ID
+	if resp.Metadata.ProjectMetadataResponse != nil && resp.Metadata.ProjectMetadataResponse.ID != "" {
+		k.projectID = resp.Metadata.ProjectMetadataResponse.ID
 	}
 	if k.projectID == "" && k.RespURI() != "" {
 		ids := parseURIIDs(k.RespURI())

--- a/pkg/aruba/resource_key_pair_test.go
+++ b/pkg/aruba/resource_key_pair_test.go
@@ -163,7 +163,7 @@ func keyPairTestResponse(id, name, uri string) *types.KeyPairResponse {
 			Tags:             []string{"tag1"},
 			LocationResponse: loc,
 		},
-		Properties: types.KeyPairPropertiesResult{
+		Properties: types.KeyPairPropertiesResponse{
 			Value: "ssh-rsa AAAA...",
 		},
 	}

--- a/pkg/aruba/resource_key_pair_test.go
+++ b/pkg/aruba/resource_key_pair_test.go
@@ -198,7 +198,7 @@ func TestKeyPair_FromResponseHydration(t *testing.T) {
 	if kp.Raw() != resp {
 		t.Error("Raw() should return the hydrated response pointer")
 	}
-	// ProjectID backfilled from URI when ProjectResponseMetadata is nil
+	// ProjectID backfilled from URI when ProjectMetadataResponse is nil
 	if kp.ProjectID() != "p" {
 		t.Errorf("ProjectID() = %q", kp.ProjectID())
 	}
@@ -636,7 +636,7 @@ func TestKeyPair_FromResponse_SetsStatus(t *testing.T) {
 	k := &KeyPair{}
 	state := types.State("Active")
 	k.fromResponse(&types.KeyPairResponse{
-		Status: types.ResourceStatus{State: &state},
+		Status: types.ResourceStatusResponse{State: &state},
 	})
 	if k.State() != types.StateActive {
 		t.Errorf("State() = %q after fromResponse, want Active", k.State())
@@ -653,7 +653,7 @@ func TestKeyPair_WaitUntilActive_HappyPath(t *testing.T) {
 			state = "Active"
 		}
 		s := state
-		k.setStatus(&types.ResourceStatus{State: &s})
+		k.setStatus(&types.ResourceStatusResponse{State: &s})
 		return nil
 	})
 	if err := k.WaitUntilActive(context.Background(), fastOpts()...); err != nil {

--- a/pkg/aruba/resource_key_test.go
+++ b/pkg/aruba/resource_key_test.go
@@ -28,7 +28,7 @@ func keyMakeKMSParent(projectID, kmsID string) *KMS {
 			ID:                      &id,
 			Name:                    &name,
 			URI:                     &u,
-			ProjectResponseMetadata: &types.ProjectResponseMetadata{ID: projectID},
+			ProjectMetadataResponse: &types.ProjectMetadataResponse{ID: projectID},
 		},
 	}
 	k := &KMS{}

--- a/pkg/aruba/resource_kmip.go
+++ b/pkg/aruba/resource_kmip.go
@@ -248,7 +248,7 @@ func kmipIDsFromRef(ref Ref) (projectID, kmsID, kmipID string, err error) {
 // *types.Response[T] preserves HTTP envelope details (status code, headers,
 // raw body) for the wrapper's diagnostics.
 type kmipsLowLevelClient interface {
-	List(ctx context.Context, projectID, kmsID string, params *types.RequestParameters) (*types.Response[types.KmipList], error)
+	List(ctx context.Context, projectID, kmsID string, params *types.RequestParameters) (*types.Response[types.KmipListResponse], error)
 	Get(ctx context.Context, projectID, kmsID, kmipID string, params *types.RequestParameters) (*types.Response[types.KmipResponse], error)
 	Create(ctx context.Context, projectID, kmsID string, body types.KmipRequest, params *types.RequestParameters) (*types.Response[types.KmipResponse], error)
 	Delete(ctx context.Context, projectID, kmsID, kmipID string, params *types.RequestParameters) (*types.Response[any], error)
@@ -401,7 +401,7 @@ func (a *kmipsClientAdapter) List(ctx context.Context, parent Ref, opts ...CallO
 	}
 	var refetch func(ctx context.Context, pageURL string) (*List[*Kmip], error)
 	refetch = func(ctx context.Context, pageURL string) (*List[*Kmip], error) {
-		fetch := listPageFetch[types.KmipList](a.rest, opts)
+		fetch := listPageFetch[types.KmipListResponse](a.rest, opts)
 		pageResp, fetchErr := fetch(ctx, pageURL)
 		if fetchErr != nil {
 			return nil, fetchErr

--- a/pkg/aruba/resource_kmip_test.go
+++ b/pkg/aruba/resource_kmip_test.go
@@ -28,7 +28,7 @@ func kmipMakeKMSParent(projectID, kmsID string) *KMS {
 			ID:                      &id,
 			Name:                    &name,
 			URI:                     &u,
-			ProjectResponseMetadata: &types.ProjectResponseMetadata{ID: projectID},
+			ProjectMetadataResponse: &types.ProjectMetadataResponse{ID: projectID},
 		},
 	}
 	k := &KMS{}

--- a/pkg/aruba/resource_kms.go
+++ b/pkg/aruba/resource_kms.go
@@ -140,8 +140,8 @@ func (k *KMS) fromResponse(resp *types.KmsResponse) {
 		k.billingPeriod = resp.Properties.BillingPeriod
 	}
 
-	if resp.Metadata.ProjectResponseMetadata != nil && resp.Metadata.ProjectResponseMetadata.ID != "" {
-		k.projectID = resp.Metadata.ProjectResponseMetadata.ID
+	if resp.Metadata.ProjectMetadataResponse != nil && resp.Metadata.ProjectMetadataResponse.ID != "" {
+		k.projectID = resp.Metadata.ProjectMetadataResponse.ID
 	}
 	if k.projectID == "" && k.RespURI() != "" {
 		if pid := parseURIIDs(k.RespURI())["projects"]; pid != "" {

--- a/pkg/aruba/resource_kms.go
+++ b/pkg/aruba/resource_kms.go
@@ -185,7 +185,7 @@ func kmsIDsFromRef(ref Ref) (projectID, kmsID string, err error) {
 // *types.Response[T] preserves HTTP envelope details (status code, headers,
 // raw body) for the wrapper's diagnostics.
 type kmsLowLevelClient interface {
-	List(ctx context.Context, projectID string, params *types.RequestParameters) (*types.Response[types.KmsList], error)
+	List(ctx context.Context, projectID string, params *types.RequestParameters) (*types.Response[types.KmsListResponse], error)
 	Get(ctx context.Context, projectID, kmsID string, params *types.RequestParameters) (*types.Response[types.KmsResponse], error)
 	Create(ctx context.Context, projectID string, body types.KmsRequest, params *types.RequestParameters) (*types.Response[types.KmsResponse], error)
 	Update(ctx context.Context, projectID, kmsID string, body types.KmsRequest, params *types.RequestParameters) (*types.Response[types.KmsResponse], error)
@@ -379,7 +379,7 @@ func (a *kmsClientAdapter) List(ctx context.Context, parent Ref, opts ...CallOpt
 	}
 	var refetch func(ctx context.Context, pageURL string) (*List[*KMS], error)
 	refetch = func(ctx context.Context, pageURL string) (*List[*KMS], error) {
-		fetch := listPageFetch[types.KmsList](a.rest, opts)
+		fetch := listPageFetch[types.KmsListResponse](a.rest, opts)
 		pageResp, fetchErr := fetch(ctx, pageURL)
 		if fetchErr != nil {
 			return nil, fetchErr

--- a/pkg/aruba/resource_kms_test.go
+++ b/pkg/aruba/resource_kms_test.go
@@ -141,14 +141,14 @@ func kmsTestResponse(name string) *types.KmsResponse {
 			Name:             func() *string { s := name; return &s }(),
 			Tags:             []string{"tag1"},
 			LocationResponse: &types.LocationResponse{Value: RegionITBGBergamo},
-			ProjectResponseMetadata: &types.ProjectResponseMetadata{
+			ProjectMetadataResponse: &types.ProjectMetadataResponse{
 				ID: "p",
 			},
 		},
 		Properties: types.KmsPropertiesResponse{
 			BillingPeriod: func() *BillingPeriod { v := BillingPeriodHour; return &v }(),
 		},
-		Status: types.ResourceStatus{State: &state},
+		Status: types.ResourceStatusResponse{State: &state},
 	}
 }
 
@@ -768,7 +768,7 @@ func TestKMS_FromResponse_SetsStatus(t *testing.T) {
 	k := &KMS{}
 	state := types.State("Active")
 	k.fromResponse(&types.KmsResponse{
-		Status: types.ResourceStatus{State: &state},
+		Status: types.ResourceStatusResponse{State: &state},
 	})
 	if k.State() != types.StateActive {
 		t.Errorf("State() = %q after fromResponse, want Active", k.State())

--- a/pkg/aruba/resource_load_balancer.go
+++ b/pkg/aruba/resource_load_balancer.go
@@ -112,7 +112,7 @@ func loadBalancerDerefString(p *string) string {
 // *types.Response[T] preserves HTTP envelope details (status code, headers,
 // raw body) for the wrapper's diagnostics.
 type loadBalancerLowLevelClient interface {
-	List(ctx context.Context, projectID string, params *types.RequestParameters) (*types.Response[types.LoadBalancerList], error)
+	List(ctx context.Context, projectID string, params *types.RequestParameters) (*types.Response[types.LoadBalancerListResponse], error)
 	Get(ctx context.Context, projectID, loadBalancerID string, params *types.RequestParameters) (*types.Response[types.LoadBalancerResponse], error)
 }
 
@@ -209,7 +209,7 @@ func (a *loadBalancersClientAdapter) List(ctx context.Context, project Ref, opts
 	}
 	var refetch func(ctx context.Context, pageURL string) (*List[*LoadBalancer], error)
 	refetch = func(ctx context.Context, pageURL string) (*List[*LoadBalancer], error) {
-		fetch := listPageFetch[types.LoadBalancerList](a.rest, opts)
+		fetch := listPageFetch[types.LoadBalancerListResponse](a.rest, opts)
 		pageResp, fetchErr := fetch(ctx, pageURL)
 		if fetchErr != nil {
 			return nil, fetchErr

--- a/pkg/aruba/resource_load_balancer.go
+++ b/pkg/aruba/resource_load_balancer.go
@@ -29,9 +29,9 @@ type LoadBalancer struct {
 	linkedMixin           // LinkedResources()
 	httpEnvelopeMixin     // RawHTTP(), StatusCode(), Headers(), RawError()
 
-	address  *string                     // Properties.Address (read-only from response)
-	vpc      *types.ReferenceResource    // Properties.VPC (linked VPC reference)
-	response *types.LoadBalancerResponse // backs Raw()
+	address  *string                        // Properties.Address (read-only from response)
+	vpc      *types.ReferenceResourceCommon // Properties.VPC (linked VPC reference)
+	response *types.LoadBalancerResponse    // backs Raw()
 }
 
 // Getters — general → specific
@@ -89,8 +89,8 @@ func (l *LoadBalancer) fromResponse(resp *types.LoadBalancerResponse) {
 		l.vpc = &v
 	}
 
-	if resp.Metadata.ProjectResponseMetadata != nil && resp.Metadata.ProjectResponseMetadata.ID != "" {
-		l.projectID = resp.Metadata.ProjectResponseMetadata.ID
+	if resp.Metadata.ProjectMetadataResponse != nil && resp.Metadata.ProjectMetadataResponse.ID != "" {
+		l.projectID = resp.Metadata.ProjectMetadataResponse.ID
 	}
 	if l.projectID == "" && l.RespURI() != "" {
 		if pid := parseURIIDs(l.RespURI())["projects"]; pid != "" {

--- a/pkg/aruba/resource_load_balancer_test.go
+++ b/pkg/aruba/resource_load_balancer_test.go
@@ -33,20 +33,20 @@ func loadBalancerTestResponse(id, name, uri, projectID string) *types.LoadBalanc
 			Name:             &name,
 			Tags:             []string{"lb-tag"},
 			LocationResponse: loc,
-			ProjectResponseMetadata: &types.ProjectResponseMetadata{
+			ProjectMetadataResponse: &types.ProjectMetadataResponse{
 				ID: projectID,
 			},
 		},
 		Properties: types.LoadBalancerPropertiesResponse{
 			Address: &addr,
-			VPC:     &types.ReferenceResource{URI: vpcURI},
-			LinkedResources: []types.LinkedResource{
+			VPC:     &types.ReferenceResourceCommon{URI: vpcURI},
+			LinkedResources: []types.LinkedResourceCommon{
 				{URI: "/projects/p/providers/Aruba.Compute/cloudservers/cs1", StrictCorrelation: true},
 			},
 		},
-		Status: types.ResourceStatus{
+		Status: types.ResourceStatusResponse{
 			State: &state,
-			DisableStatusInfo: &types.DisableStatusInfo{
+			DisableStatusInfoResponse: &types.DisableStatusInfoResponse{
 				IsDisabled: false,
 			},
 		},
@@ -127,7 +127,7 @@ func TestLoadBalancer_FromResponseProjectIDFromURI(t *testing.T) {
 			ID:   &id,
 			URI:  &uri,
 			Name: &name,
-			// ProjectResponseMetadata intentionally nil
+			// ProjectMetadataResponse intentionally nil
 		},
 	}
 	lb := &LoadBalancer{}
@@ -484,7 +484,7 @@ func TestLoadBalancer_FromResponse_SetsStatus(t *testing.T) {
 	l := &LoadBalancer{}
 	state := types.State("Active")
 	l.fromResponse(&types.LoadBalancerResponse{
-		Status: types.ResourceStatus{State: &state},
+		Status: types.ResourceStatusResponse{State: &state},
 	})
 	if l.State() != types.StateActive {
 		t.Errorf("State() = %q after fromResponse, want Active", l.State())

--- a/pkg/aruba/resource_metric.go
+++ b/pkg/aruba/resource_metric.go
@@ -65,7 +65,7 @@ func (m *Metric) ReferenceName() string {
 
 // Metadata returns the metric metadata entries, or nil when absent.
 // Each entry contains a Field and Value string.
-func (m *Metric) Metadata() []types.MetricMetadata {
+func (m *Metric) Metadata() []types.MetricMetadataResponse {
 	if m.response == nil {
 		return nil
 	}
@@ -74,7 +74,7 @@ func (m *Metric) Metadata() []types.MetricMetadata {
 
 // Data returns the metric datapoints, or nil when absent.
 // Each datapoint contains a Time and Measure string.
-func (m *Metric) Data() []types.MetricData {
+func (m *Metric) Data() []types.MetricDataResponse {
 	if m.response == nil {
 		return nil
 	}

--- a/pkg/aruba/resource_metric_test.go
+++ b/pkg/aruba/resource_metric_test.go
@@ -28,11 +28,11 @@ func metricMakeFullResponse() types.MetricResponse {
 		ReferenceID:   "metric-ref-1",
 		Name:          "cpu_usage",
 		ReferenceName: "CPU Usage",
-		Metadata: []types.MetricMetadata{
+		Metadata: []types.MetricMetadataResponse{
 			{Field: "unit", Value: "%"},
 			{Field: "aggregation", Value: "avg"},
 		},
-		Data: []types.MetricData{
+		Data: []types.MetricDataResponse{
 			{Time: "2025-03-10T08:00:00Z", Measure: "72.5"},
 			{Time: "2025-03-10T08:05:00Z", Measure: "68.1"},
 		},
@@ -144,7 +144,7 @@ func TestMetric_URI_AlwaysEmpty(t *testing.T) {
 }
 
 func TestMetric_Metadata_PreservesOrderAndContent(t *testing.T) {
-	entries := []types.MetricMetadata{
+	entries := []types.MetricMetadataResponse{
 		{Field: "unit", Value: "%"},
 		{Field: "aggregation", Value: "avg"},
 		{Field: "type", Value: "gauge"},
@@ -158,7 +158,7 @@ func TestMetric_Metadata_PreservesOrderAndContent(t *testing.T) {
 }
 
 func TestMetric_Data_PreservesOrderAndContent(t *testing.T) {
-	datapoints := []types.MetricData{
+	datapoints := []types.MetricDataResponse{
 		{Time: "2025-01-01T00:00:00Z", Measure: "10.0"},
 		{Time: "2025-01-01T00:05:00Z", Measure: "20.0"},
 		{Time: "2025-01-01T00:10:00Z", Measure: "15.5"},

--- a/pkg/aruba/resource_project.go
+++ b/pkg/aruba/resource_project.go
@@ -23,6 +23,7 @@ type Project struct {
 
 	description *string
 	defaultProj bool // ProjectPropertiesRequest.Default is plain bool — no tri-state needed
+	response    *types.ProjectResponse
 }
 
 // NewProject returns a fresh *Project ready for fluent setters and a Create call.
@@ -78,6 +79,18 @@ func (p *Project) Description() string {
 // IsDefault returns true if this project is marked as the account default.
 func (p *Project) IsDefault() bool { return p.defaultProj }
 
+// Raw returns the raw server response, or nil before the first reply.
+func (p *Project) Raw() *types.ProjectResponse { return p.response }
+
+// RawJSON returns the raw server response as JSON, or nil.
+func (p *Project) RawJSON() []byte { return marshalRawJSON(p.response) }
+
+// RawYAML returns the raw server response as YAML, or nil.
+func (p *Project) RawYAML() []byte { return marshalRawYAML(p.response) }
+
+// RawRequest returns the current setter state as a wire request body.
+func (p *Project) RawRequest() types.ProjectRequest { return p.toRequest() }
+
 // Wire converters
 
 // toRequest assembles the Create/Update body from current setter state. Defaults are applied at the wire boundary.
@@ -96,6 +109,7 @@ func (p *Project) fromResponse(resp *types.ProjectResponse) {
 	if resp == nil {
 		return
 	}
+	p.response = resp
 	p.setMeta(&resp.Metadata)
 	p.named(projectDerefString(resp.Metadata.Name))
 	if len(resp.Metadata.Tags) > 0 {

--- a/pkg/aruba/resource_project.go
+++ b/pkg/aruba/resource_project.go
@@ -137,7 +137,7 @@ func projectDerefString(s *string) string {
 // Satisfied by *project.projectsClientImpl. Defined here so tests can substitute
 // a fake without depending on internal/clients/project test code.
 type projectLowLevelClient interface {
-	List(ctx context.Context, params *types.RequestParameters) (*types.Response[types.ProjectList], error)
+	List(ctx context.Context, params *types.RequestParameters) (*types.Response[types.ProjectListResponse], error)
 	Get(ctx context.Context, projectID string, params *types.RequestParameters) (*types.Response[types.ProjectResponse], error)
 	Create(ctx context.Context, body types.ProjectRequest, params *types.RequestParameters) (*types.Response[types.ProjectResponse], error)
 	Update(ctx context.Context, projectID string, body types.ProjectRequest, params *types.RequestParameters) (*types.Response[types.ProjectResponse], error)
@@ -272,7 +272,7 @@ func (a *projectClientAdapter) List(ctx context.Context, opts ...CallOption) (*L
 	}
 	var refetch func(ctx context.Context, pageURL string) (*List[*Project], error)
 	refetch = func(ctx context.Context, pageURL string) (*List[*Project], error) {
-		fetch := listPageFetch[types.ProjectList](a.rest, opts)
+		fetch := listPageFetch[types.ProjectListResponse](a.rest, opts)
 		pageResp, fetchErr := fetch(ctx, pageURL)
 		if fetchErr != nil {
 			return nil, fetchErr

--- a/pkg/aruba/resource_project_test.go
+++ b/pkg/aruba/resource_project_test.go
@@ -203,6 +203,57 @@ func TestProjectIDFromRef_BadURI(t *testing.T) {
 }
 
 // --------------------------------------------------------------------------
+// Raw / RawJSON / RawYAML / RawRequest
+// --------------------------------------------------------------------------
+
+func TestProject_Raw_AfterHydrate(t *testing.T) {
+	p := &Project{}
+	resp := projectTestResponse("id-1", "n1", "/projects/id-1")
+	p.fromResponse(resp)
+
+	if p.Raw() == nil {
+		t.Fatal("Raw() should be non-nil after fromResponse")
+	}
+	if p.Raw() != resp {
+		t.Error("Raw() should return the stored response pointer")
+	}
+	if p.Raw().Metadata.ID == nil || *p.Raw().Metadata.ID != "id-1" {
+		t.Errorf("Raw().Metadata.ID = %v", p.Raw().Metadata.ID)
+	}
+}
+
+func TestProject_RawJSON_NilSafe(t *testing.T) {
+	p := NewProject()
+	if p.RawJSON() != nil {
+		t.Error("RawJSON() before hydration should be nil")
+	}
+
+	p2 := &Project{}
+	p2.fromResponse(projectTestResponse("id-2", "n2", "/projects/id-2"))
+	b := p2.RawJSON()
+	if len(b) == 0 {
+		t.Error("RawJSON() after hydration should be non-empty")
+	}
+	if string(b[:1]) != "{" {
+		t.Errorf("RawJSON() does not look like JSON: %s", string(b[:10]))
+	}
+}
+
+func TestProject_RawRequest(t *testing.T) {
+	p := NewProject().Named("myproj").DescribedAs("desc").AsDefault()
+	req := p.RawRequest()
+	if req.Metadata.Name != "myproj" {
+		t.Errorf("RawRequest().Metadata.Name = %q", req.Metadata.Name)
+	}
+	if req.Properties.Description == nil || *req.Properties.Description != "desc" {
+		t.Errorf("RawRequest().Properties.Description = %v", req.Properties.Description)
+	}
+	if !req.Properties.Default {
+		t.Error("RawRequest().Properties.Default should be true")
+	}
+}
+
+// --------------------------------------------------------------------------
 // projectClientAdapter — CRUD integration tests (httptest-based)
 // --------------------------------------------------------------------------
 

--- a/pkg/aruba/resource_security_group.go
+++ b/pkg/aruba/resource_security_group.go
@@ -168,7 +168,7 @@ func securityGroupDerefString(p *string) string {
 // *types.Response[T] preserves HTTP envelope details (status code, headers,
 // raw body) for the wrapper's diagnostics.
 type securityGroupLowLevelClient interface {
-	List(ctx context.Context, projectID, vpcID string, params *types.RequestParameters) (*types.Response[types.SecurityGroupList], error)
+	List(ctx context.Context, projectID, vpcID string, params *types.RequestParameters) (*types.Response[types.SecurityGroupListResponse], error)
 	Get(ctx context.Context, projectID, vpcID, securityGroupID string, params *types.RequestParameters) (*types.Response[types.SecurityGroupResponse], error)
 	Create(ctx context.Context, projectID, vpcID string, body types.SecurityGroupRequest, params *types.RequestParameters) (*types.Response[types.SecurityGroupResponse], error)
 	Update(ctx context.Context, projectID, vpcID, securityGroupID string, body types.SecurityGroupRequest, params *types.RequestParameters) (*types.Response[types.SecurityGroupResponse], error)
@@ -364,7 +364,7 @@ func (a *securityGroupsClientAdapter) List(ctx context.Context, vpc Ref, opts ..
 	}
 	var refetch func(ctx context.Context, pageURL string) (*List[*SecurityGroup], error)
 	refetch = func(ctx context.Context, pageURL string) (*List[*SecurityGroup], error) {
-		fetch := listPageFetch[types.SecurityGroupList](a.rest, opts)
+		fetch := listPageFetch[types.SecurityGroupListResponse](a.rest, opts)
 		pageResp, fetchErr := fetch(ctx, pageURL)
 		if fetchErr != nil {
 			return nil, fetchErr

--- a/pkg/aruba/resource_security_group.go
+++ b/pkg/aruba/resource_security_group.go
@@ -102,10 +102,10 @@ func (sg *SecurityGroup) IsDefault() bool {
 	return *sg.defaultSG
 }
 
-// Rules returns the linked security group rules as a slice of LinkedResource.
+// Rules returns the linked security group rules as a slice of LinkedResourceCommon.
 // This is an alias for LinkedResources(), exposing the rules under a domain-specific name.
 // Returns nil when no rules are linked.
-func (sg *SecurityGroup) Rules() []types.LinkedResource {
+func (sg *SecurityGroup) Rules() []types.LinkedResourceCommon {
 	return sg.LinkedResources()
 }
 
@@ -140,9 +140,9 @@ func (sg *SecurityGroup) fromResponse(resp *types.SecurityGroupResponse) {
 	d := resp.Properties.Default
 	sg.defaultSG = &d
 
-	// Backfill ancestor IDs: prefer ProjectResponseMetadata, then URI parse.
-	if resp.Metadata.ProjectResponseMetadata != nil && resp.Metadata.ProjectResponseMetadata.ID != "" {
-		sg.projectID = resp.Metadata.ProjectResponseMetadata.ID
+	// Backfill ancestor IDs: prefer ProjectMetadataResponse, then URI parse.
+	if resp.Metadata.ProjectMetadataResponse != nil && resp.Metadata.ProjectMetadataResponse.ID != "" {
+		sg.projectID = resp.Metadata.ProjectMetadataResponse.ID
 	}
 	if (sg.vpcID == "" || sg.projectID == "") && sg.RespURI() != "" {
 		ids := parseURIIDs(sg.RespURI())

--- a/pkg/aruba/resource_security_group.go
+++ b/pkg/aruba/resource_security_group.go
@@ -102,6 +102,13 @@ func (sg *SecurityGroup) IsDefault() bool {
 	return *sg.defaultSG
 }
 
+// Rules returns the linked security group rules as a slice of LinkedResource.
+// This is an alias for LinkedResources(), exposing the rules under a domain-specific name.
+// Returns nil when no rules are linked.
+func (sg *SecurityGroup) Rules() []types.LinkedResource {
+	return sg.LinkedResources()
+}
+
 // Wire converters
 
 // toRequest assembles the Create/Update body from current setter state. Defaults are applied at the wire boundary.

--- a/pkg/aruba/resource_security_group_test.go
+++ b/pkg/aruba/resource_security_group_test.go
@@ -120,19 +120,19 @@ func securityGroupTestResponse(id, name, uri, projectID string) *types.SecurityG
 			URI:  &uri,
 			Name: &name,
 			Tags: []string{"sg-tag"},
-			ProjectResponseMetadata: &types.ProjectResponseMetadata{
+			ProjectMetadataResponse: &types.ProjectMetadataResponse{
 				ID: projectID,
 			},
 		},
 		Properties: types.SecurityGroupPropertiesResponse{
 			Default: true,
-			LinkedResources: []types.LinkedResource{
+			LinkedResources: []types.LinkedResourceCommon{
 				{URI: "/projects/p/providers/Aruba.Compute/cloudservers/cs1", StrictCorrelation: true},
 			},
 		},
-		Status: types.ResourceStatus{
+		Status: types.ResourceStatusResponse{
 			State: &state,
-			DisableStatusInfo: &types.DisableStatusInfo{
+			DisableStatusInfoResponse: &types.DisableStatusInfoResponse{
 				IsDisabled: false,
 			},
 		},
@@ -214,7 +214,7 @@ func TestSecurityGroup_FromResponseURIBackfill(t *testing.T) {
 			ID:   &id,
 			URI:  &uri,
 			Name: &name,
-			// ProjectResponseMetadata intentionally nil
+			// ProjectMetadataResponse intentionally nil
 		},
 	}
 	sg := &SecurityGroup{}
@@ -886,7 +886,7 @@ func TestSecurityGroup_FromResponse_SetsStatus(t *testing.T) {
 	sg := &SecurityGroup{}
 	state := types.State("Active")
 	sg.fromResponse(&types.SecurityGroupResponse{
-		Status: types.ResourceStatus{State: &state},
+		Status: types.ResourceStatusResponse{State: &state},
 	})
 	if sg.State() != types.StateActive {
 		t.Errorf("State() = %q after fromResponse, want Active", sg.State())

--- a/pkg/aruba/resource_security_group_test.go
+++ b/pkg/aruba/resource_security_group_test.go
@@ -930,3 +930,41 @@ func TestSecurityGroupIDsFromRef_URIRef_DocsForm(t *testing.T) {
 		t.Fatalf("SecurityGroupRef → securityGroupIDsFromRef round-trip failed: (%q, %q, %q, %v)", pid, vid, sgid, err)
 	}
 }
+
+// --------------------------------------------------------------------------
+// Rules getter
+// --------------------------------------------------------------------------
+
+func TestSecurityGroup_Rules_NilWhenEmpty(t *testing.T) {
+	sg := &SecurityGroup{}
+	if rules := sg.Rules(); rules != nil {
+		t.Errorf("Rules() = %v, want nil", rules)
+	}
+}
+
+func TestSecurityGroup_Rules_AliasForLinkedResources(t *testing.T) {
+	sg := &SecurityGroup{}
+	sg.fromResponse(securityGroupTestResponse("sg-1", "my-sg", "/projects/p/providers/Aruba.Network/vpcs/v/securityGroups/sg-1", "p"))
+	rules := sg.Rules()
+	linked := sg.LinkedResources()
+	if len(rules) != len(linked) {
+		t.Fatalf("Rules() len = %d, LinkedResources() len = %d — should be equal", len(rules), len(linked))
+	}
+	for i := range rules {
+		if rules[i].URI != linked[i].URI {
+			t.Errorf("Rules()[%d].URI = %q, LinkedResources()[%d].URI = %q", i, rules[i].URI, i, linked[i].URI)
+		}
+	}
+}
+
+func TestSecurityGroup_Rules_ReturnsRulesFromResponse(t *testing.T) {
+	sg := &SecurityGroup{}
+	sg.fromResponse(securityGroupTestResponse("sg-1", "my-sg", "/projects/p/providers/Aruba.Network/vpcs/v/securityGroups/sg-1", "p"))
+	rules := sg.Rules()
+	if len(rules) != 1 {
+		t.Fatalf("Rules() len = %d, want 1", len(rules))
+	}
+	if rules[0].URI != "/projects/p/providers/Aruba.Compute/cloudservers/cs1" {
+		t.Errorf("Rules()[0].URI = %q", rules[0].URI)
+	}
+}

--- a/pkg/aruba/resource_security_rule.go
+++ b/pkg/aruba/resource_security_rule.go
@@ -35,7 +35,7 @@ type SecurityRule struct {
 	direction *types.RuleDirection
 	protocol  *RuleProtocol
 	port      *string
-	target    *types.RuleTarget
+	target    *types.RuleTargetCommon
 	response  *types.SecurityRuleResponse
 }
 
@@ -102,7 +102,7 @@ func (r *SecurityRule) TargetingCIDR(cidr string) *SecurityRule {
 		r.addErr(fmt.Errorf("TargetingCIDR: target already set to SecurityGroup; pick one"))
 		return r
 	}
-	r.target = &types.RuleTarget{Kind: types.EndpointTypeIP, Value: cidr}
+	r.target = &types.RuleTargetCommon{Kind: types.EndpointTypeIP, Value: cidr}
 	return r
 }
 
@@ -118,7 +118,7 @@ func (r *SecurityRule) TargetingSecurityGroup(sg Ref) *SecurityRule {
 		r.addErr(fmt.Errorf("TargetingSecurityGroup: target SecurityGroup Ref has empty URI"))
 		return r
 	}
-	r.target = &types.RuleTarget{Kind: types.EndpointTypeSecurityGroup, Value: uri}
+	r.target = &types.RuleTargetCommon{Kind: types.EndpointTypeSecurityGroup, Value: uri}
 	return r
 }
 
@@ -269,7 +269,7 @@ func securityRuleDerefString(p *string) string {
 // *types.Response[T] preserves HTTP envelope details (status code, headers,
 // raw body) for the wrapper's diagnostics.
 type securityRuleLowLevelClient interface {
-	List(ctx context.Context, projectID, vpcID, securityGroupID string, params *types.RequestParameters) (*types.Response[types.SecurityRuleList], error)
+	List(ctx context.Context, projectID, vpcID, securityGroupID string, params *types.RequestParameters) (*types.Response[types.SecurityRuleListResponse], error)
 	Get(ctx context.Context, projectID, vpcID, securityGroupID, securityRuleID string, params *types.RequestParameters) (*types.Response[types.SecurityRuleResponse], error)
 	Create(ctx context.Context, projectID, vpcID, securityGroupID string, body types.SecurityRuleRequest, params *types.RequestParameters) (*types.Response[types.SecurityRuleResponse], error)
 	Update(ctx context.Context, projectID, vpcID, securityGroupID, securityRuleID string, body types.SecurityRuleRequest, params *types.RequestParameters) (*types.Response[types.SecurityRuleResponse], error)
@@ -478,7 +478,7 @@ func (a *securityRulesClientAdapter) List(ctx context.Context, sg Ref, opts ...C
 	}
 	var refetch func(ctx context.Context, pageURL string) (*List[*SecurityRule], error)
 	refetch = func(ctx context.Context, pageURL string) (*List[*SecurityRule], error) {
-		fetch := listPageFetch[types.SecurityRuleList](a.rest, opts)
+		fetch := listPageFetch[types.SecurityRuleListResponse](a.rest, opts)
 		pageResp, fetchErr := fetch(ctx, pageURL)
 		if fetchErr != nil {
 			return nil, fetchErr

--- a/pkg/aruba/resource_security_rule.go
+++ b/pkg/aruba/resource_security_rule.go
@@ -239,8 +239,8 @@ func (r *SecurityRule) fromResponse(resp *types.SecurityRuleResponse) {
 		r.target = &t
 	}
 
-	if resp.Metadata.ProjectResponseMetadata != nil && resp.Metadata.ProjectResponseMetadata.ID != "" {
-		r.projectID = resp.Metadata.ProjectResponseMetadata.ID
+	if resp.Metadata.ProjectMetadataResponse != nil && resp.Metadata.ProjectMetadataResponse.ID != "" {
+		r.projectID = resp.Metadata.ProjectMetadataResponse.ID
 	}
 	if (r.vpcID == "" || r.projectID == "" || r.securityGroupID == "") && r.RespURI() != "" {
 		ids := parseURIIDs(r.RespURI())

--- a/pkg/aruba/resource_security_rule_test.go
+++ b/pkg/aruba/resource_security_rule_test.go
@@ -267,7 +267,7 @@ func securityRuleTestResponse(id, name, uri, projectID string) *types.SecurityRu
 			Direction: dir,
 			Protocol:  proto,
 			Port:      port,
-			Target:    &types.RuleTarget{Kind: EndpointTypeIP, Value: "1.2.3.4/32"},
+			Target:    &types.RuleTargetCommon{Kind: EndpointTypeIP, Value: "1.2.3.4/32"},
 		},
 		Status: types.ResourceStatus{
 			State: &state,

--- a/pkg/aruba/resource_security_rule_test.go
+++ b/pkg/aruba/resource_security_rule_test.go
@@ -256,7 +256,7 @@ func securityRuleTestResponse(id, name, uri, projectID string) *types.SecurityRu
 			URI:  &uri,
 			Name: &name,
 			Tags: []string{"rule-tag"},
-			ProjectResponseMetadata: &types.ProjectResponseMetadata{
+			ProjectMetadataResponse: &types.ProjectMetadataResponse{
 				ID: projectID,
 			},
 			LocationResponse: &types.LocationResponse{
@@ -269,7 +269,7 @@ func securityRuleTestResponse(id, name, uri, projectID string) *types.SecurityRu
 			Port:      port,
 			Target:    &types.RuleTargetCommon{Kind: EndpointTypeIP, Value: "1.2.3.4/32"},
 		},
-		Status: types.ResourceStatus{
+		Status: types.ResourceStatusResponse{
 			State: &state,
 		},
 	}
@@ -1122,7 +1122,7 @@ func TestSecurityRule_FromResponse_SetsStatus(t *testing.T) {
 	r := &SecurityRule{}
 	state := types.State("Active")
 	r.fromResponse(&types.SecurityRuleResponse{
-		Status: types.ResourceStatus{State: &state},
+		Status: types.ResourceStatusResponse{State: &state},
 	})
 	if r.State() != types.StateActive {
 		t.Errorf("State() = %q after fromResponse, want Active", r.State())

--- a/pkg/aruba/resource_snapshot.go
+++ b/pkg/aruba/resource_snapshot.go
@@ -236,7 +236,7 @@ func snapshotDerefZone(p *Zone) Zone {
 // *types.Response[T] preserves HTTP envelope details (status code, headers,
 // raw body) for the wrapper's diagnostics.
 type snapshotLowLevelClient interface {
-	List(ctx context.Context, projectID string, params *types.RequestParameters) (*types.Response[types.SnapshotList], error)
+	List(ctx context.Context, projectID string, params *types.RequestParameters) (*types.Response[types.SnapshotListResponse], error)
 	Get(ctx context.Context, projectID, snapshotID string, params *types.RequestParameters) (*types.Response[types.SnapshotResponse], error)
 	Create(ctx context.Context, projectID string, body types.SnapshotRequest, params *types.RequestParameters) (*types.Response[types.SnapshotResponse], error)
 	Update(ctx context.Context, projectID, snapshotID string, body types.SnapshotRequest, params *types.RequestParameters) (*types.Response[types.SnapshotResponse], error)
@@ -430,7 +430,7 @@ func (a *snapshotsClientAdapter) List(ctx context.Context, project Ref, opts ...
 	}
 	var refetch func(ctx context.Context, pageURL string) (*List[*Snapshot], error)
 	refetch = func(ctx context.Context, pageURL string) (*List[*Snapshot], error) {
-		fetch := listPageFetch[types.SnapshotList](a.rest, opts)
+		fetch := listPageFetch[types.SnapshotListResponse](a.rest, opts)
 		pageResp, fetchErr := fetch(ctx, pageURL)
 		if fetchErr != nil {
 			return nil, fetchErr

--- a/pkg/aruba/resource_snapshot.go
+++ b/pkg/aruba/resource_snapshot.go
@@ -154,7 +154,7 @@ func (s *Snapshot) toRequest() types.SnapshotRequest {
 		BillingPeriod: defaultBillingPeriod(s.billingPeriod),
 	}
 	if s.volumeRef != nil {
-		props.Volume = types.ReferenceResource{URI: *s.volumeRef}
+		props.Volume = types.ReferenceResourceCommon{URI: *s.volumeRef}
 	}
 	return types.SnapshotRequest{
 		Metadata: types.RegionalResourceMetadataRequest{
@@ -206,8 +206,8 @@ func (s *Snapshot) fromResponse(resp *types.SnapshotResponse) {
 		s.volumeRef = &v
 	}
 
-	if resp.Metadata.ProjectResponseMetadata != nil && resp.Metadata.ProjectResponseMetadata.ID != "" {
-		s.projectID = resp.Metadata.ProjectResponseMetadata.ID
+	if resp.Metadata.ProjectMetadataResponse != nil && resp.Metadata.ProjectMetadataResponse.ID != "" {
+		s.projectID = resp.Metadata.ProjectMetadataResponse.ID
 	}
 	if s.projectID == "" && s.RespURI() != "" {
 		if pid := parseURIIDs(s.RespURI())["projects"]; pid != "" {

--- a/pkg/aruba/resource_snapshot_test.go
+++ b/pkg/aruba/resource_snapshot_test.go
@@ -201,7 +201,7 @@ func snapshotTestResponse(id, name, uri, projectID string) *types.SnapshotRespon
 			Name:             &name,
 			Tags:             []string{"tag1"},
 			LocationResponse: loc,
-			ProjectResponseMetadata: &types.ProjectResponseMetadata{
+			ProjectMetadataResponse: &types.ProjectMetadataResponse{
 				ID: projectID,
 			},
 		},
@@ -215,9 +215,9 @@ func snapshotTestResponse(id, name, uri, projectID string) *types.SnapshotRespon
 				URI: &volURI,
 			},
 		},
-		Status: types.ResourceStatus{
+		Status: types.ResourceStatusResponse{
 			State: &state,
-			DisableStatusInfo: &types.DisableStatusInfo{
+			DisableStatusInfoResponse: &types.DisableStatusInfoResponse{
 				IsDisabled: false,
 			},
 		},
@@ -304,12 +304,12 @@ func TestSnapshot_FromResponseURIBackfill(t *testing.T) {
 			ID:  &id,
 			URI: &uri,
 		},
-		Status: types.ResourceStatus{State: &state},
+		Status: types.ResourceStatusResponse{State: &state},
 	}
 	snap := &Snapshot{}
 	snap.fromResponse(resp)
 
-	// ProjectResponseMetadata is nil → should backfill from URI.
+	// ProjectMetadataResponse is nil → should backfill from URI.
 	if snap.ProjectID() != "p-uri" {
 		t.Errorf("ProjectID() via URI backfill = %q", snap.ProjectID())
 	}
@@ -329,7 +329,7 @@ func TestSnapshot_FromResponse_VolumeInfo_NilURI(t *testing.T) {
 				URI: nil, // URI is nil
 			},
 		},
-		Status: types.ResourceStatus{State: &state},
+		Status: types.ResourceStatusResponse{State: &state},
 	}
 	snap := &Snapshot{}
 	snap.fromResponse(resp)
@@ -698,7 +698,7 @@ func TestSnapshotsClientAdapter_Update_NoProject(t *testing.T) {
 		Metadata: types.ResourceMetadataResponse{
 			ID: strPtr("snap-1"),
 		},
-		Status: types.ResourceStatus{},
+		Status: types.ResourceStatusResponse{},
 	})
 
 	_, err := adapter.Update(context.Background(), snap)
@@ -921,7 +921,7 @@ func TestSnapshot_FromResponse_SetsStatus(t *testing.T) {
 	s := &Snapshot{}
 	state := types.State("Active")
 	s.fromResponse(&types.SnapshotResponse{
-		Status: types.ResourceStatus{State: &state},
+		Status: types.ResourceStatusResponse{State: &state},
 	})
 	if s.State() != types.StateActive {
 		t.Errorf("State() = %q after fromResponse, want Active", s.State())

--- a/pkg/aruba/resource_snapshot_test.go
+++ b/pkg/aruba/resource_snapshot_test.go
@@ -211,7 +211,7 @@ func snapshotTestResponse(id, name, uri, projectID string) *types.SnapshotRespon
 			Type:          BlockStorageTypeStandard,
 			Zone:          zone,
 			Bootable:      &boot,
-			Volume: &types.VolumeInfo{
+			Volume: &types.VolumeInfoResponse{
 				URI: &volURI,
 			},
 		},
@@ -325,7 +325,7 @@ func TestSnapshot_FromResponse_VolumeInfo_NilURI(t *testing.T) {
 			URI: &uri,
 		},
 		Properties: types.SnapshotPropertiesResponse{
-			Volume: &types.VolumeInfo{
+			Volume: &types.VolumeInfoResponse{
 				URI: nil, // URI is nil
 			},
 		},
@@ -422,7 +422,7 @@ type fakeSnapshotLowLevel struct {
 	getFunc    func(ctx context.Context, projectID, snapshotID string, params *types.RequestParameters) (*types.Response[types.SnapshotResponse], error)
 	updateFunc func(ctx context.Context, projectID, snapshotID string, body types.SnapshotRequest, params *types.RequestParameters) (*types.Response[types.SnapshotResponse], error)
 	deleteFunc func(ctx context.Context, projectID, snapshotID string, params *types.RequestParameters) (*types.Response[any], error)
-	listFunc   func(ctx context.Context, projectID string, params *types.RequestParameters) (*types.Response[types.SnapshotList], error)
+	listFunc   func(ctx context.Context, projectID string, params *types.RequestParameters) (*types.Response[types.SnapshotListResponse], error)
 }
 
 func (f *fakeSnapshotLowLevel) Create(ctx context.Context, projectID string, body types.SnapshotRequest, params *types.RequestParameters) (*types.Response[types.SnapshotResponse], error) {
@@ -437,7 +437,7 @@ func (f *fakeSnapshotLowLevel) Update(ctx context.Context, projectID, snapshotID
 func (f *fakeSnapshotLowLevel) Delete(ctx context.Context, projectID, snapshotID string, params *types.RequestParameters) (*types.Response[any], error) {
 	return f.deleteFunc(ctx, projectID, snapshotID, params)
 }
-func (f *fakeSnapshotLowLevel) List(ctx context.Context, projectID string, params *types.RequestParameters) (*types.Response[types.SnapshotList], error) {
+func (f *fakeSnapshotLowLevel) List(ctx context.Context, projectID string, params *types.RequestParameters) (*types.Response[types.SnapshotListResponse], error) {
 	return f.listFunc(ctx, projectID, params)
 }
 

--- a/pkg/aruba/resource_storage_backup.go
+++ b/pkg/aruba/resource_storage_backup.go
@@ -159,7 +159,7 @@ func (b *StorageBackup) toRequest() types.StorageBackupRequest {
 		props.StorageBackupType = *b.backupType
 	}
 	if b.originRef != nil {
-		props.Origin = types.ReferenceResource{URI: *b.originRef}
+		props.Origin = types.ReferenceResourceCommon{URI: *b.originRef}
 	}
 	return types.StorageBackupRequest{
 		Metadata: types.RegionalResourceMetadataRequest{
@@ -202,8 +202,8 @@ func (b *StorageBackup) fromResponse(resp *types.StorageBackupResponse) {
 		b.billingPeriod = storageBackupBillingPeriodWire().In(resp.Properties.BillingPeriod)
 	}
 
-	if resp.Metadata.ProjectResponseMetadata != nil && resp.Metadata.ProjectResponseMetadata.ID != "" {
-		b.projectID = resp.Metadata.ProjectResponseMetadata.ID
+	if resp.Metadata.ProjectMetadataResponse != nil && resp.Metadata.ProjectMetadataResponse.ID != "" {
+		b.projectID = resp.Metadata.ProjectMetadataResponse.ID
 	}
 	if b.projectID == "" && b.RespURI() != "" {
 		if pid := parseURIIDs(b.RespURI())["projects"]; pid != "" {

--- a/pkg/aruba/resource_storage_backup.go
+++ b/pkg/aruba/resource_storage_backup.go
@@ -235,7 +235,7 @@ func storageBackupBillingPeriodWire() *billingPeriodTranslator {
 // *types.Response[T] preserves HTTP envelope details (status code, headers,
 // raw body) for the wrapper's diagnostics.
 type storageBackupLowLevelClient interface {
-	List(ctx context.Context, projectID string, params *types.RequestParameters) (*types.Response[types.StorageBackupList], error)
+	List(ctx context.Context, projectID string, params *types.RequestParameters) (*types.Response[types.StorageBackupListResponse], error)
 	Get(ctx context.Context, projectID, backupID string, params *types.RequestParameters) (*types.Response[types.StorageBackupResponse], error)
 	Create(ctx context.Context, projectID string, body types.StorageBackupRequest, params *types.RequestParameters) (*types.Response[types.StorageBackupResponse], error)
 	Update(ctx context.Context, projectID, backupID string, body types.StorageBackupRequest, params *types.RequestParameters) (*types.Response[types.StorageBackupResponse], error)
@@ -426,7 +426,7 @@ func (a *storageBackupsClientAdapter) List(ctx context.Context, project Ref, opt
 	}
 	var refetch func(ctx context.Context, pageURL string) (*List[*StorageBackup], error)
 	refetch = func(ctx context.Context, pageURL string) (*List[*StorageBackup], error) {
-		fetch := listPageFetch[types.StorageBackupList](a.rest, opts)
+		fetch := listPageFetch[types.StorageBackupListResponse](a.rest, opts)
 		pageResp, fetchErr := fetch(ctx, pageURL)
 		if fetchErr != nil {
 			return nil, fetchErr

--- a/pkg/aruba/resource_storage_backup_test.go
+++ b/pkg/aruba/resource_storage_backup_test.go
@@ -239,7 +239,7 @@ func storageBackupTestResponse(id, name, uri, projectID string) *types.StorageBa
 				ID: projectID,
 			},
 		},
-		Properties: types.StorageBackupPropertiesResult{
+		Properties: types.StorageBackupPropertiesResponse{
 			Type:          StorageBackupTypeFull,
 			Origin:        types.ReferenceResource{URI: originURI},
 			RetentionDays: &retentionDays,
@@ -422,7 +422,7 @@ type fakeStorageBackupLowLevel struct {
 	getFunc    func(ctx context.Context, projectID, backupID string, params *types.RequestParameters) (*types.Response[types.StorageBackupResponse], error)
 	updateFunc func(ctx context.Context, projectID, backupID string, body types.StorageBackupRequest, params *types.RequestParameters) (*types.Response[types.StorageBackupResponse], error)
 	deleteFunc func(ctx context.Context, projectID, backupID string, params *types.RequestParameters) (*types.Response[any], error)
-	listFunc   func(ctx context.Context, projectID string, params *types.RequestParameters) (*types.Response[types.StorageBackupList], error)
+	listFunc   func(ctx context.Context, projectID string, params *types.RequestParameters) (*types.Response[types.StorageBackupListResponse], error)
 }
 
 func (f *fakeStorageBackupLowLevel) Create(ctx context.Context, projectID string, body types.StorageBackupRequest, params *types.RequestParameters) (*types.Response[types.StorageBackupResponse], error) {
@@ -437,7 +437,7 @@ func (f *fakeStorageBackupLowLevel) Update(ctx context.Context, projectID, backu
 func (f *fakeStorageBackupLowLevel) Delete(ctx context.Context, projectID, backupID string, params *types.RequestParameters) (*types.Response[any], error) {
 	return f.deleteFunc(ctx, projectID, backupID, params)
 }
-func (f *fakeStorageBackupLowLevel) List(ctx context.Context, projectID string, params *types.RequestParameters) (*types.Response[types.StorageBackupList], error) {
+func (f *fakeStorageBackupLowLevel) List(ctx context.Context, projectID string, params *types.RequestParameters) (*types.Response[types.StorageBackupListResponse], error) {
 	return f.listFunc(ctx, projectID, params)
 }
 
@@ -948,7 +948,7 @@ func TestStorageBackup_BillingPeriod_WireTranslation(t *testing.T) {
 		wireVal := BillingPeriod(c.wire)
 		b := &StorageBackup{}
 		b.fromResponse(&types.StorageBackupResponse{
-			Properties: types.StorageBackupPropertiesResult{BillingPeriod: &wireVal},
+			Properties: types.StorageBackupPropertiesResponse{BillingPeriod: &wireVal},
 		})
 		if b.BillingPeriod() != c.sdk {
 			t.Errorf("fromResponse(%q) = %q, want %q", c.wire, b.BillingPeriod(), c.sdk)

--- a/pkg/aruba/resource_storage_backup_test.go
+++ b/pkg/aruba/resource_storage_backup_test.go
@@ -235,19 +235,19 @@ func storageBackupTestResponse(id, name, uri, projectID string) *types.StorageBa
 			Name:             &name,
 			Tags:             []string{"tag1"},
 			LocationResponse: loc,
-			ProjectResponseMetadata: &types.ProjectResponseMetadata{
+			ProjectMetadataResponse: &types.ProjectMetadataResponse{
 				ID: projectID,
 			},
 		},
 		Properties: types.StorageBackupPropertiesResponse{
 			Type:          StorageBackupTypeFull,
-			Origin:        types.ReferenceResource{URI: originURI},
+			Origin:        types.ReferenceResourceCommon{URI: originURI},
 			RetentionDays: &retentionDays,
 			BillingPeriod: &billingPeriod,
 		},
-		Status: types.ResourceStatus{
+		Status: types.ResourceStatusResponse{
 			State: &state,
-			DisableStatusInfo: &types.DisableStatusInfo{
+			DisableStatusInfoResponse: &types.DisableStatusInfoResponse{
 				IsDisabled: false,
 			},
 		},
@@ -329,12 +329,12 @@ func TestStorageBackup_FromResponseURIBackfill(t *testing.T) {
 			ID:  &id,
 			URI: &uri,
 		},
-		Status: types.ResourceStatus{State: &state},
+		Status: types.ResourceStatusResponse{State: &state},
 	}
 	bkp := &StorageBackup{}
 	bkp.fromResponse(resp)
 
-	// ProjectResponseMetadata is nil → should backfill from URI.
+	// ProjectMetadataResponse is nil → should backfill from URI.
 	if bkp.ProjectID() != "p-uri" {
 		t.Errorf("ProjectID() via URI backfill = %q", bkp.ProjectID())
 	}
@@ -697,7 +697,7 @@ func TestStorageBackupsClientAdapter_Update_NoProject(t *testing.T) {
 		Metadata: types.ResourceMetadataResponse{
 			ID: strPtr("bkp-1"),
 		},
-		Status: types.ResourceStatus{},
+		Status: types.ResourceStatusResponse{},
 	})
 
 	_, err := adapter.Update(context.Background(), bkp)
@@ -920,7 +920,7 @@ func TestStorageBackup_FromResponse_SetsStatus(t *testing.T) {
 	b := &StorageBackup{}
 	state := types.State("Active")
 	b.fromResponse(&types.StorageBackupResponse{
-		Status: types.ResourceStatus{State: &state},
+		Status: types.ResourceStatusResponse{State: &state},
 	})
 	if b.State() != types.StateActive {
 		t.Errorf("State() = %q after fromResponse, want Active", b.State())

--- a/pkg/aruba/resource_storage_restore.go
+++ b/pkg/aruba/resource_storage_restore.go
@@ -106,7 +106,7 @@ func (r *StorageRestore) TargetURI() string { return storageRestoreDerefString(r
 func (r *StorageRestore) toRequest() types.StorageRestoreRequest {
 	props := types.StorageRestorePropertiesRequest{}
 	if r.targetRef != nil {
-		props.Target = types.ReferenceResource{URI: *r.targetRef}
+		props.Target = types.ReferenceResourceCommon{URI: *r.targetRef}
 	}
 	return types.StorageRestoreRequest{
 		Metadata: types.RegionalResourceMetadataRequest{
@@ -139,8 +139,8 @@ func (r *StorageRestore) fromResponse(resp *types.StorageRestoreResponse) {
 		r.targetRef = &v
 	}
 
-	if resp.Metadata.ProjectResponseMetadata != nil && resp.Metadata.ProjectResponseMetadata.ID != "" {
-		r.projectID = resp.Metadata.ProjectResponseMetadata.ID
+	if resp.Metadata.ProjectMetadataResponse != nil && resp.Metadata.ProjectMetadataResponse.ID != "" {
+		r.projectID = resp.Metadata.ProjectMetadataResponse.ID
 	}
 	if (r.projectID == "" || r.backupID == "") && r.RespURI() != "" {
 		ids := parseURIIDs(r.RespURI())

--- a/pkg/aruba/resource_storage_restore.go
+++ b/pkg/aruba/resource_storage_restore.go
@@ -166,7 +166,7 @@ func storageRestoreDerefString(p *string) string {
 // *types.Response[T] preserves HTTP envelope details (status code, headers,
 // raw body) for the wrapper's diagnostics.
 type storageRestoreLowLevelClient interface {
-	List(ctx context.Context, projectID, backupID string, params *types.RequestParameters) (*types.Response[types.StorageRestoreList], error)
+	List(ctx context.Context, projectID, backupID string, params *types.RequestParameters) (*types.Response[types.StorageRestoreListResponse], error)
 	Get(ctx context.Context, projectID, backupID, restoreID string, params *types.RequestParameters) (*types.Response[types.StorageRestoreResponse], error)
 	Create(ctx context.Context, projectID, backupID string, body types.StorageRestoreRequest, params *types.RequestParameters) (*types.Response[types.StorageRestoreResponse], error)
 	Update(ctx context.Context, projectID, backupID, restoreID string, body types.StorageRestoreRequest, params *types.RequestParameters) (*types.Response[types.StorageRestoreResponse], error)
@@ -373,7 +373,7 @@ func (a *storageRestoresClientAdapter) List(ctx context.Context, backup Ref, opt
 	}
 	var refetch func(ctx context.Context, pageURL string) (*List[*StorageRestore], error)
 	refetch = func(ctx context.Context, pageURL string) (*List[*StorageRestore], error) {
-		fetch := listPageFetch[types.StorageRestoreList](a.rest, opts)
+		fetch := listPageFetch[types.StorageRestoreListResponse](a.rest, opts)
 		pageResp, fetchErr := fetch(ctx, pageURL)
 		if fetchErr != nil {
 			return nil, fetchErr

--- a/pkg/aruba/resource_storage_restore_test.go
+++ b/pkg/aruba/resource_storage_restore_test.go
@@ -200,9 +200,9 @@ func storageRestoreTestResponse(id, name, uri, targetURI string) *types.StorageR
 			LocationResponse: loc,
 		},
 		Properties: types.StorageRestorePropertiesResponse{
-			Destination: types.ReferenceResource{URI: targetURI},
+			Destination: types.ReferenceResourceCommon{URI: targetURI},
 		},
-		Status: types.ResourceStatus{
+		Status: types.ResourceStatusResponse{
 			State: &state,
 		},
 	}
@@ -253,12 +253,12 @@ func TestStorageRestore_FromResponseURIBackfill(t *testing.T) {
 			ID:  &id,
 			URI: &uri,
 		},
-		Status: types.ResourceStatus{State: &state},
+		Status: types.ResourceStatusResponse{State: &state},
 	}
 	r := &StorageRestore{}
 	r.fromResponse(resp)
 
-	// Neither ProjectResponseMetadata nor pre-set IDs → backfill from URI.
+	// Neither ProjectMetadataResponse nor pre-set IDs → backfill from URI.
 	if r.ProjectID() != "p-uri" {
 		t.Errorf("ProjectID() via URI backfill = %q", r.ProjectID())
 	}
@@ -667,7 +667,7 @@ func TestStorageRestoresClientAdapter_Update_NoBackup(t *testing.T) {
 	id := "r-1"
 	r.fromResponse(&types.StorageRestoreResponse{
 		Metadata: types.ResourceMetadataResponse{ID: &id},
-		Status:   types.ResourceStatus{},
+		Status:   types.ResourceStatusResponse{},
 	})
 
 	_, err := adapter.Update(context.Background(), r)
@@ -907,7 +907,7 @@ func TestStorageRestore_FromResponse_SetsStatus(t *testing.T) {
 	r := &StorageRestore{}
 	state := types.State("Active")
 	r.fromResponse(&types.StorageRestoreResponse{
-		Status: types.ResourceStatus{State: &state},
+		Status: types.ResourceStatusResponse{State: &state},
 	})
 	if r.State() != types.StateActive {
 		t.Errorf("State() = %q after fromResponse, want Active", r.State())

--- a/pkg/aruba/resource_storage_restore_test.go
+++ b/pkg/aruba/resource_storage_restore_test.go
@@ -199,7 +199,7 @@ func storageRestoreTestResponse(id, name, uri, targetURI string) *types.StorageR
 			Tags:             []string{"tag1"},
 			LocationResponse: loc,
 		},
-		Properties: types.StorageRestorePropertiesResult{
+		Properties: types.StorageRestorePropertiesResponse{
 			Destination: types.ReferenceResource{URI: targetURI},
 		},
 		Status: types.ResourceStatus{
@@ -381,7 +381,7 @@ type fakeStorageRestoreLowLevel struct {
 	getFunc    func(ctx context.Context, projectID, backupID, restoreID string, params *types.RequestParameters) (*types.Response[types.StorageRestoreResponse], error)
 	updateFunc func(ctx context.Context, projectID, backupID, restoreID string, body types.StorageRestoreRequest, params *types.RequestParameters) (*types.Response[types.StorageRestoreResponse], error)
 	deleteFunc func(ctx context.Context, projectID, backupID, restoreID string, params *types.RequestParameters) (*types.Response[any], error)
-	listFunc   func(ctx context.Context, projectID, backupID string, params *types.RequestParameters) (*types.Response[types.StorageRestoreList], error)
+	listFunc   func(ctx context.Context, projectID, backupID string, params *types.RequestParameters) (*types.Response[types.StorageRestoreListResponse], error)
 }
 
 func (f *fakeStorageRestoreLowLevel) Create(ctx context.Context, projectID, backupID string, body types.StorageRestoreRequest, params *types.RequestParameters) (*types.Response[types.StorageRestoreResponse], error) {
@@ -396,7 +396,7 @@ func (f *fakeStorageRestoreLowLevel) Update(ctx context.Context, projectID, back
 func (f *fakeStorageRestoreLowLevel) Delete(ctx context.Context, projectID, backupID, restoreID string, params *types.RequestParameters) (*types.Response[any], error) {
 	return f.deleteFunc(ctx, projectID, backupID, restoreID, params)
 }
-func (f *fakeStorageRestoreLowLevel) List(ctx context.Context, projectID, backupID string, params *types.RequestParameters) (*types.Response[types.StorageRestoreList], error) {
+func (f *fakeStorageRestoreLowLevel) List(ctx context.Context, projectID, backupID string, params *types.RequestParameters) (*types.Response[types.StorageRestoreListResponse], error) {
 	return f.listFunc(ctx, projectID, backupID, params)
 }
 
@@ -847,7 +847,7 @@ func TestStorageRestoresClientAdapter_List_BadRef(t *testing.T) {
 func TestStorageRestoresClientAdapter_List_LowLevelError(t *testing.T) {
 	// Exercises the err != nil branch of a.low.List.
 	fake := &fakeStorageRestoreLowLevel{
-		listFunc: func(_ context.Context, _, _ string, _ *types.RequestParameters) (*types.Response[types.StorageRestoreList], error) {
+		listFunc: func(_ context.Context, _, _ string, _ *types.RequestParameters) (*types.Response[types.StorageRestoreListResponse], error) {
 			return nil, fmt.Errorf("network error")
 		},
 	}

--- a/pkg/aruba/resource_subnet.go
+++ b/pkg/aruba/resource_subnet.go
@@ -134,6 +134,10 @@ func (s *Subnet) CIDR() string {
 	return *s.cidr
 }
 
+// Network returns the subnet network address in CIDR notation.
+// It is an alias for CIDR() and returns "" if the address is unset.
+func (s *Subnet) Network() string { return s.CIDR() }
+
 // DHCP returns the attached DHCP configuration sub-builder, or nil if not set.
 func (s *Subnet) DHCP() *SubnetDHCP { return s.dhcp }
 

--- a/pkg/aruba/resource_subnet.go
+++ b/pkg/aruba/resource_subnet.go
@@ -199,8 +199,8 @@ func (s *Subnet) fromResponse(resp *types.SubnetResponse) {
 		s.dhcp = dhcpFromType(resp.Properties.DHCP)
 	}
 
-	if resp.Metadata.ProjectResponseMetadata != nil && resp.Metadata.ProjectResponseMetadata.ID != "" {
-		s.projectID = resp.Metadata.ProjectResponseMetadata.ID
+	if resp.Metadata.ProjectMetadataResponse != nil && resp.Metadata.ProjectMetadataResponse.ID != "" {
+		s.projectID = resp.Metadata.ProjectMetadataResponse.ID
 	}
 	// Backfill ancestor IDs from response URI if not already set.
 	if (s.vpcID == "" || s.projectID == "") && s.RespURI() != "" {

--- a/pkg/aruba/resource_subnet.go
+++ b/pkg/aruba/resource_subnet.go
@@ -37,7 +37,7 @@ type Subnet struct {
 	subnetType    *SubnetType           // Properties.Type ("Basic" / "Advanced")
 	defaultSubnet *bool                 // Properties.Default
 	cidr          *string               // Properties.Network.Address
-	dhcp          *SubnetDHCP           // Properties.DHCP (sub-builder)
+	dhcp          *SubnetDHCPCommon     // Properties.DHCP (sub-builder)
 	response      *types.SubnetResponse // backs Raw()
 }
 
@@ -92,7 +92,7 @@ func (s *Subnet) NotDefault() *Subnet { f := false; s.defaultSubnet = &f; return
 func (s *Subnet) WithCIDR(cidr string) *Subnet { s.cidr = &cidr; return s }
 
 // WithDHCP attaches a DHCP configuration sub-builder to the subnet.
-func (s *Subnet) WithDHCP(d *SubnetDHCP) *Subnet { s.dhcp = d; return s }
+func (s *Subnet) WithDHCP(d *SubnetDHCPCommon) *Subnet { s.dhcp = d; return s }
 
 // Getters — general → specific
 
@@ -139,7 +139,7 @@ func (s *Subnet) CIDR() string {
 func (s *Subnet) Network() string { return s.CIDR() }
 
 // DHCP returns the attached DHCP configuration sub-builder, or nil if not set.
-func (s *Subnet) DHCP() *SubnetDHCP { return s.dhcp }
+func (s *Subnet) DHCP() *SubnetDHCPCommon { return s.dhcp }
 
 // Wire converters
 
@@ -153,7 +153,7 @@ func (s *Subnet) toRequest() types.SubnetRequest {
 		props.Default = s.defaultSubnet
 	}
 	if s.cidr != nil {
-		props.Network = &types.SubnetNetwork{Address: *s.cidr}
+		props.Network = &types.SubnetNetworkCommon{Address: *s.cidr}
 	}
 	if s.dhcp != nil {
 		props.DHCP = s.dhcp.build()
@@ -227,7 +227,7 @@ func subnetDerefString(p *string) string {
 // *types.Response[T] preserves HTTP envelope details (status code, headers,
 // raw body) for the wrapper's diagnostics.
 type subnetLowLevelClient interface {
-	List(ctx context.Context, projectID, vpcID string, params *types.RequestParameters) (*types.Response[types.SubnetList], error)
+	List(ctx context.Context, projectID, vpcID string, params *types.RequestParameters) (*types.Response[types.SubnetListResponse], error)
 	Get(ctx context.Context, projectID, vpcID, subnetID string, params *types.RequestParameters) (*types.Response[types.SubnetResponse], error)
 	Create(ctx context.Context, projectID, vpcID string, body types.SubnetRequest, params *types.RequestParameters) (*types.Response[types.SubnetResponse], error)
 	Update(ctx context.Context, projectID, vpcID, subnetID string, body types.SubnetRequest, params *types.RequestParameters) (*types.Response[types.SubnetResponse], error)
@@ -421,7 +421,7 @@ func (a *subnetsClientAdapter) List(ctx context.Context, vpc Ref, opts ...CallOp
 	}
 	var refetch func(ctx context.Context, pageURL string) (*List[*Subnet], error)
 	refetch = func(ctx context.Context, pageURL string) (*List[*Subnet], error) {
-		fetch := listPageFetch[types.SubnetList](a.rest, opts)
+		fetch := listPageFetch[types.SubnetListResponse](a.rest, opts)
 		pageResp, fetchErr := fetch(ctx, pageURL)
 		if fetchErr != nil {
 			return nil, fetchErr

--- a/pkg/aruba/resource_subnet_dhcp.go
+++ b/pkg/aruba/resource_subnet_dhcp.go
@@ -4,44 +4,44 @@ import "github.com/Arubacloud/sdk-go/pkg/types"
 
 // ---- Sub-builder ----
 
-// SubnetDHCP is the fluent sub-builder for Properties.DHCP on a Subnet.
+// SubnetDHCPCommon is the fluent sub-builder for Properties.DHCP on a Subnet.
 // Construct with aruba.NewSubnetDHCP() and attach via (*Subnet).WithDHCP.
-type SubnetDHCP struct {
+type SubnetDHCPCommon struct {
 	errMixin
-	inner types.SubnetDHCP
+	inner types.SubnetDHCPCommon
 }
 
 // NewSubnetDHCP returns an empty (disabled) DHCP block.
-func NewSubnetDHCP() *SubnetDHCP { return &SubnetDHCP{} }
+func NewSubnetDHCP() *SubnetDHCPCommon { return &SubnetDHCPCommon{} }
 
 // Enabled marks DHCP as enabled.
-func (d *SubnetDHCP) Enabled() *SubnetDHCP { d.inner.Enabled = true; return d }
+func (d *SubnetDHCPCommon) Enabled() *SubnetDHCPCommon { d.inner.Enabled = true; return d }
 
 // WithRange sets a single DHCP allocation range.
-func (d *SubnetDHCP) WithRange(start string, count int) *SubnetDHCP {
-	d.inner.Range = &types.SubnetDHCPRange{Start: start, Count: count}
+func (d *SubnetDHCPCommon) WithRange(start string, count int) *SubnetDHCPCommon {
+	d.inner.Range = &types.SubnetDHCPRangeCommon{Start: start, Count: count}
 	return d
 }
 
 // WithRoutes appends static routes advertised via DHCP. Repeated calls append.
-func (d *SubnetDHCP) WithRoutes(routes ...SubnetDHCPRoute) *SubnetDHCP {
+func (d *SubnetDHCPCommon) WithRoutes(routes ...SubnetDHCPRouteCommon) *SubnetDHCPCommon {
 	for _, r := range routes {
-		d.inner.Routes = append(d.inner.Routes, types.SubnetDHCPRoute{Address: r.Address, Gateway: r.Gateway})
+		d.inner.Routes = append(d.inner.Routes, types.SubnetDHCPRouteCommon{Address: r.Address, Gateway: r.Gateway})
 	}
 	return d
 }
 
 // WithDNSServers appends DNS servers advertised via DHCP. Repeated calls append.
-func (d *SubnetDHCP) WithDNSServers(ips ...string) *SubnetDHCP {
+func (d *SubnetDHCPCommon) WithDNSServers(ips ...string) *SubnetDHCPCommon {
 	d.inner.DNS = append(d.inner.DNS, ips...)
 	return d
 }
 
 // IsEnabled reports whether DHCP is enabled on this subnet.
-func (d *SubnetDHCP) IsEnabled() bool { return d.inner.Enabled }
+func (d *SubnetDHCPCommon) IsEnabled() bool { return d.inner.Enabled }
 
 // RangeStart returns the start address of the DHCP allocation range, or "" if unset.
-func (d *SubnetDHCP) RangeStart() string {
+func (d *SubnetDHCPCommon) RangeStart() string {
 	if d.inner.Range == nil {
 		return ""
 	}
@@ -49,7 +49,7 @@ func (d *SubnetDHCP) RangeStart() string {
 }
 
 // RangeCount returns the number of addresses in the DHCP allocation range, or 0 if unset.
-func (d *SubnetDHCP) RangeCount() int {
+func (d *SubnetDHCPCommon) RangeCount() int {
 	if d.inner.Range == nil {
 		return 0
 	}
@@ -57,38 +57,38 @@ func (d *SubnetDHCP) RangeCount() int {
 }
 
 // Routes returns a copy of the static routes advertised via DHCP, or nil if none.
-func (d *SubnetDHCP) Routes() []SubnetDHCPRoute {
+func (d *SubnetDHCPCommon) Routes() []SubnetDHCPRouteCommon {
 	if len(d.inner.Routes) == 0 {
 		return nil
 	}
-	out := make([]SubnetDHCPRoute, len(d.inner.Routes))
+	out := make([]SubnetDHCPRouteCommon, len(d.inner.Routes))
 	for i, r := range d.inner.Routes {
-		out[i] = SubnetDHCPRoute{Address: r.Address, Gateway: r.Gateway}
+		out[i] = SubnetDHCPRouteCommon{Address: r.Address, Gateway: r.Gateway}
 	}
 	return out
 }
 
 // DNS returns a copy of the DNS server list advertised via DHCP, or nil if none.
-func (d *SubnetDHCP) DNS() []string {
+func (d *SubnetDHCPCommon) DNS() []string {
 	if len(d.inner.DNS) == 0 {
 		return nil
 	}
 	return append([]string(nil), d.inner.DNS...)
 }
 
-// SubnetDHCPRoute mirrors types.SubnetDHCPRoute at the wrapper boundary.
-type SubnetDHCPRoute struct {
+// SubnetDHCPRouteCommon mirrors types.SubnetDHCPRouteCommon at the wrapper boundary.
+type SubnetDHCPRouteCommon struct {
 	Address string
 	Gateway string
 }
 
-func (d *SubnetDHCP) build() *types.SubnetDHCP {
+func (d *SubnetDHCPCommon) build() *types.SubnetDHCPCommon {
 	if d == nil {
 		return nil
 	}
 	cp := d.inner
 	if len(d.inner.Routes) > 0 {
-		cp.Routes = append([]types.SubnetDHCPRoute(nil), d.inner.Routes...)
+		cp.Routes = append([]types.SubnetDHCPRouteCommon(nil), d.inner.Routes...)
 	}
 	if len(d.inner.DNS) > 0 {
 		cp.DNS = append([]string(nil), d.inner.DNS...)
@@ -100,17 +100,17 @@ func (d *SubnetDHCP) build() *types.SubnetDHCP {
 	return &cp
 }
 
-func dhcpFromType(t *types.SubnetDHCP) *SubnetDHCP {
+func dhcpFromType(t *types.SubnetDHCPCommon) *SubnetDHCPCommon {
 	if t == nil {
 		return nil
 	}
-	d := &SubnetDHCP{inner: types.SubnetDHCP{Enabled: t.Enabled}}
+	d := &SubnetDHCPCommon{inner: types.SubnetDHCPCommon{Enabled: t.Enabled}}
 	if t.Range != nil {
 		r := *t.Range
 		d.inner.Range = &r
 	}
 	if len(t.Routes) > 0 {
-		d.inner.Routes = append([]types.SubnetDHCPRoute(nil), t.Routes...)
+		d.inner.Routes = append([]types.SubnetDHCPRouteCommon(nil), t.Routes...)
 	}
 	if len(t.DNS) > 0 {
 		d.inner.DNS = append([]string(nil), t.DNS...)

--- a/pkg/aruba/resource_subnet_test.go
+++ b/pkg/aruba/resource_subnet_test.go
@@ -1040,3 +1040,39 @@ func TestSubnetRef(t *testing.T) {
 		t.Errorf("parseURIIDs = %v", ids)
 	}
 }
+
+// --------------------------------------------------------------------------
+// Network getter
+// --------------------------------------------------------------------------
+
+func TestSubnet_Network_Unset(t *testing.T) {
+	s := &Subnet{}
+	if got := s.Network(); got != "" {
+		t.Errorf("Network() = %q, want empty", got)
+	}
+}
+
+func TestSubnet_Network_WithCIDR(t *testing.T) {
+	s := NewSubnet().WithCIDR("192.168.1.0/24")
+	if got := s.Network(); got != "192.168.1.0/24" {
+		t.Errorf("Network() = %q, want 192.168.1.0/24", got)
+	}
+}
+
+func TestSubnet_Network_AliasForCIDR(t *testing.T) {
+	uri := "/projects/p/providers/Aruba.Network/vpcs/v/subnets/s-1"
+	s := &Subnet{}
+	s.fromResponse(subnetTestResponse("s-1", "my-subnet", uri, "p"))
+	if got, want := s.Network(), s.CIDR(); got != want {
+		t.Errorf("Network() = %q, CIDR() = %q — should be equal", got, want)
+	}
+}
+
+func TestSubnet_Network_FromResponse(t *testing.T) {
+	uri := "/projects/p/providers/Aruba.Network/vpcs/v/subnets/s-1"
+	s := &Subnet{}
+	s.fromResponse(subnetTestResponse("s-1", "my-subnet", uri, "p"))
+	if got := s.Network(); got != "10.0.0.0/24" {
+		t.Errorf("Network() = %q, want 10.0.0.0/24", got)
+	}
+}

--- a/pkg/aruba/resource_subnet_test.go
+++ b/pkg/aruba/resource_subnet_test.go
@@ -88,15 +88,15 @@ func TestSubnet_IntoVPC_BadRef(t *testing.T) {
 }
 
 // --------------------------------------------------------------------------
-// SubnetDHCP sub-builder
+// SubnetDHCPCommon sub-builder
 // --------------------------------------------------------------------------
 
 func TestSubnet_DHCPSubBuilder(t *testing.T) {
 	d := NewSubnetDHCP().
 		Enabled().
 		WithRange("10.0.0.10", 50).
-		WithRoutes(SubnetDHCPRoute{Address: "0.0.0.0/0", Gateway: "10.0.0.1"}).
-		WithRoutes(SubnetDHCPRoute{Address: "192.168.0.0/16", Gateway: "10.0.0.2"}).
+		WithRoutes(SubnetDHCPRouteCommon{Address: "0.0.0.0/0", Gateway: "10.0.0.1"}).
+		WithRoutes(SubnetDHCPRouteCommon{Address: "192.168.0.0/16", Gateway: "10.0.0.2"}).
 		WithDNSServers("1.1.1.1").
 		WithDNSServers("8.8.8.8")
 
@@ -133,7 +133,7 @@ func TestSubnet_DHCPSubBuilder(t *testing.T) {
 	}
 
 	// Nil DHCP toType must return nil.
-	var nilDHCP *SubnetDHCP
+	var nilDHCP *SubnetDHCPCommon
 	if nilDHCP.build() != nil {
 		t.Error("nil.build() should return nil")
 	}
@@ -168,7 +168,7 @@ func TestSubnet_ToRequestRoundTrip(t *testing.T) {
 		WithDHCP(NewSubnetDHCP().
 			Enabled().
 			WithRange("10.1.2.10", 20).
-			WithRoutes(SubnetDHCPRoute{Address: "0.0.0.0/0", Gateway: "10.1.2.1"}).
+			WithRoutes(SubnetDHCPRouteCommon{Address: "0.0.0.0/0", Gateway: "10.1.2.1"}).
 			WithDNSServers("9.9.9.9"))
 
 	req := s.RawRequest()
@@ -230,10 +230,10 @@ func subnetTestResponse(id, name, uri, projectID string) *types.SubnetResponse {
 		Properties: types.SubnetPropertiesResponse{
 			Type:    SubnetTypeAdvanced,
 			Default: true,
-			Network: &types.SubnetNetwork{Address: addr},
-			DHCP: &types.SubnetDHCP{
+			Network: &types.SubnetNetworkCommon{Address: addr},
+			DHCP: &types.SubnetDHCPCommon{
 				Enabled: true,
-				Range:   &types.SubnetDHCPRange{Start: "10.0.0.10", Count: 50},
+				Range:   &types.SubnetDHCPRangeCommon{Start: "10.0.0.10", Count: 50},
 				DNS:     []string{"8.8.8.8"},
 			},
 			LinkedResources: []types.LinkedResource{
@@ -720,9 +720,9 @@ func TestDHCPFromType_Nil(t *testing.T) {
 
 func TestDHCPFromType_WithRoutes(t *testing.T) {
 	// Covers the t.Routes > 0 branch in dhcpFromType.
-	dhcp := &types.SubnetDHCP{
+	dhcp := &types.SubnetDHCPCommon{
 		Enabled: true,
-		Routes:  []types.SubnetDHCPRoute{{Address: "10.0.0.0/8", Gateway: "10.0.0.1"}},
+		Routes:  []types.SubnetDHCPRouteCommon{{Address: "10.0.0.0/8", Gateway: "10.0.0.1"}},
 	}
 	got := dhcpFromType(dhcp)
 	if got == nil {

--- a/pkg/aruba/resource_subnet_test.go
+++ b/pkg/aruba/resource_subnet_test.go
@@ -223,7 +223,7 @@ func subnetTestResponse(id, name, uri, projectID string) *types.SubnetResponse {
 			Name:             &name,
 			Tags:             []string{"tag1"},
 			LocationResponse: loc,
-			ProjectResponseMetadata: &types.ProjectResponseMetadata{
+			ProjectMetadataResponse: &types.ProjectMetadataResponse{
 				ID: projectID,
 			},
 		},
@@ -236,13 +236,13 @@ func subnetTestResponse(id, name, uri, projectID string) *types.SubnetResponse {
 				Range:   &types.SubnetDHCPRangeCommon{Start: "10.0.0.10", Count: 50},
 				DNS:     []string{"8.8.8.8"},
 			},
-			LinkedResources: []types.LinkedResource{
+			LinkedResources: []types.LinkedResourceCommon{
 				{URI: uri + "/linked-res", StrictCorrelation: false},
 			},
 		},
-		Status: types.ResourceStatus{
+		Status: types.ResourceStatusResponse{
 			State: &state,
-			DisableStatusInfo: &types.DisableStatusInfo{
+			DisableStatusInfoResponse: &types.DisableStatusInfoResponse{
 				IsDisabled: false,
 			},
 		},
@@ -1006,7 +1006,7 @@ func TestSubnet_FromResponse_SetsStatus(t *testing.T) {
 	s := &Subnet{}
 	state := types.State("Active")
 	s.fromResponse(&types.SubnetResponse{
-		Status: types.ResourceStatus{State: &state},
+		Status: types.ResourceStatusResponse{State: &state},
 	})
 	if s.State() != types.StateActive {
 		t.Errorf("State() = %q after fromResponse, want Active", s.State())

--- a/pkg/aruba/resource_user.go
+++ b/pkg/aruba/resource_user.go
@@ -182,7 +182,7 @@ func userIDsFromRef(ref Ref) (projectID, dbaasID, userID string, err error) {
 // *types.Response[T] preserves HTTP envelope details (status code, headers,
 // raw body) for the wrapper's diagnostics.
 type usersLowLevelClient interface {
-	List(ctx context.Context, projectID, dbaasID string, params *types.RequestParameters) (*types.Response[types.UserList], error)
+	List(ctx context.Context, projectID, dbaasID string, params *types.RequestParameters) (*types.Response[types.DatabaseUserListResponse], error)
 	Get(ctx context.Context, projectID, dbaasID, userID string, params *types.RequestParameters) (*types.Response[types.UserResponse], error)
 	Create(ctx context.Context, projectID, dbaasID string, body types.UserRequest, params *types.RequestParameters) (*types.Response[types.UserResponse], error)
 	Update(ctx context.Context, projectID, dbaasID, userID string, body types.UserRequest, params *types.RequestParameters) (*types.Response[types.UserResponse], error)
@@ -388,7 +388,7 @@ func (a *usersClientAdapter) List(ctx context.Context, dbaas Ref, opts ...CallOp
 	}
 	var refetch func(ctx context.Context, pageURL string) (*List[*User], error)
 	refetch = func(ctx context.Context, pageURL string) (*List[*User], error) {
-		fetch := listPageFetch[types.UserList](a.rest, opts)
+		fetch := listPageFetch[types.DatabaseUserListResponse](a.rest, opts)
 		pageResp, fetchErr := fetch(ctx, pageURL)
 		if fetchErr != nil {
 			return nil, fetchErr

--- a/pkg/aruba/resource_vpc.go
+++ b/pkg/aruba/resource_vpc.go
@@ -157,8 +157,8 @@ func (v *VPC) fromResponse(resp *types.VPCResponse) {
 	v.setLinked(resp.Properties.LinkedResources)
 	d := resp.Properties.Default
 	v.defaultVPC = &d
-	if resp.Metadata.ProjectResponseMetadata != nil && resp.Metadata.ProjectResponseMetadata.ID != "" {
-		v.projectID = resp.Metadata.ProjectResponseMetadata.ID
+	if resp.Metadata.ProjectMetadataResponse != nil && resp.Metadata.ProjectMetadataResponse.ID != "" {
+		v.projectID = resp.Metadata.ProjectMetadataResponse.ID
 	}
 }
 

--- a/pkg/aruba/resource_vpc.go
+++ b/pkg/aruba/resource_vpc.go
@@ -125,9 +125,9 @@ func (v *VPC) IsPreset() bool {
 
 // toRequest assembles the Create/Update body from current setter state. Defaults are applied at the wire boundary.
 func (v *VPC) toRequest() types.VPCRequest {
-	var props *types.VPCProperties
+	var props *types.VPCPropertiesInnerRequest
 	if v.defaultVPC != nil || v.preset != nil {
-		props = &types.VPCProperties{Default: v.defaultVPC, Preset: v.preset}
+		props = &types.VPCPropertiesInnerRequest{Default: v.defaultVPC, Preset: v.preset}
 	}
 	return types.VPCRequest{
 		Metadata: types.RegionalResourceMetadataRequest{
@@ -175,7 +175,7 @@ func vpcDerefString(s *string) string {
 // *types.Response[T] preserves HTTP envelope details (status code, headers,
 // raw body) for the wrapper's diagnostics.
 type vpcLowLevelClient interface {
-	List(ctx context.Context, projectID string, params *types.RequestParameters) (*types.Response[types.VPCList], error)
+	List(ctx context.Context, projectID string, params *types.RequestParameters) (*types.Response[types.VPCListResponse], error)
 	Get(ctx context.Context, projectID, vpcID string, params *types.RequestParameters) (*types.Response[types.VPCResponse], error)
 	Create(ctx context.Context, projectID string, body types.VPCRequest, params *types.RequestParameters) (*types.Response[types.VPCResponse], error)
 	Update(ctx context.Context, projectID, vpcID string, body types.VPCRequest, params *types.RequestParameters) (*types.Response[types.VPCResponse], error)
@@ -362,7 +362,7 @@ func (a *vpcsClientAdapter) List(ctx context.Context, project Ref, opts ...CallO
 	}
 	var refetch func(ctx context.Context, pageURL string) (*List[*VPC], error)
 	refetch = func(ctx context.Context, pageURL string) (*List[*VPC], error) {
-		fetch := listPageFetch[types.VPCList](a.rest, opts)
+		fetch := listPageFetch[types.VPCListResponse](a.rest, opts)
 		pageResp, fetchErr := fetch(ctx, pageURL)
 		if fetchErr != nil {
 			return nil, fetchErr

--- a/pkg/aruba/resource_vpc_peering.go
+++ b/pkg/aruba/resource_vpc_peering.go
@@ -178,7 +178,7 @@ func vpcPeeringDerefString(s *string) string {
 // *types.Response[T] preserves HTTP envelope details (status code, headers,
 // raw body) for the wrapper's diagnostics.
 type vpcPeeringLowLevelClient interface {
-	List(ctx context.Context, projectID, vpcID string, params *types.RequestParameters) (*types.Response[types.VPCPeeringList], error)
+	List(ctx context.Context, projectID, vpcID string, params *types.RequestParameters) (*types.Response[types.VPCPeeringListResponse], error)
 	Get(ctx context.Context, projectID, vpcID, vpcPeeringID string, params *types.RequestParameters) (*types.Response[types.VPCPeeringResponse], error)
 	Create(ctx context.Context, projectID, vpcID string, body types.VPCPeeringRequest, params *types.RequestParameters) (*types.Response[types.VPCPeeringResponse], error)
 	Update(ctx context.Context, projectID, vpcID, vpcPeeringID string, body types.VPCPeeringRequest, params *types.RequestParameters) (*types.Response[types.VPCPeeringResponse], error)
@@ -375,7 +375,7 @@ func (a *vpcPeeringsClientAdapter) List(ctx context.Context, vpc Ref, opts ...Ca
 	}
 	var refetch func(ctx context.Context, pageURL string) (*List[*VPCPeering], error)
 	refetch = func(ctx context.Context, pageURL string) (*List[*VPCPeering], error) {
-		fetch := listPageFetch[types.VPCPeeringList](a.rest, opts)
+		fetch := listPageFetch[types.VPCPeeringListResponse](a.rest, opts)
 		pageResp, fetchErr := fetch(ctx, pageURL)
 		if fetchErr != nil {
 			return nil, fetchErr

--- a/pkg/aruba/resource_vpc_peering.go
+++ b/pkg/aruba/resource_vpc_peering.go
@@ -32,7 +32,7 @@ type VPCPeering struct {
 	linkedMixin
 	httpEnvelopeMixin
 
-	remoteVPC *types.ReferenceResource
+	remoteVPC *types.ReferenceResourceCommon
 	response  *types.VPCPeeringResponse
 }
 
@@ -82,7 +82,7 @@ func (p *VPCPeering) PeeredWith(v Ref) *VPCPeering {
 		p.addErr(fmt.Errorf("PeeredWith: remote VPC Ref has empty URI"))
 		return p
 	}
-	p.remoteVPC = &types.ReferenceResource{URI: uri}
+	p.remoteVPC = &types.ReferenceResourceCommon{URI: uri}
 	return p
 }
 
@@ -151,8 +151,8 @@ func (p *VPCPeering) fromResponse(resp *types.VPCPeeringResponse) {
 		p.remoteVPC = &rv
 	}
 
-	if resp.Metadata.ProjectResponseMetadata != nil && resp.Metadata.ProjectResponseMetadata.ID != "" {
-		p.projectID = resp.Metadata.ProjectResponseMetadata.ID
+	if resp.Metadata.ProjectMetadataResponse != nil && resp.Metadata.ProjectMetadataResponse.ID != "" {
+		p.projectID = resp.Metadata.ProjectMetadataResponse.ID
 	}
 	if (p.vpcID == "" || p.projectID == "") && p.RespURI() != "" {
 		ids := parseURIIDs(p.RespURI())

--- a/pkg/aruba/resource_vpc_peering_route.go
+++ b/pkg/aruba/resource_vpc_peering_route.go
@@ -213,7 +213,7 @@ func vpcPeeringRouteDerefString(p *string) string {
 // *types.Response[T] preserves HTTP envelope details (status code, headers,
 // raw body) for the wrapper's diagnostics.
 type vpcPeeringRouteLowLevelClient interface {
-	List(ctx context.Context, projectID, vpcID, vpcPeeringID string, params *types.RequestParameters) (*types.Response[types.VPCPeeringRouteList], error)
+	List(ctx context.Context, projectID, vpcID, vpcPeeringID string, params *types.RequestParameters) (*types.Response[types.VPCPeeringRouteListResponse], error)
 	Get(ctx context.Context, projectID, vpcID, vpcPeeringID, vpcPeeringRouteID string, params *types.RequestParameters) (*types.Response[types.VPCPeeringRouteResponse], error)
 	Create(ctx context.Context, projectID, vpcID, vpcPeeringID string, body types.VPCPeeringRouteRequest, params *types.RequestParameters) (*types.Response[types.VPCPeeringRouteResponse], error)
 	Update(ctx context.Context, projectID, vpcID, vpcPeeringID, vpcPeeringRouteID string, body types.VPCPeeringRouteRequest, params *types.RequestParameters) (*types.Response[types.VPCPeeringRouteResponse], error)
@@ -416,7 +416,7 @@ func (a *vpcPeeringRoutesClientAdapter) List(ctx context.Context, peering Ref, o
 	}
 	var refetch func(ctx context.Context, pageURL string) (*List[*VPCPeeringRoute], error)
 	refetch = func(ctx context.Context, pageURL string) (*List[*VPCPeeringRoute], error) {
-		fetch := listPageFetch[types.VPCPeeringRouteList](a.rest, opts)
+		fetch := listPageFetch[types.VPCPeeringRouteListResponse](a.rest, opts)
 		pageResp, fetchErr := fetch(ctx, pageURL)
 		if fetchErr != nil {
 			return nil, fetchErr

--- a/pkg/aruba/resource_vpc_peering_route.go
+++ b/pkg/aruba/resource_vpc_peering_route.go
@@ -138,7 +138,7 @@ func (r *VPCPeeringRoute) BillingPeriod() BillingPeriod {
 // toRequest assembles the Create/Update body from current setter state. Defaults are applied at the wire boundary.
 func (r *VPCPeeringRoute) toRequest() types.VPCPeeringRouteRequest {
 	props := types.VPCPeeringRoutePropertiesRequest{
-		BillingPlan: &types.BillingPlan{BillingPeriod: defaultBillingPeriod(r.billingPeriod)},
+		BillingPlanCommon: &types.BillingPlanCommon{BillingPeriod: defaultBillingPeriod(r.billingPeriod)},
 	}
 	if r.localCIDR != nil {
 		props.LocalNetworkAddress = *r.localCIDR
@@ -179,12 +179,12 @@ func (r *VPCPeeringRoute) fromResponse(resp *types.VPCPeeringRouteResponse) {
 		v := resp.Properties.RemoteNetworkAddress
 		r.remoteCIDR = &v
 	}
-	if resp.Properties.BillingPlan != nil && resp.Properties.BillingPlan.BillingPeriod != nil {
-		r.billingPeriod = resp.Properties.BillingPlan.BillingPeriod
+	if resp.Properties.BillingPlanCommon != nil && resp.Properties.BillingPlanCommon.BillingPeriod != nil {
+		r.billingPeriod = resp.Properties.BillingPlanCommon.BillingPeriod
 	}
 
-	if resp.Metadata.ProjectResponseMetadata != nil && resp.Metadata.ProjectResponseMetadata.ID != "" {
-		r.projectID = resp.Metadata.ProjectResponseMetadata.ID
+	if resp.Metadata.ProjectMetadataResponse != nil && resp.Metadata.ProjectMetadataResponse.ID != "" {
+		r.projectID = resp.Metadata.ProjectMetadataResponse.ID
 	}
 	if (r.vpcID == "" || r.projectID == "" || r.vpcPeeringID == "") && r.RespURI() != "" {
 		ids := parseURIIDs(r.RespURI())

--- a/pkg/aruba/resource_vpc_peering_route_test.go
+++ b/pkg/aruba/resource_vpc_peering_route_test.go
@@ -174,8 +174,8 @@ func TestVPCPeeringRoute_ToRequestRoundTrip(t *testing.T) {
 	if req.Properties.RemoteNetworkAddress != "192.168.0.0/24" {
 		t.Errorf("Properties.RemoteNetworkAddress = %q", req.Properties.RemoteNetworkAddress)
 	}
-	if req.Properties.BillingPlan == nil || req.Properties.BillingPlan.BillingPeriod == nil || *req.Properties.BillingPlan.BillingPeriod != BillingPeriodHour {
-		t.Errorf("Properties.BillingPlan.BillingPeriod = %v", req.Properties.BillingPlan)
+	if req.Properties.BillingPlanCommon == nil || req.Properties.BillingPlanCommon.BillingPeriod == nil || *req.Properties.BillingPlanCommon.BillingPeriod != BillingPeriodHour {
+		t.Errorf("Properties.BillingPlanCommon.BillingPeriod = %v", req.Properties.BillingPlanCommon)
 	}
 
 	// Unset CIDRs must produce empty strings.
@@ -191,16 +191,16 @@ func TestVPCPeeringRoute_ToRequestRoundTrip(t *testing.T) {
 }
 
 // --------------------------------------------------------------------------
-// BillingPlan always emitted (value type, no omitempty)
+// BillingPlanCommon always emitted (value type, no omitempty)
 // --------------------------------------------------------------------------
 
 func TestVPCPeeringRoute_ToRequest_BillingPeriodAlwaysEmitted(t *testing.T) {
 	r := NewVPCPeeringRoute().
 		Named("bare")
 	req := r.RawRequest()
-	// BillingPlan is always emitted — defaults to Hour when not explicitly set.
-	if req.Properties.BillingPlan == nil || req.Properties.BillingPlan.BillingPeriod == nil || *req.Properties.BillingPlan.BillingPeriod != BillingPeriodHour {
-		t.Errorf("BillingPlan.BillingPeriod should default to Hour when not set, got %v", req.Properties.BillingPlan)
+	// BillingPlanCommon is always emitted — defaults to Hour when not explicitly set.
+	if req.Properties.BillingPlanCommon == nil || req.Properties.BillingPlanCommon.BillingPeriod == nil || *req.Properties.BillingPlanCommon.BillingPeriod != BillingPeriodHour {
+		t.Errorf("BillingPlanCommon.BillingPeriod should default to Hour when not set, got %v", req.Properties.BillingPlanCommon)
 	}
 }
 
@@ -218,19 +218,19 @@ func vpcPeeringRouteTestResponse(id, name, uri, projectID string) *types.VPCPeer
 			Name:             &name,
 			Tags:             []string{"route-tag"},
 			LocationResponse: loc,
-			ProjectResponseMetadata: &types.ProjectResponseMetadata{
+			ProjectMetadataResponse: &types.ProjectMetadataResponse{
 				ID: projectID,
 			},
 		},
 		Properties: types.VPCPeeringRoutePropertiesResponse{
 			LocalNetworkAddress:  "10.0.0.0/24",
 			RemoteNetworkAddress: "192.168.0.0/24",
-			BillingPlan: func() *types.BillingPlan {
+			BillingPlanCommon: func() *types.BillingPlanCommon {
 				v := BillingPeriodHour
-				return &types.BillingPlan{BillingPeriod: &v}
+				return &types.BillingPlanCommon{BillingPeriod: &v}
 			}(),
 		},
-		Status: types.ResourceStatus{
+		Status: types.ResourceStatusResponse{
 			State: &state,
 		},
 	}
@@ -317,7 +317,7 @@ func TestVPCPeeringRoute_FromResponseURIBackfill_HyphenForm(t *testing.T) {
 			ID:   &id,
 			URI:  &uri,
 			Name: &name,
-			// ProjectResponseMetadata intentionally nil
+			// ProjectMetadataResponse intentionally nil
 		},
 	}
 	r := &VPCPeeringRoute{}
@@ -499,8 +499,8 @@ func TestVPCPeeringRoutesClientAdapter_Create_Success(t *testing.T) {
 	if gotBody.Properties.LocalNetworkAddress != "10.0.0.0/24" {
 		t.Errorf("request LocalNetworkAddress = %q", gotBody.Properties.LocalNetworkAddress)
 	}
-	if gotBody.Properties.BillingPlan == nil || gotBody.Properties.BillingPlan.BillingPeriod == nil || *gotBody.Properties.BillingPlan.BillingPeriod != BillingPeriodHour {
-		t.Errorf("request BillingPlan.BillingPeriod = %v", gotBody.Properties.BillingPlan)
+	if gotBody.Properties.BillingPlanCommon == nil || gotBody.Properties.BillingPlanCommon.BillingPeriod == nil || *gotBody.Properties.BillingPlanCommon.BillingPeriod != BillingPeriodHour {
+		t.Errorf("request BillingPlanCommon.BillingPeriod = %v", gotBody.Properties.BillingPlanCommon)
 	}
 }
 
@@ -1053,7 +1053,7 @@ func TestVPCPeeringRoute_FromResponse_SetsStatus(t *testing.T) {
 	r := &VPCPeeringRoute{}
 	state := types.State("Active")
 	r.fromResponse(&types.VPCPeeringRouteResponse{
-		Status: types.ResourceStatus{State: &state},
+		Status: types.ResourceStatusResponse{State: &state},
 	})
 	if r.State() != types.StateActive {
 		t.Errorf("State() = %q after fromResponse, want Active", r.State())

--- a/pkg/aruba/resource_vpc_peering_test.go
+++ b/pkg/aruba/resource_vpc_peering_test.go
@@ -213,17 +213,17 @@ func vpcPeeringTestResponse(id, name, uri, projectID string) *types.VPCPeeringRe
 			Name:             &name,
 			Tags:             []string{"peer-tag"},
 			LocationResponse: loc,
-			ProjectResponseMetadata: &types.ProjectResponseMetadata{
+			ProjectMetadataResponse: &types.ProjectMetadataResponse{
 				ID: projectID,
 			},
 		},
 		Properties: types.VPCPeeringPropertiesResponse{
-			LinkedResources: []types.LinkedResource{
+			LinkedResources: []types.LinkedResourceCommon{
 				{URI: "/projects/p/providers/Aruba.Compute/cloudservers/cs1"},
 			},
-			RemoteVPC: &types.ReferenceResource{URI: remoteURI},
+			RemoteVPC: &types.ReferenceResourceCommon{URI: remoteURI},
 		},
-		Status: types.ResourceStatus{
+		Status: types.ResourceStatusResponse{
 			State: &state,
 		},
 	}
@@ -304,7 +304,7 @@ func TestVPCPeering_FromResponseURIBackfill(t *testing.T) {
 			ID:   &id,
 			URI:  &uri,
 			Name: &name,
-			// ProjectResponseMetadata intentionally nil
+			// ProjectMetadataResponse intentionally nil
 		},
 	}
 	p := &VPCPeering{}
@@ -983,7 +983,7 @@ func TestVPCPeering_FromResponse_SetsStatus(t *testing.T) {
 	p := &VPCPeering{}
 	state := types.State("Active")
 	p.fromResponse(&types.VPCPeeringResponse{
-		Status: types.ResourceStatus{State: &state},
+		Status: types.ResourceStatusResponse{State: &state},
 	})
 	if p.State() != types.StateActive {
 		t.Errorf("State() = %q after fromResponse, want Active", p.State())

--- a/pkg/aruba/resource_vpc_test.go
+++ b/pkg/aruba/resource_vpc_test.go
@@ -142,19 +142,19 @@ func vpcTestResponse(id, name, uri, projectID string) *types.VPCResponse {
 			Name:             &name,
 			Tags:             []string{"tag1"},
 			LocationResponse: loc,
-			ProjectResponseMetadata: &types.ProjectResponseMetadata{
+			ProjectMetadataResponse: &types.ProjectMetadataResponse{
 				ID: projectID,
 			},
 		},
 		Properties: types.VPCPropertiesResponse{
 			Default: true,
-			LinkedResources: []types.LinkedResource{
+			LinkedResources: []types.LinkedResourceCommon{
 				{URI: "/projects/p/network/vpcs/v/subnets/s1", StrictCorrelation: true},
 			},
 		},
-		Status: types.ResourceStatus{
+		Status: types.ResourceStatusResponse{
 			State: &state,
-			DisableStatusInfo: &types.DisableStatusInfo{
+			DisableStatusInfoResponse: &types.DisableStatusInfoResponse{
 				IsDisabled: false,
 			},
 		},
@@ -835,7 +835,7 @@ func TestVPC_FromResponse_SetsStatus(t *testing.T) {
 	v := &VPC{}
 	state := types.State("Active")
 	v.fromResponse(&types.VPCResponse{
-		Status: types.ResourceStatus{State: &state},
+		Status: types.ResourceStatusResponse{State: &state},
 	})
 	if v.State() != types.StateActive {
 		t.Errorf("State() = %q after fromResponse, want Active", v.State())

--- a/pkg/aruba/resource_vpn_esp.go
+++ b/pkg/aruba/resource_vpn_esp.go
@@ -4,7 +4,7 @@ import "github.com/Arubacloud/sdk-go/pkg/types"
 
 // ---- Sub-builder ----
 
-// VPNESP is a fluent builder for the ESPSettings block of a VPNTunnel.
+// VPNESP is a fluent builder for the ESPSettingsCommon block of a VPNTunnel.
 // Construct with NewVPNESP() and attach via VPNTunnel.WithESPSettings.
 type VPNESP struct {
 	errMixin
@@ -29,11 +29,11 @@ func (e *VPNESP) WithHash(v ESPHash) *VPNESP { e.hash = &v; return e }
 // WithPFS sets the Perfect Forward Secrecy group for ESP.
 func (e *VPNESP) WithPFS(v ESPPFSGroup) *VPNESP { e.pfs = &v; return e }
 
-func (e *VPNESP) build() *types.ESPSettings {
+func (e *VPNESP) build() *types.ESPSettingsCommon {
 	if e == nil {
 		return nil
 	}
-	return &types.ESPSettings{
+	return &types.ESPSettingsCommon{
 		Lifetime:   e.lifetime,
 		Encryption: e.encryption,
 		Hash:       e.hash,

--- a/pkg/aruba/resource_vpn_ike.go
+++ b/pkg/aruba/resource_vpn_ike.go
@@ -4,7 +4,7 @@ import "github.com/Arubacloud/sdk-go/pkg/types"
 
 // ---- Sub-builder ----
 
-// VPNIKE is a fluent builder for the IKESettings block of a VPNTunnel.
+// VPNIKE is a fluent builder for the IKESettingsCommon block of a VPNTunnel.
 // Construct with NewVPNIKE() and attach via VPNTunnel.WithIKESettings.
 type VPNIKE struct {
 	errMixin
@@ -41,11 +41,11 @@ func (k *VPNIKE) WithDPDIntervalSeconds(s int) *VPNIKE { k.dpdInterval = int32(s
 // WithDPDTimeoutSeconds sets the DPD timeout in seconds.
 func (k *VPNIKE) WithDPDTimeoutSeconds(s int) *VPNIKE { k.dpdTimeout = int32(s); return k }
 
-func (k *VPNIKE) build() *types.IKESettings {
+func (k *VPNIKE) build() *types.IKESettingsCommon {
 	if k == nil {
 		return nil
 	}
-	return &types.IKESettings{
+	return &types.IKESettingsCommon{
 		Lifetime:    k.lifetime,
 		Encryption:  k.encryption,
 		Hash:        k.hash,

--- a/pkg/aruba/resource_vpn_ipconfig.go
+++ b/pkg/aruba/resource_vpn_ipconfig.go
@@ -8,7 +8,7 @@ import (
 
 // ---- Sub-builder ----
 
-// VPNIPConfig is a fluent builder for the IPConfigurations block of a VPNTunnel.
+// VPNIPConfig is a fluent builder for the IPConfigurationsCommon block of a VPNTunnel.
 // Construct with NewVPNIPConfig() and attach via VPNTunnel.WithIPConfig.
 type VPNIPConfig struct {
 	errMixin
@@ -48,13 +48,13 @@ func (c *VPNIPConfig) WithSubnet(name, cidr string) *VPNIPConfig {
 	return c
 }
 
-func (c *VPNIPConfig) build() *types.IPConfigurations {
+func (c *VPNIPConfig) build() *types.IPConfigurationsCommon {
 	if c == nil {
 		return nil
 	}
-	out := &types.IPConfigurations{VPC: c.vpc, PublicIP: c.publicIP}
+	out := &types.IPConfigurationsCommon{VPC: c.vpc, PublicIP: c.publicIP}
 	if c.hasSubnet {
-		out.Subnet = &types.SubnetInfo{Name: c.subnetName, CIDR: c.subnetCIDR}
+		out.Subnet = &types.SubnetInfoCommon{Name: c.subnetName, CIDR: c.subnetCIDR}
 	}
 	return out
 }

--- a/pkg/aruba/resource_vpn_ipconfig.go
+++ b/pkg/aruba/resource_vpn_ipconfig.go
@@ -12,8 +12,8 @@ import (
 // Construct with NewVPNIPConfig() and attach via VPNTunnel.WithIPConfig.
 type VPNIPConfig struct {
 	errMixin
-	vpc        *types.ReferenceResource
-	publicIP   *types.ReferenceResource
+	vpc        *types.ReferenceResourceCommon
+	publicIP   *types.ReferenceResourceCommon
 	subnetName string
 	subnetCIDR string
 	hasSubnet  bool
@@ -28,7 +28,7 @@ func (c *VPNIPConfig) WithVPC(v Ref) *VPNIPConfig {
 		c.addErr(fmt.Errorf("WithVPC: VPC Ref has empty URI"))
 		return c
 	}
-	c.vpc = &types.ReferenceResource{URI: v.URI()}
+	c.vpc = &types.ReferenceResourceCommon{URI: v.URI()}
 	return c
 }
 
@@ -38,7 +38,7 @@ func (c *VPNIPConfig) WithElasticIP(v Ref) *VPNIPConfig {
 		c.addErr(fmt.Errorf("WithElasticIP: PublicIP Ref has empty URI"))
 		return c
 	}
-	c.publicIP = &types.ReferenceResource{URI: v.URI()}
+	c.publicIP = &types.ReferenceResourceCommon{URI: v.URI()}
 	return c
 }
 

--- a/pkg/aruba/resource_vpn_psk.go
+++ b/pkg/aruba/resource_vpn_psk.go
@@ -4,7 +4,7 @@ import "github.com/Arubacloud/sdk-go/pkg/types"
 
 // ---- Sub-builder ----
 
-// VPNPSK is a fluent builder for the PSKSettings block of a VPNTunnel.
+// VPNPSK is a fluent builder for the PSKSettingsCommon block of a VPNTunnel.
 // Construct with NewVPNPSK() and attach via VPNTunnel.WithPSKSettings.
 type VPNPSK struct {
 	errMixin
@@ -25,11 +25,11 @@ func (p *VPNPSK) WithOnPremSite(v string) *VPNPSK { p.onPremSite = &v; return p 
 // WithKey sets the pre-shared secret key.
 func (p *VPNPSK) WithKey(v string) *VPNPSK { p.secret = &v; return p }
 
-func (p *VPNPSK) build() *types.PSKSettings {
+func (p *VPNPSK) build() *types.PSKSettingsCommon {
 	if p == nil {
 		return nil
 	}
-	return &types.PSKSettings{
+	return &types.PSKSettingsCommon{
 		CloudSite:  p.cloudSite,
 		OnPremSite: p.onPremSite,
 		Secret:     p.secret,

--- a/pkg/aruba/resource_vpn_route.go
+++ b/pkg/aruba/resource_vpn_route.go
@@ -189,7 +189,7 @@ func vpnRouteDerefString(p *string) string {
 // *types.Response[T] preserves HTTP envelope details (status code, headers,
 // raw body) for the wrapper's diagnostics.
 type vpnRouteLowLevelClient interface {
-	List(ctx context.Context, projectID, vpnTunnelID string, params *types.RequestParameters) (*types.Response[types.VPNRouteList], error)
+	List(ctx context.Context, projectID, vpnTunnelID string, params *types.RequestParameters) (*types.Response[types.VPNRouteListResponse], error)
 	Get(ctx context.Context, projectID, vpnTunnelID, vpnRouteID string, params *types.RequestParameters) (*types.Response[types.VPNRouteResponse], error)
 	Create(ctx context.Context, projectID, vpnTunnelID string, body types.VPNRouteRequest, params *types.RequestParameters) (*types.Response[types.VPNRouteResponse], error)
 	Update(ctx context.Context, projectID, vpnTunnelID, vpnRouteID string, body types.VPNRouteRequest, params *types.RequestParameters) (*types.Response[types.VPNRouteResponse], error)
@@ -386,7 +386,7 @@ func (a *vpnRoutesClientAdapter) List(ctx context.Context, tunnel Ref, opts ...C
 	}
 	var refetch func(ctx context.Context, pageURL string) (*List[*VPNRoute], error)
 	refetch = func(ctx context.Context, pageURL string) (*List[*VPNRoute], error) {
-		fetch := listPageFetch[types.VPNRouteList](a.rest, opts)
+		fetch := listPageFetch[types.VPNRouteListResponse](a.rest, opts)
 		pageResp, fetchErr := fetch(ctx, pageURL)
 		if fetchErr != nil {
 			return nil, fetchErr

--- a/pkg/aruba/resource_vpn_route.go
+++ b/pkg/aruba/resource_vpn_route.go
@@ -101,6 +101,20 @@ func (r *VPNRoute) RawRequest() types.VPNRouteRequest { return r.toRequest() }
 // CloudSubnet returns the configured cloud subnet CIDR ("" if unset).
 func (r *VPNRoute) CloudSubnet() string { return vpnRouteDerefString(r.cloudSubnet) }
 
+// CloudSubnetCIDR is an alias for CloudSubnet — returns the cloud-side subnet CIDR ("" if unset).
+func (r *VPNRoute) CloudSubnetCIDR() string { return r.CloudSubnet() }
+
+// VPNTunnelURI returns the URI of the parent VPN tunnel from the response, or "" if absent.
+func (r *VPNRoute) VPNTunnelURI() string {
+	if r.response == nil {
+		return ""
+	}
+	if r.response.Properties.VPNTunnel == nil {
+		return ""
+	}
+	return r.response.Properties.VPNTunnel.URI
+}
+
 // OnPremSubnet returns the configured on-premises subnet CIDR ("" if unset).
 func (r *VPNRoute) OnPremSubnet() string { return vpnRouteDerefString(r.onPremSubnet) }
 

--- a/pkg/aruba/resource_vpn_route.go
+++ b/pkg/aruba/resource_vpn_route.go
@@ -162,8 +162,8 @@ func (r *VPNRoute) fromResponse(resp *types.VPNRouteResponse) {
 		v := resp.Properties.OnPremSubnet
 		r.onPremSubnet = &v
 	}
-	if resp.Metadata.ProjectResponseMetadata != nil && resp.Metadata.ProjectResponseMetadata.ID != "" {
-		r.projectID = resp.Metadata.ProjectResponseMetadata.ID
+	if resp.Metadata.ProjectMetadataResponse != nil && resp.Metadata.ProjectMetadataResponse.ID != "" {
+		r.projectID = resp.Metadata.ProjectMetadataResponse.ID
 	}
 	if (r.projectID == "" || r.vpnTunnelID == "") && r.RespURI() != "" {
 		ids := parseURIIDs(r.RespURI())

--- a/pkg/aruba/resource_vpn_route_test.go
+++ b/pkg/aruba/resource_vpn_route_test.go
@@ -1054,3 +1054,49 @@ func TestVPNRouteRef(t *testing.T) {
 		t.Errorf("parseURIIDs = %v", ids)
 	}
 }
+
+// --------------------------------------------------------------------------
+// VPNTunnelURI and CloudSubnetCIDR getters
+// --------------------------------------------------------------------------
+
+func TestVPNRoute_VPNTunnelURI_NilResponse(t *testing.T) {
+	r := &VPNRoute{}
+	if got := r.VPNTunnelURI(); got != "" {
+		t.Errorf("VPNTunnelURI() on nil response = %q, want \"\"", got)
+	}
+}
+
+func TestVPNRoute_VPNTunnelURI_NilTunnel(t *testing.T) {
+	r := &VPNRoute{}
+	r.response = &types.VPNRouteResponse{}
+	if got := r.VPNTunnelURI(); got != "" {
+		t.Errorf("VPNTunnelURI() with nil VPNTunnel = %q, want \"\"", got)
+	}
+}
+
+func TestVPNRoute_VPNTunnelURI_Populated(t *testing.T) {
+	tunnelURI := "/projects/p/providers/Aruba.Network/vpnTunnels/t-1"
+	r := &VPNRoute{}
+	r.response = &types.VPNRouteResponse{
+		Properties: types.VPNRoutePropertiesResponse{
+			VPNTunnel: &types.ReferenceResource{URI: tunnelURI},
+		},
+	}
+	if got := r.VPNTunnelURI(); got != tunnelURI {
+		t.Errorf("VPNTunnelURI() = %q, want %q", got, tunnelURI)
+	}
+}
+
+func TestVPNRoute_CloudSubnetCIDR_Alias(t *testing.T) {
+	r := NewVPNRoute().WithCloudSubnet("10.1.2.0/24")
+	if got := r.CloudSubnetCIDR(); got != "10.1.2.0/24" {
+		t.Errorf("CloudSubnetCIDR() = %q, want %q", got, "10.1.2.0/24")
+	}
+}
+
+func TestVPNRoute_CloudSubnetCIDR_NilResponse(t *testing.T) {
+	r := &VPNRoute{}
+	if got := r.CloudSubnetCIDR(); got != "" {
+		t.Errorf("CloudSubnetCIDR() on nil = %q, want \"\"", got)
+	}
+}

--- a/pkg/aruba/resource_vpn_route_test.go
+++ b/pkg/aruba/resource_vpn_route_test.go
@@ -232,18 +232,18 @@ func vpnRouteTestResponse(id, name, uri, projectID string) *types.VPNRouteRespon
 			Name:             &name,
 			Tags:             []string{"route-tag"},
 			LocationResponse: loc,
-			ProjectResponseMetadata: &types.ProjectResponseMetadata{
+			ProjectMetadataResponse: &types.ProjectMetadataResponse{
 				ID: projectID,
 			},
 		},
 		Properties: types.VPNRoutePropertiesResponse{
 			CloudSubnet:  types.SubnetCIDROrRef{CIDR: cloud},
 			OnPremSubnet: onPrem,
-			LinkedResources: []types.LinkedResource{
+			LinkedResources: []types.LinkedResourceCommon{
 				{URI: "/projects/p/providers/Aruba.Network/vpnTunnels/t-1"},
 			},
 		},
-		Status: types.ResourceStatus{State: &state},
+		Status: types.ResourceStatusResponse{State: &state},
 	}
 }
 
@@ -320,7 +320,7 @@ func TestVPNRoute_FromResponseURIBackfill_CamelCase(t *testing.T) {
 			ID:   &id,
 			URI:  &uri,
 			Name: &name,
-			// ProjectResponseMetadata intentionally nil
+			// ProjectMetadataResponse intentionally nil
 		},
 	}
 	r := &VPNRoute{}
@@ -977,7 +977,7 @@ func TestVPNRoute_FromResponse_SetsStatus(t *testing.T) {
 	r := &VPNRoute{}
 	state := types.State("Active")
 	r.fromResponse(&types.VPNRouteResponse{
-		Status: types.ResourceStatus{State: &state},
+		Status: types.ResourceStatusResponse{State: &state},
 	})
 	if r.State() != types.StateActive {
 		t.Errorf("State() = %q after fromResponse, want Active", r.State())
@@ -1079,7 +1079,7 @@ func TestVPNRoute_VPNTunnelURI_Populated(t *testing.T) {
 	r := &VPNRoute{}
 	r.response = &types.VPNRouteResponse{
 		Properties: types.VPNRoutePropertiesResponse{
-			VPNTunnel: &types.ReferenceResource{URI: tunnelURI},
+			VPNTunnel: &types.ReferenceResourceCommon{URI: tunnelURI},
 		},
 	}
 	if got := r.VPNTunnelURI(); got != tunnelURI {

--- a/pkg/aruba/resource_vpn_tunnel.go
+++ b/pkg/aruba/resource_vpn_tunnel.go
@@ -202,6 +202,15 @@ func (t *VPNTunnel) BillingPeriod() BillingPeriod {
 // PeerClientPublicIP returns the peer client public IP address, or "" if unset.
 func (t *VPNTunnel) PeerClientPublicIP() string { return vpnTunnelDerefString(t.peerClientPublicIP) }
 
+// RoutesNumber returns the number of valid VPN routes associated with this tunnel,
+// as reported by the last server response. Returns 0 before any response.
+func (t *VPNTunnel) RoutesNumber() int32 {
+	if t.response == nil {
+		return 0
+	}
+	return t.response.Properties.RoutesNumber
+}
+
 // Wire converters
 
 // toRequest assembles the Create/Update body from current setter state. Defaults are applied at the wire boundary.
@@ -263,9 +272,49 @@ func (t *VPNTunnel) fromResponse(resp *types.VPNTunnelResponse) {
 	if resp.Properties.BillingPlan != nil && resp.Properties.BillingPlan.BillingPeriod != nil {
 		t.billingPeriod = resp.Properties.BillingPlan.BillingPeriod
 	}
-	if cs := resp.Properties.VPNClientSettings; cs != nil && cs.PeerClientPublicIP != nil {
-		v := *cs.PeerClientPublicIP
-		t.peerClientPublicIP = &v
+	if cs := resp.Properties.VPNClientSettings; cs != nil {
+		if cs.PeerClientPublicIP != nil {
+			v := *cs.PeerClientPublicIP
+			t.peerClientPublicIP = &v
+		}
+		if cs.IKE != nil {
+			k := &VPNIKE{
+				lifetime:    cs.IKE.Lifetime,
+				encryption:  cs.IKE.Encryption,
+				hash:        cs.IKE.Hash,
+				dhGroup:     cs.IKE.DHGroup,
+				dpdAction:   cs.IKE.DPDAction,
+				dpdInterval: cs.IKE.DPDInterval,
+				dpdTimeout:  cs.IKE.DPDTimeout,
+			}
+			t.ike = k
+		}
+		if cs.ESP != nil {
+			e := &VPNESP{
+				lifetime:   cs.ESP.Lifetime,
+				encryption: cs.ESP.Encryption,
+				hash:       cs.ESP.Hash,
+				pfs:        cs.ESP.PFS,
+			}
+			t.esp = e
+		}
+		if cs.PSK != nil {
+			p := &VPNPSK{
+				cloudSite:  cs.PSK.CloudSite,
+				onPremSite: cs.PSK.OnPremSite,
+				secret:     cs.PSK.Secret,
+			}
+			t.psk = p
+		}
+	}
+	if ipc := resp.Properties.IPConfigurations; ipc != nil {
+		c := &VPNIPConfig{vpc: ipc.VPC, publicIP: ipc.PublicIP}
+		if ipc.Subnet != nil {
+			c.subnetName = ipc.Subnet.Name
+			c.subnetCIDR = ipc.Subnet.CIDR
+			c.hasSubnet = true
+		}
+		t.ipConfig = c
 	}
 
 	if resp.Metadata.ProjectResponseMetadata != nil && resp.Metadata.ProjectResponseMetadata.ID != "" {

--- a/pkg/aruba/resource_vpn_tunnel.go
+++ b/pkg/aruba/resource_vpn_tunnel.go
@@ -220,10 +220,10 @@ func (t *VPNTunnel) toRequest() types.VPNTunnelRequest {
 		VPNClientProtocol: t.vpnClientProtocol,
 	}
 	if t.ipConfig != nil {
-		props.IPConfigurations = t.ipConfig.build()
+		props.IPConfigurationsCommon = t.ipConfig.build()
 	}
 	if t.ike != nil || t.esp != nil || t.psk != nil || t.peerClientPublicIP != nil {
-		cs := &types.VPNClientSettings{PeerClientPublicIP: t.peerClientPublicIP}
+		cs := &types.VPNClientSettingsCommon{PeerClientPublicIP: t.peerClientPublicIP}
 		if t.ike != nil {
 			cs.IKE = t.ike.build()
 		}
@@ -233,7 +233,7 @@ func (t *VPNTunnel) toRequest() types.VPNTunnelRequest {
 		if t.psk != nil {
 			cs.PSK = t.psk.build()
 		}
-		props.VPNClientSettings = cs
+		props.VPNClientSettingsCommon = cs
 	}
 	props.BillingPlan = &types.BillingPlan{BillingPeriod: defaultBillingPeriod(t.billingPeriod)}
 	return types.VPNTunnelRequest{
@@ -272,7 +272,7 @@ func (t *VPNTunnel) fromResponse(resp *types.VPNTunnelResponse) {
 	if resp.Properties.BillingPlan != nil && resp.Properties.BillingPlan.BillingPeriod != nil {
 		t.billingPeriod = resp.Properties.BillingPlan.BillingPeriod
 	}
-	if cs := resp.Properties.VPNClientSettings; cs != nil {
+	if cs := resp.Properties.VPNClientSettingsCommon; cs != nil {
 		if cs.PeerClientPublicIP != nil {
 			v := *cs.PeerClientPublicIP
 			t.peerClientPublicIP = &v
@@ -307,7 +307,7 @@ func (t *VPNTunnel) fromResponse(resp *types.VPNTunnelResponse) {
 			t.psk = p
 		}
 	}
-	if ipc := resp.Properties.IPConfigurations; ipc != nil {
+	if ipc := resp.Properties.IPConfigurationsCommon; ipc != nil {
 		c := &VPNIPConfig{vpc: ipc.VPC, publicIP: ipc.PublicIP}
 		if ipc.Subnet != nil {
 			c.subnetName = ipc.Subnet.Name
@@ -340,7 +340,7 @@ func vpnTunnelDerefString(p *string) string {
 // *types.Response[T] preserves HTTP envelope details (status code, headers,
 // raw body) for the wrapper's diagnostics.
 type vpnTunnelLowLevelClient interface {
-	List(ctx context.Context, projectID string, params *types.RequestParameters) (*types.Response[types.VPNTunnelList], error)
+	List(ctx context.Context, projectID string, params *types.RequestParameters) (*types.Response[types.VPNTunnelListResponse], error)
 	Get(ctx context.Context, projectID, vpnTunnelID string, params *types.RequestParameters) (*types.Response[types.VPNTunnelResponse], error)
 	Create(ctx context.Context, projectID string, body types.VPNTunnelRequest, params *types.RequestParameters) (*types.Response[types.VPNTunnelResponse], error)
 	Update(ctx context.Context, projectID, vpnTunnelID string, body types.VPNTunnelRequest, params *types.RequestParameters) (*types.Response[types.VPNTunnelResponse], error)
@@ -531,7 +531,7 @@ func (a *vpnTunnelsClientAdapter) List(ctx context.Context, project Ref, opts ..
 	}
 	var refetch func(ctx context.Context, pageURL string) (*List[*VPNTunnel], error)
 	refetch = func(ctx context.Context, pageURL string) (*List[*VPNTunnel], error) {
-		fetch := listPageFetch[types.VPNTunnelList](a.rest, opts)
+		fetch := listPageFetch[types.VPNTunnelListResponse](a.rest, opts)
 		pageResp, fetchErr := fetch(ctx, pageURL)
 		if fetchErr != nil {
 			return nil, fetchErr

--- a/pkg/aruba/resource_vpn_tunnel.go
+++ b/pkg/aruba/resource_vpn_tunnel.go
@@ -235,7 +235,7 @@ func (t *VPNTunnel) toRequest() types.VPNTunnelRequest {
 		}
 		props.VPNClientSettingsCommon = cs
 	}
-	props.BillingPlan = &types.BillingPlan{BillingPeriod: defaultBillingPeriod(t.billingPeriod)}
+	props.BillingPlanCommon = &types.BillingPlanCommon{BillingPeriod: defaultBillingPeriod(t.billingPeriod)}
 	return types.VPNTunnelRequest{
 		Metadata: types.RegionalResourceMetadataRequest{
 			ResourceMetadataRequest: t.toMetadata(),
@@ -269,8 +269,8 @@ func (t *VPNTunnel) fromResponse(resp *types.VPNTunnelResponse) {
 		p := *resp.Properties.VPNClientProtocol
 		t.vpnClientProtocol = &p
 	}
-	if resp.Properties.BillingPlan != nil && resp.Properties.BillingPlan.BillingPeriod != nil {
-		t.billingPeriod = resp.Properties.BillingPlan.BillingPeriod
+	if resp.Properties.BillingPlanCommon != nil && resp.Properties.BillingPlanCommon.BillingPeriod != nil {
+		t.billingPeriod = resp.Properties.BillingPlanCommon.BillingPeriod
 	}
 	if cs := resp.Properties.VPNClientSettingsCommon; cs != nil {
 		if cs.PeerClientPublicIP != nil {
@@ -317,8 +317,8 @@ func (t *VPNTunnel) fromResponse(resp *types.VPNTunnelResponse) {
 		t.ipConfig = c
 	}
 
-	if resp.Metadata.ProjectResponseMetadata != nil && resp.Metadata.ProjectResponseMetadata.ID != "" {
-		t.projectID = resp.Metadata.ProjectResponseMetadata.ID
+	if resp.Metadata.ProjectMetadataResponse != nil && resp.Metadata.ProjectMetadataResponse.ID != "" {
+		t.projectID = resp.Metadata.ProjectMetadataResponse.ID
 	}
 	if t.projectID == "" && t.RespURI() != "" {
 		if id := parseURIIDs(t.RespURI())["projects"]; id != "" {

--- a/pkg/aruba/resource_vpn_tunnel_test.go
+++ b/pkg/aruba/resource_vpn_tunnel_test.go
@@ -1346,3 +1346,119 @@ func TestVPNTunnelRef(t *testing.T) {
 		t.Errorf("parseURIIDs = %v", ids)
 	}
 }
+
+// --------------------------------------------------------------------------
+// fromResponse — rehydration of IKE/ESP/PSK/IPConfig sub-builders + RoutesNumber
+// --------------------------------------------------------------------------
+
+func TestVPNTunnel_FromResponse_RehydratesSubBuilders(t *testing.T) {
+	enc := IKEEncryption("AES256")
+	hash := IKEHash("SHA256")
+	dhGrp := IKEDHGroup("MODP2048")
+	dpdAct := IKEDPDAction("restart")
+	espEnc := ESPEncryption("AES256")
+	espHash := ESPHash("SHA256")
+	espPFS := ESPPFSGroup("MODP2048")
+	cloudSite := "cloud-site"
+	onPremSite := "on-prem"
+	secret := "s3cr3t"
+	peerIP := "1.2.3.4"
+	vpcURI := "/vpcs/v-1"
+	pubIPURI := "/eips/eip-1"
+
+	resp := &types.VPNTunnelResponse{
+		Properties: types.VPNTunnelPropertiesResponse{
+			RoutesNumber: 3,
+			VPNClientSettings: &types.VPNClientSettings{
+				PeerClientPublicIP: &peerIP,
+				IKE: &types.IKESettings{
+					Lifetime:    3600,
+					Encryption:  &enc,
+					Hash:        &hash,
+					DHGroup:     &dhGrp,
+					DPDAction:   &dpdAct,
+					DPDInterval: 30,
+					DPDTimeout:  120,
+				},
+				ESP: &types.ESPSettings{
+					Lifetime:   1800,
+					Encryption: &espEnc,
+					Hash:       &espHash,
+					PFS:        &espPFS,
+				},
+				PSK: &types.PSKSettings{
+					CloudSite:  &cloudSite,
+					OnPremSite: &onPremSite,
+					Secret:     &secret,
+				},
+			},
+			IPConfigurations: &types.IPConfigurations{
+				VPC:      &types.ReferenceResource{URI: vpcURI},
+				PublicIP: &types.ReferenceResource{URI: pubIPURI},
+				Subnet:   &types.SubnetInfo{Name: "sn-1", CIDR: "10.0.0.0/24"},
+			},
+		},
+	}
+
+	tun := &VPNTunnel{}
+	tun.fromResponse(resp)
+
+	if tun.RoutesNumber() != 3 {
+		t.Errorf("RoutesNumber() = %d, want 3", tun.RoutesNumber())
+	}
+	if tun.PeerClientPublicIP() != peerIP {
+		t.Errorf("PeerClientPublicIP() = %q", tun.PeerClientPublicIP())
+	}
+	if tun.IKE() == nil {
+		t.Fatal("IKE() is nil after rehydration")
+	}
+	if tun.IKE().lifetime != 3600 {
+		t.Errorf("IKE.lifetime = %d", tun.IKE().lifetime)
+	}
+	if tun.ESP() == nil {
+		t.Fatal("ESP() is nil after rehydration")
+	}
+	if tun.ESP().lifetime != 1800 {
+		t.Errorf("ESP.lifetime = %d", tun.ESP().lifetime)
+	}
+	if tun.PSK() == nil {
+		t.Fatal("PSK() is nil after rehydration")
+	}
+	if tun.PSK().cloudSite == nil || *tun.PSK().cloudSite != cloudSite {
+		t.Errorf("PSK.cloudSite = %v", tun.PSK().cloudSite)
+	}
+	if tun.IPConfig() == nil {
+		t.Fatal("IPConfig() is nil after rehydration")
+	}
+	if tun.IPConfig().vpc == nil || tun.IPConfig().vpc.URI != vpcURI {
+		t.Errorf("IPConfig.vpc = %v", tun.IPConfig().vpc)
+	}
+	if tun.IPConfig().subnetCIDR != "10.0.0.0/24" {
+		t.Errorf("IPConfig.subnetCIDR = %q", tun.IPConfig().subnetCIDR)
+	}
+
+	// Round-trip: toRequest must emit the same VPNClientSettings shape.
+	req := tun.toRequest()
+	if req.Properties.VPNClientSettings == nil {
+		t.Fatal("toRequest().Properties.VPNClientSettings is nil after rehydration")
+	}
+	if req.Properties.VPNClientSettings.IKE == nil || req.Properties.VPNClientSettings.IKE.Lifetime != 3600 {
+		t.Errorf("round-trip IKE = %+v", req.Properties.VPNClientSettings.IKE)
+	}
+	if req.Properties.VPNClientSettings.ESP == nil || req.Properties.VPNClientSettings.ESP.Lifetime != 1800 {
+		t.Errorf("round-trip ESP = %+v", req.Properties.VPNClientSettings.ESP)
+	}
+	if req.Properties.VPNClientSettings.PSK == nil || req.Properties.VPNClientSettings.PSK.Secret == nil {
+		t.Errorf("round-trip PSK = %+v", req.Properties.VPNClientSettings.PSK)
+	}
+	if req.Properties.IPConfigurations == nil || req.Properties.IPConfigurations.Subnet == nil {
+		t.Errorf("round-trip IPConfigurations = %+v", req.Properties.IPConfigurations)
+	}
+}
+
+func TestVPNTunnel_RoutesNumber_BeforeHydration(t *testing.T) {
+	tun := NewVPNTunnel()
+	if tun.RoutesNumber() != 0 {
+		t.Errorf("RoutesNumber() before hydration = %d, want 0", tun.RoutesNumber())
+	}
+}

--- a/pkg/aruba/resource_vpn_tunnel_test.go
+++ b/pkg/aruba/resource_vpn_tunnel_test.go
@@ -397,8 +397,8 @@ func TestVPNTunnel_ToRequestRoundTrip(t *testing.T) {
 	if req.Properties.BillingPlan == nil || req.Properties.BillingPlan.BillingPeriod == nil || *req.Properties.BillingPlan.BillingPeriod != BillingPeriodHour {
 		t.Errorf("BillingPlan.BillingPeriod = %v", req.Properties.BillingPlan)
 	}
-	if cs := req.Properties.VPNClientSettings; cs == nil {
-		t.Fatal("VPNClientSettings must be set")
+	if cs := req.Properties.VPNClientSettingsCommon; cs == nil {
+		t.Fatal("VPNClientSettingsCommon must be set")
 	} else {
 		if cs.PeerClientPublicIP == nil || *cs.PeerClientPublicIP != "1.2.3.4" {
 			t.Errorf("PeerClientPublicIP = %v", cs.PeerClientPublicIP)
@@ -416,8 +416,8 @@ func TestVPNTunnel_ToRequestRoundTrip(t *testing.T) {
 			t.Fatal("PSK must be set")
 		}
 	}
-	if ip := req.Properties.IPConfigurations; ip == nil {
-		t.Fatal("IPConfigurations must be set")
+	if ip := req.Properties.IPConfigurationsCommon; ip == nil {
+		t.Fatal("IPConfigurationsCommon must be set")
 	} else {
 		if ip.VPC == nil || ip.VPC.URI != "/projects/p/providers/Aruba.Network/vpcs/v" {
 			t.Errorf("IPConfig.VPC.URI = %q", func() string {
@@ -446,24 +446,24 @@ func TestVPNTunnel_ToRequest_NoVPNClientSettings_OmitsObject(t *testing.T) {
 	tun := NewVPNTunnel().
 		Named("bare")
 	req := tun.RawRequest()
-	if req.Properties.VPNClientSettings != nil {
-		t.Errorf("VPNClientSettings should be nil when IKE/ESP/PSK/PeerIP all unset")
+	if req.Properties.VPNClientSettingsCommon != nil {
+		t.Errorf("VPNClientSettingsCommon should be nil when IKE/ESP/PSK/PeerIP all unset")
 	}
 }
 
 func TestVPNTunnel_ToRequest_PeerClientPublicIPOnly_EmitsClientSettings(t *testing.T) {
 	tun := NewVPNTunnel().WithPeerClientPublicIP("5.6.7.8")
 	req := tun.RawRequest()
-	if req.Properties.VPNClientSettings == nil {
-		t.Fatal("VPNClientSettings must be non-nil when PeerClientPublicIP is set")
+	if req.Properties.VPNClientSettingsCommon == nil {
+		t.Fatal("VPNClientSettingsCommon must be non-nil when PeerClientPublicIP is set")
 	}
-	if req.Properties.VPNClientSettings.IKE != nil {
+	if req.Properties.VPNClientSettingsCommon.IKE != nil {
 		t.Error("IKE should be nil")
 	}
-	if req.Properties.VPNClientSettings.ESP != nil {
+	if req.Properties.VPNClientSettingsCommon.ESP != nil {
 		t.Error("ESP should be nil")
 	}
-	if req.Properties.VPNClientSettings.PSK != nil {
+	if req.Properties.VPNClientSettingsCommon.PSK != nil {
 		t.Error("PSK should be nil")
 	}
 }
@@ -507,7 +507,7 @@ func vpnTunnelTestResponse(id, name, uri, projectID string) *types.VPNTunnelResp
 			VPNType:           &vpnType,
 			VPNClientProtocol: &proto,
 			BillingPlan:       &types.BillingPlan{BillingPeriod: &bp},
-			VPNClientSettings: &types.VPNClientSettings{
+			VPNClientSettingsCommon: &types.VPNClientSettingsCommon{
 				PeerClientPublicIP: &peerIP,
 			},
 		},
@@ -741,7 +741,7 @@ func TestVPNTunnelsClientAdapter_Create_Success(t *testing.T) {
 	if gotBody.Properties.VPNType == nil || *gotBody.Properties.VPNType != VPNTypeSiteToSite {
 		t.Errorf("request VPNType = %v", gotBody.Properties.VPNType)
 	}
-	if gotBody.Properties.VPNClientSettings == nil || gotBody.Properties.VPNClientSettings.IKE == nil {
+	if gotBody.Properties.VPNClientSettingsCommon == nil || gotBody.Properties.VPNClientSettingsCommon.IKE == nil {
 		t.Error("request IKE must be present")
 	}
 }
@@ -1369,9 +1369,9 @@ func TestVPNTunnel_FromResponse_RehydratesSubBuilders(t *testing.T) {
 	resp := &types.VPNTunnelResponse{
 		Properties: types.VPNTunnelPropertiesResponse{
 			RoutesNumber: 3,
-			VPNClientSettings: &types.VPNClientSettings{
+			VPNClientSettingsCommon: &types.VPNClientSettingsCommon{
 				PeerClientPublicIP: &peerIP,
-				IKE: &types.IKESettings{
+				IKE: &types.IKESettingsCommon{
 					Lifetime:    3600,
 					Encryption:  &enc,
 					Hash:        &hash,
@@ -1380,22 +1380,22 @@ func TestVPNTunnel_FromResponse_RehydratesSubBuilders(t *testing.T) {
 					DPDInterval: 30,
 					DPDTimeout:  120,
 				},
-				ESP: &types.ESPSettings{
+				ESP: &types.ESPSettingsCommon{
 					Lifetime:   1800,
 					Encryption: &espEnc,
 					Hash:       &espHash,
 					PFS:        &espPFS,
 				},
-				PSK: &types.PSKSettings{
+				PSK: &types.PSKSettingsCommon{
 					CloudSite:  &cloudSite,
 					OnPremSite: &onPremSite,
 					Secret:     &secret,
 				},
 			},
-			IPConfigurations: &types.IPConfigurations{
+			IPConfigurationsCommon: &types.IPConfigurationsCommon{
 				VPC:      &types.ReferenceResource{URI: vpcURI},
 				PublicIP: &types.ReferenceResource{URI: pubIPURI},
-				Subnet:   &types.SubnetInfo{Name: "sn-1", CIDR: "10.0.0.0/24"},
+				Subnet:   &types.SubnetInfoCommon{Name: "sn-1", CIDR: "10.0.0.0/24"},
 			},
 		},
 	}
@@ -1437,22 +1437,22 @@ func TestVPNTunnel_FromResponse_RehydratesSubBuilders(t *testing.T) {
 		t.Errorf("IPConfig.subnetCIDR = %q", tun.IPConfig().subnetCIDR)
 	}
 
-	// Round-trip: toRequest must emit the same VPNClientSettings shape.
+	// Round-trip: toRequest must emit the same VPNClientSettingsCommon shape.
 	req := tun.toRequest()
-	if req.Properties.VPNClientSettings == nil {
-		t.Fatal("toRequest().Properties.VPNClientSettings is nil after rehydration")
+	if req.Properties.VPNClientSettingsCommon == nil {
+		t.Fatal("toRequest().Properties.VPNClientSettingsCommon is nil after rehydration")
 	}
-	if req.Properties.VPNClientSettings.IKE == nil || req.Properties.VPNClientSettings.IKE.Lifetime != 3600 {
-		t.Errorf("round-trip IKE = %+v", req.Properties.VPNClientSettings.IKE)
+	if req.Properties.VPNClientSettingsCommon.IKE == nil || req.Properties.VPNClientSettingsCommon.IKE.Lifetime != 3600 {
+		t.Errorf("round-trip IKE = %+v", req.Properties.VPNClientSettingsCommon.IKE)
 	}
-	if req.Properties.VPNClientSettings.ESP == nil || req.Properties.VPNClientSettings.ESP.Lifetime != 1800 {
-		t.Errorf("round-trip ESP = %+v", req.Properties.VPNClientSettings.ESP)
+	if req.Properties.VPNClientSettingsCommon.ESP == nil || req.Properties.VPNClientSettingsCommon.ESP.Lifetime != 1800 {
+		t.Errorf("round-trip ESP = %+v", req.Properties.VPNClientSettingsCommon.ESP)
 	}
-	if req.Properties.VPNClientSettings.PSK == nil || req.Properties.VPNClientSettings.PSK.Secret == nil {
-		t.Errorf("round-trip PSK = %+v", req.Properties.VPNClientSettings.PSK)
+	if req.Properties.VPNClientSettingsCommon.PSK == nil || req.Properties.VPNClientSettingsCommon.PSK.Secret == nil {
+		t.Errorf("round-trip PSK = %+v", req.Properties.VPNClientSettingsCommon.PSK)
 	}
-	if req.Properties.IPConfigurations == nil || req.Properties.IPConfigurations.Subnet == nil {
-		t.Errorf("round-trip IPConfigurations = %+v", req.Properties.IPConfigurations)
+	if req.Properties.IPConfigurationsCommon == nil || req.Properties.IPConfigurationsCommon.Subnet == nil {
+		t.Errorf("round-trip IPConfigurationsCommon = %+v", req.Properties.IPConfigurationsCommon)
 	}
 }
 

--- a/pkg/aruba/resource_vpn_tunnel_test.go
+++ b/pkg/aruba/resource_vpn_tunnel_test.go
@@ -394,8 +394,8 @@ func TestVPNTunnel_ToRequestRoundTrip(t *testing.T) {
 	if req.Properties.VPNClientProtocol == nil || *req.Properties.VPNClientProtocol != VPNClientProtocolIKEv2 {
 		t.Errorf("Properties.VPNClientProtocol = %v", req.Properties.VPNClientProtocol)
 	}
-	if req.Properties.BillingPlan == nil || req.Properties.BillingPlan.BillingPeriod == nil || *req.Properties.BillingPlan.BillingPeriod != BillingPeriodHour {
-		t.Errorf("BillingPlan.BillingPeriod = %v", req.Properties.BillingPlan)
+	if req.Properties.BillingPlanCommon == nil || req.Properties.BillingPlanCommon.BillingPeriod == nil || *req.Properties.BillingPlanCommon.BillingPeriod != BillingPeriodHour {
+		t.Errorf("BillingPlanCommon.BillingPeriod = %v", req.Properties.BillingPlanCommon)
 	}
 	if cs := req.Properties.VPNClientSettingsCommon; cs == nil {
 		t.Fatal("VPNClientSettingsCommon must be set")
@@ -437,8 +437,8 @@ func TestVPNTunnel_ToRequest_NoBillingPeriod_DefaultsToHour(t *testing.T) {
 	tun := NewVPNTunnel().
 		Named("bare")
 	req := tun.RawRequest()
-	if req.Properties.BillingPlan == nil || req.Properties.BillingPlan.BillingPeriod == nil || *req.Properties.BillingPlan.BillingPeriod != BillingPeriodHour {
-		t.Errorf("BillingPlan.BillingPeriod should default to Hour when not set, got %+v", req.Properties.BillingPlan)
+	if req.Properties.BillingPlanCommon == nil || req.Properties.BillingPlanCommon.BillingPeriod == nil || *req.Properties.BillingPlanCommon.BillingPeriod != BillingPeriodHour {
+		t.Errorf("BillingPlanCommon.BillingPeriod should default to Hour when not set, got %+v", req.Properties.BillingPlanCommon)
 	}
 }
 
@@ -499,19 +499,19 @@ func vpnTunnelTestResponse(id, name, uri, projectID string) *types.VPNTunnelResp
 			Name:             &name,
 			Tags:             []string{"vpn-tag"},
 			LocationResponse: loc,
-			ProjectResponseMetadata: &types.ProjectResponseMetadata{
+			ProjectMetadataResponse: &types.ProjectMetadataResponse{
 				ID: projectID,
 			},
 		},
 		Properties: types.VPNTunnelPropertiesResponse{
 			VPNType:           &vpnType,
 			VPNClientProtocol: &proto,
-			BillingPlan:       &types.BillingPlan{BillingPeriod: &bp},
+			BillingPlanCommon: &types.BillingPlanCommon{BillingPeriod: &bp},
 			VPNClientSettingsCommon: &types.VPNClientSettingsCommon{
 				PeerClientPublicIP: &peerIP,
 			},
 		},
-		Status: types.ResourceStatus{
+		Status: types.ResourceStatusResponse{
 			State: &state,
 		},
 	}
@@ -593,7 +593,7 @@ func TestVPNTunnel_FromResponseURIBackfill(t *testing.T) {
 			ID:   &id,
 			URI:  &uri,
 			Name: &name,
-			// ProjectResponseMetadata intentionally nil
+			// ProjectMetadataResponse intentionally nil
 		},
 	}
 	tun := &VPNTunnel{}
@@ -1312,7 +1312,7 @@ func TestVPNTunnel_FromResponse_SetsStatus(t *testing.T) {
 	tun := &VPNTunnel{}
 	state := types.State("Active")
 	tun.fromResponse(&types.VPNTunnelResponse{
-		Status: types.ResourceStatus{State: &state},
+		Status: types.ResourceStatusResponse{State: &state},
 	})
 	if tun.State() != types.StateActive {
 		t.Errorf("State() = %q after fromResponse, want Active", tun.State())
@@ -1393,8 +1393,8 @@ func TestVPNTunnel_FromResponse_RehydratesSubBuilders(t *testing.T) {
 				},
 			},
 			IPConfigurationsCommon: &types.IPConfigurationsCommon{
-				VPC:      &types.ReferenceResource{URI: vpcURI},
-				PublicIP: &types.ReferenceResource{URI: pubIPURI},
+				VPC:      &types.ReferenceResourceCommon{URI: vpcURI},
+				PublicIP: &types.ReferenceResourceCommon{URI: pubIPURI},
 				Subnet:   &types.SubnetInfoCommon{Name: "sn-1", CIDR: "10.0.0.0/24"},
 			},
 		},

--- a/pkg/aruba/version.go
+++ b/pkg/aruba/version.go
@@ -1,0 +1,8 @@
+package aruba
+
+// Version is the current SDK release version.
+const Version = "0.3.1"
+
+// defaultUserAgent is injected as the User-Agent header on every request
+// unless overridden via Options.WithUserAgent.
+const defaultUserAgent = "sdk-go@" + Version

--- a/pkg/async/doc.go
+++ b/pkg/async/doc.go
@@ -1,0 +1,40 @@
+// Package async provides low-level polling primitives for long-running operations.
+//
+// # When to use this package
+//
+// Most callers should use the wrapper-level wait helpers instead:
+//
+//	result.WaitUntilReady(ctx)                     // waits for any healthy state
+//	result.WaitUntilActive(ctx)                    // waits for StateActive
+//	result.WaitUntilStates(ctx, targets, opts...)  // waits for a specific state set
+//
+// Reach for pkg/async directly when you need to:
+//   - Start multiple resource waits concurrently (fan-out futures).
+//   - Poll an arbitrary condition — not a resource lifecycle state.
+//   - Control retries, base delay, and timeout independently per call.
+//
+// # Core types
+//
+// [WaitFor] launches a polling goroutine and returns an [AsyncClient] future.
+// Call [AsyncClient.Await] to block for the result; subsequent calls return the
+// cached value immediately (safe to call multiple times).
+//
+// [DefaultWaitFor] is a convenience wrapper that uses the package defaults:
+//   - DefaultRetries   = 60  (poll attempts)
+//   - DefaultBaseDelay = 10s (fixed delay between attempts)
+//   - DefaultTimeout   = 600s (wall-clock deadline)
+//
+// # Polling semantics
+//
+// WaitFor retries the call function at most `retries` times with a fixed
+// `baseDelay` between attempts (no exponential backoff — intentional for
+// predictability). A separate `timeout` context deadline terminates the loop
+// regardless of remaining retries.
+//
+// The check function receives the full *types.Response[T] and returns:
+//   - (true, nil)   — success, stop polling and deliver the result.
+//   - (true, error) — terminal failure, stop polling and deliver the error.
+//   - (false, nil)  — keep polling.
+//
+// If check is nil, any non-nil response.Data is treated as success.
+package async

--- a/pkg/multitenant/doc.go
+++ b/pkg/multitenant/doc.go
@@ -1,0 +1,40 @@
+// Package multitenant provides a per-tenant aruba.Client registry with
+// automatic idle-eviction.
+//
+// # Overview
+//
+// Create a manager and register clients by tenant ID:
+//
+//	mt := multitenant.New()
+//	mt.NewFromOptions("tenant-a", aruba.DefaultOptions(idA, secretA))
+//	mt.NewFromOptions("tenant-b", aruba.DefaultOptions(idB, secretB))
+//
+//	client, ok := mt.Get("tenant-a")
+//
+// # Constructors
+//
+//   - [New] — empty manager; tenants must be added via NewFromOptions or Add.
+//   - [NewWithTemplate] — every New("tenant") call deep-copies the template
+//     Options; slices are deep-copied, *http.Client / logger / middleware are
+//     shallow-copied as shared singletons.
+//
+// # Access methods
+//
+// All three access methods ([Multitenant.Get], [Multitenant.MustGet],
+// [Multitenant.GetOrNil]) update the entry's lastUsage timestamp on each call.
+// This timestamp drives idle-eviction via [Multitenant.CleanUp].
+//
+// # Idle eviction
+//
+// Call [StartCleanupRoutine] to start a background goroutine that periodically
+// removes entries idle longer than `fromDuration`:
+//
+//	cancel := multitenant.StartCleanupRoutine(ctx, mt, 5*time.Minute, 24*time.Hour)
+//	defer cancel()
+//
+// Default recommended values: tick every hour, evict after 24 hours.
+//
+// Note: the lastUsage field is written under a read lock (TD-003 in
+// ai/TECH_DEBT.md) — use a single-goroutine access pattern or apply the fix
+// before production use under high concurrency.
+package multitenant

--- a/pkg/types/audit.event.go
+++ b/pkg/types/audit.event.go
@@ -2,95 +2,95 @@ package types
 
 import "time"
 
-// Operation represents an operation in the audit log
-type Operation struct {
+// EventOperationResponse represents an operation in the audit log
+type EventOperationResponse struct {
 	ID    string  `json:"id"`
 	Value *string `json:"value,omitempty"`
 }
 
-// EventInfo represents event information
-type EventInfo struct {
+// EventInfoResponse represents event information
+type EventInfoResponse struct {
 	ID    string  `json:"id"`
 	Value *string `json:"value,omitempty"`
 	Type  string  `json:"type"`
 }
 
-// EventCategory represents the event category
-type EventCategory struct {
+// EventCategoryResponse represents the event category
+type EventCategoryResponse struct {
 	Value       string  `json:"value"`
 	Description *string `json:"description,omitempty"`
 }
 
-// RegionInfo represents the region information in an audit log event.
-type RegionInfo struct {
+// EventRegionInfoResponse represents the region information in an audit log event.
+type EventRegionInfoResponse struct {
 	Name             *string `json:"name,omitempty"`
 	AvailabilityZone *string `json:"availabilityZone,omitempty"`
 }
 
-// Status represents the status of the event
-type Status struct {
+// EventStatusResponse represents the status of the event
+type EventStatusResponse struct {
 	Value       string                 `json:"value"`
 	Description *string                `json:"description,omitempty"`
 	Code        *int32                 `json:"code,omitempty"`
 	Properties  map[string]interface{} `json:"properties,omitempty"`
 }
 
-// SubStatus represents the sub-status of the event
-type SubStatus struct {
+// EventSubStatusResponse represents the sub-status of the event
+type EventSubStatusResponse struct {
 	Value       *string                `json:"value,omitempty"`
 	Description *string                `json:"description,omitempty"`
 	Properties  map[string]interface{} `json:"properties,omitempty"`
 }
 
-// Caller represents the caller identity
-type Caller struct {
+// EventCallerResponse represents the caller identity
+type EventCallerResponse struct {
 	Subject  string  `json:"subject"`
 	Username *string `json:"username,omitempty"`
 	Company  *string `json:"company,omitempty"`
 	TenantID *string `json:"tenantId,omitempty"`
 }
 
-// Identity represents the identity information
-type Identity struct {
-	Caller     Caller                 `json:"caller"`
+// EventIdentityResponse represents the identity information
+type EventIdentityResponse struct {
+	Caller     EventCallerResponse    `json:"caller"`
 	Properties map[string]interface{} `json:"properties,omitempty"`
 }
 
-// Action represents an available action
-type Action struct {
+// EventActionResponse represents an available action
+type EventActionResponse struct {
 	Key        *string `json:"key,omitempty"`
 	Disabled   *bool   `json:"disabled,omitempty"`
 	Executable *bool   `json:"executable,omitempty"`
 }
 
-// LogFormatVersion represents the log format version
-type LogFormatVersion struct {
+// EventLogFormatVersionResponse represents the log format version
+type EventLogFormatVersionResponse struct {
 	Version string `json:"version"`
 }
 
-// AuditEvent represents the complete audit event response
-type AuditEvent struct {
-	SeverityLevel string                 `json:"severityLevel"`
-	LogFormat     LogFormatVersion       `json:"logFormat"`
-	Timestamp     time.Time              `json:"@timestamp"`
-	Operation     Operation              `json:"operation"`
-	Event         EventInfo              `json:"event"`
-	Category      EventCategory          `json:"category"`
-	Region        *RegionInfo            `json:"region,omitempty"`
-	Origin        string                 `json:"origin"`
-	Channel       string                 `json:"channel"`
-	Status        Status                 `json:"status"`
-	SubStatus     *SubStatus             `json:"subStatus,omitempty"`
-	Identity      Identity               `json:"identity"`
-	Properties    map[string]interface{} `json:"properties,omitempty"`
-	Actions       []Action               `json:"actions,omitempty"`
-	CategoryID    *string                `json:"categoryId,omitempty"`
-	TypologyID    *string                `json:"typologyId,omitempty"`
-	Title         *string                `json:"title,omitempty"`
+// AuditEventResponse represents the complete audit event response
+type AuditEventResponse struct {
+	SeverityLevel string                        `json:"severityLevel"`
+	LogFormat     EventLogFormatVersionResponse `json:"logFormat"`
+	Timestamp     time.Time                     `json:"@timestamp"`
+	Operation     EventOperationResponse        `json:"operation"`
+	Event         EventInfoResponse             `json:"event"`
+	Category      EventCategoryResponse         `json:"category"`
+	Region        *EventRegionInfoResponse      `json:"region,omitempty"`
+	Origin        string                        `json:"origin"`
+	Channel       string                        `json:"channel"`
+	Status        EventStatusResponse           `json:"status"`
+	SubStatus     *EventSubStatusResponse       `json:"subStatus,omitempty"`
+	Identity      EventIdentityResponse         `json:"identity"`
+	Properties    map[string]interface{}        `json:"properties,omitempty"`
+	Actions       []EventActionResponse         `json:"actions,omitempty"`
+	CategoryID    *string                       `json:"categoryId,omitempty"`
+	TypologyID    *string                       `json:"typologyId,omitempty"`
+	Title         *string                       `json:"title,omitempty"`
 }
 
 // AuditEventListResponse represents a paginated list of audit events
 type AuditEventListResponse struct {
 	ListResponse
-	Values []AuditEvent `json:"values"`
+	Values []AuditEventResponse `json:"values"`
 }

--- a/pkg/types/compute.cloudserver.go
+++ b/pkg/types/compute.cloudserver.go
@@ -27,25 +27,25 @@ const (
 type CloudServerPropertiesRequest struct {
 	Zone Zone `json:"dataCenter"`
 
-	VPC ReferenceResource `json:"vpc"`
+	VPC ReferenceResourceCommon `json:"vpc"`
 
 	VPCPreset bool `json:"vpcPreset,omitempty"`
 
 	FlavorName *CloudServerFlavor `json:"flavorName,omitempty"`
 
-	ElasticIP *ReferenceResource `json:"elasticIp,omitempty"`
+	ElasticIP *ReferenceResourceCommon `json:"elasticIp,omitempty"`
 
-	BootVolume ReferenceResource `json:"bootVolume"`
+	BootVolume ReferenceResourceCommon `json:"bootVolume"`
 
-	KeyPair *ReferenceResource `json:"keyPair,omitempty"`
+	KeyPair *ReferenceResourceCommon `json:"keyPair,omitempty"`
 
-	Subnets []ReferenceResource `json:"subnets,omitempty"`
+	Subnets []ReferenceResourceCommon `json:"subnets,omitempty"`
 
-	SecurityGroups []ReferenceResource `json:"securityGroups,omitempty"`
+	SecurityGroups []ReferenceResourceCommon `json:"securityGroups,omitempty"`
 
 	UserData *string `json:"userData,omitempty"`
 
-	BillingPlan *BillingPlan `json:"billingPlan,omitempty"`
+	BillingPlanCommon *BillingPlanCommon `json:"billingPlan,omitempty"`
 }
 
 type CloudServerFlavorResponse struct {
@@ -71,23 +71,23 @@ type CloudServerNetworkInterfaceResponse struct {
 }
 
 type CloudServerPropertiesResponse struct {
-	LinkedResources []LinkedResource `json:"linkedResources,omitempty"`
+	LinkedResources []LinkedResourceCommon `json:"linkedResources,omitempty"`
 
 	Zone Zone `json:"dataCenter"`
 
-	VPC ReferenceResource `json:"vpc"`
+	VPC ReferenceResourceCommon `json:"vpc"`
 
 	Flavor CloudServerFlavorResponse `json:"flavor,omitempty"`
 
-	Template ReferenceResource `json:"template"`
+	Template ReferenceResourceCommon `json:"template"`
 
-	BootVolume ReferenceResource `json:"bootVolume"`
+	BootVolume ReferenceResourceCommon `json:"bootVolume"`
 
-	KeyPair ReferenceResource `json:"keyPair"`
+	KeyPair ReferenceResourceCommon `json:"keyPair"`
 
 	NetworkInterfaces []CloudServerNetworkInterfaceResponse `json:"networkInterfaces,omitempty"`
 
-	BillingPlan *BillingPlan `json:"billingPlan,omitempty"`
+	BillingPlanCommon *BillingPlanCommon `json:"billingPlan,omitempty"`
 }
 
 type CloudServerRequest struct {
@@ -100,7 +100,7 @@ type CloudServerResponse struct {
 	Metadata   ResourceMetadataResponse      `json:"metadata"`
 	Properties CloudServerPropertiesResponse `json:"properties"`
 
-	Status ResourceStatus `json:"status,omitempty"`
+	Status ResourceStatusResponse `json:"status,omitempty"`
 }
 
 type CloudServerListResponse struct {

--- a/pkg/types/compute.cloudserver.go
+++ b/pkg/types/compute.cloudserver.go
@@ -62,7 +62,7 @@ type CloudServerFlavorResponse struct {
 	HD int32 `json:"hd"`
 }
 
-type CloudServerNetworkInterfaceDetails struct {
+type CloudServerNetworkInterfaceResponse struct {
 	Subnet *string `json:"subnet,omitempty"`
 
 	MacAddress *string `json:"macAddress,omitempty"`
@@ -70,7 +70,7 @@ type CloudServerNetworkInterfaceDetails struct {
 	IPs []string `json:"ips,omitempty"`
 }
 
-type CloudServerPropertiesResult struct {
+type CloudServerPropertiesResponse struct {
 	LinkedResources []LinkedResource `json:"linkedResources,omitempty"`
 
 	Zone Zone `json:"dataCenter"`
@@ -85,7 +85,7 @@ type CloudServerPropertiesResult struct {
 
 	KeyPair ReferenceResource `json:"keyPair"`
 
-	NetworkInterfaces []CloudServerNetworkInterfaceDetails `json:"networkInterfaces,omitempty"`
+	NetworkInterfaces []CloudServerNetworkInterfaceResponse `json:"networkInterfaces,omitempty"`
 
 	BillingPlan *BillingPlan `json:"billingPlan,omitempty"`
 }
@@ -97,13 +97,13 @@ type CloudServerRequest struct {
 }
 
 type CloudServerResponse struct {
-	Metadata   ResourceMetadataResponse    `json:"metadata"`
-	Properties CloudServerPropertiesResult `json:"properties"`
+	Metadata   ResourceMetadataResponse      `json:"metadata"`
+	Properties CloudServerPropertiesResponse `json:"properties"`
 
 	Status ResourceStatus `json:"status,omitempty"`
 }
 
-type CloudServerList struct {
+type CloudServerListResponse struct {
 	ListResponse
 	Values []CloudServerResponse `json:"values"`
 }

--- a/pkg/types/compute.keypair.go
+++ b/pkg/types/compute.keypair.go
@@ -4,7 +4,7 @@ type KeyPairPropertiesRequest struct {
 	Value string `json:"value"`
 }
 
-type KeyPairPropertiesResult struct {
+type KeyPairPropertiesResponse struct {
 	LinkedResources []LinkedResource `json:"linkedResources,omitempty"`
 
 	Value string `json:"value"`
@@ -17,9 +17,9 @@ type KeyPairRequest struct {
 }
 
 type KeyPairResponse struct {
-	Metadata   ResourceMetadataResponse `json:"metadata"`
-	Properties KeyPairPropertiesResult  `json:"properties"`
-	Status     ResourceStatus           `json:"status"`
+	Metadata   ResourceMetadataResponse  `json:"metadata"`
+	Properties KeyPairPropertiesResponse `json:"properties"`
+	Status     ResourceStatus            `json:"status"`
 }
 
 type KeyPairListResponse struct {

--- a/pkg/types/compute.keypair.go
+++ b/pkg/types/compute.keypair.go
@@ -5,7 +5,7 @@ type KeyPairPropertiesRequest struct {
 }
 
 type KeyPairPropertiesResponse struct {
-	LinkedResources []LinkedResource `json:"linkedResources,omitempty"`
+	LinkedResources []LinkedResourceCommon `json:"linkedResources,omitempty"`
 
 	Value string `json:"value"`
 }
@@ -19,7 +19,7 @@ type KeyPairRequest struct {
 type KeyPairResponse struct {
 	Metadata   ResourceMetadataResponse  `json:"metadata"`
 	Properties KeyPairPropertiesResponse `json:"properties"`
-	Status     ResourceStatus            `json:"status"`
+	Status     ResourceStatusResponse    `json:"status"`
 }
 
 type KeyPairListResponse struct {

--- a/pkg/types/container.containerregistry.go
+++ b/pkg/types/container.containerregistry.go
@@ -21,21 +21,21 @@ type UserCredentialCommon struct {
 type ContainerRegistryPropertiesRequest struct {
 
 	// PublicIp is the public IP associated with the container registry
-	PublicIp ReferenceResource `json:"publicIp"`
+	PublicIp ReferenceResourceCommon `json:"publicIp"`
 
-	VPC ReferenceResource `json:"vpc"`
+	VPC ReferenceResourceCommon `json:"vpc"`
 
 	// Subnet is the subnet associated with the container registry
-	Subnet ReferenceResource `json:"subnet"`
+	Subnet ReferenceResourceCommon `json:"subnet"`
 
 	// SecurityGroup is the security group associated with the container registry
-	SecurityGroup ReferenceResource `json:"securityGroup"`
+	SecurityGroup ReferenceResourceCommon `json:"securityGroup"`
 
 	// BlockStorage is the block storage associated with the container registry
-	BlockStorage ReferenceResource `json:"blockStorage"`
+	BlockStorage ReferenceResourceCommon `json:"blockStorage"`
 
-	// BillingPlan is the billing plan for the container registry
-	BillingPlan *BillingPlan `json:"billingPlan,omitempty"`
+	// BillingPlanCommon is the billing plan for the container registry
+	BillingPlanCommon *BillingPlanCommon `json:"billingPlan,omitempty"`
 
 	// AdminUser is the administrator user for the container registry
 	AdminUser *UserCredentialCommon `json:"adminUser,omitempty"`
@@ -47,22 +47,22 @@ type ContainerRegistryPropertiesRequest struct {
 type ContainerRegistryPropertiesResponse struct {
 
 	// PublicIp is the public IP associated with the container registry
-	PublicIp ReferenceResource `json:"publicIp"`
+	PublicIp ReferenceResourceCommon `json:"publicIp"`
 
 	// VPC is the VPC associated with the container registry
-	VPC ReferenceResource `json:"vpc"`
+	VPC ReferenceResourceCommon `json:"vpc"`
 
 	// Subnet is the subnet associated with the container registry
-	Subnet ReferenceResource `json:"subnet"`
+	Subnet ReferenceResourceCommon `json:"subnet"`
 
 	// SecurityGroup is the security group associated with the container registry
-	SecurityGroup ReferenceResource `json:"securityGroup"`
+	SecurityGroup ReferenceResourceCommon `json:"securityGroup"`
 
 	// BlockStorage is the block storage associated with the container registry
-	BlockStorage ReferenceResource `json:"blockStorage"`
+	BlockStorage ReferenceResourceCommon `json:"blockStorage"`
 
-	// BillingPlan is the billing plan for the container registry
-	BillingPlan *BillingPlan `json:"billingPlan,omitempty"`
+	// BillingPlanCommon is the billing plan for the container registry
+	BillingPlanCommon *BillingPlanCommon `json:"billingPlan,omitempty"`
 
 	// AdminUser is the administrator user for the container registry
 	AdminUser *UserCredentialCommon `json:"adminUser,omitempty"`
@@ -106,7 +106,7 @@ type ContainerRegistryResponse struct {
 	Metadata   ResourceMetadataResponse            `json:"metadata"`
 	Properties ContainerRegistryPropertiesResponse `json:"properties"`
 	Data       *ContainerRegistryDataResponse      `json:"data,omitempty"`
-	Status     ResourceStatus                      `json:"status,omitempty"`
+	Status     ResourceStatusResponse              `json:"status,omitempty"`
 }
 
 type ContainerRegistryListResponse struct {

--- a/pkg/types/container.containerregistry.go
+++ b/pkg/types/container.containerregistry.go
@@ -15,6 +15,11 @@ type UserCredential struct {
 
 	// Username is the administrator username for the container registry
 	Username string `json:"username"`
+
+	// Password is the administrator password for the container registry.
+	// Required by the provisioner when Username is supplied; omitted from
+	// GET responses (the server never echoes credentials back).
+	Password *string `json:"password,omitempty"`
 }
 
 type ContainerRegistryPropertiesRequest struct {

--- a/pkg/types/container.containerregistry.go
+++ b/pkg/types/container.containerregistry.go
@@ -13,7 +13,7 @@ const (
 	ContainerRegistrySizeFlavorHighPerf ContainerRegistrySizeFlavor = "HighPerf"
 )
 
-type UserCredential struct {
+type UserCredentialCommon struct {
 	// Username is the administrator username for the container registry.
 	Username string `json:"username"`
 }
@@ -38,7 +38,7 @@ type ContainerRegistryPropertiesRequest struct {
 	BillingPlan *BillingPlan `json:"billingPlan,omitempty"`
 
 	// AdminUser is the administrator user for the container registry
-	AdminUser *UserCredential `json:"adminUser,omitempty"`
+	AdminUser *UserCredentialCommon `json:"adminUser,omitempty"`
 
 	// Size is the number of concurrent users allowed for the container registry
 	ConcurrentUsers *string `json:"size,omitempty"`
@@ -65,35 +65,35 @@ type ContainerRegistryPropertiesResponse struct {
 	BillingPlan *BillingPlan `json:"billingPlan,omitempty"`
 
 	// AdminUser is the administrator user for the container registry
-	AdminUser *UserCredential `json:"adminUser,omitempty"`
+	AdminUser *UserCredentialCommon `json:"adminUser,omitempty"`
 
 	// Size is the number of concurrent users allowed for the container registry
 	ConcurrentUsers *string `json:"size,omitempty"`
 }
 
-// ContainerRegistryDataPrivate holds credential-state information returned by
+// ContainerRegistryDataPrivateResponse holds credential-state information returned by
 // the platform after the Aruba provisioner has processed the registry. The
 // admin password itself is never returned over the wire; only its readiness
 // state is exposed here.
-type ContainerRegistryDataPrivate struct {
+type ContainerRegistryDataPrivateResponse struct {
 	// PasswordSet reports whether the provisioner has generated the admin password.
 	PasswordSet       *bool      `json:"passwordSet,omitempty"`
 	PasswordLastSetAt *time.Time `json:"passwordLastSetAt,omitempty"`
 }
 
-// ContainerRegistryDataInfo holds operational endpoint information for the registry.
-type ContainerRegistryDataInfo struct {
+// ContainerRegistryDataInfoResponse holds operational endpoint information for the registry.
+type ContainerRegistryDataInfoResponse struct {
 	FQDN           *string `json:"fqdn,omitempty"`
 	PublicBaseURL  *string `json:"publicBaseUrl,omitempty"`
 	PrivateBaseURL *string `json:"privateBaseUrl,omitempty"`
 	Version        *string `json:"version,omitempty"`
 }
 
-// ContainerRegistryData is the top-level data block returned alongside
+// ContainerRegistryDataResponse is the top-level data block returned alongside
 // metadata/properties/status on Create and Get responses.
-type ContainerRegistryData struct {
-	Private *ContainerRegistryDataPrivate `json:"private,omitempty"`
-	Info    *ContainerRegistryDataInfo    `json:"info,omitempty"`
+type ContainerRegistryDataResponse struct {
+	Private *ContainerRegistryDataPrivateResponse `json:"private,omitempty"`
+	Info    *ContainerRegistryDataInfoResponse    `json:"info,omitempty"`
 }
 
 type ContainerRegistryRequest struct {
@@ -105,11 +105,11 @@ type ContainerRegistryRequest struct {
 type ContainerRegistryResponse struct {
 	Metadata   ResourceMetadataResponse            `json:"metadata"`
 	Properties ContainerRegistryPropertiesResponse `json:"properties"`
-	Data       *ContainerRegistryData              `json:"data,omitempty"`
+	Data       *ContainerRegistryDataResponse      `json:"data,omitempty"`
 	Status     ResourceStatus                      `json:"status,omitempty"`
 }
 
-type ContainerRegistryList struct {
+type ContainerRegistryListResponse struct {
 	ListResponse
 	Values []ContainerRegistryResponse `json:"values"`
 }

--- a/pkg/types/container.containerregistry.go
+++ b/pkg/types/container.containerregistry.go
@@ -1,5 +1,7 @@
 package types
 
+import "time"
+
 // ContainerRegistrySizeFlavor is the concurrent-users tier for a container
 // registry. Wire-encoded into the "size" JSON field of the request.
 // Accepted values per the platform: "Small", "Medium", "HighPerf".
@@ -12,14 +14,8 @@ const (
 )
 
 type UserCredential struct {
-
-	// Username is the administrator username for the container registry
+	// Username is the administrator username for the container registry.
 	Username string `json:"username"`
-
-	// Password is the administrator password for the container registry.
-	// Required by the provisioner when Username is supplied; omitted from
-	// GET responses (the server never echoes credentials back).
-	Password *string `json:"password,omitempty"`
 }
 
 type ContainerRegistryPropertiesRequest struct {
@@ -48,7 +44,7 @@ type ContainerRegistryPropertiesRequest struct {
 	ConcurrentUsers *string `json:"size,omitempty"`
 }
 
-type ContainerRegistryPropertiesResult struct {
+type ContainerRegistryPropertiesResponse struct {
 
 	// PublicIp is the public IP associated with the container registry
 	PublicIp ReferenceResource `json:"publicIp"`
@@ -75,6 +71,31 @@ type ContainerRegistryPropertiesResult struct {
 	ConcurrentUsers *string `json:"size,omitempty"`
 }
 
+// ContainerRegistryDataPrivate holds credential-state information returned by
+// the platform after the Aruba provisioner has processed the registry. The
+// admin password itself is never returned over the wire; only its readiness
+// state is exposed here.
+type ContainerRegistryDataPrivate struct {
+	// PasswordSet reports whether the provisioner has generated the admin password.
+	PasswordSet       *bool      `json:"passwordSet,omitempty"`
+	PasswordLastSetAt *time.Time `json:"passwordLastSetAt,omitempty"`
+}
+
+// ContainerRegistryDataInfo holds operational endpoint information for the registry.
+type ContainerRegistryDataInfo struct {
+	FQDN           *string `json:"fqdn,omitempty"`
+	PublicBaseURL  *string `json:"publicBaseUrl,omitempty"`
+	PrivateBaseURL *string `json:"privateBaseUrl,omitempty"`
+	Version        *string `json:"version,omitempty"`
+}
+
+// ContainerRegistryData is the top-level data block returned alongside
+// metadata/properties/status on Create and Get responses.
+type ContainerRegistryData struct {
+	Private *ContainerRegistryDataPrivate `json:"private,omitempty"`
+	Info    *ContainerRegistryDataInfo    `json:"info,omitempty"`
+}
+
 type ContainerRegistryRequest struct {
 	Metadata RegionalResourceMetadataRequest `json:"metadata"`
 
@@ -82,14 +103,10 @@ type ContainerRegistryRequest struct {
 }
 
 type ContainerRegistryResponse struct {
-	Metadata   ResourceMetadataResponse          `json:"metadata"`
-	Properties ContainerRegistryPropertiesResult `json:"properties"`
-	Status     ResourceStatus                    `json:"status,omitempty"`
-}
-
-type ContainerRegistryPropertiesResponse struct {
-	Metadata   ResourceMetadataResponse          `json:"metadata"`
-	Properties ContainerRegistryPropertiesResult `json:"properties"`
+	Metadata   ResourceMetadataResponse            `json:"metadata"`
+	Properties ContainerRegistryPropertiesResponse `json:"properties"`
+	Data       *ContainerRegistryData              `json:"data,omitempty"`
+	Status     ResourceStatus                      `json:"status,omitempty"`
 }
 
 type ContainerRegistryList struct {

--- a/pkg/types/container.kaas.go
+++ b/pkg/types/container.kaas.go
@@ -122,13 +122,13 @@ type OpenstackProjectResponse struct {
 type KaaSPropertiesRequest struct {
 
 	//LinkedResources linked resources to the KaaS cluster
-	LinkedResources []LinkedResource `json:"linkedResources,omitempty"`
+	LinkedResources []LinkedResourceCommon `json:"linkedResources,omitempty"`
 
 	Preset *bool `json:"preset,omitempty"`
 
-	VPC ReferenceResource `json:"vpc"`
+	VPC ReferenceResourceCommon `json:"vpc"`
 
-	Subnet ReferenceResource `json:"subnet"`
+	Subnet ReferenceResourceCommon `json:"subnet"`
 
 	NodeCIDR NodeCIDRPropertiesRequest `json:"nodeCidr"`
 
@@ -144,7 +144,7 @@ type KaaSPropertiesRequest struct {
 
 	Storage StorageKubernetesCommon `json:"storage,omitempty"`
 
-	BillingPlan *BillingPlan `json:"billingPlan,omitempty"`
+	BillingPlanCommon *BillingPlanCommon `json:"billingPlan,omitempty"`
 
 	Identity *KaaSIdentityPropertiesRequest `json:"identity,omitempty"`
 
@@ -246,7 +246,7 @@ type KaasSecurityGroupPropertiesResponse struct {
 type KaaSPropertiesResponse struct {
 
 	//LinkedResources linked resources to the KaaS cluster
-	LinkedResources []LinkedResource `json:"linkedResources,omitempty"`
+	LinkedResources []LinkedResourceCommon `json:"linkedResources,omitempty"`
 
 	Preset bool `json:"preset"`
 
@@ -268,7 +268,7 @@ type KaaSPropertiesResponse struct {
 
 	Storage *StorageKubernetesCommon `json:"storage,omitempty"`
 
-	BillingPlan *BillingPlan `json:"billingPlan,omitempty"`
+	BillingPlanCommon *BillingPlanCommon `json:"billingPlan,omitempty"`
 
 	ManagementIP *string `json:"managementIp,omitempty"`
 
@@ -288,7 +288,7 @@ type KaaSPropertiesUpdateRequest struct {
 
 	Storage *StorageKubernetesCommon `json:"storage,omitempty"`
 
-	BillingPlan *BillingPlan `json:"billingPlan,omitempty"`
+	BillingPlanCommon *BillingPlanCommon `json:"billingPlan,omitempty"`
 }
 
 type KaaSRequest struct {
@@ -305,7 +305,7 @@ type KaaSResponse struct {
 	Metadata   ResourceMetadataResponse `json:"metadata"`
 	Properties KaaSPropertiesResponse   `json:"properties"`
 
-	Status ResourceStatus `json:"status,omitempty"`
+	Status ResourceStatusResponse `json:"status,omitempty"`
 }
 
 type KaaSListResponse struct {

--- a/pkg/types/container.kaas.go
+++ b/pkg/types/container.kaas.go
@@ -38,7 +38,7 @@ const (
 	NodePoolInstanceK32A64 NodePoolInstance = "K32A64"
 )
 
-type NodeCIDRProperties struct {
+type NodeCIDRPropertiesRequest struct {
 
 	// Address in CIDR notation The IP range must be between 10.0.0.0/8, 172.16.0.0/12, 192.168.0.0/16
 	Address string `json:"address"`
@@ -47,20 +47,20 @@ type NodeCIDRProperties struct {
 	Name string `json:"name"`
 }
 
-type KubernetesVersionInfo struct {
+type KubernetesVersionInfoRequest struct {
 	Value KubernetesVersion `json:"value"`
 }
 
-type KubernetesVersionInfoUpdate struct {
+type KubernetesVersionInfoUpdateRequest struct {
 	Value       KubernetesVersion `json:"value"`
 	UpgradeDate *string           `json:"upgradeDate,omitempty"`
 }
 
-type StorageKubernetes struct {
+type StorageKubernetesCommon struct {
 	MaxCumulativeVolumeSize *int32 `json:"maxCumulativeVolumeSize,omitempty"`
 }
 
-type NodePoolProperties struct {
+type NodePoolPropertiesRequest struct {
 
 	// Name Nodepool name
 	Name string `json:"name"`
@@ -88,11 +88,11 @@ type NodePoolProperties struct {
 	Autoscaling bool `json:"autoscaling"`
 }
 
-type SecurityGroupProperties struct {
+type KaaSSecurityGroupPropertiesRequest struct {
 	Name string `json:"name"`
 }
 
-type IdentityProperties struct {
+type KaaSIdentityPropertiesRequest struct {
 	ClientID     *string `json:"clientId,omitempty"`
 	ClientSecret *string `json:"clientSecret,omitempty"`
 }
@@ -101,7 +101,7 @@ type IdentityPropertiesResponse struct {
 	ClientID *string `json:"clientId,omitempty"`
 }
 
-type APIServerAccessProfileProperties struct {
+type KaaSAPIServerAccessProfilePropertiesRequest struct {
 	AuthorizedIPRanges   *[]string `json:"authorizedIpRanges,omitempty"`
 	EnablePrivateCluster bool      `json:"enablePrivateCluster"`
 }
@@ -130,25 +130,25 @@ type KaaSPropertiesRequest struct {
 
 	Subnet ReferenceResource `json:"subnet"`
 
-	NodeCIDR NodeCIDRProperties `json:"nodeCidr"`
+	NodeCIDR NodeCIDRPropertiesRequest `json:"nodeCidr"`
 
 	PodCIDR *string `json:"podCidr,omitempty"`
 
-	SecurityGroup SecurityGroupProperties `json:"securityGroup"`
+	SecurityGroup KaaSSecurityGroupPropertiesRequest `json:"securityGroup"`
 
-	KubernetesVersion KubernetesVersionInfo `json:"kubernetesVersion"`
+	KubernetesVersion KubernetesVersionInfoRequest `json:"kubernetesVersion"`
 
-	NodePools []NodePoolProperties `json:"nodePools"`
+	NodePools []NodePoolPropertiesRequest `json:"nodePools"`
 
 	HA *bool `json:"ha,omitempty"`
 
-	Storage StorageKubernetes `json:"storage,omitempty"`
+	Storage StorageKubernetesCommon `json:"storage,omitempty"`
 
 	BillingPlan *BillingPlan `json:"billingPlan,omitempty"`
 
-	Identity *IdentityProperties `json:"identity,omitempty"`
+	Identity *KaaSIdentityPropertiesRequest `json:"identity,omitempty"`
 
-	APIServerAccessProfile *APIServerAccessProfileProperties `json:"apiServerAccessProfile,omitempty"`
+	APIServerAccessProfile *KaaSAPIServerAccessProfilePropertiesRequest `json:"apiServerAccessProfile,omitempty"`
 }
 
 type KubernetesVersionInfoUpgradeResponse struct {
@@ -158,7 +158,7 @@ type KubernetesVersionInfoUpgradeResponse struct {
 	ScheduledAt *string `json:"scheduledAt,omitempty"`
 }
 
-type InstanceResponse struct {
+type KaaSNodePoolInstanceResponse struct {
 	// ID Instance identifier (nullable)
 	ID *string `json:"id,omitempty"`
 
@@ -166,7 +166,7 @@ type InstanceResponse struct {
 	Name *string `json:"name,omitempty"`
 }
 
-type DataCenterResponse struct {
+type KaaSNodePoolDataCenterResponse struct {
 	// Code Data center code (nullable)
 	Code *string `json:"code,omitempty"`
 
@@ -182,10 +182,10 @@ type NodePoolPropertiesResponse struct {
 	Nodes *int32 `json:"nodes,omitempty"`
 
 	// Instance Configuration of the nodes
-	Instance *InstanceResponse `json:"instance,omitempty"`
+	Instance *KaaSNodePoolInstanceResponse `json:"instance,omitempty"`
 
 	// DataCenter Datacenter in which the nodes of the pool will be located
-	DataCenter *DataCenterResponse `json:"dataCenter,omitempty"`
+	DataCenter *KaaSNodePoolDataCenterResponse `json:"dataCenter,omitempty"`
 
 	// MinCount Minimum number of nodes for autoscaling (nullable)
 	MinCount *int32 `json:"minCount,omitempty"`
@@ -200,7 +200,7 @@ type NodePoolPropertiesResponse struct {
 	CreationDate *string `json:"creationDate,omitempty"`
 }
 
-// KubernetesVersionInfoResponse extends KubernetesVersionInfo with additional response fields
+// KubernetesVersionInfoResponse extends KubernetesVersionInfoRequest with additional response fields
 type KubernetesVersionInfoResponse struct {
 	// Value Value of the version (nullable)
 	Value *string `json:"value,omitempty"`
@@ -266,7 +266,7 @@ type KaaSPropertiesResponse struct {
 
 	HA *bool `json:"ha,omitempty"`
 
-	Storage *StorageKubernetes `json:"storage,omitempty"`
+	Storage *StorageKubernetesCommon `json:"storage,omitempty"`
 
 	BillingPlan *BillingPlan `json:"billingPlan,omitempty"`
 
@@ -280,13 +280,13 @@ type KaaSPropertiesResponse struct {
 }
 
 type KaaSPropertiesUpdateRequest struct {
-	KubernetesVersion KubernetesVersionInfoUpdate `json:"kubernetesVersion"`
+	KubernetesVersion KubernetesVersionInfoUpdateRequest `json:"kubernetesVersion"`
 
-	NodePools []NodePoolProperties `json:"nodePools"`
+	NodePools []NodePoolPropertiesRequest `json:"nodePools"`
 
 	HA *bool `json:"ha,omitempty"`
 
-	Storage *StorageKubernetes `json:"storage,omitempty"`
+	Storage *StorageKubernetesCommon `json:"storage,omitempty"`
 
 	BillingPlan *BillingPlan `json:"billingPlan,omitempty"`
 }
@@ -308,7 +308,7 @@ type KaaSResponse struct {
 	Status ResourceStatus `json:"status,omitempty"`
 }
 
-type KaaSList struct {
+type KaaSListResponse struct {
 	ListResponse
 	Values []KaaSResponse `json:"values"`
 }

--- a/pkg/types/database.backup.go
+++ b/pkg/types/database.backup.go
@@ -3,11 +3,11 @@ package types
 type BackupPropertiesRequest struct {
 	Zone Zone `json:"datacenter"`
 
-	DBaaS ReferenceResource `json:"dbaas"`
+	DBaaS ReferenceResourceCommon `json:"dbaas"`
 
-	Database ReferenceResource `json:"database"`
+	Database ReferenceResourceCommon `json:"database"`
 
-	BillingPlan *BillingPlan `json:"billingPlan,omitempty"`
+	BillingPlanCommon *BillingPlanCommon `json:"billingPlan,omitempty"`
 }
 
 type BackupStorageResponse struct {
@@ -15,15 +15,15 @@ type BackupStorageResponse struct {
 }
 
 type BackupPropertiesResponse struct {
-	LinkedResources []LinkedResource `json:"linkedResources,omitempty"`
+	LinkedResources []LinkedResourceCommon `json:"linkedResources,omitempty"`
 
 	Zone Zone `json:"datacenter"`
 
-	DBaaS ReferenceResource `json:"dbaas"`
+	DBaaS ReferenceResourceCommon `json:"dbaas"`
 
-	Database ReferenceResource `json:"database"`
+	Database ReferenceResourceCommon `json:"database"`
 
-	BillingPlan *BillingPlan `json:"billingPlan,omitempty"`
+	BillingPlanCommon *BillingPlanCommon `json:"billingPlan,omitempty"`
 
 	Storage BackupStorageResponse `json:"storage"`
 }
@@ -36,7 +36,7 @@ type BackupRequest struct {
 type BackupResponse struct {
 	Metadata   ResourceMetadataResponse `json:"metadata"`
 	Properties BackupPropertiesResponse `json:"properties"`
-	Status     ResourceStatus           `json:"status,omitempty"`
+	Status     ResourceStatusResponse   `json:"status,omitempty"`
 }
 
 type DBaaSBackupListResponse struct {

--- a/pkg/types/database.backup.go
+++ b/pkg/types/database.backup.go
@@ -39,7 +39,7 @@ type BackupResponse struct {
 	Status     ResourceStatus           `json:"status,omitempty"`
 }
 
-type BackupList struct {
+type DBaaSBackupListResponse struct {
 	ListResponse
 	Values []BackupResponse `json:"values"`
 }

--- a/pkg/types/database.database.go
+++ b/pkg/types/database.database.go
@@ -12,7 +12,7 @@ type DatabaseResponse struct {
 	CreatedBy    *string    `json:"createdBy,omitempty"`
 }
 
-type DatabaseList struct {
+type DatabaseListResponse struct {
 	ListResponse
 	Values []DatabaseResponse `json:"values"`
 }

--- a/pkg/types/database.dbaas.go
+++ b/pkg/types/database.dbaas.go
@@ -40,8 +40,8 @@ const (
 	DBaaSFlavorDBO32A64 DBaaSFlavor = "DBO32A64"
 )
 
-// DBaaSEngine contains the database engine configuration
-type DBaaSEngine struct {
+// DBaaSEngineRequest contains the database engine configuration
+type DBaaSEngineRequest struct {
 	// ID Type of DB engine to activate (nullable)
 	// For more information, check the documentation.
 	ID *DatabaseEngine `json:"id,omitempty"`
@@ -73,8 +73,8 @@ type DBaaSEngineResponse struct {
 	PrivateIPAddress *string `json:"privateIpAddress,omitempty"`
 }
 
-// DBaaSFlavorSpec contains the flavor configuration for a DBaaS request.
-type DBaaSFlavorSpec struct {
+// DBaaSFlavorRequest contains the flavor configuration for a DBaaS request.
+type DBaaSFlavorRequest struct {
 	// Name Type of flavor to use (nullable)
 	// For more information, check the documentation.
 	Name *DBaaSFlavor `json:"name,omitempty"`
@@ -95,8 +95,8 @@ type DBaaSFlavorResponse struct {
 	RAM *int32 `json:"ram,omitempty"`
 }
 
-// DBaaSStorage contains the storage configuration
-type DBaaSStorage struct {
+// DBaaSStorageRequest contains the storage configuration
+type DBaaSStorageRequest struct {
 	// SizeGB Size in GB to use (nullable)
 	SizeGB *int32 `json:"sizeGb,omitempty"`
 }
@@ -107,8 +107,8 @@ type DBaaSStorageResponse struct {
 	SizeGB *int32 `json:"sizeGb,omitempty"`
 }
 
-// DBaaSNetworking contains the network information to use when creating the new DBaaS
-type DBaaSNetworking struct {
+// DBaaSNetworkingRequest contains the network information to use when creating the new DBaaS
+type DBaaSNetworkingRequest struct {
 	// VPCURI The URI of the VPC resource to bind to this DBaaS instance (nullable)
 	// Required when user has at least one VPC (with at least one subnet and a security group).
 	VPCURI *string `json:"vpcUri,omitempty"`
@@ -142,8 +142,8 @@ type DBaaSNetworkingResponse struct {
 	ElasticIP *ReferenceResource `json:"elasticIp,omitempty"`
 }
 
-// DBaaSAutoscaling contains the autoscaling configuration
-type DBaaSAutoscaling struct {
+// DBaaSAutoscalingRequest contains the autoscaling configuration
+type DBaaSAutoscalingRequest struct {
 	// Enabled Indicates if autoscaling is enabled (nullable)
 	Enabled *bool `json:"enabled,omitempty"`
 
@@ -176,22 +176,22 @@ type DBaaSPropertiesRequest struct {
 	Zone *Zone `json:"dataCenter,omitempty"`
 
 	// Engine Database engine configuration
-	Engine *DBaaSEngine `json:"engine,omitempty"`
+	Engine *DBaaSEngineRequest `json:"engine,omitempty"`
 
 	// Flavor Flavor configuration
-	Flavor *DBaaSFlavorSpec `json:"flavor,omitempty"`
+	Flavor *DBaaSFlavorRequest `json:"flavor,omitempty"`
 
 	// Storage Storage configuration
-	Storage *DBaaSStorage `json:"storage,omitempty"`
+	Storage *DBaaSStorageRequest `json:"storage,omitempty"`
 
 	// BillingPlan Billing plan (wraps billingPeriod)
 	BillingPlan *BillingPlan `json:"billingPlan,omitempty"`
 
 	// Networking Network information for the DBaaS instance
-	Networking *DBaaSNetworking `json:"networking,omitempty"`
+	Networking *DBaaSNetworkingRequest `json:"networking,omitempty"`
 
 	// Autoscaling Autoscaling configuration
-	Autoscaling *DBaaSAutoscaling `json:"autoscaling,omitempty"`
+	Autoscaling *DBaaSAutoscalingRequest `json:"autoscaling,omitempty"`
 }
 
 // DBaaSPropertiesResponse contains the response properties of a DBaaS instance
@@ -236,7 +236,7 @@ type DBaaSResponse struct {
 	Status ResourceStatus `json:"status,omitempty"`
 }
 
-type DBaaSList struct {
+type DBaaSListResponse struct {
 	ListResponse
 	Values []DBaaSResponse `json:"values"`
 }

--- a/pkg/types/database.dbaas.go
+++ b/pkg/types/database.dbaas.go
@@ -130,16 +130,16 @@ type DBaaSNetworkingRequest struct {
 // DBaaSNetworkingResponse contains the network response information
 type DBaaSNetworkingResponse struct {
 	// VPC VPC resource reference (nullable)
-	VPC *ReferenceResource `json:"vpc,omitempty"`
+	VPC *ReferenceResourceCommon `json:"vpc,omitempty"`
 
 	// Subnet Subnet resource reference (nullable)
-	Subnet *ReferenceResource `json:"subnet,omitempty"`
+	Subnet *ReferenceResourceCommon `json:"subnet,omitempty"`
 
 	// SecurityGroup Security group resource reference (nullable)
-	SecurityGroup *ReferenceResource `json:"securityGroup,omitempty"`
+	SecurityGroup *ReferenceResourceCommon `json:"securityGroup,omitempty"`
 
 	// ElasticIP Elastic IP resource reference (nullable)
-	ElasticIP *ReferenceResource `json:"elasticIp,omitempty"`
+	ElasticIP *ReferenceResourceCommon `json:"elasticIp,omitempty"`
 }
 
 // DBaaSAutoscalingRequest contains the autoscaling configuration
@@ -184,8 +184,8 @@ type DBaaSPropertiesRequest struct {
 	// Storage Storage configuration
 	Storage *DBaaSStorageRequest `json:"storage,omitempty"`
 
-	// BillingPlan Billing plan (wraps billingPeriod)
-	BillingPlan *BillingPlan `json:"billingPlan,omitempty"`
+	// BillingPlanCommon Billing plan (wraps billingPeriod)
+	BillingPlanCommon *BillingPlanCommon `json:"billingPlan,omitempty"`
 
 	// Networking Network information for the DBaaS instance
 	Networking *DBaaSNetworkingRequest `json:"networking,omitempty"`
@@ -197,7 +197,7 @@ type DBaaSPropertiesRequest struct {
 // DBaaSPropertiesResponse contains the response properties of a DBaaS instance
 type DBaaSPropertiesResponse struct {
 	// LinkedResources Array of resources linked to the DBaaS instance (nullable)
-	LinkedResources []LinkedResource `json:"linkedResources,omitempty"`
+	LinkedResources []LinkedResourceCommon `json:"linkedResources,omitempty"`
 
 	// Engine Database engine response configuration
 	Engine *DBaaSEngineResponse `json:"engine,omitempty"`
@@ -211,8 +211,8 @@ type DBaaSPropertiesResponse struct {
 	// Storage Storage response configuration
 	Storage *DBaaSStorageResponse `json:"storage,omitempty"`
 
-	// BillingPlan Billing plan (wraps billingPeriod)
-	BillingPlan *BillingPlan `json:"billingPlan,omitempty"`
+	// BillingPlanCommon Billing plan (wraps billingPeriod)
+	BillingPlanCommon *BillingPlanCommon `json:"billingPlan,omitempty"`
 
 	// Autoscaling Autoscaling response configuration
 	Autoscaling *DBaaSAutoscalingResponse `json:"autoscaling,omitempty"`
@@ -233,7 +233,7 @@ type DBaaSResponse struct {
 	// Spec contains the DBaaS instance specification
 	Properties DBaaSPropertiesResponse `json:"properties"`
 
-	Status ResourceStatus `json:"status,omitempty"`
+	Status ResourceStatusResponse `json:"status,omitempty"`
 }
 
 type DBaaSListResponse struct {

--- a/pkg/types/database.grant.go
+++ b/pkg/types/database.grant.go
@@ -2,11 +2,11 @@ package types
 
 import "time"
 
-type GrantUser struct {
+type GrantUserCommon struct {
 	Username string `json:"username"`
 }
 
-type GrantRole struct {
+type GrantRoleCommon struct {
 	Name string `json:"name"`
 }
 
@@ -14,19 +14,19 @@ type GrantDatabaseResponse struct {
 	Name string `json:"name"`
 }
 type GrantRequest struct {
-	User GrantUser `json:"user"`
-	Role GrantRole `json:"role"`
+	User GrantUserCommon `json:"user"`
+	Role GrantRoleCommon `json:"role"`
 }
 
 type GrantResponse struct {
-	User         GrantUser             `json:"user"`
-	Role         GrantRole             `json:"role"`
+	User         GrantUserCommon       `json:"user"`
+	Role         GrantRoleCommon       `json:"role"`
 	Database     GrantDatabaseResponse `json:"database"`
 	CreationDate *time.Time            `json:"creationDate,omitempty"`
 	CreatedBy    *string               `json:"createdBy,omitempty"`
 }
 
-type GrantList struct {
+type GrantListResponse struct {
 	ListResponse
 	Values []GrantResponse `json:"values"`
 }

--- a/pkg/types/database.user.go
+++ b/pkg/types/database.user.go
@@ -13,7 +13,7 @@ type UserResponse struct {
 	CreatedBy    *string    `json:"createdBy,omitempty"`
 }
 
-type UserList struct {
+type DatabaseUserListResponse struct {
 	ListResponse
 	Values []UserResponse `json:"values"`
 }

--- a/pkg/types/doc.go
+++ b/pkg/types/doc.go
@@ -1,0 +1,34 @@
+// Package types defines all wire-level data-transfer objects (DTOs) used by the
+// Aruba Cloud SDK — both outbound request bodies and inbound response bodies.
+//
+// # Naming convention
+//
+// Every exported struct in this package carries a suffix that declares its wire role:
+//
+//   - *Request  — serialised into an outbound HTTP request body only.
+//   - *Response — deserialised from an inbound HTTP response body only.
+//   - *Common   — appears on both the request AND the response side of the wire
+//     (i.e. the same JSON shape is sent in a request body and received back in a
+//     response body). Use *Common for shared nested shapes such as billing plans,
+//     linked-resource references, or VPN settings structs.
+//
+// The following categories are intentionally out of scope for the three-way rule and
+// carry no Request/Response/Common suffix:
+//
+//   - Scalar enum / constant types (State, Region, Zone, BillingPeriod, RuleProtocol,
+//     KeyAlgorithm, …) — their role is determined by the parent field, not the type.
+//   - The generic transport envelope Response[T] and its embedded ListResponse.
+//   - HTTP-utility types (RequestParameters, AcceptHeader).
+//   - Error types (ErrorResponse, ValidationError, MetadataValidationError).
+//   - The Resource interface.
+//   - Custom (un)marshaler helpers (SubnetCIDROrRef).
+//
+// # File organisation
+//
+// Each file groups the DTOs for a single resource domain:
+//
+//	<domain>.<resource>.go   e.g. compute.cloudserver.go, network.vpc.go
+//
+// Cross-resource base types (metadata envelopes, status, billing, linked-resource
+// references) live in resource.go.
+package types

--- a/pkg/types/metrics.alert.go
+++ b/pkg/types/metrics.alert.go
@@ -12,15 +12,15 @@ const (
 	ActionTypeAutoscalingDBaaS  ActionType = "AutoscalingDbaas"
 )
 
-// ExecutedAlertAction represents an executed alert action
-type ExecutedAlertAction struct {
+// ExecutedAlertActionResponse represents an executed alert action
+type ExecutedAlertActionResponse struct {
 	ActionType   ActionType `json:"actionType,omitempty"`
 	Success      bool       `json:"success,omitempty"`
 	ErrorMessage string     `json:"errorMessage,omitempty"`
 }
 
-// AlertAction represents a possible alert action
-type AlertAction struct {
+// AlertActionResponse represents a possible alert action
+type AlertActionResponse struct {
 	Key        string `json:"key,omitempty"`
 	Disabled   bool   `json:"disabled,omitempty"`
 	Executable bool   `json:"executable,omitempty"`
@@ -28,33 +28,33 @@ type AlertAction struct {
 
 // AlertResponse represents an alert response
 type AlertResponse struct {
-	ID                   string                `json:"id,omitempty"`
-	EventID              string                `json:"eventId,omitempty"`
-	EventName            string                `json:"eventName,omitempty"`
-	Username             string                `json:"username,omitempty"`
-	ServiceCategory      string                `json:"serviceCategory,omitempty"`
-	ServiceTypology      string                `json:"serviceTypology,omitempty"`
-	ResourceID           string                `json:"resourceId,omitempty"`
-	ServiceName          string                `json:"serviceName,omitempty"`
-	ResourceTypology     string                `json:"resourceTypology,omitempty"`
-	Metric               string                `json:"metric,omitempty"`
-	LastReception        time.Time             `json:"lastReception,omitempty"`
-	Rule                 string                `json:"rule,omitempty"`
-	Theshold             int64                 `json:"theshold,omitempty"`
-	UM                   string                `json:"um,omitempty"`
-	Duration             string                `json:"duration,omitempty"`
-	ThesholdExceedence   string                `json:"thesholdExceedence,omitempty"`
-	Component            string                `json:"component,omitempty"`
-	ClusterTypology      string                `json:"clusterTypology,omitempty"`
-	Cluster              string                `json:"cluster,omitempty"`
-	Clustername          string                `json:"clustername,omitempty"`
-	NodePool             string                `json:"nodePool,omitempty"`
-	SMS                  bool                  `json:"sms,omitempty"`
-	Email                bool                  `json:"email,omitempty"`
-	Panel                bool                  `json:"panel,omitempty"`
-	Hidden               bool                  `json:"hidden,omitempty"`
-	ExecutedAlertActions []ExecutedAlertAction `json:"executedAlertActions,omitempty"`
-	Actions              []AlertAction         `json:"actions,omitempty"`
+	ID                   string                        `json:"id,omitempty"`
+	EventID              string                        `json:"eventId,omitempty"`
+	EventName            string                        `json:"eventName,omitempty"`
+	Username             string                        `json:"username,omitempty"`
+	ServiceCategory      string                        `json:"serviceCategory,omitempty"`
+	ServiceTypology      string                        `json:"serviceTypology,omitempty"`
+	ResourceID           string                        `json:"resourceId,omitempty"`
+	ServiceName          string                        `json:"serviceName,omitempty"`
+	ResourceTypology     string                        `json:"resourceTypology,omitempty"`
+	Metric               string                        `json:"metric,omitempty"`
+	LastReception        time.Time                     `json:"lastReception,omitempty"`
+	Rule                 string                        `json:"rule,omitempty"`
+	Theshold             int64                         `json:"theshold,omitempty"`
+	UM                   string                        `json:"um,omitempty"`
+	Duration             string                        `json:"duration,omitempty"`
+	ThesholdExceedence   string                        `json:"thesholdExceedence,omitempty"`
+	Component            string                        `json:"component,omitempty"`
+	ClusterTypology      string                        `json:"clusterTypology,omitempty"`
+	Cluster              string                        `json:"cluster,omitempty"`
+	Clustername          string                        `json:"clustername,omitempty"`
+	NodePool             string                        `json:"nodePool,omitempty"`
+	SMS                  bool                          `json:"sms,omitempty"`
+	Email                bool                          `json:"email,omitempty"`
+	Panel                bool                          `json:"panel,omitempty"`
+	Hidden               bool                          `json:"hidden,omitempty"`
+	ExecutedAlertActions []ExecutedAlertActionResponse `json:"executedAlertActions,omitempty"`
+	Actions              []AlertActionResponse         `json:"actions,omitempty"`
 }
 
 // AlertsListResponse represents a list of alerts

--- a/pkg/types/metrics.metric.go
+++ b/pkg/types/metrics.metric.go
@@ -1,24 +1,24 @@
 package types
 
-// MetricMetadata represents metadata for a metric
-type MetricMetadata struct {
+// MetricMetadataResponse represents metadata for a metric
+type MetricMetadataResponse struct {
 	Field string `json:"field,omitempty"`
 	Value string `json:"value,omitempty"`
 }
 
-// MetricData represents data points for a metric
-type MetricData struct {
+// MetricDataResponse represents data points for a metric
+type MetricDataResponse struct {
 	Time    string `json:"time,omitempty"`
 	Measure string `json:"measure,omitempty"`
 }
 
 // Metric represents a metric response
 type MetricResponse struct {
-	ReferenceID   string           `json:"referenceId,omitempty"`
-	Name          string           `json:"name,omitempty"`
-	ReferenceName string           `json:"referenceName,omitempty"`
-	Metadata      []MetricMetadata `json:"metadata,omitempty"`
-	Data          []MetricData     `json:"data,omitempty"`
+	ReferenceID   string                   `json:"referenceId,omitempty"`
+	Name          string                   `json:"name,omitempty"`
+	ReferenceName string                   `json:"referenceName,omitempty"`
+	Metadata      []MetricMetadataResponse `json:"metadata,omitempty"`
+	Data          []MetricDataResponse     `json:"data,omitempty"`
 }
 
 // MetricList represents a list of metrics

--- a/pkg/types/network.elastic-ip.go
+++ b/pkg/types/network.elastic-ip.go
@@ -23,7 +23,7 @@ type ElasticIPResponse struct {
 	Status ResourceStatus `json:"status,omitempty"`
 }
 
-type ElasticList struct {
+type ElasticIPListResponse struct {
 	ListResponse
 	Values []ElasticIPResponse `json:"values"`
 }

--- a/pkg/types/network.elastic-ip.go
+++ b/pkg/types/network.elastic-ip.go
@@ -1,14 +1,14 @@
 package types
 
 type ElasticIPPropertiesRequest struct {
-	BillingPlan *BillingPlan `json:"billingPlan,omitempty"`
+	BillingPlanCommon *BillingPlanCommon `json:"billingPlan,omitempty"`
 }
 
 type ElasticIPPropertiesResponse struct {
-	LinkedResources []LinkedResource `json:"linkedResources,omitempty"`
+	LinkedResources []LinkedResourceCommon `json:"linkedResources,omitempty"`
 
-	Address     *string      `json:"address,omitempty"`
-	BillingPlan *BillingPlan `json:"billingPlan,omitempty"`
+	Address           *string            `json:"address,omitempty"`
+	BillingPlanCommon *BillingPlanCommon `json:"billingPlan,omitempty"`
 }
 
 type ElasticIPRequest struct {
@@ -20,7 +20,7 @@ type ElasticIPResponse struct {
 	Metadata   ResourceMetadataResponse    `json:"metadata"`
 	Properties ElasticIPPropertiesResponse `json:"properties"`
 
-	Status ResourceStatus `json:"status,omitempty"`
+	Status ResourceStatusResponse `json:"status,omitempty"`
 }
 
 type ElasticIPListResponse struct {

--- a/pkg/types/network.load-balancer.go
+++ b/pkg/types/network.load-balancer.go
@@ -2,9 +2,9 @@ package types
 
 type LoadBalancerPropertiesResponse struct {
 	// LinkedResources array of resources linked to the Load Balancer (nullable)
-	LinkedResources []LinkedResource   `json:"linkedResources,omitempty"`
-	Address         *string            `json:"address,omitempty"`
-	VPC             *ReferenceResource `json:"vpc,omitempty"`
+	LinkedResources []LinkedResourceCommon   `json:"linkedResources,omitempty"`
+	Address         *string                  `json:"address,omitempty"`
+	VPC             *ReferenceResourceCommon `json:"vpc,omitempty"`
 }
 
 type LoadBalancerResponse struct {
@@ -13,7 +13,7 @@ type LoadBalancerResponse struct {
 	// Spec contains the Load Balancer specification
 	Properties LoadBalancerPropertiesResponse `json:"properties"`
 
-	Status ResourceStatus `json:"status,omitempty"`
+	Status ResourceStatusResponse `json:"status,omitempty"`
 }
 
 type LoadBalancerListResponse struct {

--- a/pkg/types/network.load-balancer.go
+++ b/pkg/types/network.load-balancer.go
@@ -16,7 +16,7 @@ type LoadBalancerResponse struct {
 	Status ResourceStatus `json:"status,omitempty"`
 }
 
-type LoadBalancerList struct {
+type LoadBalancerListResponse struct {
 	ListResponse
 	Values []LoadBalancerResponse `json:"values"`
 }

--- a/pkg/types/network.security-group.go
+++ b/pkg/types/network.security-group.go
@@ -27,7 +27,7 @@ type SecurityGroupResponse struct {
 	Status ResourceStatus `json:"status,omitempty"`
 }
 
-type SecurityGroupList struct {
+type SecurityGroupListResponse struct {
 	ListResponse
 	Values []SecurityGroupResponse `json:"values"`
 }

--- a/pkg/types/network.security-group.go
+++ b/pkg/types/network.security-group.go
@@ -5,7 +5,7 @@ type SecurityGroupPropertiesRequest struct {
 	Default *bool `json:"default,omitempty"`
 }
 type SecurityGroupPropertiesResponse struct {
-	LinkedResources []LinkedResource `json:"linkedResources,omitempty"`
+	LinkedResources []LinkedResourceCommon `json:"linkedResources,omitempty"`
 
 	Default bool `json:"default,omitempty"`
 }
@@ -24,7 +24,7 @@ type SecurityGroupResponse struct {
 	// Spec contains the Security Group specification
 	Properties SecurityGroupPropertiesResponse `json:"properties"`
 
-	Status ResourceStatus `json:"status,omitempty"`
+	Status ResourceStatusResponse `json:"status,omitempty"`
 }
 
 type SecurityGroupListResponse struct {

--- a/pkg/types/network.security-rule.go
+++ b/pkg/types/network.security-rule.go
@@ -60,7 +60,7 @@ type SecurityRulePropertiesRequest struct {
 }
 
 type SecurityRulePropertiesResponse struct {
-	LinkedResources []LinkedResource `json:"linkedResources,omitempty"`
+	LinkedResources []LinkedResourceCommon `json:"linkedResources,omitempty"`
 
 	// Direction of the rule. Admissible values: Ingress, Egress
 	Direction RuleDirection `json:"direction,omitempty"`
@@ -88,7 +88,7 @@ type SecurityRuleRequest struct {
 
 type SecurityRuleResponse struct {
 	Metadata   ResourceMetadataResponse       `json:"metadata"`
-	Status     ResourceStatus                 `json:"status"`
+	Status     ResourceStatusResponse         `json:"status"`
 	Properties SecurityRulePropertiesResponse `json:"properties"`
 }
 

--- a/pkg/types/network.security-rule.go
+++ b/pkg/types/network.security-rule.go
@@ -28,8 +28,8 @@ const (
 	EndpointTypeSecurityGroup EndpointTypeDto = "SecurityGroup"
 )
 
-// RuleTarget represents the target of the rule (source or destination according to the direction)
-type RuleTarget struct {
+// RuleTargetCommon represents the target of the rule (source or destination according to the direction)
+type RuleTargetCommon struct {
 	// Kind Type of the target. Admissible values: Ip, SecurityGroup
 	Kind EndpointTypeDto `json:"kind,omitempty"`
 
@@ -56,7 +56,7 @@ type SecurityRulePropertiesRequest struct {
 	Port string `json:"port,omitempty"`
 
 	// Target The target of the rule (source or destination according to the direction)
-	Target *RuleTarget `json:"target,omitempty"`
+	Target *RuleTargetCommon `json:"target,omitempty"`
 }
 
 type SecurityRulePropertiesResponse struct {
@@ -77,7 +77,7 @@ type SecurityRulePropertiesResponse struct {
 	Port string `json:"port,omitempty"`
 
 	// Target The target of the rule (source or destination according to the direction)
-	Target *RuleTarget `json:"target,omitempty"`
+	Target *RuleTargetCommon `json:"target,omitempty"`
 }
 
 type SecurityRuleRequest struct {
@@ -92,7 +92,7 @@ type SecurityRuleResponse struct {
 	Properties SecurityRulePropertiesResponse `json:"properties"`
 }
 
-type SecurityRuleList struct {
+type SecurityRuleListResponse struct {
 	ListResponse
 	Values []SecurityRuleResponse `json:"values"`
 }

--- a/pkg/types/network.subnet.go
+++ b/pkg/types/network.subnet.go
@@ -59,7 +59,7 @@ type SubnetPropertiesRequest struct {
 // SubnetPropertiesResponse contains the specification returned for a Subnet
 type SubnetPropertiesResponse struct {
 	// LinkedResources array of resources linked to the Subnet (nullable)
-	LinkedResources []LinkedResource `json:"linkedResources,omitempty"`
+	LinkedResources []LinkedResourceCommon `json:"linkedResources,omitempty"`
 
 	// Type of subnet
 	Type SubnetType `json:"type,omitempty"`
@@ -88,7 +88,7 @@ type SubnetResponse struct {
 	// Spec contains the Subnet specification
 	Properties SubnetPropertiesResponse `json:"properties"`
 
-	Status ResourceStatus `json:"status,omitempty"`
+	Status ResourceStatusResponse `json:"status,omitempty"`
 }
 
 type SubnetListResponse struct {

--- a/pkg/types/network.subnet.go
+++ b/pkg/types/network.subnet.go
@@ -8,35 +8,35 @@ const (
 	SubnetTypeAdvanced SubnetType = "Advanced"
 )
 
-// SubnetNetwork contains the network configuration
-type SubnetNetwork struct {
+// SubnetNetworkCommon contains the network configuration
+type SubnetNetworkCommon struct {
 	Address string `json:"address"`
 }
 
-// SubnetDHCPRange contains the DHCP range configuration
-type SubnetDHCPRange struct {
+// SubnetDHCPRangeCommon contains the DHCP range configuration
+type SubnetDHCPRangeCommon struct {
 	// Start is the starting IP address of the DHCP range
 	Start string `json:"start"`
 	// Count is the number of IP addresses in the DHCP range
 	Count int `json:"count"`
 }
 
-// SubnetDHCPRoute contains the DHCP route configuration
-type SubnetDHCPRoute struct {
+// SubnetDHCPRouteCommon contains the DHCP route configuration
+type SubnetDHCPRouteCommon struct {
 	// Address is the destination network address
 	Address string `json:"address"`
 	// Gateway is the gateway IP address for the route
 	Gateway string `json:"gateway"`
 }
 
-// SubnetDHCP contains the DHCP configuration
-type SubnetDHCP struct {
+// SubnetDHCPCommon contains the DHCP configuration
+type SubnetDHCPCommon struct {
 	// Enabled indicates if DHCP is enabled
 	Enabled bool `json:"enabled"`
 	// Range contains the DHCP IP address range
-	Range *SubnetDHCPRange `json:"range,omitempty"`
+	Range *SubnetDHCPRangeCommon `json:"range,omitempty"`
 	// Routes contains the DHCP routes configuration
-	Routes []SubnetDHCPRoute `json:"routes,omitempty"`
+	Routes []SubnetDHCPRouteCommon `json:"routes,omitempty"`
 	// DNS contains the DNS server addresses
 	DNS []string `json:"dns,omitempty"`
 }
@@ -50,10 +50,10 @@ type SubnetPropertiesRequest struct {
 	Default *bool `json:"default,omitempty"`
 
 	// Network configuration
-	Network *SubnetNetwork `json:"network,omitempty"`
+	Network *SubnetNetworkCommon `json:"network,omitempty"`
 
 	// DHCP configuration
-	DHCP *SubnetDHCP `json:"dhcp,omitempty"`
+	DHCP *SubnetDHCPCommon `json:"dhcp,omitempty"`
 }
 
 // SubnetPropertiesResponse contains the specification returned for a Subnet
@@ -68,10 +68,10 @@ type SubnetPropertiesResponse struct {
 	Default bool `json:"default,omitempty"`
 
 	// Network configuration
-	Network *SubnetNetwork `json:"network,omitempty"`
+	Network *SubnetNetworkCommon `json:"network,omitempty"`
 
 	// DHCP configuration
-	DHCP *SubnetDHCP `json:"dhcp,omitempty"`
+	DHCP *SubnetDHCPCommon `json:"dhcp,omitempty"`
 }
 
 type SubnetRequest struct {
@@ -91,7 +91,7 @@ type SubnetResponse struct {
 	Status ResourceStatus `json:"status,omitempty"`
 }
 
-type SubnetList struct {
+type SubnetListResponse struct {
 	ListResponse
 	Values []SubnetResponse `json:"values"`
 }

--- a/pkg/types/network.vpc-peering-route.go
+++ b/pkg/types/network.vpc-peering-route.go
@@ -8,7 +8,7 @@ type VPCPeeringRoutePropertiesRequest struct {
 	// RemoteNetworkAddress Remote network address in CIDR notation
 	RemoteNetworkAddress string `json:"remoteNetworkAddress"`
 
-	BillingPlan *BillingPlan `json:"billingPlan,omitempty"`
+	BillingPlanCommon *BillingPlanCommon `json:"billingPlan,omitempty"`
 }
 
 type VPCPeeringRoutePropertiesResponse struct {
@@ -18,7 +18,7 @@ type VPCPeeringRoutePropertiesResponse struct {
 	// RemoteNetworkAddress Remote network address in CIDR notation
 	RemoteNetworkAddress string `json:"remoteNetworkAddress"`
 
-	BillingPlan *BillingPlan `json:"billingPlan,omitempty"`
+	BillingPlanCommon *BillingPlanCommon `json:"billingPlan,omitempty"`
 }
 
 type VPCPeeringRouteRequest struct {
@@ -35,7 +35,7 @@ type VPCPeeringRouteResponse struct {
 	// Spec contains the VPC Peering Route specification
 	Properties VPCPeeringRoutePropertiesResponse `json:"properties"`
 
-	Status ResourceStatus `json:"status,omitempty"`
+	Status ResourceStatusResponse `json:"status,omitempty"`
 }
 
 type VPCPeeringRouteListResponse struct {

--- a/pkg/types/network.vpc-peering-route.go
+++ b/pkg/types/network.vpc-peering-route.go
@@ -38,7 +38,7 @@ type VPCPeeringRouteResponse struct {
 	Status ResourceStatus `json:"status,omitempty"`
 }
 
-type VPCPeeringRouteList struct {
+type VPCPeeringRouteListResponse struct {
 	ListResponse
 	Values []VPCPeeringRouteResponse `json:"values"`
 }

--- a/pkg/types/network.vpc-peering.go
+++ b/pkg/types/network.vpc-peering.go
@@ -27,7 +27,7 @@ type VPCPeeringResponse struct {
 	Status ResourceStatus `json:"status,omitempty"`
 }
 
-type VPCPeeringList struct {
+type VPCPeeringListResponse struct {
 	ListResponse
 	Values []VPCPeeringResponse `json:"values"`
 }

--- a/pkg/types/network.vpc-peering.go
+++ b/pkg/types/network.vpc-peering.go
@@ -2,12 +2,12 @@ package types
 
 // VPCPeeringRoutePropertiesRequest contains properties of a VPC peering route to create
 type VPCPeeringPropertiesRequest struct {
-	RemoteVPC *ReferenceResource `json:"remoteVpc,omitempty"`
+	RemoteVPC *ReferenceResourceCommon `json:"remoteVpc,omitempty"`
 }
 
 type VPCPeeringPropertiesResponse struct {
-	LinkedResources []LinkedResource   `json:"linkedResources,omitempty"`
-	RemoteVPC       *ReferenceResource `json:"remoteVpc,omitempty"`
+	LinkedResources []LinkedResourceCommon   `json:"linkedResources,omitempty"`
+	RemoteVPC       *ReferenceResourceCommon `json:"remoteVpc,omitempty"`
 }
 
 type VPCPeeringRequest struct {
@@ -24,7 +24,7 @@ type VPCPeeringResponse struct {
 	// Spec contains the VPC Peering specification
 	Properties VPCPeeringPropertiesResponse `json:"properties"`
 
-	Status ResourceStatus `json:"status,omitempty"`
+	Status ResourceStatusResponse `json:"status,omitempty"`
 }
 
 type VPCPeeringListResponse struct {

--- a/pkg/types/network.vpc.go
+++ b/pkg/types/network.vpc.go
@@ -1,7 +1,7 @@
 package types
 
-// VPCProperties contains the properties of a VPC
-type VPCProperties struct {
+// VPCPropertiesInnerRequest contains the properties of a VPC
+type VPCPropertiesInnerRequest struct {
 	// Default indicates if the vpc must be a default vpc. Only one default vpc for region is admissible.
 	// Default value: true
 	Default *bool `json:"default,omitempty"`
@@ -14,7 +14,7 @@ type VPCProperties struct {
 // VPCPropertiesRequest contains the specification for creating a VPC
 type VPCPropertiesRequest struct {
 	// Properties of the vpc (nullable object)
-	Properties *VPCProperties `json:"properties,omitempty"`
+	Properties *VPCPropertiesInnerRequest `json:"properties,omitempty"`
 }
 
 // VPCPropertiesResponse contains the specification returned for a VPC
@@ -43,7 +43,7 @@ type VPCResponse struct {
 	Status ResourceStatus `json:"status,omitempty"`
 }
 
-type VPCList struct {
+type VPCListResponse struct {
 	ListResponse
 	Values []VPCResponse `json:"values"`
 }

--- a/pkg/types/network.vpc.go
+++ b/pkg/types/network.vpc.go
@@ -20,7 +20,7 @@ type VPCPropertiesRequest struct {
 // VPCPropertiesResponse contains the specification returned for a VPC
 type VPCPropertiesResponse struct {
 	// LinkedResources array of resources linked to the VPC (nullable)
-	LinkedResources []LinkedResource `json:"linkedResources,omitempty"`
+	LinkedResources []LinkedResourceCommon `json:"linkedResources,omitempty"`
 
 	// Default indicates if the vpc is the default one within the region
 	Default bool `json:"default,omitempty"`
@@ -40,7 +40,7 @@ type VPCResponse struct {
 	// Spec contains the VPC specification
 	Properties VPCPropertiesResponse `json:"properties"`
 
-	Status ResourceStatus `json:"status,omitempty"`
+	Status ResourceStatusResponse `json:"status,omitempty"`
 }
 
 type VPCListResponse struct {

--- a/pkg/types/network.vpn-route.go
+++ b/pkg/types/network.vpn-route.go
@@ -24,18 +24,26 @@ func (s *SubnetCIDROrRef) UnmarshalJSON(data []byte) error {
 		s.CIDR = str
 		return nil
 	}
-	// Full subnet object — extract properties.network.address
+	// Full subnet object shape — try both the nested form
+	// (properties.network.address) and the flat form (network.address).
 	var obj struct {
 		Properties struct {
 			Network struct {
 				Address string `json:"address"`
 			} `json:"network"`
 		} `json:"properties"`
+		Network struct {
+			Address string `json:"address"`
+		} `json:"network"`
 	}
 	if err := json.Unmarshal(data, &obj); err != nil {
 		return err
 	}
-	s.CIDR = obj.Properties.Network.Address
+	if obj.Properties.Network.Address != "" {
+		s.CIDR = obj.Properties.Network.Address
+	} else {
+		s.CIDR = obj.Network.Address
+	}
 	return nil
 }
 

--- a/pkg/types/network.vpn-route.go
+++ b/pkg/types/network.vpn-route.go
@@ -52,7 +52,7 @@ func (s SubnetCIDROrRef) MarshalJSON() ([]byte, error) {
 }
 
 type VPNRoutePropertiesResponse struct {
-	LinkedResources []LinkedResource `json:"linkedResources,omitempty"`
+	LinkedResources []LinkedResourceCommon `json:"linkedResources,omitempty"`
 
 	// CloudSubnet CIDR of the cloud subnet (plain string or full subnet object on Create)
 	CloudSubnet SubnetCIDROrRef `json:"cloudSubnet"`
@@ -60,7 +60,7 @@ type VPNRoutePropertiesResponse struct {
 	// OnPremSubnet CIDR of the onPrem subnet
 	OnPremSubnet string `json:"onPremSubnet"`
 
-	VPNTunnel *ReferenceResource `json:"vpnTunnel,omitempty"`
+	VPNTunnel *ReferenceResourceCommon `json:"vpnTunnel,omitempty"`
 }
 
 type VPNRouteRequest struct {
@@ -77,7 +77,7 @@ type VPNRouteResponse struct {
 	// Spec contains the VPC Route specification
 	Properties VPNRoutePropertiesResponse `json:"properties"`
 
-	Status ResourceStatus `json:"status,omitempty"`
+	Status ResourceStatusResponse `json:"status,omitempty"`
 }
 
 type VPNRouteListResponse struct {

--- a/pkg/types/network.vpn-route.go
+++ b/pkg/types/network.vpn-route.go
@@ -80,7 +80,7 @@ type VPNRouteResponse struct {
 	Status ResourceStatus `json:"status,omitempty"`
 }
 
-type VPNRouteList struct {
+type VPNRouteListResponse struct {
 	ListResponse
 	Values []VPNRouteResponse `json:"values"`
 }

--- a/pkg/types/network.vpn-route_test.go
+++ b/pkg/types/network.vpn-route_test.go
@@ -28,6 +28,18 @@ func TestSubnetCIDROrRef_UnmarshalJSON_FullObject(t *testing.T) {
 	}
 }
 
+func TestSubnetCIDROrRef_UnmarshalJSON_FlatNetworkObject(t *testing.T) {
+	// GET response shape: {network:{address:"..."}} without properties wrapper
+	raw := `{"name":"my-subnet","network":{"address":"10.2.0.0/24"}}`
+	var s types.SubnetCIDROrRef
+	if err := json.Unmarshal([]byte(raw), &s); err != nil {
+		t.Fatalf("UnmarshalJSON error: %v", err)
+	}
+	if s.CIDR != "10.2.0.0/24" {
+		t.Errorf("CIDR = %q, want %q", s.CIDR, "10.2.0.0/24")
+	}
+}
+
 func TestSubnetCIDROrRef_UnmarshalJSON_EmptyString(t *testing.T) {
 	var s types.SubnetCIDROrRef
 	if err := json.Unmarshal([]byte(`""`), &s); err != nil {

--- a/pkg/types/network.vpn-tunnel.go
+++ b/pkg/types/network.vpn-tunnel.go
@@ -252,13 +252,13 @@ type SubnetInfoCommon struct {
 // IPConfigurationsCommon contains network configuration of the VPN tunnel
 type IPConfigurationsCommon struct {
 	// VPC reference to the VPC (nullable)
-	VPC *ReferenceResource `json:"vpc,omitempty"`
+	VPC *ReferenceResourceCommon `json:"vpc,omitempty"`
 
 	// Subnet info (nullable)
 	Subnet *SubnetInfoCommon `json:"subnet,omitempty"`
 
 	// PublicIP reference to the public IP (nullable)
-	PublicIP *ReferenceResource `json:"publicIp,omitempty"`
+	PublicIP *ReferenceResourceCommon `json:"publicIp,omitempty"`
 }
 
 // IKESettingsCommon contains IKE settings
@@ -341,8 +341,8 @@ type VPNTunnelPropertiesRequest struct {
 	// VPNClientSettingsCommon Client settings of the VPN tunnel (nullable)
 	VPNClientSettingsCommon *VPNClientSettingsCommon `json:"vpnClientSettings,omitempty"`
 
-	// BillingPlan Billing plan
-	BillingPlan *BillingPlan `json:"billingPlan,omitempty"`
+	// BillingPlanCommon Billing plan
+	BillingPlanCommon *BillingPlanCommon `json:"billingPlan,omitempty"`
 }
 
 // VPNTunnelPropertiesResponse contains the response properties of a VPN tunnel
@@ -362,8 +362,8 @@ type VPNTunnelPropertiesResponse struct {
 	// RoutesNumber Number of valid VPN routes of the VPN tunnel
 	RoutesNumber int32 `json:"routesNumber,omitempty"`
 
-	// BillingPlan Billing plan (nullable)
-	BillingPlan *BillingPlan `json:"billingPlan,omitempty"`
+	// BillingPlanCommon Billing plan (nullable)
+	BillingPlanCommon *BillingPlanCommon `json:"billingPlan,omitempty"`
 }
 
 type VPNTunnelRequest struct {
@@ -380,7 +380,7 @@ type VPNTunnelResponse struct {
 	// Spec contains the VPN Tunnel specification
 	Properties VPNTunnelPropertiesResponse `json:"properties"`
 
-	Status ResourceStatus `json:"status,omitempty"`
+	Status ResourceStatusResponse `json:"status,omitempty"`
 }
 
 type VPNTunnelListResponse struct {

--- a/pkg/types/network.vpn-tunnel.go
+++ b/pkg/types/network.vpn-tunnel.go
@@ -1,6 +1,6 @@
 package types
 
-// IKEEncryption is the encryption algorithm for IKESettings.Encryption.
+// IKEEncryption is the encryption algorithm for IKESettingsCommon.Encryption.
 //
 // GET /providers/Aruba.Network/vpn-tunnels for the live catalog.
 type IKEEncryption string
@@ -62,7 +62,7 @@ const (
 	IKEEncryptionChaCha20Poly1305  IKEEncryption = "chacha20poly1305"
 )
 
-// IKEHash is the hash algorithm for IKESettings.Hash.
+// IKEHash is the hash algorithm for IKESettingsCommon.Hash.
 type IKEHash string
 
 const (
@@ -81,7 +81,7 @@ const (
 	IKEHashAES256GMAC IKEHash = "aes256gmac"
 )
 
-// IKEDHGroup is the Diffie-Hellman group for IKESettings.DHGroup.
+// IKEDHGroup is the Diffie-Hellman group for IKESettingsCommon.DHGroup.
 type IKEDHGroup string
 
 const (
@@ -109,7 +109,7 @@ const (
 	IKEDHGroup32 IKEDHGroup = "32"
 )
 
-// IKEDPDAction is the Dead Peer Detection action for IKESettings.DPDAction.
+// IKEDPDAction is the Dead Peer Detection action for IKESettingsCommon.DPDAction.
 type IKEDPDAction string
 
 const (
@@ -118,7 +118,7 @@ const (
 	IKEDPDActionRestart IKEDPDAction = "restart"
 )
 
-// ESPEncryption is the encryption algorithm for ESPSettings.Encryption.
+// ESPEncryption is the encryption algorithm for ESPSettingsCommon.Encryption.
 //
 // GET /providers/Aruba.Network/vpn-tunnels for the live catalog.
 type ESPEncryption string
@@ -180,7 +180,7 @@ const (
 	ESPEncryptionChaCha20Poly1305  ESPEncryption = "chacha20poly1305"
 )
 
-// ESPHash is the hash algorithm for ESPSettings.Hash.
+// ESPHash is the hash algorithm for ESPSettingsCommon.Hash.
 type ESPHash string
 
 const (
@@ -199,7 +199,7 @@ const (
 	ESPHashAES256GMAC ESPHash = "aes256gmac"
 )
 
-// ESPPFSGroup is the Perfect Forward Secrecy group for ESPSettings.PFS.
+// ESPPFSGroup is the Perfect Forward Secrecy group for ESPSettingsCommon.PFS.
 type ESPPFSGroup string
 
 const (
@@ -243,26 +243,26 @@ const (
 	VPNClientProtocolIKEv2 VPNClientProtocol = "ikev2"
 )
 
-// SubnetInfo contains subnet CIDR and name for VPN tunnel IP configuration
-type SubnetInfo struct {
+// SubnetInfoCommon contains subnet CIDR and name for VPN tunnel IP configuration
+type SubnetInfoCommon struct {
 	CIDR string `json:"cidr,omitempty"`
 	Name string `json:"name,omitempty"`
 }
 
-// IPConfigurations contains network configuration of the VPN tunnel
-type IPConfigurations struct {
+// IPConfigurationsCommon contains network configuration of the VPN tunnel
+type IPConfigurationsCommon struct {
 	// VPC reference to the VPC (nullable)
 	VPC *ReferenceResource `json:"vpc,omitempty"`
 
 	// Subnet info (nullable)
-	Subnet *SubnetInfo `json:"subnet,omitempty"`
+	Subnet *SubnetInfoCommon `json:"subnet,omitempty"`
 
 	// PublicIP reference to the public IP (nullable)
 	PublicIP *ReferenceResource `json:"publicIp,omitempty"`
 }
 
-// IKESettings contains IKE settings
-type IKESettings struct {
+// IKESettingsCommon contains IKE settings
+type IKESettingsCommon struct {
 	// Lifetime Lifetime value
 	Lifetime int32 `json:"lifetime,omitempty"`
 
@@ -285,8 +285,8 @@ type IKESettings struct {
 	DPDTimeout int32 `json:"dpdTimeout,omitempty"`
 }
 
-// ESPSettings contains ESP settings
-type ESPSettings struct {
+// ESPSettingsCommon contains ESP settings
+type ESPSettingsCommon struct {
 	// Lifetime Lifetime value
 	Lifetime int32 `json:"lifetime,omitempty"`
 
@@ -300,8 +300,8 @@ type ESPSettings struct {
 	PFS *ESPPFSGroup `json:"pfs,omitempty"`
 }
 
-// PSKSettings contains Pre-Shared Key settings
-type PSKSettings struct {
+// PSKSettingsCommon contains Pre-Shared Key settings
+type PSKSettingsCommon struct {
 	// CloudSite Cloud site identifier (nullable)
 	CloudSite *string `json:"cloudSite,omitempty"`
 
@@ -312,16 +312,16 @@ type PSKSettings struct {
 	Secret *string `json:"secret,omitempty"`
 }
 
-// VPNClientSettings contains client settings of the VPN tunnel
-type VPNClientSettings struct {
+// VPNClientSettingsCommon contains client settings of the VPN tunnel
+type VPNClientSettingsCommon struct {
 	// IKE settings (nullable)
-	IKE *IKESettings `json:"ike,omitempty"`
+	IKE *IKESettingsCommon `json:"ike,omitempty"`
 
 	// ESP settings (nullable)
-	ESP *ESPSettings `json:"esp,omitempty"`
+	ESP *ESPSettingsCommon `json:"esp,omitempty"`
 
 	// PSK Pre-Shared Key settings (nullable)
-	PSK *PSKSettings `json:"psk,omitempty"`
+	PSK *PSKSettingsCommon `json:"psk,omitempty"`
 
 	// PeerClientPublicIP Peer client public IP address (nullable)
 	PeerClientPublicIP *string `json:"peerClientPublicIp,omitempty"`
@@ -335,11 +335,11 @@ type VPNTunnelPropertiesRequest struct {
 	// VPNClientProtocol Protocol of the VPN tunnel. Admissible values: ikev2 (nullable)
 	VPNClientProtocol *VPNClientProtocol `json:"vpnClientProtocol,omitempty"`
 
-	// IPConfigurations Network configuration of the VPN tunnel (nullable)
-	IPConfigurations *IPConfigurations `json:"ipConfigurations,omitempty"`
+	// IPConfigurationsCommon Network configuration of the VPN tunnel (nullable)
+	IPConfigurationsCommon *IPConfigurationsCommon `json:"ipConfigurations,omitempty"`
 
-	// VPNClientSettings Client settings of the VPN tunnel (nullable)
-	VPNClientSettings *VPNClientSettings `json:"vpnClientSettings,omitempty"`
+	// VPNClientSettingsCommon Client settings of the VPN tunnel (nullable)
+	VPNClientSettingsCommon *VPNClientSettingsCommon `json:"vpnClientSettings,omitempty"`
 
 	// BillingPlan Billing plan
 	BillingPlan *BillingPlan `json:"billingPlan,omitempty"`
@@ -353,11 +353,11 @@ type VPNTunnelPropertiesResponse struct {
 	// VPNClientProtocol Protocol of the VPN tunnel (nullable)
 	VPNClientProtocol *VPNClientProtocol `json:"vpnClientProtocol,omitempty"`
 
-	// IPConfigurations Network configuration of the VPN tunnel (nullable)
-	IPConfigurations *IPConfigurations `json:"ipConfigurations,omitempty"`
+	// IPConfigurationsCommon Network configuration of the VPN tunnel (nullable)
+	IPConfigurationsCommon *IPConfigurationsCommon `json:"ipConfigurations,omitempty"`
 
-	// VPNClientSettings Client settings of the VPN tunnel (nullable)
-	VPNClientSettings *VPNClientSettings `json:"vpnClientSettings,omitempty"`
+	// VPNClientSettingsCommon Client settings of the VPN tunnel (nullable)
+	VPNClientSettingsCommon *VPNClientSettingsCommon `json:"vpnClientSettings,omitempty"`
 
 	// RoutesNumber Number of valid VPN routes of the VPN tunnel
 	RoutesNumber int32 `json:"routesNumber,omitempty"`
@@ -383,7 +383,7 @@ type VPNTunnelResponse struct {
 	Status ResourceStatus `json:"status,omitempty"`
 }
 
-type VPNTunnelList struct {
+type VPNTunnelListResponse struct {
 	ListResponse
 	Values []VPNTunnelResponse `json:"values"`
 }

--- a/pkg/types/project.project.go
+++ b/pkg/types/project.project.go
@@ -37,7 +37,7 @@ type ProjectResponse struct {
 	//Status ResourceStatus `json:"status,omitempty"`
 }
 
-type ProjectList struct {
+type ProjectListResponse struct {
 	ListResponse
 	Values []ProjectResponse `json:"values"`
 }

--- a/pkg/types/project.project.go
+++ b/pkg/types/project.project.go
@@ -34,7 +34,7 @@ type ProjectResponse struct {
 	// Spec contains the Project specification
 	Properties ProjectPropertiesResponse `json:"properties"`
 
-	//Status ResourceStatus `json:"status,omitempty"`
+	//Status ResourceStatusResponse `json:"status,omitempty"`
 }
 
 type ProjectListResponse struct {

--- a/pkg/types/resource.go
+++ b/pkg/types/resource.go
@@ -32,7 +32,7 @@ type LocationResponse struct {
 	Value   Region `json:"value,omitempty"`
 }
 
-type ProjectResponseMetadata struct {
+type ProjectMetadataResponse struct {
 	ID string `json:"id,omitempty"`
 }
 
@@ -40,15 +40,15 @@ type ResourceRequest struct {
 	Metadata *ResourceMetadataRequest `json:"metadata"`
 }
 
-type TypologyResponseMetadata struct {
+type TypologyMetadataResponse struct {
 	ID   string `json:"id,omitempty"`
 	Name string `json:"name,omitempty"`
 }
 
-type CategoryResponseMetadata struct {
+type CategoryMetadataResponse struct {
 	Name     string                   `json:"name,omitempty"`
 	Provider string                   `json:"provider,omitempty"`
-	Typology TypologyResponseMetadata `json:"typology,omitempty"`
+	Typology TypologyMetadataResponse `json:"typology,omitempty"`
 }
 
 type ResourceMetadataResponse struct {
@@ -56,9 +56,9 @@ type ResourceMetadataResponse struct {
 	URI                     *string                   `json:"uri,omitempty"`
 	Name                    *string                   `json:"name,omitempty"`
 	LocationResponse        *LocationResponse         `json:"location,omitempty"`
-	ProjectResponseMetadata *ProjectResponseMetadata  `json:"project,omitempty"`
+	ProjectMetadataResponse *ProjectMetadataResponse  `json:"project,omitempty"`
 	Tags                    []string                  `json:"tags,omitempty"`
-	Category                *CategoryResponseMetadata `json:"category,omitempty"`
+	Category                *CategoryMetadataResponse `json:"category,omitempty"`
 	CreationDate            *time.Time                `json:"creationDate,omitempty"`
 	CreatedBy               *string                   `json:"createdBy,omitempty"`
 	UpdateDate              *time.Time                `json:"updateDate,omitempty"`
@@ -69,26 +69,26 @@ type ResourceMetadataResponse struct {
 }
 
 // Status
-type PreviousStatus struct {
+type PreviousStatusResponse struct {
 	State        *State     `json:"state,omitempty"`
 	CreationDate *time.Time `json:"creationDate,omitempty"`
 }
 
-type DisableStatusInfo struct {
+type DisableStatusInfoResponse struct {
 	IsDisabled bool     `json:"isDisabled,omitempty"`
 	Reasons    []string `json:"reasons,omitempty"`
 }
 
-type ResourceStatus struct {
-	State             *State             `json:"state,omitempty"`
-	CreationDate      *time.Time         `json:"creationDate,omitempty"`
-	DisableStatusInfo *DisableStatusInfo `json:"disableStatusInfo,omitempty"`
-	PreviousStatus    *PreviousStatus    `json:"previousStatus,omitempty"`
-	FailureReason     *string            `json:"failureReason,omitempty"`
+type ResourceStatusResponse struct {
+	State                     *State                     `json:"state,omitempty"`
+	CreationDate              *time.Time                 `json:"creationDate,omitempty"`
+	DisableStatusInfoResponse *DisableStatusInfoResponse `json:"disableStatusInfo,omitempty"`
+	PreviousStatusResponse    *PreviousStatusResponse    `json:"previousStatus,omitempty"`
+	FailureReason             *string                    `json:"failureReason,omitempty"`
 }
 
-// LinkedResource represents a resource linked
-type LinkedResource struct {
+// LinkedResourceCommon represents a resource linked
+type LinkedResourceCommon struct {
 	// URI of the linked resource
 	URI string `json:"uri"`
 
@@ -109,13 +109,13 @@ const (
 	BillingPeriodYear  BillingPeriod = "Year"
 )
 
-// BillingPlan is the nested wire wrapper used by resources whose API encodes
+// BillingPlanCommon is the nested wire wrapper used by resources whose API encodes
 // billing inside a billingPlan object rather than as a flat billingPeriod field.
-type BillingPlan struct {
+type BillingPlanCommon struct {
 	BillingPeriod *BillingPeriod `json:"billingPeriod,omitempty"`
 }
 
-type ReferenceResource struct {
+type ReferenceResourceCommon struct {
 	URI string `json:"uri"`
 }
 

--- a/pkg/types/schedule.job.go
+++ b/pkg/types/schedule.job.go
@@ -42,11 +42,18 @@ const (
 	HTTPVerbPATCH  HTTPVerb = "PATCH"
 )
 
-// JobStep represents a step that will be executed as part of the job
-type JobStep struct {
+// JobStepRequest represents a step that will be executed as part of the job.
+// Typology must match the server-side catalog ID of the target resource
+// (e.g. "cloudServer"). Use the JobStepTypology* constants in pkg/aruba.
+type JobStepRequest struct {
 	// Name Descriptive name of the step (nullable)
 	// For more information, check the documentation.
 	Name *string `json:"name,omitempty"`
+
+	// Typology identifies the resource category for this step (e.g. "cloudServer").
+	// Required by the API for step dispatch; values come from category.typology.id
+	// on any GET response for the target resource type.
+	Typology *string `json:"typology,omitempty"`
 
 	// ResourceURI URI of the resource on which the action will be performed
 	ResourceURI string `json:"resourceUri"`
@@ -118,7 +125,7 @@ type JobPropertiesRequest struct {
 	Cron *string `json:"cron,omitempty"`
 
 	// Steps Steps that will be executed as part of the job (nullable)
-	Steps []JobStep `json:"steps,omitempty"`
+	Steps []JobStepRequest `json:"steps,omitempty"`
 }
 
 // JobPropertiesResponse contains the response properties of a job

--- a/pkg/types/schedule.job.go
+++ b/pkg/types/schedule.job.go
@@ -175,8 +175,8 @@ type JobResponse struct {
 	Status ResourceStatus `json:"status,omitempty"`
 }
 
-// JobList represents a list of jobs
-type JobList struct {
+// JobListResponse represents a list of jobs
+type JobListResponse struct {
 	ListResponse
 	Values []JobResponse `json:"values"`
 }

--- a/pkg/types/schedule.job.go
+++ b/pkg/types/schedule.job.go
@@ -172,7 +172,7 @@ type JobResponse struct {
 	Properties JobPropertiesResponse `json:"properties"`
 
 	// Status of the job
-	Status ResourceStatus `json:"status,omitempty"`
+	Status ResourceStatusResponse `json:"status,omitempty"`
 }
 
 // JobListResponse represents a list of jobs

--- a/pkg/types/schedule.job.go
+++ b/pkg/types/schedule.job.go
@@ -43,17 +43,10 @@ const (
 )
 
 // JobStepRequest represents a step that will be executed as part of the job.
-// Typology must match the server-side catalog ID of the target resource
-// (e.g. "cloudServer"). Use the JobStepTypology* constants in pkg/aruba.
 type JobStepRequest struct {
 	// Name Descriptive name of the step (nullable)
 	// For more information, check the documentation.
 	Name *string `json:"name,omitempty"`
-
-	// Typology identifies the resource category for this step (e.g. "cloudServer").
-	// Required by the API for step dispatch; values come from category.typology.id
-	// on any GET response for the target resource type.
-	Typology *string `json:"typology,omitempty"`
 
 	// ResourceURI URI of the resource on which the action will be performed
 	ResourceURI string `json:"resourceUri"`

--- a/pkg/types/security.kms.go
+++ b/pkg/types/security.kms.go
@@ -21,7 +21,7 @@ type KmsResponse struct {
 	Status     ResourceStatus           `json:"status,omitempty"`
 }
 
-type KmsList struct {
+type KmsListResponse struct {
 	ListResponse
 	Values []KmsResponse `json:"values"`
 }
@@ -77,7 +77,7 @@ type KeyResponse struct {
 	Status         *KeyStatus         `json:"status,omitempty"`
 }
 
-type KeyList struct {
+type KeyListResponse struct {
 	ListResponse
 	Values []KeyResponse `json:"values"`
 }
@@ -109,7 +109,7 @@ type KmipResponse struct {
 	DeletionDate *string        `json:"deletionDate,omitempty"` // date-time format, nullable
 }
 
-type KmipList struct {
+type KmipListResponse struct {
 	ListResponse
 	Values []KmipResponse `json:"values"`
 }

--- a/pkg/types/security.kms.go
+++ b/pkg/types/security.kms.go
@@ -18,7 +18,7 @@ type KmsRequest struct {
 type KmsResponse struct {
 	Metadata   ResourceMetadataResponse `json:"metadata"`
 	Properties KmsPropertiesResponse    `json:"properties"`
-	Status     ResourceStatus           `json:"status,omitempty"`
+	Status     ResourceStatusResponse   `json:"status,omitempty"`
 }
 
 type KmsListResponse struct {

--- a/pkg/types/state.go
+++ b/pkg/types/state.go
@@ -1,6 +1,6 @@
 package types
 
-// State is the lifecycle state of an Aruba Cloud resource (ResourceStatus.State).
+// State is the lifecycle state of an Aruba Cloud resource (ResourceStatusResponse.State).
 type State string
 
 const (

--- a/pkg/types/storage.backup.go
+++ b/pkg/types/storage.backup.go
@@ -13,7 +13,7 @@ type StorageBackupPropertiesRequest struct {
 	StorageBackupType StorageBackupType `json:"type"`
 
 	// Origin indicates the source volume
-	Origin ReferenceResource `json:"sourceVolume"`
+	Origin ReferenceResourceCommon `json:"sourceVolume"`
 
 	// RetentionDays indicates the number of days to retain the backup
 	RetentionDays *int `json:"retentionDays,omitempty"`
@@ -28,7 +28,7 @@ type StorageBackupPropertiesResponse struct {
 	Type StorageBackupType `json:"type"`
 
 	// Origin indicates the source volume
-	Origin ReferenceResource `json:"sourceVolume"`
+	Origin ReferenceResourceCommon `json:"sourceVolume"`
 
 	// RetentionDays indicates the number of days to retain the backup
 	RetentionDays *int `json:"retentionDays,omitempty"`
@@ -48,7 +48,7 @@ type StorageBackupResponse struct {
 
 	Properties StorageBackupPropertiesResponse `json:"properties"`
 
-	Status ResourceStatus `json:"status,omitempty"`
+	Status ResourceStatusResponse `json:"status,omitempty"`
 }
 
 type StorageBackupListResponse struct {

--- a/pkg/types/storage.backup.go
+++ b/pkg/types/storage.backup.go
@@ -22,7 +22,7 @@ type StorageBackupPropertiesRequest struct {
 	BillingPeriod *BillingPeriod `json:"billingPeriod,omitempty"`
 }
 
-type StorageBackupPropertiesResult struct {
+type StorageBackupPropertiesResponse struct {
 
 	// StorageBackupType indicates whether the StorageBackup is full or incremental
 	Type StorageBackupType `json:"type"`
@@ -46,12 +46,12 @@ type StorageBackupRequest struct {
 type StorageBackupResponse struct {
 	Metadata ResourceMetadataResponse `json:"metadata"`
 
-	Properties StorageBackupPropertiesResult `json:"properties"`
+	Properties StorageBackupPropertiesResponse `json:"properties"`
 
 	Status ResourceStatus `json:"status,omitempty"`
 }
 
-type StorageBackupList struct {
+type StorageBackupListResponse struct {
 	ListResponse
 	Values []StorageBackupResponse `json:"values"`
 }

--- a/pkg/types/storage.block-storage.go
+++ b/pkg/types/storage.block-storage.go
@@ -102,7 +102,7 @@ type BlockStorageResponse struct {
 	Status ResourceStatus `json:"status,omitempty"`
 }
 
-type BlockStorageList struct {
+type BlockStorageListResponse struct {
 	ListResponse
 	Values []BlockStorageResponse `json:"values"`
 }

--- a/pkg/types/storage.block-storage.go
+++ b/pkg/types/storage.block-storage.go
@@ -54,7 +54,7 @@ type BlockStoragePropertiesRequest struct {
 	// Type of block storage. Admissible values: Standard, Performance
 	Type BlockStorageType `json:"type"`
 
-	Snapshot *ReferenceResource `json:"snapshot,omitempty"`
+	Snapshot *ReferenceResourceCommon `json:"snapshot,omitempty"`
 
 	Bootable *bool `json:"bootable,omitempty"`
 
@@ -62,7 +62,7 @@ type BlockStoragePropertiesRequest struct {
 }
 
 type BlockStoragePropertiesResponse struct {
-	LinkedResources []LinkedResource `json:"linkedResources,omitempty"`
+	LinkedResources []LinkedResourceCommon `json:"linkedResources,omitempty"`
 
 	// SizeGB Size of the block storage in GB
 	SizeGB int `json:"sizeGb"`
@@ -76,7 +76,7 @@ type BlockStoragePropertiesResponse struct {
 	// Type of block storage. Admissible values: Standard, Performance
 	Type BlockStorageType `json:"type"`
 
-	Snapshot *ReferenceResource `json:"snapshot,omitempty"`
+	Snapshot *ReferenceResourceCommon `json:"snapshot,omitempty"`
 
 	Bootable *bool `json:"bootable,omitempty"`
 
@@ -99,7 +99,7 @@ type BlockStorageResponse struct {
 	// Spec contains the Block Storage specification
 	Properties BlockStoragePropertiesResponse `json:"properties"`
 
-	Status ResourceStatus `json:"status,omitempty"`
+	Status ResourceStatusResponse `json:"status,omitempty"`
 }
 
 type BlockStorageListResponse struct {

--- a/pkg/types/storage.restore.go
+++ b/pkg/types/storage.restore.go
@@ -1,11 +1,11 @@
 package types
 
 type StorageRestorePropertiesRequest struct {
-	Target ReferenceResource `json:"destinationVolume"`
+	Target ReferenceResourceCommon `json:"destinationVolume"`
 }
 
 type StorageRestorePropertiesResponse struct {
-	Destination ReferenceResource `json:"destinationVolume"`
+	Destination ReferenceResourceCommon `json:"destinationVolume"`
 }
 
 type StorageRestoreRequest struct {
@@ -19,7 +19,7 @@ type StorageRestoreResponse struct {
 
 	Properties StorageRestorePropertiesResponse `json:"properties"`
 
-	Status ResourceStatus `json:"status,omitempty"`
+	Status ResourceStatusResponse `json:"status,omitempty"`
 }
 
 type StorageRestoreListResponse struct {

--- a/pkg/types/storage.restore.go
+++ b/pkg/types/storage.restore.go
@@ -4,7 +4,7 @@ type StorageRestorePropertiesRequest struct {
 	Target ReferenceResource `json:"destinationVolume"`
 }
 
-type StorageRestorePropertiesResult struct {
+type StorageRestorePropertiesResponse struct {
 	Destination ReferenceResource `json:"destinationVolume"`
 }
 
@@ -17,12 +17,12 @@ type StorageRestoreRequest struct {
 type StorageRestoreResponse struct {
 	Metadata ResourceMetadataResponse `json:"metadata"`
 
-	Properties StorageRestorePropertiesResult `json:"properties"`
+	Properties StorageRestorePropertiesResponse `json:"properties"`
 
 	Status ResourceStatus `json:"status,omitempty"`
 }
 
-type StorageRestoreList struct {
+type StorageRestoreListResponse struct {
 	ListResponse
 	Values []StorageRestoreResponse `json:"values"`
 }

--- a/pkg/types/storage.snapshot.go
+++ b/pkg/types/storage.snapshot.go
@@ -7,8 +7,8 @@ type SnapshotPropertiesRequest struct {
 	Volume ReferenceResource `json:"volume,omitempty"`
 }
 
-// VolumeInfo contains information about the original volume
-type VolumeInfo struct {
+// VolumeInfoResponse contains information about the original volume
+type VolumeInfoResponse struct {
 	// URI of the volume
 	URI *string `json:"uri,omitempty"`
 
@@ -26,7 +26,7 @@ type SnapshotPropertiesResponse struct {
 	BillingPeriod *BillingPeriod `json:"billingPeriod,omitempty"`
 
 	// Volume information about the original volume
-	Volume *VolumeInfo `json:"volume,omitempty"`
+	Volume *VolumeInfoResponse `json:"volume,omitempty"`
 
 	// Type of block storage. Admissible values: Standard, Performance
 	Type BlockStorageType `json:"type"`
@@ -55,7 +55,7 @@ type SnapshotResponse struct {
 	Status ResourceStatus `json:"status,omitempty"`
 }
 
-type SnapshotList struct {
+type SnapshotListResponse struct {
 	ListResponse
 	Values []SnapshotResponse `json:"values"`
 }

--- a/pkg/types/storage.snapshot.go
+++ b/pkg/types/storage.snapshot.go
@@ -4,7 +4,7 @@ type SnapshotPropertiesRequest struct {
 	// BillingPeriod The billing period for blockStorage. Only Hour is a valid value (nullable)
 	BillingPeriod *BillingPeriod `json:"billingPeriod,omitempty"`
 
-	Volume ReferenceResource `json:"volume,omitempty"`
+	Volume ReferenceResourceCommon `json:"volume,omitempty"`
 }
 
 // VolumeInfoResponse contains information about the original volume
@@ -15,7 +15,7 @@ type VolumeInfoResponse struct {
 	// Type of the original volume from which the snapshot was created (nullable)
 	Name *string `json:"name,omitempty"`
 
-	CompoundResource *ReferenceResource `json:"compoundResource,omitempty"`
+	CompoundResource *ReferenceResourceCommon `json:"compoundResource,omitempty"`
 }
 
 type SnapshotPropertiesResponse struct {
@@ -52,7 +52,7 @@ type SnapshotResponse struct {
 	// Spec contains the Snapshot specification
 	Properties SnapshotPropertiesResponse `json:"properties"`
 
-	Status ResourceStatus `json:"status,omitempty"`
+	Status ResourceStatusResponse `json:"status,omitempty"`
 }
 
 type SnapshotListResponse struct {

--- a/pkg/util/middleware/doc.go
+++ b/pkg/util/middleware/doc.go
@@ -1,0 +1,23 @@
+// Package restclient provides HTTP interceptor helper functions for use with
+// the Aruba Cloud SDK middleware chain.
+//
+// # Note on package name
+//
+// This package is located at pkg/util/middleware/ but is named "restclient"
+// (see TD-025 in ai/TECH_DEBT.md for the planned rename). Import it as:
+//
+//	import restclient "github.com/Arubacloud/sdk-go/pkg/util/middleware"
+//
+// # Provided helpers
+//
+// Each function returns an interceptor.InterceptFunc suitable for use with
+// aruba.NewOptions().WithCustomMiddleware(interceptor):
+//
+//   - [WithCustomHeaders] — attaches a static map of request headers.
+//   - [WithUserAgent]     — sets the User-Agent header.
+//   - [WithContentType]   — sets the Content-Type header.
+//   - [WithAccept]        — sets the Accept header.
+//
+// These helpers are intended for cases where the built-in SDK middleware is
+// insufficient. Most callers do not need to import this package directly.
+package restclient


### PR DESCRIPTION
## Summary
- #304 — *Project now exposes Raw(), RawJSON(), RawYAML(), RawRequest()
- #305 — Verified NewJobStep + Job.WithSteps(...) already satisfies the issue's intent
- #306 — VPNTunnel.fromResponse now rehydrates IKE / ESP / PSK / IPConfig
- #307 — CloudServer.fromResponse now rehydrates subnetRefs
- #308 — SubnetCIDROrRef.UnmarshalJSON extended to handle the flat GET shape
- #309 — Full flattened-getter sweep across every Family-A wrapper
- #310 — pkg/aruba/version.go introduces Version = "1.0.0" and defaultUserAgent

Plus: CHANGELOG sections folded into [1.0.0] — 2026-05-29, branch policy retargeted at v1.x, options.md and TECH_DEBT TD-021/TD-022 references updated.

Closes #304, #305, #306, #307, #308, #309, #310