### PR TITLE
docs(i18n): complete Italian translations v0.2.3 → v1.0.0

### DIFF
--- a/docs/website/i18n/it/docusaurus-plugin-content-docs/current/options.md
+++ b/docs/website/i18n/it/docusaurus-plugin-content-docs/current/options.md
@@ -1,6 +1,6 @@
 # Opzioni di Configurazione SDK
 
-L'SDK Aruba Cloud per Go è configurato utilizzando un'API fluente che ti consente di concatenare i setter di opzioni per costruire una configurazione client. Questa guida dettaglia tutte le opzioni disponibili, raggruppate per argomento.
+L'SDK Aruba Cloud per Go è configurato mediante un'API fluente che consente di concatenare i setter di opzioni per costruire una configurazione client. Questa guida dettaglia tutte le opzioni disponibili, raggruppate per argomento.
 
 ## Iniziare
 
@@ -17,13 +17,13 @@ L'SDK Aruba Cloud per Go è configurato utilizzando un'API fluente che ti consen
   <tbody>
     <tr>
       <td><code>DefaultOptions(clientID, clientSecret)</code></td>
-      <td>Crea una configurazione standard per l'ambiente di produzione utilizzando il tuo Client ID e Secret API.</td>
+      <td>Crea una configurazione standard per l'ambiente di produzione utilizzando il Client ID e il Secret API.</td>
       <td>Questo è il punto di partenza consigliato per la maggior parte delle applicazioni. Imposta l'API di produzione e gli URL dei token e configura l'autenticazione.</td>
     </tr>
     <tr>
       <td><code>NewOptions()</code></td>
-      <td>Crea un nuovo builder di configurazione vuoto. Devi configurare manualmente tutte le impostazioni richieste, inclusa l'autenticazione.</td>
-      <td>Usa questo se hai bisogno di controllo completo sulla configurazione da zero.</td>
+      <td>Crea un nuovo builder di configurazione vuoto. È necessario configurare manualmente tutte le impostazioni richieste, inclusa l'autenticazione.</td>
+      <td>Usa questa opzione se hai bisogno di controllo completo sulla configurazione da zero.</td>
     </tr>
   </tbody>
 </table>
@@ -42,11 +42,11 @@ L'SDK Aruba Cloud per Go è configurato utilizzando un'API fluente che ti consen
     <tr>
       <td><code>WithBaseURL(baseURL)</code></td>
       <td>Sovrascrive l'URL API Aruba Cloud predefinito.</td>
-      <td>Il predefinito è <code>https://api.arubacloud.com</code>. Dovresti cambiarlo solo se devi puntare a un ambiente diverso.</td>
+      <td>Il valore predefinito è <code>https://api.arubacloud.com</code>. Modificalo solo se devi puntare a un ambiente diverso.</td>
     </tr>
     <tr>
       <td><code>WithDefaultBaseURL()</code></td>
-      <td>Un helper che imposta l'URL API al predefinito di produzione.</td>
+      <td>Helper che imposta l'URL API al valore predefinito di produzione.</td>
       <td>Chiamato da <code>DefaultOptions()</code>.</td>
     </tr>
   </tbody>
@@ -54,7 +54,7 @@ L'SDK Aruba Cloud per Go è configurato utilizzando un'API fluente che ti consen
 
 ## Autenticazione
 
-<p>L'autenticazione è una parte critica della configurazione. Devi scegliere <b>uno</b> dei seguenti metodi.</p>
+<p>L'autenticazione è una parte critica della configurazione. È necessario scegliere <b>uno</b> dei seguenti metodi.</p>
 
 <table>
   <thead>
@@ -66,41 +66,49 @@ L'SDK Aruba Cloud per Go è configurato utilizzando un'API fluente che ti consen
   </thead>
   <tbody>
     <tr>
+      <td><code>WithDefaultTokenManagerSchema(clientID, clientSecret)</code></td>
+      <td>Configura l'autenticazione Client Credentials standard con l'URL del token issuer predefinito e senza caching persistente. Chiamato internamente da <code>DefaultOptions()</code>.</td>
+      <td>Da usare quando si vuole ripristinare il token manager alle impostazioni di fabbrica prima di applicare sovrascritture selettive.</td>
+    </tr>
+    <tr>
       <td><code>WithClientCredentials(clientID, clientSecret)</code></td>
       <td><b>(Consigliato)</b> Configura l'SDK per utilizzare il flusso OAuth2 Client Credentials. L'SDK gestirà automaticamente il recupero e il rinnovo del token di accesso.</td>
-      <td><b>Esclusione Reciproca</b>: Non può essere utilizzato con <code>WithToken()</code> o <code>WithVaultCredentialsRepository()</code>. Questo è il metodo standard e più sicuro per l'autenticazione service-to-service.</td>
+      <td><b>Esclusione reciproca</b>: non può essere usato con <code>WithToken()</code> o <code>WithVaultCredentialsRepository()</code>. È il metodo standard e più sicuro per l'autenticazione service-to-service.</td>
     </tr>
     <tr>
       <td><code>WithToken(token)</code></td>
       <td>Configura l'SDK per utilizzare un token di accesso OAuth2 statico preesistente.</td>
-      <td><b>Esclusione Reciproca</b>: Non può essere utilizzato con qualsiasi altra opzione di autenticazione o token issuer.<br/> <b>Avviso</b>: L'SDK <b>non</b> rinnoverà questo token. Una volta scaduto, tutte le chiamate API falliranno. Questo metodo è consigliato solo per client di breve durata o script semplici e atomici.</td>
+      <td><b>Esclusione reciproca</b>: non può essere usato con nessun'altra opzione di autenticazione o token issuer.<br/>
+      <b>Avviso</b>: L'SDK <b>non</b> rinnoverà questo token. Una volta scaduto, tutte le chiamate API falliranno. Questo metodo è consigliato solo per client di breve durata o script semplici e atomici.</td>
     </tr>
     <tr>
       <td><code>WithVaultCredentialsRepository(...)</code></td>
-      <td>Configura l'SDK per recuperare <code>clientID</code> e <code>clientSecret</code> da un'istanza HashiCorp Vault. L'SDK utilizzerà quindi queste credenziali per gestire il token di accesso.</td>
-      <td><b>Esclusione Reciproca</b>: Non può essere utilizzato con <code>WithClientCredentials()</code> o <code>WithToken()</code>.<br/> <b>Parametri</b>: <code>vaultURI</code>, <code>kvMount</code>, <code>kvPath</code>, <code>namespace</code>, <code>rolePath</code>, <code>roleID</code>, <code>secretID</code>.</td>
+      <td>Configura l'SDK per recuperare <code>clientID</code> e <code>clientSecret</code> da un'istanza HashiCorp Vault. L'SDK utilizzerà poi queste credenziali per gestire il token di accesso.</td>
+      <td><b>Esclusione reciproca</b>: non può essere usato con <code>WithClientCredentials()</code> o <code>WithToken()</code>.<br/>
+      <b>Parametri</b>: <code>vaultURI</code>, <code>kvMount</code>, <code>kvPath</code>, <code>namespace</code>,
+      <code>rolePath</code>, <code>roleID</code>, <code>secretID</code>.</td>
     </tr>
     <tr>
       <td><code>WithTokenIssuerURL(url)</code></td>
       <td>Sovrascrive l'URL predefinito per l'endpoint del token OAuth2.</td>
-      <td>Il predefinito è <code>https://login.aruba.it/...</code>. Dovresti cambiarlo solo se devi puntare a un endpoint di autenticazione diverso.</td>
+      <td>Il valore predefinito è <code>https://mylogin.aruba.it/auth/realms/cmp-new-apikey/protocol/openid-connect/token</code>. Modificalo solo se devi puntare a un endpoint di autenticazione diverso.</td>
     </tr>
     <tr>
       <td><code>WithSecurityScopes(scopes ...)</code></td>
       <td>Imposta gli scope di sicurezza da richiedere durante l'autenticazione.</td>
-      <td>Sostituisce qualsiasi scope precedentemente impostato.</td>
+      <td>Sostituisce qualsiasi scope precedentemente configurato.</td>
     </tr>
     <tr>
       <td><code>WithAdditionalSecurityScopes(scopes ...)</code></td>
-      <td>Aggiunge scope di sicurezza aggiuntivi all'elenco esistente.</td>
-      <td>Non sovrascrive gli scope esistenti.</td>
+      <td>Aggiunge scope di sicurezza supplementari all'elenco esistente.</td>
+      <td>Non sovrascrive gli scope già presenti.</td>
     </tr>
   </tbody>
 </table>
 
-## Cache Token (Opzionale)
+## Caching del Token (Opzionale)
 
-<p>Per migliorare le prestazioni e la resilienza, l'SDK può memorizzare nella cache il token di accesso in un archivio esterno. Questo è altamente consigliato per le applicazioni di produzione per evitare di recuperare un nuovo token ad ogni avvio.</p>
+<p>Per migliorare le prestazioni e la resilienza, l'SDK può memorizzare nella cache il token di accesso su uno store esterno. È fortemente consigliato nelle applicazioni di produzione per evitare di richiedere un nuovo token a ogni avvio.</p>
 
 <table>
   <thead>
@@ -113,28 +121,46 @@ L'SDK Aruba Cloud per Go è configurato utilizzando un'API fluente che ti consen
   <tbody>
     <tr>
       <td><code>WithRedisTokenRepositoryFromURI(redisURI)</code></td>
-      <td>Configura un'istanza Redis come cache persistente per il token di accesso.</td>
-      <td><b>Esclusione Reciproca</b>: Non può essere utilizzato con le opzioni <code>WithFileTokenRepository...</code>.<br/> Il formato URI è <code>redis://&lt;user&gt;:&lt;pass&gt;@&lt;host&gt;:&lt;port&gt;/&lt;db&gt;</code>.</td>
+      <td>Configura un'istanza Redis come cache persistente per il token di accesso, specificando l'URI completo.</td>
+      <td><b>Esclusione reciproca</b>: non può essere usato con le opzioni <code>WithFileTokenRepository...</code>.<br/>
+      Il formato URI è <code>redis://&lt;user&gt;:&lt;pass&gt;@&lt;host&gt;:&lt;port&gt;/&lt;db&gt;</code>.</td>
+    </tr>
+    <tr>
+      <td><code>WithRedisTokenRepositoryFromStandardURI()</code></td>
+      <td>Configura il caching Redis usando l'URI locale standard (<code>redis://admin:admin@localhost:6379/0</code>).</td>
+      <td>Scorciatoia per lo sviluppo locale. Non imposta il drift di scadenza; abbinare con
+      <code>WithStandardTokenExpirationDriftSeconds()</code> o usare <code>WithStandardRedisTokenRepository()</code>.</td>
     </tr>
     <tr>
       <td><code>WithFileTokenRepositoryFromBaseDir(baseDir)</code></td>
       <td>Configura una directory locale per memorizzare il token di accesso in un file JSON.</td>
-      <td><b>Esclusione Reciproca</b>: Non può essere utilizzato con le opzioni <code>WithRedisTokenRepository...</code>. Il processo SDK deve avere i permessi di lettura/scrittura sulla directory specificata.</td>
+      <td><b>Esclusione reciproca</b>: non può essere usato con le opzioni <code>WithRedisTokenRepository...</code>. Il processo SDK deve avere i permessi di lettura/scrittura sulla directory specificata.</td>
+    </tr>
+    <tr>
+      <td><code>WithFileTokenRepositoryFromStandardBaseDir()</code></td>
+      <td>Configura il caching su file in <code>/tmp/sdk-go</code>.</td>
+      <td>Scorciatoia per lo sviluppo locale. Non imposta il drift di scadenza; abbinare con
+      <code>WithStandardTokenExpirationDriftSeconds()</code> o usare <code>WithStandardFileTokenRepository()</code>.</td>
     </tr>
     <tr>
       <td><code>WithTokenExpirationDriftSeconds(seconds)</code></td>
-      <td>Imposta un buffer di sicurezza (in secondi) per trattare un token come scaduto prima che lo faccia effettivamente.</td>
-      <td>Questo previene condizioni di race dove l'SDK utilizza un token che scade appena prima che la richiesta API venga completata. Il predefinito è 300 secondi (5 minuti). Questa opzione non ha effetto se un meccanismo di cache (Redis o File) non è configurato.</td>
+      <td>Imposta un buffer di sicurezza (in secondi) per considerare un token scaduto prima che lo sia effettivamente.</td>
+      <td>Previene race condition in cui l'SDK usa un token che scade appena prima del completamento della richiesta API. Il valore predefinito è 300 secondi (5 minuti). Questa opzione non ha effetto se non è configurato un meccanismo di caching (Redis o File).</td>
+    </tr>
+    <tr>
+      <td><code>WithStandardTokenExpirationDriftSeconds()</code></td>
+      <td>Imposta il drift di scadenza a 300 secondi (5 minuti).</td>
+      <td>Equivalente a <code>WithTokenExpirationDriftSeconds(300)</code>.</td>
     </tr>
     <tr>
       <td><code>WithStandardRedisTokenRepository()</code></td>
-      <td>Helper per configurare la cache Redis su <code>localhost:6379</code> e imposta lo drift di scadenza standard (300s).</td>
-      <td>Una scorciatoia conveniente per lo sviluppo locale.</td>
+      <td>Helper che configura il caching Redis su <code>localhost:6379</code> e imposta il drift di scadenza standard (300s).</td>
+      <td>Scorciatoia comoda per lo sviluppo locale.</td>
     </tr>
     <tr>
       <td><code>WithStandardFileTokenRepository()</code></td>
-      <td>Helper per configurare la cache file in <code>/tmp/sdk-go</code> e imposta lo drift di scadenza standard (300s).</td>
-      <td>Una scorciatoia conveniente per lo sviluppo locale.</td>
+      <td>Helper che configura il caching su file in <code>/tmp/sdk-go</code> e imposta il drift di scadenza standard (300s).</td>
+      <td>Scorciatoia comoda per lo sviluppo locale.</td>
     </tr>
   </tbody>
 </table>
@@ -153,6 +179,11 @@ L'SDK Aruba Cloud per Go è configurato utilizzando un'API fluente che ti consen
   </thead>
   <tbody>
     <tr>
+      <td><code>WithDefaultLogger()</code></td>
+      <td>Ripristina il logger al valore predefinito dell'SDK (nessun log). Chiamato da <code>DefaultOptions()</code>.</td>
+      <td>Da usare quando si vuole ripristinare esplicitamente il logging dopo aver configurato un logger personalizzato.</td>
+    </tr>
+    <tr>
       <td><code>WithNoLogs()</code></td>
       <td>Disabilita tutto il logging dell'SDK.</td>
       <td>Questo è il comportamento predefinito.</td>
@@ -164,20 +195,44 @@ L'SDK Aruba Cloud per Go è configurato utilizzando un'API fluente che ti consen
     </tr>
     <tr>
       <td><code>WithLoggerType(loggerType)</code></td>
-      <td>Una funzione più generale per impostare il tipo di logger.</td>
+      <td>Funzione più generale per impostare il tipo di logger.</td>
       <td><code>loggerType</code> può essere <code>LoggerNoLog</code> o <code>LoggerNative</code>.</td>
     </tr>
     <tr>
       <td><code>WithCustomLogger(logger)</code></td>
       <td>Inietta un logger personalizzato che rispetta l'interfaccia <code>ports/logger.Logger</code>.</td>
-      <td>Consente l'integrazione con il framework di logging della tua applicazione (ad esempio, Logrus, Zap). Impostare questo imposta automaticamente il tipo di logger su <code>loggerCustom</code>.</td>
+      <td>Consente l'integrazione con il framework di logging dell'applicazione (ad esempio, Logrus, Zap). Impostando questo valore, il tipo di logger viene automaticamente impostato su <code>loggerCustom</code>.</td>
+    </tr>
+  </tbody>
+</table>
+
+## Identità del Client HTTP
+
+<p>L'SDK imposta automaticamente un header <code>User-Agent</code> su ogni richiesta in uscita, in modo che i log di accesso API possano essere attribuiti alla versione dell'SDK. Per impostazione predefinita il valore dell'header è <code>sdk-go@&lt;version&gt;</code>
+(ad esempio <code>sdk-go@1.0.0</code>), derivato dalla costante <code>aruba.Version</code> definita in
+<code>pkg/aruba/version.go</code>.</p>
+
+<table>
+  <thead>
+    <tr>
+      <th>Setter Opzione</th>
+      <th>Descrizione</th>
+      <th>Note</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td><code>WithUserAgent(ua)</code></td>
+      <td>Sovrascrive il valore predefinito dell'header <code>User-Agent</code> inviato con ogni richiesta.</td>
+      <td>Da usare quando si costruisce uno strumento sopra l'SDK e si vuole che i log API mostrino l'identità del proprio strumento invece di (o in aggiunta a) la versione grezza dell'SDK. Esempio:
+      <code>WithUserAgent("acloud-cli@1.0.0")</code>.</td>
     </tr>
   </tbody>
 </table>
 
 ## Avanzato / Dipendenze Personalizzate
 
-<p>Queste opzioni sono per casi d'uso avanzati dove devi iniettare i tuoi componenti personalizzati nel flusso di lavoro dell'SDK.</p>
+<p>Queste opzioni sono destinate a casi d'uso avanzati in cui è necessario iniettare componenti personalizzati nel flusso di lavoro dell'SDK.</p>
 
 <table>
   <thead>
@@ -196,7 +251,7 @@ L'SDK Aruba Cloud per Go è configurato utilizzando un'API fluente che ti consen
     <tr>
       <td><code>WithCustomMiddleware(middleware)</code></td>
       <td>Inietta un middleware personalizzato che rispetta l'interfaccia <code>ports/interceptor.Interceptor</code>.</td>
-      <td>Ti consente di aggiungere logica personalizzata (come logging o tracing di richiesta/risposta) nella catena di chiamate HTTP dell'SDK. Il middleware di autenticazione dell'SDK sarà automaticamente collegato alla fine della tua catena di middleware personalizzata.</td>
+      <td>Consente di aggiungere logica personalizzata (come logging o tracing di richiesta/risposta) nella catena di chiamate HTTP dell'SDK. Il middleware di autenticazione dell'SDK verrà automaticamente collegato alla fine della catena di middleware personalizzata.</td>
     </tr>
   </tbody>
 </table>

--- a/docs/website/i18n/it/docusaurus-plugin-content-docs/current/resources.md
+++ b/docs/website/i18n/it/docusaurus-plugin-content-docs/current/resources.md
@@ -47,6 +47,21 @@ fmt.Println(result.ID(), result.Name(), result.State())
 L'API di Aruba valida i valori dei tag contro `^[A-Za-z0-9-]{4,30}$`: **solo caratteri alfanumerici e trattini, lunghezza da 4 a 30**. Due punti, punti, underscore, spazi e altra punteggiatura vengono rifiutati con `400 — One or more validation error occurred`. L'SDK non valida i tag lato client, quindi un tag non valido fallisce solo quando la richiesta raggiunge il server.
 :::
 
+### Lettura dello stato del wrapper
+
+Ogni wrapper promuove i campi di risposta più usati a accessor piatti. Preferiscili rispetto a `wrapper.Raw().Properties.X`:
+
+```go
+fmt.Println(result.ID())        // UUID
+fmt.Println(result.Name())      // nome della risorsa
+fmt.Println(result.State())     // stato del ciclo di vita
+fmt.Println(result.Region())    // slug della regione
+fmt.Println(result.RawJSON())   // payload JSON wire completo (per --output json)
+fmt.Println(result.RawYAML())   // payload YAML wire completo (per --output yaml)
+```
+
+Gli scalari specifici della risorsa (es. `cs.Subnets()`, `vpnRoute.CloudSubnetCIDR()`, `kaas.PodCIDR()`) sono documentati nella sezione **Accessor di risposta** di ogni risorsa qui sotto. Vedi [Gestione delle risposte](./response-handling#lettura-dello-stato-del-wrapper) per la tassonomia completa degli accessor.
+
 Ogni sezione di risorsa elenca anche i suoi **Setter** (metodi builder concatenabili raggruppati per l'ordine canonico della catena da `ai/CONVENTIONS.md`) e un collegamento all'esempio eseguibile in `examples/all-resources/`.
 
 ---
@@ -83,6 +98,9 @@ fmt.Printf("✓ Progetto: %s (ID: %s)\n", proj.Name(), proj.ID())
 - `IsDefault()` — se questo è il progetto predefinito
 - `Tags()` — lista di tag `[]string`
 - `CreatedAt()`, `UpdatedAt()` — timestamp
+- `Raw()` — struct wire sottostante `*types.ProjectResponse`
+- `RawJSON()` / `RawYAML()` — payload serializzato per i flag `--output json/yaml`
+- `RawRequest()` — `types.ProjectRequest` per i flussi round-trip `Get → Update`
 
 **Setter**:
 - *Name*: `Named(string)`
@@ -167,7 +185,7 @@ if err != nil {
 }
 
 if err := cs.WaitUntilReady(ctx); err != nil {
-    log.Fatalf("Cloud Server did not become Active: %v", err)
+    log.Fatalf("Cloud Server did not become Ready: %v", err)
 }
 fmt.Printf("✓ Cloud Server: %s (zona: %s, flavor: %s)\n", cs.Name(), cs.Zone(), cs.Flavor())
 ```
@@ -295,7 +313,7 @@ if err != nil {
 }
 
 if err := k.WaitUntilReady(ctx); err != nil {
-    log.Fatalf("KaaS did not become Active: %v", err)
+    log.Fatalf("KaaS did not become Ready: %v", err)
 }
 fmt.Printf("✓ Cluster KaaS: %s (k8s: %s)\n", k.Name(), k.KubernetesVersion())
 ```
@@ -351,7 +369,7 @@ arubaClient.FromContainer().ContainerRegistry()
 ```
 
 **Operazioni supportate**: `Create`, `List`, `Get`, `Update`, `Delete`
-**Asincrono**: sì — chiama `WaitUntilReady(ctx)` dopo `Create`.
+**Asincrono**: sì — chiama `WaitUntilReady(ctx)` dopo `Create`. Questa risorsa può impiegare 20–40 minuti per convergere — utilizza un budget di attesa generoso.
 
 ```go
 reg, err := arubaClient.FromContainer().ContainerRegistry().Create(
@@ -373,7 +391,7 @@ if err != nil {
 }
 
 if err := reg.WaitUntilReady(ctx); err != nil {
-    log.Fatalf("ContainerRegistry did not become Active: %v", err)
+    log.Fatalf("ContainerRegistry did not become Ready: %v", err)
 }
 fmt.Printf("✓ Registry: %s (IP pubblico: %s)\n", reg.Name(), reg.PublicIP())
 ```
@@ -381,10 +399,9 @@ fmt.Printf("✓ Registry: %s (IP pubblico: %s)\n", reg.Name(), reg.PublicIP())
 **Accessor di risposta**:
 - `ID()`, `URI()`, `Name()`, `Tags()`
 - `ContainerRegistryID()` — ID registry assegnato dal provider
-- `PublicIP()` — IP dell'endpoint pubblico
+- `ElasticIP()` — URI dell'endpoint pubblico
 - `VPC()`, `Subnet()`, `SecurityGroup()`, `BlockStorage()` — `aruba.Ref` alle risorse collegate
 - `AdminUsername()` — utente amministratore del registry
-- `ConcurrentUsers()` — limite di utenti concorrenti configurato
 - `BillingPeriod()` — cadenza di fatturazione
 - `State()`, `FailureReason()`, `PreviousState()`, `IsDisabled()`, `DisableReasons()`
 - `WaitUntilReady(ctx, opts...)`, `WaitUntilActive(ctx, opts...)`, `WaitUntilStates(ctx, []types.State{...}, opts...)`, `WaitUntilGone(ctx, opts...)`
@@ -429,7 +446,6 @@ db, err := arubaClient.FromDatabase().DBaaS().Create(
         InRegion(aruba.RegionITBGBergamo).
         InZone(aruba.ZoneITBG1).
         SizedGB(20).
-        WithAutoscaling(2, 5).
         WithVPC(vpc).
         WithSubnet(subnet).
         WithSecurityGroup(sg).
@@ -440,7 +456,7 @@ if err != nil {
 }
 
 if err := db.WaitUntilReady(ctx); err != nil {
-    log.Fatalf("DBaaS did not become Active: %v", err)
+    log.Fatalf("DBaaS did not become Ready: %v", err)
 }
 fmt.Printf("✓ DBaaS: %s (engine: %s)\n", db.Name(), db.Engine())
 ```
@@ -448,12 +464,12 @@ fmt.Printf("✓ DBaaS: %s (engine: %s)\n", db.Name(), db.Engine())
 **Accessor di risposta**:
 - `ID()`, `URI()`, `Name()`, `Tags()`
 - `DBaaSID()` — ID istanza assegnato dal provider
-- `Engine()` — slug dell'engine (es. `"mysql-8.0"`)
+- `Engine()` — identificatore dell'engine (costante `DatabaseEngine`)
 - `EngineRaw()` — struct engine completa
-- `Flavor()` — slug del flavor
+- `Flavor()` — identificatore del flavor (costante `DBaaSFlavor`)
 - `FlavorRaw()` — struct flavor completa
-- `Storage()` — dimensione storage in GB
-- `Autoscaling()` — bool
+- `SizeGB()` — dimensione dello storage in GB
+- `AutoscalingEnabled()` — bool
 - `VPC()`, `Subnet()`, `SecurityGroup()`, `ElasticIP()` — `aruba.Ref` alle risorse di rete
 - `BillingPeriod()` — cadenza di fatturazione
 - `State()`, `FailureReason()`, `PreviousState()`, `IsDisabled()`, `DisableReasons()`
@@ -497,7 +513,7 @@ if err != nil {
 }
 
 if err := database.WaitUntilReady(ctx); err != nil {
-    log.Fatalf("Database did not become Active: %v", err)
+    log.Fatalf("Database did not become Ready: %v", err)
 }
 fmt.Printf("✓ Database: %s\n", database.Name())
 ```
@@ -505,7 +521,7 @@ fmt.Printf("✓ Database: %s\n", database.Name())
 **Accessor di risposta**:
 - `ID()`, `URI()`, `Name()`, `Tags()`
 - `DatabaseID()` — ID database assegnato dal provider
-- `DBaaSID()` — ID DBaaS genitore
+- `DBaaSID()` — ID DBaaS padre
 - `State()`, `FailureReason()`, `PreviousState()`, `IsDisabled()`, `DisableReasons()`
 - `WaitUntilReady(ctx, opts...)`, `WaitUntilActive(ctx, opts...)`, `WaitUntilStates(ctx, []types.State{...}, opts...)`, `WaitUntilGone(ctx, opts...)`
 - `Raw()` — struct wire sottostante
@@ -520,7 +536,7 @@ Esempio end-to-end completo: [`examples/all-resources/resource_database.go`](htt
 
 ---
 
-### Utente
+### User
 
 ```go
 arubaClient.FromDatabase().Users()
@@ -533,6 +549,7 @@ arubaClient.FromDatabase().Users()
 user, err := arubaClient.FromDatabase().Users().Create(
     ctx,
     aruba.NewUser().
+        Tagged("app-backend").
         InDBaaS(db).
         WithUsername("app_user").
         WithPassword("Str0ngP@ssword!"))
@@ -541,7 +558,7 @@ if err != nil {
 }
 
 if err := user.WaitUntilReady(ctx); err != nil {
-    log.Fatalf("User did not become Active: %v", err)
+    log.Fatalf("User did not become Ready: %v", err)
 }
 fmt.Printf("✓ Utente: %s\n", user.Name())
 ```
@@ -549,7 +566,8 @@ fmt.Printf("✓ Utente: %s\n", user.Name())
 **Accessor di risposta**:
 - `ID()`, `URI()`, `Name()`, `Tags()`
 - `UserID()` — ID utente assegnato dal provider
-- `DBaaSID()` — ID DBaaS genitore
+- `Username()` — nome utente del database
+- `DBaaSID()` — ID DBaaS padre
 - `State()`, `FailureReason()`, `PreviousState()`, `IsDisabled()`, `DisableReasons()`
 - `WaitUntilReady(ctx, opts...)`, `WaitUntilActive(ctx, opts...)`, `WaitUntilStates(ctx, []types.State{...}, opts...)`, `WaitUntilGone(ctx, opts...)`
 - `Raw()` — struct wire sottostante
@@ -586,16 +604,16 @@ if err != nil {
 }
 
 if err := grant.WaitUntilReady(ctx); err != nil {
-    log.Fatalf("Grant did not become Active: %v", err)
+    log.Fatalf("Grant did not become Ready: %v", err)
 }
-fmt.Printf("✓ Grant: %s\n", grant.ID())
+fmt.Printf("✓ Grant: %s (privilegi: %s)\n", grant.Name(), grant.Privileges())
 ```
 
 **Accessor di risposta**:
-- `ID()`, `URI()`
+- `ID()`, `URI()`, `Name()`, `Tags()`
 - `GrantID()` — ID grant assegnato dal provider
-- `DatabaseID()` — ID Database genitore
-- `Role()` — ruolo assegnato (es. `"liteadmin"`)
+- `DatabaseID()` — ID Database padre
+- `Privileges()` — stringa dei privilegi
 - `State()`, `FailureReason()`, `PreviousState()`, `IsDisabled()`, `DisableReasons()`
 - `WaitUntilReady(ctx, opts...)`, `WaitUntilActive(ctx, opts...)`, `WaitUntilStates(ctx, []types.State{...}, opts...)`, `WaitUntilGone(ctx, opts...)`
 - `Raw()` — struct wire sottostante
@@ -633,17 +651,19 @@ if err != nil {
 }
 
 if err := backup.WaitUntilReady(ctx); err != nil {
-    log.Fatalf("DBaaS Backup did not become Active: %v", err)
+    log.Fatalf("DBaaS Backup did not become Ready: %v", err)
 }
 fmt.Printf("✓ DBaaS Backup: %s\n", backup.Name())
 ```
 
 **Accessor di risposta**:
 - `ID()`, `URI()`, `Name()`, `Tags()`
-- `BackupID()` — ID backup assegnato dal provider
-- `DBaaSID()` — ID DBaaS sorgente
-- `Type()` — stringa del tipo di backup
-- `RetentionDays()` — periodo di conservazione
+- `DBaaSBackupID()` — ID backup assegnato dal provider
+- `DBaaSURI()` — URI del DBaaS sorgente
+- `DatabaseURI()` — URI del Database sorgente (se applicabile)
+- `SizeGB()` — dimensione del backup in GB
+- `Zone()` — zona di disponibilità
+- `BillingPeriod()` — cadenza di fatturazione
 - `State()`, `FailureReason()`, `PreviousState()`, `IsDisabled()`, `DisableReasons()`
 - `WaitUntilReady(ctx, opts...)`, `WaitUntilActive(ctx, opts...)`, `WaitUntilStates(ctx, []types.State{...}, opts...)`, `WaitUntilGone(ctx, opts...)`
 - `Raw()` — struct wire sottostante
@@ -656,7 +676,7 @@ fmt.Printf("✓ DBaaS Backup: %s\n", backup.Name())
 - *Billing*: `BilledBy(BillingPeriod)`
 
 :::tip Esempio eseguibile
-Le operazioni DBaaS Backup sono coperte nell'esempio DBaaS: [`examples/all-resources/resource_dbaas.go`](https://github.com/Arubacloud/sdk-go/blob/main/examples/all-resources/resource_dbaas.go)
+Le operazioni di DBaaS Backup sono trattate nell'esempio DBaaS: [`examples/all-resources/resource_dbaas.go`](https://github.com/Arubacloud/sdk-go/blob/main/examples/all-resources/resource_dbaas.go)
 :::
 
 ---
@@ -686,7 +706,7 @@ for _, a := range list.Items() {
 **Accessor di risposta**:
 - `ID()`, `URI()`, `Name()`
 - `Threshold()` — valore soglia dell'alert
-- `Action()` — azione scatenata dall'alert
+- `Action()` — azione scatenata all'alert
 - `IsActive()` — bool
 - `Raw()` — struct wire sottostante
 
@@ -704,7 +724,7 @@ arubaClient.FromMetric().Metrics()
 
 **Operazioni supportate**: `List`
 
-Le metriche sono risultati di query di serie temporali in sola lettura.
+Le Metric sono risultati di query di serie temporali in sola lettura.
 
 ```go
 list, err := arubaClient.FromMetric().Metrics().List(ctx, proj,
@@ -753,7 +773,7 @@ if err != nil {
 }
 
 if err := vpc.WaitUntilReady(ctx); err != nil {
-    log.Fatalf("VPC did not become Active: %v", err)
+    log.Fatalf("VPC did not become Ready: %v", err)
 }
 fmt.Printf("✓ VPC: %s\n", vpc.Name())
 ```
@@ -791,7 +811,7 @@ arubaClient.FromNetwork().Subnets()
 
 `OfType` accetta `aruba.SubnetTypeBasic` o `aruba.SubnetTypeAdvanced` (costanti tipizzate — nessun cast a stringa necessario).
 
-`aruba.NewSubnetDHCP()` è un sub-builder per la configurazione DHCP. Si allega con `WithDHCP(...)`.
+`aruba.NewSubnetDHCP()` è un sub-builder per la configurazione DHCP. Collegalo con `WithDHCP(...)`.
 
 ```go
 subnet, err := arubaClient.FromNetwork().Subnets().Create(
@@ -806,7 +826,7 @@ subnet, err := arubaClient.FromNetwork().Subnets().Create(
         WithDHCP(aruba.NewSubnetDHCP().
             Enabled().
             WithRange("192.168.1.10", 50).
-            WithRoutes(aruba.SubnetDHCPRoute{Address: "0.0.0.0/0", Gateway: "192.168.1.1"}).
+            WithRoutes(aruba.SubnetDHCPRouteCommon{Address: "0.0.0.0/0", Gateway: "192.168.1.1"}).
             WithDNSServers("8.8.8.8", "8.8.4.4")).
         NotDefault())
 if err != nil {
@@ -814,7 +834,7 @@ if err != nil {
 }
 
 if err := subnet.WaitUntilReady(ctx); err != nil {
-    log.Fatalf("Subnet did not become Active: %v", err)
+    log.Fatalf("Subnet did not become Ready: %v", err)
 }
 fmt.Printf("✓ Subnet: %s (CIDR: %s)\n", subnet.Name(), subnet.CIDR())
 ```
@@ -822,7 +842,7 @@ fmt.Printf("✓ Subnet: %s (CIDR: %s)\n", subnet.Name(), subnet.CIDR())
 **Accessor di risposta**:
 - `ID()`, `URI()`, `Name()`, `Tags()`
 - `SubnetID()` — ID subnet assegnato dal provider
-- `Type()` — stringa del tipo di subnet
+- `Type()` — tipo di subnet (costante `SubnetType`)
 - `CIDR()` — blocco CIDR
 - `DHCP()` — configurazione DHCP
 - `IsDefault()` — bool
@@ -870,7 +890,7 @@ if err != nil {
 }
 
 if err := eip.WaitUntilReady(ctx); err != nil {
-    log.Fatalf("ElasticIP did not become Active: %v", err)
+    log.Fatalf("ElasticIP did not become Ready: %v", err)
 }
 fmt.Printf("✓ Elastic IP: %s (%s)\n", eip.Name(), eip.Address())
 ```
@@ -878,11 +898,11 @@ fmt.Printf("✓ Elastic IP: %s (%s)\n", eip.Name(), eip.Address())
 **Accessor di risposta**:
 - `ID()`, `URI()`, `Name()`, `Tags()`
 - `ElasticIPID()` — ID IP assegnato dal provider
-- `Address()` — l'indirizzo IP pubblico allocato
+- `Address()` — indirizzo IP pubblico allocato
 - `BillingPeriod()` — cadenza di fatturazione
 - `Region()` — slug della regione
 - `State()`, `FailureReason()`, `PreviousState()`, `IsDisabled()`, `DisableReasons()`
-- `WaitUntilReady(ctx, opts...)`, `WaitUntilActive(ctx, opts...)`, `WaitUntilStates(ctx, []types.State{...}, opts...)`, `WaitUntilGone(ctx, opts...)`
+- `WaitUntilReady(ctx, opts...)`, `WaitUntilActive(ctx, opts...)`, `WaitUntilNotUsed(ctx, opts...)`, `WaitUntilUsed(ctx, opts...)`, `WaitUntilStates(ctx, []types.State{...}, opts...)`, `WaitUntilGone(ctx, opts...)`
 - `Raw()` — struct wire sottostante
 
 **Setter**:
@@ -928,7 +948,7 @@ fmt.Printf("✓ Security Group: %s (ID: %s)\n", sg.Name(), sg.ID())
 **Accessor di risposta**:
 - `ID()`, `URI()`, `Name()`, `Tags()`
 - `SecurityGroupID()` — ID gruppo assegnato dal provider
-- `Default()` — bool
+- `IsDefault()` — bool
 - `State()`, `FailureReason()`, `PreviousState()`, `IsDisabled()`, `DisableReasons()`
 - `WaitUntilReady(ctx, opts...)`, `WaitUntilActive(ctx, opts...)`, `WaitUntilStates(ctx, []types.State{...}, opts...)`, `WaitUntilGone(ctx, opts...)`
 - `Raw()` — struct wire sottostante
@@ -954,9 +974,9 @@ arubaClient.FromNetwork().SecurityGroupRules()
 **Operazioni supportate**: `Create`, `List`, `Get`, `Delete`
 **Asincrono**: sì — `State()` e `FailureReason()` sono disponibili.
 
-`WithDirection` accetta `aruba.RuleDirectionIngress` o `aruba.RuleDirectionEgress`.
+`WithDirection` accetta `aruba.RuleDirectionIngress` o `aruba.RuleDirectionEgress`. `WithProtocol` accetta `aruba.RuleProtocolTCP`, `aruba.RuleProtocolUDP`, `aruba.RuleProtocolICMP` o `aruba.RuleProtocolANY`.
 
-> **Avvertenza**: `TargetingCIDR` e `TargetingSecurityGroup` si escludono a vicenda. Impostarli entrambi registra un errore al momento del setter che emerge su `Create`.
+> **Avvertenza**: `TargetingCIDR` e `TargetingSecurityGroup` sono mutuamente esclusivi. Impostare entrambi registra un errore al momento del setter, che emerge al momento di `Create`.
 
 ```go
 rule, err := arubaClient.FromNetwork().SecurityGroupRules().Create(
@@ -981,7 +1001,7 @@ fmt.Printf("✓ Security Rule: %s\n", rule.Name())
 - `SecurityRuleID()` — ID regola assegnato dal provider
 - `Direction()` — `"Ingress"` o `"Egress"`
 - `Protocol()` — es. `"TCP"`, `"UDP"`, `"ICMP"`
-- `Port()` — numero o intervallo di porte
+- `Port()` — numero di porta o intervallo
 - `TargetKind()` — `"Ip"` o `"SecurityGroup"`
 - `TargetValue()` — stringa CIDR o URI del Security Group
 - `Region()` — slug della regione
@@ -1121,7 +1141,7 @@ fmt.Printf("✓ Peering Route: %s (CIDR: %s)\n", route.Name(), route.CIDR())
 - `ID()`, `URI()`, `Name()`, `Tags()`
 - `CIDR()` — blocco CIDR della route
 - `Target()` — `aruba.Ref` al target della route
-- `VPCPeeringID()` — ID peering genitore
+- `VPCPeeringID()` — ID peering padre
 - `State()`, `FailureReason()`, `PreviousState()`, `IsDisabled()`, `DisableReasons()`
 - `WaitUntilReady(ctx, opts...)`, `WaitUntilActive(ctx, opts...)`, `WaitUntilStates(ctx, []types.State{...}, opts...)`, `WaitUntilGone(ctx, opts...)`
 - `Raw()` — struct wire sottostante
@@ -1150,9 +1170,9 @@ arubaClient.FromNetwork().VPNTunnels()
 **Asincrono**: sì — chiama `WaitUntilReady(ctx)` dopo `Create`.
 
 Sub-builder del VPN Tunnel:
-- `aruba.NewVPNIKE()` — parametri IKE fase 1 (`WithEncryption(IKEEncryption)`, `WithHash(IKEHash)`, `WithDHGroup(IKEDHGroup)`, `WithDPDAction(IKEDPDAction)`)
-- `aruba.NewVPNESP()` — parametri ESP fase 2 (`WithEncryption(ESPEncryption)`, `WithHash(ESPHash)`, `WithPFS(ESPPFSGroup)`)
-- `aruba.NewVPNPSK()` — configurazione della pre-shared key (`WithKey(string)`, `WithCloudSite(string)`, `WithOnPremSite(string)`)
+- `aruba.NewVPNIKE()` — parametri fase 1 IKE (`WithEncryption(IKEEncryption)`, `WithHash(IKEHash)`, `WithDHGroup(IKEDHGroup)`, `WithDPDAction(IKEDPDAction)`)
+- `aruba.NewVPNESP()` — parametri fase 2 ESP (`WithEncryption(ESPEncryption)`, `WithHash(ESPHash)`, `WithPFS(ESPPFSGroup)`)
+- `aruba.NewVPNPSK()` — configurazione pre-shared key (`WithKey(string)`, `WithCloudSite(string)`, `WithOnPremSite(string)`)
 
 ```go
 tunnel, err := arubaClient.FromNetwork().VPNTunnels().Create(
@@ -1185,7 +1205,10 @@ fmt.Printf("✓ VPN Tunnel: %s (gateway: %s)\n", tunnel.Name(), tunnel.PeerClien
 **Accessor di risposta**:
 - `ID()`, `URI()`, `Name()`, `Tags()`
 - `VPNTunnelID()` — ID tunnel assegnato dal provider
-- `PeerClientPublicIP()` — IP del gateway peer remoto
+- `PeerClientPublicIP()` — IP gateway del peer remoto
+- `IKE()` — impostazioni IKE `*aruba.VPNIKE`
+- `ESP()` — impostazioni ESP `*aruba.VPNESP`
+- `PSK()` — impostazioni PSK `*aruba.VPNPSK`
 - `State()`, `FailureReason()`, `PreviousState()`, `IsDisabled()`, `DisableReasons()`
 - `WaitUntilReady(ctx, opts...)`, `WaitUntilActive(ctx, opts...)`, `WaitUntilStates(ctx, []types.State{...}, opts...)`, `WaitUntilGone(ctx, opts...)`
 - `Raw()` — struct wire sottostante
@@ -1239,7 +1262,7 @@ fmt.Printf("✓ VPN Route: %s (CIDR: %s)\n", vpnRoute.Name(), vpnRoute.CIDR())
 - `ID()`, `URI()`, `Name()`, `Tags()`
 - `CIDR()` — blocco CIDR della route
 - `Target()` — `aruba.Ref` al target della route
-- `VPNTunnelID()` — ID VPN Tunnel genitore
+- `VPNTunnelID()` — ID VPN Tunnel padre
 - `State()`, `FailureReason()`, `PreviousState()`, `IsDisabled()`, `DisableReasons()`
 - `WaitUntilReady(ctx, opts...)`, `WaitUntilActive(ctx, opts...)`, `WaitUntilStates(ctx, []types.State{...}, opts...)`, `WaitUntilGone(ctx, opts...)`
 - `Raw()` — struct wire sottostante
@@ -1268,10 +1291,10 @@ arubaClient.FromSchedule().Jobs()
 **Operazioni supportate**: `Create`, `List`, `Get`, `Update`, `Delete`
 **Asincrono**: sì — `State()` e `FailureReason()` sono disponibili.
 
-Usa `OneShotAt(t time.Time)` per pianificare un job una-tantum, o `WithCron(expr string)` per un job ricorrente su pianificazione cron. Usa `RecurringUntil(t time.Time)` per impostare una data di fine per un job ricorrente.
+Usa `OneShotAt(t time.Time)` per pianificare un job one-shot, oppure `WithCron(expr string)` per un job ricorrente con una pianificazione cron. Usa `RecurringUntil(t time.Time)` per impostare una data di fine per un job ricorrente.
 
 ```go
-// Job una-tantum — si attiva una volta a un'ora specifica
+// Job one-shot — eseguito una sola volta a un orario specifico
 job, err := arubaClient.FromSchedule().Jobs().Create(
     ctx,
     aruba.NewJob().
@@ -1284,7 +1307,7 @@ if err != nil {
 }
 fmt.Printf("✓ Job: %s (tipo: %s)\n", job.Name(), job.JobType())
 
-// Job ricorrente — si attiva secondo una pianificazione cron
+// Job ricorrente — eseguito secondo una pianificazione cron
 cronJob, err := arubaClient.FromSchedule().Jobs().Create(
     ctx,
     aruba.NewJob().
@@ -1356,7 +1379,6 @@ fmt.Printf("✓ KMS: %s (ID: %s)\n", kms.Name(), kms.ID())
 - `ID()`, `URI()`, `Name()`, `Tags()`
 - `KMSID()` — ID istanza KMS assegnato dal provider
 - `BillingPeriod()` — cadenza di fatturazione
-- `Region()` — slug della regione
 - `State()`, `FailureReason()`, `PreviousState()`, `IsDisabled()`, `DisableReasons()`
 - `WaitUntilReady(ctx, opts...)`, `WaitUntilActive(ctx, opts...)`, `WaitUntilStates(ctx, []types.State{...}, opts...)`, `WaitUntilGone(ctx, opts...)`
 - `Raw()` — struct wire sottostante
@@ -1374,7 +1396,7 @@ Esempio end-to-end completo: [`examples/all-resources/resource_kms.go`](https://
 
 ---
 
-### Key (Chiave)
+### Key
 
 ```go
 arubaClient.FromSecurity().Keys()
@@ -1383,7 +1405,7 @@ arubaClient.FromSecurity().Keys()
 **Operazioni supportate**: `Create`, `List`, `Get`, `Delete`
 **Asincrono**: sì — `State()` e `FailureReason()` sono disponibili.
 
-`OfAlgorithm` accetta `aruba.KeyAlgorithmAes` o `aruba.KeyAlgorithmRsa`.
+`OfAlgorithm` accetta `aruba.KeyAlgorithmAes` o `aruba.KeyAlgorithmRsa` (costanti tipizzate — nessun cast a stringa necessario).
 
 ```go
 key, err := arubaClient.FromSecurity().Keys().Create(
@@ -1416,7 +1438,7 @@ fmt.Printf("✓ Chiave: %s (algoritmo: %s)\n", key.Name(), key.Algorithm())
 - *Containment*: `InKMS(Ref)`
 
 :::tip Esempio eseguibile
-Le operazioni Key sono coperte nell'esempio KMS: [`examples/all-resources/resource_kms.go`](https://github.com/Arubacloud/sdk-go/blob/main/examples/all-resources/resource_kms.go)
+Le operazioni sulle chiavi sono trattate nell'esempio KMS: [`examples/all-resources/resource_kms.go`](https://github.com/Arubacloud/sdk-go/blob/main/examples/all-resources/resource_kms.go)
 :::
 
 ---
@@ -1428,7 +1450,7 @@ arubaClient.FromSecurity().Kmips()
 ```
 
 **Operazioni supportate**: `Create`, `List`, `Get`, `Delete`
-**Asincrono**: sì — chiama `WaitUntilActive(ctx)` (o attendi `"CertificateAvailable"`) dopo `Create`.
+**Asincrono**: sì — chiama `WaitUntilReady(ctx)` dopo `Create`. `WaitUntilReady` del KMIP ha successo su `"CertificateAvailable"` o `"Active"`. `WaitUntilCertificateAvailable` è un alias per `WaitUntilReady`.
 
 ```go
 km, err := arubaClient.FromSecurity().Kmips().Create(
@@ -1441,9 +1463,8 @@ if err != nil {
     log.Fatalf("Create Kmip: %v", err)
 }
 
-// Attendi che il certificato sia disponibile
-if err := km.WaitUntilCertificateAvailable(ctx); err != nil {
-    log.Fatalf("Kmip certificate not available: %v", err)
+if err := km.WaitUntilReady(ctx); err != nil {
+    log.Fatalf("Kmip did not become ready: %v", err)
 }
 fmt.Printf("✓ Kmip: %s\n", km.Name())
 ```
@@ -1462,9 +1483,9 @@ fmt.Println("Key:",  cert.Key())
 **Accessor di risposta**:
 - `ID()`, `URI()`, `Name()`, `Tags()`
 - `KmipID()` — ID KMIP assegnato dal provider
-- `KmipStatus()` — stato specifico KMIP
+- `KmipStatus()` — stato specifico del KMIP
 - `State()`, `FailureReason()`, `PreviousState()`, `IsDisabled()`, `DisableReasons()`
-- `WaitUntilReady(ctx, opts...)`, `WaitUntilActive(ctx, opts...)`, `WaitUntilStates(ctx, []types.State{...}, opts...)`, `WaitUntilGone(ctx, opts...)`
+- `WaitUntilReady(ctx, opts...)`, `WaitUntilCertificateAvailable(ctx, opts...)`, `WaitUntilStates(ctx, []types.State{...}, opts...)`, `WaitUntilGone(ctx, opts...)`
 - `Raw()` — struct wire sottostante
 
 **Setter**:
@@ -1472,7 +1493,7 @@ fmt.Println("Key:",  cert.Key())
 - *Containment*: `InKMS(Ref)`
 
 :::tip Esempio eseguibile
-Le operazioni KMIP sono coperte nell'esempio KMS: [`examples/all-resources/resource_kms.go`](https://github.com/Arubacloud/sdk-go/blob/main/examples/all-resources/resource_kms.go)
+Le operazioni KMIP sono trattate nell'esempio KMS: [`examples/all-resources/resource_kms.go`](https://github.com/Arubacloud/sdk-go/blob/main/examples/all-resources/resource_kms.go)
 :::
 
 ---
@@ -1488,7 +1509,7 @@ arubaClient.FromStorage().Volumes()
 **Operazioni supportate**: `Create`, `List`, `Get`, `Update`, `Delete`
 **Asincrono**: sì — chiama `WaitUntilReady(ctx)` dopo `Create`.
 
-`OfType` accetta `aruba.BlockStorageTypeStandard` o `aruba.BlockStorageTypePerformance`. Usa `AsBootable()` per contrassegnare un volume come avviabile; `NotBootable()` per annullare. Usa `FromImage(imageID)` per specificare un'immagine base.
+`OfType` accetta `aruba.BlockStorageTypeStandard` o `aruba.BlockStorageTypePerformance`. Usa `AsBootable()` per contrassegnare un volume come avviabile; `NotBootable()` per annullare l'impostazione. Usa `FromImage(imageID)` per specificare un'immagine di base.
 
 ```go
 bs, err := arubaClient.FromStorage().Volumes().Create(
@@ -1514,7 +1535,7 @@ if err := bs.WaitUntilReady(ctx); err != nil {
 fmt.Printf("✓ Volume: %s (%d GB)\n", bs.Name(), bs.SizeGB())
 ```
 
-Per creare un volume **da uno snapshot**, usa `FromSnapshot(snapshot)` al posto di `FromImage`:
+Per creare un volume **da uno snapshot**, usa `FromSnapshot(snapshot)` invece di `FromImage`:
 
 ```go
 bs, err := arubaClient.FromStorage().Volumes().Create(
@@ -1535,14 +1556,14 @@ bs, err := arubaClient.FromStorage().Volumes().Create(
 - `ID()`, `URI()`, `Name()`, `Tags()`
 - `BlockStorageID()` — ID volume assegnato dal provider
 - `SizeGB()` — dimensione in GB
-- `Type()` — stringa del tipo di storage
+- `Type()` — tipo di storage
 - `Zone()` — zona di disponibilità
 - `BillingPeriod()` — cadenza di fatturazione
 - `IsBootable()` — bool
 - `Image()` — riferimento all'immagine
 - `SnapshotURI()` — URI dello snapshot sorgente (se creato da snapshot)
 - `State()`, `FailureReason()`, `PreviousState()`, `IsDisabled()`, `DisableReasons()`
-- `WaitUntilReady(ctx, opts...)`, `WaitUntilActive(ctx, opts...)`, `WaitUntilStates(ctx, []types.State{...}, opts...)`, `WaitUntilGone(ctx, opts...)`
+- `WaitUntilReady(ctx, opts...)`, `WaitUntilActive(ctx, opts...)`, `WaitUntilNotUsed(ctx, opts...)`, `WaitUntilUsed(ctx, opts...)`, `WaitUntilStates(ctx, []types.State{...}, opts...)`, `WaitUntilGone(ctx, opts...)`
 - `Raw()` — struct wire sottostante
 
 **Setter**:
@@ -1594,11 +1615,11 @@ fmt.Printf("✓ Snapshot: %s\n", snap.Name())
 **Accessor di risposta**:
 - `ID()`, `URI()`, `Name()`, `Tags()`
 - `SnapshotID()` — ID snapshot assegnato dal provider
-- `Size()` — dimensione snapshot in GB
+- `SizeGB()` — dimensione dello snapshot in GB
 - `Type()` — tipo di storage
 - `Zone()` — zona di disponibilità
 - `BillingPeriod()` — cadenza di fatturazione
-- `IsBootable()` — bool
+- `Bootable()` — bool
 - `VolumeURI()` — URI del volume sorgente
 - `State()`, `FailureReason()`, `PreviousState()`, `IsDisabled()`, `DisableReasons()`
 - `WaitUntilReady(ctx, opts...)`, `WaitUntilActive(ctx, opts...)`, `WaitUntilStates(ctx, []types.State{...}, opts...)`, `WaitUntilGone(ctx, opts...)`
@@ -1627,7 +1648,7 @@ arubaClient.FromStorage().Backups()
 **Operazioni supportate**: `Create`, `List`, `Get`, `Delete`
 **Asincrono**: sì — chiama `WaitUntilReady(ctx)` dopo `Create`.
 
-`OfType` accetta `aruba.StorageBackupTypeFull` o `aruba.StorageBackupTypeIncremental`.
+`OfType` accetta `aruba.StorageBackupTypeFull` o `aruba.StorageBackupTypeIncremental`. Usa `FromVolume(vol)` per specificare il volume sorgente.
 
 ```go
 backup, err := arubaClient.FromStorage().Backups().Create(
@@ -1653,9 +1674,10 @@ fmt.Printf("✓ Storage Backup: %s\n", backup.Name())
 **Accessor di risposta**:
 - `ID()`, `URI()`, `Name()`, `Tags()`
 - `BackupID()` — ID backup assegnato dal provider
-- `Type()` — stringa del tipo di backup
-- `RetentionDays()` — periodo di conservazione
+- `Type()` — tipo di backup
+- `RetentionDays()` — periodo di conservazione in giorni
 - `OriginURI()` — URI del volume sorgente
+- `BillingPeriod()` — cadenza di fatturazione
 - `State()`, `FailureReason()`, `PreviousState()`, `IsDisabled()`, `DisableReasons()`
 - `WaitUntilReady(ctx, opts...)`, `WaitUntilActive(ctx, opts...)`, `WaitUntilStates(ctx, []types.State{...}, opts...)`, `WaitUntilGone(ctx, opts...)`
 - `Raw()` — struct wire sottostante
@@ -1692,7 +1714,7 @@ restore, err := arubaClient.FromStorage().Restores().Create(
         Named("my-restore").
         Tagged("restore").
         FromBackup(backup).
-        ToVolume(aruba.URI(backup.OriginURI())))
+        WithTarget(aruba.URI(backup.OriginURI())))
 if err != nil {
     log.Fatalf("Create StorageRestore: %v", err)
 }
@@ -1706,7 +1728,7 @@ fmt.Printf("✓ Storage Restore: %s\n", restore.Name())
 **Accessor di risposta**:
 - `ID()`, `URI()`, `Name()`, `Tags()`
 - `RestoreID()` — ID restore assegnato dal provider
-- `TargetURI()` — URI del volume target
+- `TargetURI()` — URI del volume di destinazione
 - `State()`, `FailureReason()`, `PreviousState()`, `IsDisabled()`, `DisableReasons()`
 - `WaitUntilReady(ctx, opts...)`, `WaitUntilActive(ctx, opts...)`, `WaitUntilStates(ctx, []types.State{...}, opts...)`, `WaitUntilGone(ctx, opts...)`
 - `Raw()` — struct wire sottostante
@@ -1724,42 +1746,98 @@ Esempio end-to-end completo: [`examples/all-resources/resource_storage_restore.g
 
 ---
 
-## Opzioni di Chiamata
+## Opzioni di chiamata
 
 Passa le opzioni di chiamata come argomenti variadic a qualsiasi chiamata `List`, `Get`, `Create`, `Update` o `Delete`:
 
 | Opzione | Scopo |
-|---------|-------|
-| `aruba.WithFilter(expr)` | Espressione di filtro lato server |
+|--------|---------|
+| `aruba.WithFilter(expr)` | Espressione filtro lato server |
 | `aruba.WithSort(expr)` | Espressione di ordinamento |
 | `aruba.WithLimit(n)` | Dimensione della pagina |
 | `aruba.WithOffset(n)` | Offset di paginazione |
 | `aruba.WithProjection(expr)` | Proiezione dei campi |
 | `aruba.WithAPIVersion(v)` | Sovrascrive la versione API per questa chiamata |
 
-Vedi [Filtri](./filters) per la sintassi di filtro e ordinamento.
+Vedi [Filtri](./filters) per la sintassi dei filtri e degli ordinamenti.
 
 ---
 
-## Costanti Enum
+## Costanti enum
 
-Tutti i tipi enum sono ri-esportati da `pkg/aruba` — non è necessario alcun import aggiuntivo.
+Tutti i tipi enum sono ri-esportati da `pkg/aruba` — nessun import aggiuntivo necessario. L'elenco canonico si trova in `pkg/aruba/aliases.go`.
+
+### Regione e Zona
+
+| Costante | Descrizione |
+|----------|-------------|
+| `aruba.RegionITBGBergamo` | Datacenter di Bergamo (Italia) |
+| `aruba.ZoneITBG1` | Zona di disponibilità Bergamo 1 |
+| `aruba.ZoneITBG2` | Zona di disponibilità Bergamo 2 |
+| `aruba.ZoneITBG3` | Zona di disponibilità Bergamo 3 |
+
+### Fatturazione
+
+| Costante | Descrizione |
+|----------|-------------|
+| `aruba.BillingPeriodHour` | Fatturazione oraria |
+| `aruba.BillingPeriodMonth` | Fatturazione mensile |
 
 ### Network
 
 | Costante | Valore |
-|----------|--------|
+|----------|-------|
 | `aruba.RuleDirectionIngress` | `"Ingress"` |
 | `aruba.RuleDirectionEgress` | `"Egress"` |
-| `aruba.EndpointTypeIP` | `"Ip"` |
-| `aruba.EndpointTypeSecurityGroup` | `"SecurityGroup"` |
+| `aruba.RuleProtocolTCP` | `"TCP"` |
+| `aruba.RuleProtocolUDP` | `"UDP"` |
+| `aruba.RuleProtocolICMP` | `"ICMP"` |
+| `aruba.RuleProtocolANY` | (wildcard — qualsiasi protocollo) |
 | `aruba.SubnetTypeBasic` | `"Basic"` |
 | `aruba.SubnetTypeAdvanced` | `"Advanced"` |
+
+### Compute
+
+| Costante | Descrizione |
+|----------|-------------|
+| `aruba.CloudServerFlavorCSO1A2` | 1 vCPU, 2 GB RAM |
+| `aruba.CloudServerFlavorCSO2A4` | 2 vCPU, 4 GB RAM |
+| `aruba.CloudServerFlavorCSO4A8` | 4 vCPU, 8 GB RAM |
+| `aruba.CloudServerFlavorCSO8A16` | 8 vCPU, 16 GB RAM |
+| … (vedi `aliases.go` per l'elenco completo) | |
+
+### Container
+
+| Costante | Descrizione |
+|----------|-------------|
+| `aruba.KubernetesVersion1323` | Kubernetes 1.32.3 |
+| `aruba.KubernetesVersion1332` | Kubernetes 1.33.2 |
+| `aruba.KubernetesVersion1341` | Kubernetes 1.34.1 |
+| `aruba.NodePoolInstanceK2A4` | 2 vCPU, 4 GB RAM |
+| `aruba.NodePoolInstanceK4A8` | 4 vCPU, 8 GB RAM |
+| `aruba.NodePoolInstanceK8A16` | 8 vCPU, 16 GB RAM |
+| … (vedi `aliases.go` per l'elenco completo) | |
+| `aruba.ContainerRegistrySizeFlavorSmall` | Livello small di utenti concorrenti |
+| `aruba.ContainerRegistrySizeFlavorMedium` | Livello medium di utenti concorrenti |
+| `aruba.ContainerRegistrySizeFlavorHighPerf` | Livello ad alte prestazioni |
+
+### Database
+
+| Costante | Descrizione |
+|----------|-------------|
+| `aruba.DatabaseEngineMySQL80` | MySQL 8.0 |
+| `aruba.DatabaseEngineMSSQL2022Web` | SQL Server 2022 Web |
+| `aruba.DatabaseEngineMSSQL2022Standard` | SQL Server 2022 Standard |
+| `aruba.DatabaseEngineMSSQL2022Enterprise` | SQL Server 2022 Enterprise |
+| `aruba.DBaaSFlavorDBO1A2` | 1 vCPU, 2 GB RAM |
+| `aruba.DBaaSFlavorDBO2A4` | 2 vCPU, 4 GB RAM |
+| `aruba.DBaaSFlavorDBO4A8` | 4 vCPU, 8 GB RAM |
+| … (vedi `aliases.go` per l'elenco completo) | |
 
 ### Storage
 
 | Costante | Valore |
-|----------|--------|
+|----------|-------|
 | `aruba.BlockStorageTypeStandard` | `"Standard"` |
 | `aruba.BlockStorageTypePerformance` | `"Performance"` |
 | `aruba.StorageBackupTypeFull` | `"Full"` |
@@ -1768,35 +1846,41 @@ Tutti i tipi enum sono ri-esportati da `pkg/aruba` — non è necessario alcun i
 ### Security
 
 | Costante | Valore |
-|----------|--------|
+|----------|-------|
 | `aruba.KeyAlgorithmAes` | `"Aes"` |
 | `aruba.KeyAlgorithmRsa` | `"Rsa"` |
 | `aruba.KeyTypeSymmetric` | `"Symmetric"` |
 | `aruba.KeyTypeAsymmetric` | `"Asymmetric"` |
-| `aruba.KeyStatusActive` | `"Active"` |
-| `aruba.KeyStatusInCreation` | `"InCreation"` |
-| `aruba.ServiceStatusActive` | `"Active"` |
 | `aruba.ServiceStatusCertificateAvailable` | `"CertificateAvailable"` |
+
+### Crittografia VPN
+
+| Costante | Descrizione |
+|----------|-------------|
+| `aruba.IKEEncryptionAES256` | AES-256 CBC (IKE fase 1) |
+| `aruba.IKEHashSHA256` | HMAC-SHA-256 (IKE fase 1) |
+| `aruba.IKEDHGroup14` | Gruppo Diffie-Hellman MODP-2048 |
+| `aruba.ESPEncryptionAES256` | AES-256 CBC (ESP fase 2) |
+| `aruba.ESPHashSHA256` | HMAC-SHA-256 (ESP fase 2) |
+| `aruba.ESPPFSGroupEnable` | PFS abilitato (gruppo DH negoziato) |
+| `aruba.ESPPFSGroupDisable` | PFS disabilitato |
+| … (vedi `aliases.go` per gli elenchi completi) | |
 
 ### Schedule
 
 | Costante | Valore |
-|----------|--------|
+|----------|-------|
 | `aruba.JobTypeOneShot` | `"OneShot"` |
 | `aruba.JobTypeRecurring` | `"Recurring"` |
-| `aruba.RecurrenceTypeHourly` | `"Hourly"` |
-| `aruba.RecurrenceTypeDaily` | `"Daily"` |
-| `aruba.RecurrenceTypeWeekly` | `"Weekly"` |
-| `aruba.RecurrenceTypeMonthly` | `"Monthly"` |
 
 ---
 
-## Appendice: Tipi Wire Grezzi (`pkg/types`)
+## Appendice: Tipi wire grezzi (`pkg/types`)
 
-I seguenti tipi sono le struct wire di basso livello. Normalmente vi si accede solo tramite `.Raw()` o `.RawRequest()` su un wrapper, o quando si costruiscono integrazioni avanzate con `pkg/async`. Sono anche ri-esportati come alias di tipo `aruba.XxxRequest` / `aruba.XxxResponse` così da poterli referenziare senza un import aggiuntivo.
+I seguenti tipi sono le struct wire di basso livello sottostanti. Normalmente vi si accede solo tramite `.Raw()` o `.RawRequest()` su un wrapper, oppure quando si costruiscono integrazioni avanzate con `pkg/async`. Sono anche ri-esportati come alias di tipo `aruba.XxxRequest` / `aruba.XxxResponse` in modo da poterli referenziare senza un import aggiuntivo.
 
 | Tipo | File | Note |
-|------|------|------|
+|------|------|-------|
 | `Response[T]` | `resource.go` | Envelope HTTP generico restituito dagli adapter di basso livello |
 | `ErrorResponse` | `error.go` | Errore strutturato RFC 7807 |
 | `ListResponse` | `resource.go` | Link di paginazione e conteggio totale |
@@ -1804,8 +1888,8 @@ I seguenti tipi sono le struct wire di basso livello. Normalmente vi si accede s
 | `RegionalResourceMetadataRequest` | `resource.go` | Estende i metadati con Location |
 | `ResourceMetadataResponse` | `resource.go` | ID, URI, Name, timestamp |
 | `ResourceStatusResponse` | `resource.go` | Campo State |
-| `ReferenceResourceCommon` | `resource.go` | Link `{uri: "…"}` a un'altra risorsa |
-| `RequestParameters` | `parameters.go` | Struct filter/sort/limit/offset di basso livello (preferire gli helper `CallOption`) |
+| `ReferenceResourceCommon` | `resource.go` | `{uri: "…"}` link a un'altra risorsa |
+| `RequestParameters` | `parameters.go` | Struct filtro/ordinamento/limit/offset di basso livello (preferire gli helper `CallOption`) |
 | `ProjectRequest` / `ProjectResponse` / `ProjectListResponse` | `project.project.go` | |
 | `VPCRequest` / `VPCResponse` / `VPCListResponse` | `network.vpc.go` | |
 | `SubnetRequest` / `SubnetResponse` / `SubnetListResponse` | `network.subnet.go` | |

--- a/docs/website/i18n/it/docusaurus-plugin-content-docs/current/response-handling.md
+++ b/docs/website/i18n/it/docusaurus-plugin-content-docs/current/response-handling.md
@@ -2,7 +2,7 @@
 
 ## Panoramica
 
-Il layer wrapper dell'SDK gestisce automaticamente il parsing delle risposte e la segnalazione degli errori. Ogni metodo CRUD restituisce o un wrapper popolato (in caso di successo) o un errore. Raramente è necessario ispezionare direttamente l'envelope HTTP grezzo — ma gli strumenti per farlo sono sempre disponibili.
+Il layer wrapper dell'SDK gestisce automaticamente il parsing delle risposte e la segnalazione degli errori. Ogni metodo CRUD restituisce o un wrapper popolato (in caso di successo) o un errore. Raramente è necessario ispezionare direttamente l'envelope HTTP grezzo — ma gli strumenti per farlo sono sempre disponibili quando servono.
 
 ## Pattern Base
 
@@ -66,9 +66,9 @@ if err != nil {
 fmt.Printf("Project: %s (tags: %v)\n", proj.Name(), proj.Tags())
 ```
 
-## Accessori dell'Envelope HTTP
+## Accessor dell'Envelope HTTP
 
-Ogni wrapper prodotto da una chiamata Create / Get / Update / List espone il suo envelope HTTP grezzo:
+Ogni wrapper prodotto da una chiamata Create / Get / Update / List espone il proprio envelope HTTP grezzo:
 
 ```go
 // Dopo qualsiasi chiamata CRUD:
@@ -85,19 +85,19 @@ fmt.Println("Error body (if any):", proj.RawError())
 
 ## Accesso alla Risposta Wire Grezza
 
-Ogni wrapper ha un metodo `Raw()` che restituisce lo struct di risposta tipizzato sottostante da `pkg/types`. È utile per i campi non ancora promossi alla superficie del wrapper:
+Ogni wrapper dispone di un metodo `Raw()` che restituisce la struct di risposta tipizzata sottostante da `pkg/types`. È utile per accedere ai campi non ancora promossi alla superficie del wrapper:
 
 ```go
 vpc, err := arubaClient.FromNetwork().VPCs().Get(ctx, ref)
 if err != nil { /* … */ }
 
 raw := vpc.Raw()                         // struct wire sottostante
-fmt.Println(raw.Properties.IsDefault)    // campo non sul wrapper
+fmt.Println(raw.Properties.IsDefault)    // campo non presente sul wrapper
 ```
 
-### Convenienza JSON / YAML
+### Comodità JSON / YAML
 
-Per flag CLI del tipo `--output json` / `--output yaml`, ogni wrapper espone byte slice pre-serializzati:
+Per i flag CLI-style `--output json` / `--output yaml`, ogni wrapper espone slice di byte pre-serializzate:
 
 ```go
 fmt.Println(string(vpc.RawJSON()))   // payload codificato in JSON
@@ -106,9 +106,9 @@ fmt.Println(string(vpc.RawYAML()))   // payload codificato in YAML
 
 Restituisce `nil` se il wrapper non è ancora stato popolato (receiver con valore zero).
 
-## Risposte Lista
+## Risposte di Lista
 
-`List[T]` espone la stessa superficie di introspezione dei wrapper a risorsa singola, senza mai dover importare `pkg/types`:
+`List[T]` espone la stessa superficie di introspezione dei wrapper a singola risorsa, il tutto senza dover importare `pkg/types`:
 
 ```go
 vpcList, err := arubaClient.FromNetwork().VPCs().List(ctx, proj)
@@ -121,16 +121,16 @@ if vpcList.HasNext() {
     _ = nextPage
 }
 
-// Envelope HTTP — stessi accessor dei wrapper a risorsa singola.
+// Envelope HTTP — stessi accessor dei wrapper a singola risorsa.
 fmt.Println("status:", vpcList.StatusCode())
 fmt.Println("trace-id:", vpcList.Headers().Get("X-Trace-Id"))
 _, body := vpcList.RawHTTP()
 fmt.Println("raw body bytes:", len(body))
 ```
 
-### Convenienza JSON / YAML
+### Comodità JSON / YAML
 
-Anche `List[T]` espone `RawJSON()` e `RawYAML()` per il payload lista tipizzato:
+`List[T]` espone anch'esso `RawJSON()` e `RawYAML()` per il payload della lista tipizzata:
 
 ```go
 fmt.Println(string(vpcList.RawJSON()))   // payload codificato in JSON
@@ -139,11 +139,12 @@ fmt.Println(string(vpcList.RawYAML()))   // payload codificato in YAML
 
 Restituisce `nil` quando la lista non ha payload (`Raw() == nil`).
 
-> **Accedere ai campi wire non promossi.** Se hai bisogno di un campo non esposto dalla superficie del wrapper, consulta [Lavorare a Basso Livello](./working-at-low-level) — descrive il cast al tipo wire e le poche altre vie di uscita che richiedono l'importazione di `pkg/types`.
+> **Accedere ai campi non promossi.** Se hai bisogno di un campo non esposto dalla superficie del wrapper, vedi [Lavorare a Basso Livello](./working-at-low-level) —
+> illustra il cast alla struct wire tipizzata e le poche altre vie d'uscita che richiedono l'import di `pkg/types`.
 
 ## Errori in Fase di Setter
 
-I setter del builder fluente non restituiscono mai errori — li registrano internamente. L'errore emerge alla prima chiamata `Create` o `Update`. Puoi anche controllarlo in anticipo:
+I setter del builder fluente non restituiscono mai errori — li registrano internamente. L'errore emerge alla prima chiamata `Create` o `Update`. È anche possibile verificare in anticipo:
 
 ```go
 rule := aruba.NewSecurityRule().
@@ -154,6 +155,62 @@ rule := aruba.NewSecurityRule().
 if err := rule.Err(); err != nil {
     log.Fatalf("Bad rule configuration: %v", err)
 }
+```
+
+## Lettura dello Stato del Wrapper
+
+Ogni wrapper di tipo Family-A promuove i campi di risposta più utilizzati a getter piatti. È sempre preferibile utilizzare questi getter invece di accedere direttamente a `wrapper.Raw().Properties.X`:
+
+```go
+cs, err := arubaClient.FromCompute().CloudServers().Get(ctx, ref)
+if err != nil { /* … */ }
+
+// Preferisci i getter piatti
+fmt.Println(cs.Name())          // nome della risorsa
+fmt.Println(cs.State())         // stato del ciclo di vita (Active, Creating, …)
+fmt.Println(cs.ID())            // UUID
+fmt.Println(cs.Region())        // slug della regione
+fmt.Println(cs.Subnets())       // []string degli URI delle subnet
+fmt.Println(cs.ElasticIP())     // URI dell'Elastic IP, se impostato al momento della creazione
+fmt.Println(cs.UserData())      // cloud-init / user-data, se impostato al momento della creazione
+
+// Ricorri a Raw() solo per i campi non ancora promossi
+raw := cs.Raw()
+fmt.Println(raw.Properties.SomeUnpromotedField)
+```
+
+### Livelli standard dei getter
+
+| Categoria | Getter di esempio |
+|---|---|
+| Identità | `ID()`, `URI()`, `CloudServerID()` |
+| Denominazione | `Name()`, `Tags()` |
+| Geografia | `Region()`, `Zone()` |
+| Derivazione | `Project()`, `CreatedAt()`, `UpdatedAt()`, `Version()` |
+| Ciclo di vita | `State()`, `IsDisabled()`, `DisableReasons()`, `FailureReason()` |
+| Risorse collegate | `LinkedResources()` |
+| Envelope grezzo | `Raw()`, `RawJSON()`, `RawYAML()`, `RawRequest()`, `StatusCode()`, `Headers()`, `RawError()` |
+| Specifici della risorsa | es. `cs.Subnets()`, `vpnRoute.CloudSubnetCIDR()`, `kaas.PodCIDR()` |
+
+### `RawJSON()` / `RawYAML()` per l'output CLI
+
+I metodi `RawJSON()` e `RawYAML()` sono pensati per i flag CLI-style `--output json` / `--output yaml`. Serializzano la struct wire sottostante, non solo i campi promossi:
+
+```go
+cs, _ := arubaClient.FromCompute().CloudServers().Get(ctx, ref)
+fmt.Println(string(cs.RawJSON()))   // payload JSON completo
+fmt.Println(string(cs.RawYAML()))   // payload YAML completo
+```
+
+### `RawRequest()` per aggiornamenti round-trip
+
+`RawRequest()` produce un valore `types.<X>Request` che rappresenta lo stato corrente completo del wrapper — utile nei flussi `Get → modifica → Update`:
+
+```go
+cs, _ := arubaClient.FromCompute().CloudServers().Get(ctx, ref)
+// Il wrapper contiene già tutti i campi lato server; basta sovrascrivere ciò che è cambiato.
+cs.Named("new-name")
+_, err = arubaClient.FromCompute().CloudServers().Update(ctx, cs)
 ```
 
 ## Best Practice

--- a/docs/website/i18n/it/docusaurus-plugin-content-docs/version-0.2.3/async.md
+++ b/docs/website/i18n/it/docusaurus-plugin-content-docs/version-0.2.3/async.md
@@ -1,0 +1,288 @@
+---
+sidebar_position: 3
+---
+
+# Async / Await
+
+La maggior parte delle operazioni API di Aruba Cloud sono **asincrone**: la chiamata HTTP ritorna rapidamente (con un `201 Created` o `200 OK`), ma la risorsa continua a transitare tra stati in background — `Creating` → `Active`, oppure `Updating` → `Active`, oppure `Deleting` → rimossa — per secondi o svariati minuti.
+
+L'SDK espone tre livelli per gestire questa situazione:
+
+| Livello | Quando usarlo |
+|---------|---------------|
+| `WaitUntilReady(ctx)` | 95% dei casi — blocca finché la risorsa è pronta (accetta `Active`, `Running`, `Stopped`, `NotUsed`, `Reserved`, `InUse`, `Used`) |
+| `WaitUntilActive(ctx)` | Quando hai specificamente bisogno solo dello stato `Active` |
+| `WaitUntilStates(ctx, []types.State{...}, opts...)` | Attendi uno o più stati specifici (es. `[]types.State{types.StateStopped}`) |
+| `WaitUntilGone(ctx)` | Dopo `Delete` — blocca finché il `Get` della risorsa restituisce HTTP 404 (completamente rimossa) |
+| `pkg/async.WaitFor` + `AsyncClient.Await` | Avanzato — avvia il polling in una goroutine in background, fai altro lavoro, raccogli il risultato in seguito |
+
+---
+
+## `WaitUntilReady`
+
+Dopo qualsiasi `Create`, `Update` o `Get`, chiama `WaitUntilReady` sul wrapper restituito per bloccare finché la risorsa raggiunge uno qualsiasi dei 7 stati stabili: `Active`, `Running`, `Stopped`, `NotUsed`, `Reserved`, `InUse`, o `Used`.
+
+```go
+vpc, err := arubaClient.FromNetwork().VPCs().Create(ctx, vpc)
+if err != nil {
+    log.Fatalf("Create VPC: %v", err)
+}
+
+if err := vpc.WaitUntilReady(ctx); err != nil {
+    log.Fatalf("VPC did not become Ready: %v", err)
+}
+```
+
+`WaitUntilReady` effettua il polling dell'API ripetutamente con un ritardo fisso. Quando la risorsa entra in uno **stato terminale di errore** noto (es. `"Error"`, `"Failed"`), ritorna immediatamente con un errore descrittivo invece di esaurire tutti i tentativi.
+
+`WaitUntilActive` è disponibile quando hai specificamente bisogno dello stato `"Active"` — ad esempio dopo un'operazione di power-on.
+
+Vedi la [Guida al Walkthrough API](./walkthrough) per esempi completi di Create + polling + Update + Delete.
+
+### Personalizzare il comportamento di polling
+
+Tre opzioni di chiamata permettono di sovrascrivere i valori predefiniti:
+
+```go
+if err := vpc.WaitUntilReady(ctx,
+    aruba.WithRetries(30),              // max iterazioni di polling (default: 60)
+    aruba.WithBaseDelay(5*time.Second), // ritardo fisso tra i poll (default: 10s)
+    aruba.WithTimeout(3*time.Minute),   // scadenza rigida (default: 600s)
+); err != nil {
+    log.Fatalf("VPC did not become Ready: %v", err)
+}
+```
+
+Il limite effettivo è `min(retries × baseDelay, timeout)`. Con i valori predefiniti: `min(60×10s, 600s) = 600s`.
+
+Per risorse a lunga esecuzione (Container Registry, DBaaS, KaaS) che possono richiedere 20–40 minuti, usa un budget maggiore:
+
+```go
+longWait := []aruba.WaitOption{
+    aruba.WithTimeout(40 * time.Minute),
+    aruba.WithRetries(240),
+}
+if err := reg.WaitUntilReady(ctx, longWait...); err != nil {
+    log.Fatalf("ContainerRegistry did not become Ready: %v", err)
+}
+```
+
+---
+
+## `WaitUntilStates`
+
+Usa `WaitUntilStates` quando devi attendere uno o più stati specifici — ad esempio, attendere lo stato di stop dopo un'operazione di power-off:
+
+```go
+// Attendi che un Cloud Server si fermi completamente dopo PowerOff
+if err := cs.WaitUntilStates(ctx, []types.State{types.StateStopped}); err != nil {
+    log.Fatalf("Cloud Server did not stop: %v", err)
+}
+```
+
+```go
+// Attendi che un'istanza DBaaS finisca un aggiornamento in corso
+if err := db.WaitUntilActive(ctx,
+    aruba.WithRetries(120),
+    aruba.WithBaseDelay(15*time.Second),
+); err != nil {
+    log.Fatalf("DBaaS did not return to Active after update: %v", err)
+}
+```
+
+Si applica lo stesso comportamento di uscita anticipata per gli stati di errore terminali: se la risorsa raggiunge `"Error"` o `"Failed"` mentre si aspetta `"Stopped"`, la chiamata ritorna immediatamente con un errore che indica sia lo stato attuale che gli stati attesi.
+
+`WaitUntilActive` e `WaitUntilReady` sono wrapper di convenienza attorno a `WaitUntilStates`:
+- `WaitUntilActive(ctx, opts...)` — equivalente a `WaitUntilStates(ctx, []types.State{types.StateActive}, opts...)`
+- `WaitUntilReady(ctx, opts...)` — equivalente a `WaitUntilStates(ctx, []types.State{types.StateActive, types.StateRunning, types.StateStopped, types.StateNotUsed, types.StateReserved, types.StateInUse, types.StateUsed}, opts...)`
+
+---
+
+## `WaitUntilGone`
+
+Usa `WaitUntilGone` dopo una chiamata `Delete` per bloccare finché la risorsa è completamente rimossa — ovvero finché il suo `Get` restituisce HTTP 404:
+
+```go
+if err := arubaClient.FromNetwork().Subnets().Delete(ctx, subnet); err != nil {
+    log.Printf("Delete subnet: %v", err)
+} else if err := subnet.WaitUntilGone(ctx); err != nil {
+    log.Printf("Subnet not gone: %v", err)
+}
+```
+
+`WaitUntilGone` è disponibile su ogni wrapper di risorsa che supporta il polling (vedi [Risorse che Supportano il Polling](#risorse-che-supportano-il-polling) in basso). Accetta le stesse `WaitOption` di `WaitUntilReady`. Qualsiasi errore da `Get` diverso da HTTP 404 viene trattato come transitorio e riprovato; un 404 segnala il successo.
+
+`Project` non supporta il polling e quindi non ha `WaitUntilGone`. Viene eliminato per ultimo, senza figli rimasti su cui attendere.
+
+---
+
+## Accessor di Stato
+
+Ogni wrapper che supporta il polling espone anche accessor di stato dettagliati. Puoi leggerli in qualsiasi momento dopo una chiamata `Create`, `Get`, `Update` o `List`:
+
+| Metodo | Restituisce | Utilizzo tipico |
+|--------|-------------|-----------------|
+| `State()` | `types.State` — stato corrente | Logging, diramazione condizionale |
+| `PreviousState()` | `types.State` — stato prima dell'ultima transizione | Post-mortem dopo un'attesa fallita |
+| `FailureReason()` | `string` — testo di errore fornito dal server | Mostrare all'utente / log di alert |
+| `IsDisabled()` | `bool` | Bloccare operazioni quando il server disabilita una risorsa |
+| `DisableReasons()` | `[]string` | Spiegare perché una risorsa è disabilitata |
+
+Un pattern comune — chiamare `WaitUntilReady` e, in caso di errore, allegare la motivazione di fallimento del server all'errore:
+
+```go
+if err := vpc.WaitUntilReady(ctx); err != nil {
+    reason := vpc.FailureReason()
+    if reason != "" {
+        log.Fatalf("VPC failed: %v (reason: %s)", err, reason)
+    }
+    log.Fatalf("VPC polling failed: %v", err)
+}
+```
+
+---
+
+## Risorse che Supportano il Polling
+
+I seguenti wrapper di risorse supportano `WaitUntilReady`, `WaitUntilActive`, `WaitUntilStates`, `WaitUntilGone` e gli accessor di stato. Le risorse contrassegnate con un metodo wait speciale espongono un'ulteriore forma nominata.
+
+| Risorsa | Wait speciale | Note |
+|---------|---------------|------|
+| `CloudServer` | — | `WaitUntilReady` → `Active` |
+| `KaaS` | — | `WaitUntilReady` → `Active`; può richiedere 10–20 min |
+| `ContainerRegistry` | — | `WaitUntilReady` → `Active`; può richiedere 20–40 min |
+| `DBaaS` | — | `WaitUntilReady` → `Active`; può richiedere 5–15 min |
+| `Database` | — | |
+| `User` | — | |
+| `Grant` | — | |
+| `VPC` | — | |
+| `Subnet` | — | |
+| `SecurityGroup` | — | |
+| `SecurityRule` | — | |
+| `ElasticIP` | `WaitUntilNotUsed`, `WaitUntilUsed` | Delegano a `WaitUntilStates` |
+| `BlockStorage` | `WaitUntilNotUsed`, `WaitUntilUsed` | Delegano a `WaitUntilStates` |
+| `Snapshot` | — | |
+| `StorageBackup` | — | |
+| `StorageRestore` | — | |
+| `VPCPeering` | — | |
+| `VPCPeeringRoute` | — | |
+| `VPNTunnel` | — | |
+| `VPNRoute` | — | |
+| `KMS` | — | |
+| `Kmip` | `WaitUntilCertificateAvailable` | Waiter personalizzato (Family B — nessun `statusMixin`); fa il polling di `KmipResponse.Status` direttamente rispetto a una mappa di stati terminali esplicita |
+
+> **Il Progetto non supporta il polling.** È pronto in modo sincrono immediatamente dopo che `Create` ritorna — non è necessaria né disponibile alcuna chiamata `WaitUntilActive`.
+
+---
+
+## Avvertenze
+
+### Wrapper idratato obbligatorio
+
+`WaitUntilReady`, `WaitUntilActive`, `WaitUntilStates` e `WaitUntilGone` funzionano solo su wrapper che sono stati **restituiti da una chiamata adapter** (`Create`, `Get`, `Update` o `List`). Chiamare uno qualsiasi di questi metodi su un builder di richiesta appena costruito restituisce:
+
+```
+WaitUntilStates: refresh callback not set; resource must be produced by an adapter (Create/Get/Update/List) to support polling
+```
+
+Usa sempre il wrapper restituito dalla chiamata API:
+
+```go
+// Corretto — vpc è stato restituito da Create
+vpc, err := arubaClient.FromNetwork().VPCs().Create(ctx, myVPC)
+vpc.WaitUntilReady(ctx)
+
+// Errato — myVPC è un builder di richiesta, non una risposta adapter
+myVPC := aruba.NewVPC().Named("x")
+myVPC.WaitUntilReady(ctx) // restituisce "refresh callback not set"
+```
+
+### Cadenza di polling costante
+
+Il polling usa un **ritardo fisso** (senza backoff esponenziale). Se stai raggiungendo i limiti di rate dell'API, aumenta `WithBaseDelay` invece di aspettarti che l'SDK rallenti automaticamente.
+
+### Cancellazione del context
+
+Tutto il polling rispetta la scadenza e la cancellazione del `ctx`. Se il context scade durante il polling, la chiamata restituisce `ctx.Err()` (tipicamente `context.DeadlineExceeded` o `context.Canceled`).
+
+---
+
+## Avanzato: Polling in Background con `pkg/async`
+
+`WaitUntilReady`, `WaitUntilActive` e `WaitUntilStates` bloccano la goroutine chiamante. Se devi **avviare più attese in modo concorrente**, o **fare il polling di una condizione arbitraria** (non solo uno stato di risorsa), usa direttamente il pacchetto `pkg/async` di livello inferiore.
+
+`pkg/async` è un pacchetto pubblico — importalo insieme a `pkg/aruba`:
+
+```go
+import (
+    "github.com/Arubacloud/sdk-go/pkg/aruba"
+    "github.com/Arubacloud/sdk-go/pkg/async"
+    "github.com/Arubacloud/sdk-go/pkg/types"
+)
+```
+
+### `WaitFor` — avvia un future in background
+
+`async.WaitFor` avvia immediatamente una goroutine di polling e restituisce un `*async.AsyncClient[T]` (un future). Chiami `.Await(ctx)` in seguito per bloccare e ottenere il risultato:
+
+```go
+// Avvia il polling di VPC1 e VPC2 in modo concorrente
+futureVPC1 := async.DefaultWaitFor(ctx,
+    func(ctx context.Context) (*types.Response[types.VPCResponse], error) {
+        return arubaClient.FromNetwork().VPCs().Get(ctx, vpc1)
+    },
+    func(resp *types.Response[types.VPCResponse]) (bool, error) {
+        if resp == nil || resp.Data == nil {
+            return false, nil
+        }
+        var state types.State
+        if resp.Data.Properties != nil && resp.Data.Properties.Status != nil &&
+            resp.Data.Properties.Status.State != nil {
+            state = *resp.Data.Properties.Status.State
+        }
+        return state == types.StateActive, nil
+    },
+)
+
+futureVPC2 := async.DefaultWaitFor(ctx, /* stesso pattern per vpc2 */)
+
+// Blocca e attendi entrambi i risultati
+resp1, err1 := futureVPC1.Await(ctx)
+resp2, err2 := futureVPC2.Await(ctx)
+```
+
+`DefaultWaitFor` usa i valori predefiniti del pacchetto: `DefaultRetries=60`, `DefaultBaseDelay=10s`, `DefaultTimeout=600s`. Usa `async.WaitFor(ctx, retries, baseDelay, timeout, call, check)` per sovrascriverli.
+
+### Firma di `WaitFor`
+
+```go
+func WaitFor[T any](
+    ctx         context.Context,
+    retries     int,
+    baseDelay   time.Duration,
+    timeout     time.Duration,
+    call        func(ctx context.Context) (*types.Response[T], error),
+    check       func(*types.Response[T]) (bool, error),
+) *AsyncClient[T]
+```
+
+- `call` — la funzione di polling, chiamata una volta per ogni iterazione.
+- `check` — restituisce `(true, nil)` per segnalare il successo, `(true, error)` per segnalare un fallimento terminale, `(false, nil)` per continuare il polling.
+- Se `check` è `nil`, qualsiasi `response.Data` non-nil viene trattato come successo.
+
+### `AsyncClient.Await`
+
+```go
+func (f *AsyncClient[T]) Await(ctx context.Context) (*types.Response[T], error)
+```
+
+Blocca finché la goroutine in background invia il suo risultato oppure il `ctx` viene cancellato. Chiamate successive restituiscono il risultato **in cache** immediatamente — sicuro da chiamare più volte.
+
+> `pkg/async` lavora direttamente con le struct wire di `pkg/types`. Questo è l'unico livello dell'SDK dove interagirai direttamente con `types.Response[T]` e i tipi `types.*Response`.
+
+---
+
+## Vedi Anche
+
+- [Guida al Walkthrough API](./walkthrough) — esempio completo del ciclo di vita Create + `WaitUntilReady` + Update + Delete
+- [Gestione delle Risposte](./response-handling) — come `*aruba.HTTPError` si propaga attraverso `WaitUntilReady` quando l'API restituisce 4xx/5xx

--- a/docs/website/i18n/it/docusaurus-plugin-content-docs/version-0.2.3/filters.md
+++ b/docs/website/i18n/it/docusaurus-plugin-content-docs/version-0.2.3/filters.md
@@ -1,0 +1,257 @@
+# Guida al Filtraggio
+
+Questa guida spiega come utilizzare i filtri con l'SDK Aruba Cloud Go per interrogare e filtrare le risorse in base a vari criteri.
+
+## Panoramica
+
+L'SDK fornisce un sistema di filtraggio flessibile tramite helper `CallOption`. Passali direttamente a `List` (e ad altre operazioni di lettura) senza costruire struct di parametri intermedi.
+
+```go
+servers, err := arubaClient.FromCompute().CloudServers().List(ctx, proj,
+    aruba.WithFilter("status:eq:Active,cpu:gt:2"),
+    aruba.WithSort("name:asc"),
+    aruba.WithLimit(50),
+)
+```
+
+Opzioni di chiamata disponibili:
+
+| Opzione | Descrizione |
+|---------|-------------|
+| `aruba.WithFilter(expr string)` | Espressione di filtro lato server |
+| `aruba.WithSort(expr string)` | Espressione di ordinamento |
+| `aruba.WithLimit(n int)` | Dimensione della pagina |
+| `aruba.WithOffset(n int)` | Offset di paginazione |
+| `aruba.WithProjection(expr string)` | Proiezione dei campi |
+
+## Formato Filtro
+
+I filtri seguono questo formato: `campo:operatore:valore`
+
+- **Campo**: Il campo della risorsa su cui filtrare (es. `status`, `name`, `cpu`)
+- **Operatore**: L'operatore di confronto (es. `eq`, `gt`, `like`)
+- **Valore**: Il valore con cui confrontare
+
+Più filtri vengono combinati usando:
+- `,` (virgola) per operazioni **AND**
+- `;` (punto e virgola) per operazioni **OR**
+
+## Operatori Supportati
+
+| Operatore | Codice | Descrizione | Esempio |
+|-----------|--------|-------------|---------|
+| Uguale | `eq` | Corrispondenza esatta | `status:eq:Active` |
+| Diverso | `ne` | Non uguale a | `status:ne:Error` |
+| Maggiore | `gt` | Maggiore di | `cpu:gt:2` |
+| Maggiore/Uguale | `gte` | Maggiore o uguale a | `memory:gte:4096` |
+| Minore | `lt` | Minore di | `disk:lt:100` |
+| Minore/Uguale | `lte` | Minore o uguale a | `cpu:lte:8` |
+| In | `in` | Valore in lista | `region:in:us-east,us-west` |
+| Non In | `nin` | Valore non in lista | `status:nin:Error,Failed` |
+| Contiene | `like` | Corrispondenza sottostringa | `name:like:prod` |
+| Inizia Con | `sw` | Corrispondenza prefisso | `name:sw:web-` |
+| Termina Con | `ew` | Corrispondenza suffisso | `name:ew:-prod` |
+
+## Filtri Semplici
+
+### Condizione Singola
+
+```go
+// Elenca i cloud server attivi
+servers, err := arubaClient.FromCompute().CloudServers().List(ctx, proj,
+    aruba.WithFilter("status:eq:Active"),
+)
+```
+
+### Condizioni AND Multiple
+
+```go
+// Server attivi con almeno 2 vCPU e 4 GB di RAM
+servers, err := arubaClient.FromCompute().CloudServers().List(ctx, proj,
+    aruba.WithFilter("status:eq:Active,cpu:gt:2,memory:gte:4096"),
+)
+```
+
+Espressione risultante: `status:eq:Active,cpu:gt:2,memory:gte:4096`
+
+### Condizioni OR
+
+```go
+// Server che sono Attivi O in Avvio
+servers, err := arubaClient.FromCompute().CloudServers().List(ctx, proj,
+    aruba.WithFilter("status:eq:Active;status:eq:Starting"),
+)
+```
+
+Espressione risultante: `status:eq:Active;status:eq:Starting`
+
+### Filtri Complessi (AND + OR)
+
+```go
+// (environment=production AND memory>=4096) OR (tier=premium AND region IN [us-east-1,us-west-2])
+servers, err := arubaClient.FromCompute().CloudServers().List(ctx, proj,
+    aruba.WithFilter("environment:eq:production,memory:gte:4096;tier:eq:premium,region:in:us-east-1,us-west-2"),
+)
+```
+
+## Esempi Pratici
+
+### Filtra Cloud Server Attivi
+
+```go
+// Elenca server attivi con almeno 4 GB di RAM, dimensione pagina 50
+servers, err := arubaClient.FromCompute().CloudServers().List(ctx, proj,
+    aruba.WithFilter("status:eq:Active,memory:gte:4096"),
+    aruba.WithLimit(50),
+)
+if err != nil {
+    log.Fatalf("List failed: %v", err)
+}
+fmt.Printf("Found %d servers\n", servers.Total())
+for _, s := range servers.Items() {
+    fmt.Println("-", s.Name())
+}
+```
+
+### Filtra VPC per Regione
+
+```go
+// Elenca VPC in data center specifici
+vpcs, err := arubaClient.FromNetwork().VPCs().List(ctx, proj,
+    aruba.WithFilter("location:in:ITBG-Bergamo,ITMI-Milan"),
+)
+```
+
+### Filtra per Pattern Nome
+
+```go
+// Tutti i cloud server il cui nome inizia con "web-"
+servers, err := arubaClient.FromCompute().CloudServers().List(ctx, proj,
+    aruba.WithFilter("name:sw:web-"),
+)
+```
+
+### Logica di Business Complessa
+
+```go
+// Server di produzione con risorse elevate O server di sviluppo in regioni specifiche
+servers, err := arubaClient.FromCompute().CloudServers().List(ctx, proj,
+    aruba.WithFilter(
+        "environment:eq:production,cpu:gte:8,memory:gte:16384" +
+        ";environment:eq:development,region:in:ITBG-Bergamo,ITMI-Milan",
+    ),
+)
+```
+
+## Ordinamento
+
+```go
+// Ordina per nome crescente
+servers, err := arubaClient.FromCompute().CloudServers().List(ctx, proj,
+    aruba.WithSort("name:asc"),
+)
+
+// Ordina per data di creazione decrescente
+servers, err = arubaClient.FromCompute().CloudServers().List(ctx, proj,
+    aruba.WithSort("createdAt:desc"),
+)
+```
+
+## Paginazione
+
+```go
+const pageSize = 25
+
+// Prima pagina
+page1, err := arubaClient.FromCompute().CloudServers().List(ctx, proj,
+    aruba.WithLimit(pageSize),
+    aruba.WithOffset(0),
+)
+
+// Seconda pagina
+page2, err := arubaClient.FromCompute().CloudServers().List(ctx, proj,
+    aruba.WithLimit(pageSize),
+    aruba.WithOffset(pageSize),
+)
+
+fmt.Printf("Total resources: %d\n", page1.Total())
+```
+
+## Best Practice
+
+### Usa Filtri Specifici
+
+Sii il più specifico possibile per ridurre la quantità di dati trasferiti:
+
+```go
+// Bene: filtro specifico — solo le risorse necessarie
+servers, err := arubaClient.FromCompute().CloudServers().List(ctx, proj,
+    aruba.WithFilter("status:eq:Active,region:eq:ITBG-Bergamo"),
+)
+
+// Meno efficiente: nessun filtro — recupera tutto
+servers, err = arubaClient.FromCompute().CloudServers().List(ctx, proj)
+```
+
+### Combina Filtro e Paginazione
+
+```go
+servers, err := arubaClient.FromCompute().CloudServers().List(ctx, proj,
+    aruba.WithFilter("environment:eq:production"),
+    aruba.WithLimit(50),
+    aruba.WithOffset(0),
+)
+```
+
+### Valida le Stringhe di Filtro
+
+Stampa la stringa di filtro per debuggare risultati inaspettati:
+
+```go
+filter := "status:eq:Active,cpu:gt:4"
+fmt.Println("Filter:", filter)
+// Output: Filter: status:eq:Active,cpu:gt:4
+
+servers, err := arubaClient.FromCompute().CloudServers().List(ctx, proj,
+    aruba.WithFilter(filter),
+)
+```
+
+## Risoluzione dei Problemi
+
+### Filtro Non Funzionante
+
+**Problema**: Il filtro non restituisce i risultati attesi
+
+**Soluzioni**:
+1. Controlla che i nomi dei campi corrispondano esattamente allo schema API (sensibile alle maiuscole)
+2. Verifica che l'operatore sia appropriato per il tipo di campo
+3. Assicurati che i valori siano nel formato corretto (es. `Active` non `active`)
+4. Stampa la stringa di filtro per il debug
+
+### Risultati Vuoti
+
+**Problema**: Il filtro non restituisce risultati
+
+**Soluzioni**:
+1. Verifica che la logica del filtro sia corretta
+2. Prova filtri più semplici per isolare il problema
+3. Controlla se il campo supporta l'operatore utilizzato
+4. Elenca senza filtri per confermare che le risorse esistano
+
+### Problemi con Filtri Complessi
+
+**Problema**: La logica AND/OR complessa non funziona come previsto
+
+**Soluzioni**:
+1. Scomponi i filtri complessi in parti più semplici
+2. Testa ogni condizione separatamente
+3. Ricorda: virgole (`,`) = AND, punto e virgola (`;`) = OR
+4. Usa le parentesi mentalmente per capire il raggruppamento
+
+```
+// Questo: status:eq:Active,cpu:gt:2;memory:gte:4096
+// Significa: (status = Active AND cpu > 2) OR (memory >= 4096)
+
+// Non: status = Active AND (cpu > 2 OR memory >= 4096)
+```

--- a/docs/website/i18n/it/docusaurus-plugin-content-docs/version-0.2.3/intro.md
+++ b/docs/website/i18n/it/docusaurus-plugin-content-docs/version-0.2.3/intro.md
@@ -1,0 +1,78 @@
+---
+sidebar_position: 1
+---
+
+# Guida Rapida
+
+> **Nota**: Questo SDK è attualmente nella fase **Alpha**. L'API non è ancora stabile e potrebbero essere introdotte modifiche incompatibili nelle versioni future senza preavviso. Si prega di utilizzarlo con cautela e di essere pronti agli aggiornamenti.
+
+Benvenuto nell'SDK ufficiale Go per l'API Aruba Cloud. Questo SDK fornisce un modo comodo e potente per gli sviluppatori Go di interagire con l'API Aruba Cloud. L'obiettivo principale è semplificare la gestione delle risorse cloud, permettendoti di creare, leggere, aggiornare ed eliminare programmaticamente risorse come istanze di calcolo, virtual private cloud (VPC), storage a blocchi e altro ancora.
+
+## Installazione
+
+Aggiungi l'SDK al tuo progetto Go:
+
+```bash
+go get github.com/Arubacloud/sdk-go
+```
+
+## Iniziare
+
+Iniziare con l'SDK è semplice. Importa il pacchetto `aruba`, crea un client con le tue credenziali e inizia a effettuare chiamate API usando il pattern builder fluente.
+
+La prima e più fondamentale risorsa in Aruba Cloud è il **Progetto**. Tutte le altre risorse appartengono a un progetto.
+
+Ecco come inizializzare il client SDK e creare il tuo primo progetto:
+
+```go
+package main
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"time"
+
+	"github.com/Arubacloud/sdk-go/pkg/aruba"
+)
+
+func main() {
+	// Le tue credenziali API
+	clientID := "your-client-id"
+	clientSecret := "your-client-secret"
+
+	// 1. Inizializza il client SDK utilizzando le opzioni predefinite
+	arubaClient, err := aruba.NewClient(aruba.DefaultOptions(clientID, clientSecret))
+	if err != nil {
+		log.Fatalf("Failed to create SDK client: %v", err)
+	}
+
+	// Crea un contesto con un timeout
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
+	defer cancel()
+
+	// 2. Crea il Progetto — costruisci inline e passa a Create
+	fmt.Println("Creating a new project...")
+	proj, err := arubaClient.FromProject().Create(
+		ctx,
+		aruba.NewProject().
+			Named("my-first-project").
+			WithDescription("Un progetto creato con l'SDK Go").
+			AddTag("go-sdk").
+			AddTag("quick-start"))
+	if err != nil {
+		log.Fatalf("Error creating project: %v", err)
+	}
+
+	fmt.Printf("✓ Progetto creato con successo: %s (ID: %s)\n", proj.Name(), proj.ID())
+}
+```
+
+## Prossimi Passi
+
+- Leggi la [Guida al Walkthrough API](./walkthrough) per un percorso completo attraverso il ciclo di vita delle risorse
+- Scopri le [Opzioni di Configurazione](./options) per personalizzare il tuo client SDK
+- Esplora le [Risorse API](./resources) per vedere cosa puoi gestire
+- Comprendi la [Gestione delle Risposte](./response-handling) per una gestione robusta degli errori
+- Scopri il [Filtraggio](./filters) per interrogare le risorse in modo efficiente
+- Leggi [Multitenancy](./multitenancy) per gestire client specifici per tenant

--- a/docs/website/i18n/it/docusaurus-plugin-content-docs/version-0.2.3/multitenancy.md
+++ b/docs/website/i18n/it/docusaurus-plugin-content-docs/version-0.2.3/multitenancy.md
@@ -1,0 +1,152 @@
+# Multitenancy
+
+Il package `pkg/multitenant` fornisce un registro in-memory tenant-to-client per l'SDK Aruba Cloud. E utile quando la tua applicazione gestisce piu tenant e ogni tenant richiede un proprio `aruba.Client`.
+
+## Panoramica
+
+Il package espone:
+
+- Un'interfaccia `Multitenant` per creare, salvare, recuperare e pulire i client tenant
+- Un'implementazione predefinita basata su mappa e mutex
+- Un helper per routine di cleanup periodico dei tenant inattivi
+
+File principali:
+
+- `pkg/multitenant/multitenant.go`
+- `pkg/multitenant/cleanup_routine.go`
+
+## Interfaccia Principale
+
+L'interfaccia `Multitenant` supporta queste operazioni:
+
+- `New(tenant string) error`: crea client usando opzioni template
+- `NewFromOptions(tenant string, options *aruba.Options) error`: crea client da opzioni esplicite
+- `Add(tenant string, client aruba.Client)`: aggiunge un client gia inizializzato
+- `Get(tenant string) (aruba.Client, bool)`: recupera client con flag di esistenza
+- `MustGet(tenant string) aruba.Client`: recupera o termina il processo se assente
+- `GetOrNil(tenant string) aruba.Client`: recupera o restituisce `nil`
+- `CleanUp(from time.Duration)`: elimina tenant inattivi
+
+## Creazione del Manager
+
+### Manager vuoto
+
+Usalo quando vuoi aggiungere client manualmente o tramite `NewFromOptions`:
+
+```go
+mt := multitenant.New()
+```
+
+### Manager con template
+
+Usalo quando i tenant condividono una configurazione base comune:
+
+```go
+opts := aruba.DefaultOptions(clientID, clientSecret)
+mt := multitenant.NewWithTemplate(opts)
+
+// In seguito:
+if err := mt.New("tenant-a"); err != nil {
+    // gestisci errore
+}
+```
+
+## Pattern di Utilizzo
+
+### Aggiungere un client esistente
+
+```go
+client, err := aruba.NewClient(aruba.DefaultOptions(clientID, clientSecret))
+if err != nil {
+    // gestisci errore
+}
+
+mt.Add("tenant-a", client)
+```
+
+### Creare da opzioni specifiche tenant
+
+```go
+tenantOpts := aruba.DefaultOptions(tenantClientID, tenantClientSecret)
+if err := mt.NewFromOptions("tenant-a", tenantOpts); err != nil {
+    // gestisci errore
+}
+```
+
+### Recuperare un client
+
+```go
+client, ok := mt.Get("tenant-a")
+if !ok {
+    // tenant non trovato
+}
+```
+
+Se richiedi esistenza obbligatoria:
+
+```go
+client := mt.MustGet("tenant-a")
+```
+
+## Cleanup Automatico
+
+Il package include anche `StartCleanupRoutine` in `cleanup_routine.go`. Esegue `CleanUp` periodicamente in una goroutine in background.
+
+```go
+ctx, cancel := context.WithCancel(context.Background())
+defer cancel()
+
+stopCleanup := multitenant.StartCleanupRoutine(
+    ctx,
+    mt,
+    5*time.Minute,   // intervallo di esecuzione
+    24*time.Hour,    // rimuove tenant inattivi da 24h
+)
+defer stopCleanup()
+```
+
+Valori di default:
+
+- `tickInterval`: 1 ora se zero/negativo
+- `fromDuration`: 24 ore se zero/negativo
+
+## Note
+
+- Implementazione in-memory, locale al processo.
+- Ciclo di vita tenant basato su `lastUsage`.
+- `CleanUp` rimuove anche entry non valide (`nil` entry/client).
+
+## Esempio di Utilizzo (`examples/all-resources/orchestrator_multitenancy.go`)
+
+Per un esempio completo vedi:
+
+- `examples/all-resources/orchestrator_multitenancy.go`
+
+Snippet principale (cache + credenziali Vault per tenant):
+
+```go
+c, ok := r.multiTenantClient.Get(tenant)
+if ok {
+	return c, nil
+}
+
+options := aruba.NewOptions().
+	WithBaseURL(r.config.APIGateway).
+	WithDefaultTokenIssuerURL().
+	WithVaultCredentialsRepository(
+		r.config.VaultAddress,
+		r.config.KVMount,
+		tenant, // tenant -> kvPath (es. ARU-297647)
+		r.config.Namespace,
+		r.config.RolePath,
+		r.config.RoleID,
+		r.config.RoleSecret,
+	)
+
+client, err := aruba.NewClient(options)
+if err != nil {
+	return nil, err
+}
+r.multiTenantClient.Add(tenant, client)
+return client, nil
+```

--- a/docs/website/i18n/it/docusaurus-plugin-content-docs/version-0.2.3/options.md
+++ b/docs/website/i18n/it/docusaurus-plugin-content-docs/version-0.2.3/options.md
@@ -1,0 +1,202 @@
+# Opzioni di Configurazione SDK
+
+L'SDK Aruba Cloud per Go è configurato utilizzando un'API fluente che ti consente di concatenare i setter di opzioni per costruire una configurazione client. Questa guida dettaglia tutte le opzioni disponibili, raggruppate per argomento.
+
+## Iniziare
+
+<p>Il modo più semplice per configurare il client è utilizzare <code>DefaultOptions</code>, che fornisce una configurazione pronta per la produzione per il caso d'uso più comune (autenticazione Client Credentials).</p>
+
+<table>
+  <thead>
+    <tr>
+      <th>Setter Opzione</th>
+      <th>Descrizione</th>
+      <th>Note</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td><code>DefaultOptions(clientID, clientSecret)</code></td>
+      <td>Crea una configurazione standard per l'ambiente di produzione utilizzando il tuo Client ID e Secret API.</td>
+      <td>Questo è il punto di partenza consigliato per la maggior parte delle applicazioni. Imposta l'API di produzione e gli URL dei token e configura l'autenticazione.</td>
+    </tr>
+    <tr>
+      <td><code>NewOptions()</code></td>
+      <td>Crea un nuovo builder di configurazione vuoto. Devi configurare manualmente tutte le impostazioni richieste, inclusa l'autenticazione.</td>
+      <td>Usa questo se hai bisogno di controllo completo sulla configurazione da zero.</td>
+    </tr>
+  </tbody>
+</table>
+
+## Configurazione Generale
+
+<table>
+  <thead>
+    <tr>
+      <th>Setter Opzione</th>
+      <th>Descrizione</th>
+      <th>Note</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td><code>WithBaseURL(baseURL)</code></td>
+      <td>Sovrascrive l'URL API Aruba Cloud predefinito.</td>
+      <td>Il predefinito è <code>https://api.arubacloud.com</code>. Dovresti cambiarlo solo se devi puntare a un ambiente diverso.</td>
+    </tr>
+    <tr>
+      <td><code>WithDefaultBaseURL()</code></td>
+      <td>Un helper che imposta l'URL API al predefinito di produzione.</td>
+      <td>Chiamato da <code>DefaultOptions()</code>.</td>
+    </tr>
+  </tbody>
+</table>
+
+## Autenticazione
+
+<p>L'autenticazione è una parte critica della configurazione. Devi scegliere <b>uno</b> dei seguenti metodi.</p>
+
+<table>
+  <thead>
+    <tr>
+      <th>Setter Opzione</th>
+      <th>Descrizione</th>
+      <th>Note</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td><code>WithClientCredentials(clientID, clientSecret)</code></td>
+      <td><b>(Consigliato)</b> Configura l'SDK per utilizzare il flusso OAuth2 Client Credentials. L'SDK gestirà automaticamente il recupero e il rinnovo del token di accesso.</td>
+      <td><b>Esclusione Reciproca</b>: Non può essere utilizzato con <code>WithToken()</code> o <code>WithVaultCredentialsRepository()</code>. Questo è il metodo standard e più sicuro per l'autenticazione service-to-service.</td>
+    </tr>
+    <tr>
+      <td><code>WithToken(token)</code></td>
+      <td>Configura l'SDK per utilizzare un token di accesso OAuth2 statico preesistente.</td>
+      <td><b>Esclusione Reciproca</b>: Non può essere utilizzato con qualsiasi altra opzione di autenticazione o token issuer.<br/> <b>Avviso</b>: L'SDK <b>non</b> rinnoverà questo token. Una volta scaduto, tutte le chiamate API falliranno. Questo metodo è consigliato solo per client di breve durata o script semplici e atomici.</td>
+    </tr>
+    <tr>
+      <td><code>WithVaultCredentialsRepository(...)</code></td>
+      <td>Configura l'SDK per recuperare <code>clientID</code> e <code>clientSecret</code> da un'istanza HashiCorp Vault. L'SDK utilizzerà quindi queste credenziali per gestire il token di accesso.</td>
+      <td><b>Esclusione Reciproca</b>: Non può essere utilizzato con <code>WithClientCredentials()</code> o <code>WithToken()</code>.<br/> <b>Parametri</b>: <code>vaultURI</code>, <code>kvMount</code>, <code>kvPath</code>, <code>namespace</code>, <code>rolePath</code>, <code>roleID</code>, <code>secretID</code>.</td>
+    </tr>
+    <tr>
+      <td><code>WithTokenIssuerURL(url)</code></td>
+      <td>Sovrascrive l'URL predefinito per l'endpoint del token OAuth2.</td>
+      <td>Il predefinito è <code>https://login.aruba.it/...</code>. Dovresti cambiarlo solo se devi puntare a un endpoint di autenticazione diverso.</td>
+    </tr>
+    <tr>
+      <td><code>WithSecurityScopes(scopes ...)</code></td>
+      <td>Imposta gli scope di sicurezza da richiedere durante l'autenticazione.</td>
+      <td>Sostituisce qualsiasi scope precedentemente impostato.</td>
+    </tr>
+    <tr>
+      <td><code>WithAdditionalSecurityScopes(scopes ...)</code></td>
+      <td>Aggiunge scope di sicurezza aggiuntivi all'elenco esistente.</td>
+      <td>Non sovrascrive gli scope esistenti.</td>
+    </tr>
+  </tbody>
+</table>
+
+## Cache Token (Opzionale)
+
+<p>Per migliorare le prestazioni e la resilienza, l'SDK può memorizzare nella cache il token di accesso in un archivio esterno. Questo è altamente consigliato per le applicazioni di produzione per evitare di recuperare un nuovo token ad ogni avvio.</p>
+
+<table>
+  <thead>
+    <tr>
+      <th>Setter Opzione</th>
+      <th>Descrizione</th>
+      <th>Note</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td><code>WithRedisTokenRepositoryFromURI(redisURI)</code></td>
+      <td>Configura un'istanza Redis come cache persistente per il token di accesso.</td>
+      <td><b>Esclusione Reciproca</b>: Non può essere utilizzato con le opzioni <code>WithFileTokenRepository...</code>.<br/> Il formato URI è <code>redis://&lt;user&gt;:&lt;pass&gt;@&lt;host&gt;:&lt;port&gt;/&lt;db&gt;</code>.</td>
+    </tr>
+    <tr>
+      <td><code>WithFileTokenRepositoryFromBaseDir(baseDir)</code></td>
+      <td>Configura una directory locale per memorizzare il token di accesso in un file JSON.</td>
+      <td><b>Esclusione Reciproca</b>: Non può essere utilizzato con le opzioni <code>WithRedisTokenRepository...</code>. Il processo SDK deve avere i permessi di lettura/scrittura sulla directory specificata.</td>
+    </tr>
+    <tr>
+      <td><code>WithTokenExpirationDriftSeconds(seconds)</code></td>
+      <td>Imposta un buffer di sicurezza (in secondi) per trattare un token come scaduto prima che lo faccia effettivamente.</td>
+      <td>Questo previene condizioni di race dove l'SDK utilizza un token che scade appena prima che la richiesta API venga completata. Il predefinito è 300 secondi (5 minuti). Questa opzione non ha effetto se un meccanismo di cache (Redis o File) non è configurato.</td>
+    </tr>
+    <tr>
+      <td><code>WithStandardRedisTokenRepository()</code></td>
+      <td>Helper per configurare la cache Redis su <code>localhost:6379</code> e imposta lo drift di scadenza standard (300s).</td>
+      <td>Una scorciatoia conveniente per lo sviluppo locale.</td>
+    </tr>
+    <tr>
+      <td><code>WithStandardFileTokenRepository()</code></td>
+      <td>Helper per configurare la cache file in <code>/tmp/sdk-go</code> e imposta lo drift di scadenza standard (300s).</td>
+      <td>Una scorciatoia conveniente per lo sviluppo locale.</td>
+    </tr>
+  </tbody>
+</table>
+
+## Logging
+
+<p>Il logging è disabilitato per impostazione predefinita.</p>
+
+<table>
+  <thead>
+    <tr>
+      <th>Setter Opzione</th>
+      <th>Descrizione</th>
+      <th>Note</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td><code>WithNoLogs()</code></td>
+      <td>Disabilita tutto il logging dell'SDK.</td>
+      <td>Questo è il comportamento predefinito.</td>
+    </tr>
+    <tr>
+      <td><code>WithNativeLogger()</code></td>
+      <td>Abilita il logger integrato dell'SDK, che utilizza il pacchetto standard <code>log</code>.</td>
+      <td>Utile per il debug di base.</td>
+    </tr>
+    <tr>
+      <td><code>WithLoggerType(loggerType)</code></td>
+      <td>Una funzione più generale per impostare il tipo di logger.</td>
+      <td><code>loggerType</code> può essere <code>LoggerNoLog</code> o <code>LoggerNative</code>.</td>
+    </tr>
+    <tr>
+      <td><code>WithCustomLogger(logger)</code></td>
+      <td>Inietta un logger personalizzato che rispetta l'interfaccia <code>ports/logger.Logger</code>.</td>
+      <td>Consente l'integrazione con il framework di logging della tua applicazione (ad esempio, Logrus, Zap). Impostare questo imposta automaticamente il tipo di logger su <code>loggerCustom</code>.</td>
+    </tr>
+  </tbody>
+</table>
+
+## Avanzato / Dipendenze Personalizzate
+
+<p>Queste opzioni sono per casi d'uso avanzati dove devi iniettare i tuoi componenti personalizzati nel flusso di lavoro dell'SDK.</p>
+
+<table>
+  <thead>
+    <tr>
+      <th>Setter Opzione</th>
+      <th>Descrizione</th>
+      <th>Note</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td><code>WithCustomHTTPClient(client)</code></td>
+      <td>Inietta un <code>*http.Client</code> pre-configurato.</td>
+      <td>Utile per impostare timeout personalizzati, transport o altre configurazioni a livello HTTP.</td>
+    </tr>
+    <tr>
+      <td><code>WithCustomMiddleware(middleware)</code></td>
+      <td>Inietta un middleware personalizzato che rispetta l'interfaccia <code>ports/interceptor.Interceptor</code>.</td>
+      <td>Ti consente di aggiungere logica personalizzata (come logging o tracing di richiesta/risposta) nella catena di chiamate HTTP dell'SDK. Il middleware di autenticazione dell'SDK sarà automaticamente collegato alla fine della tua catena di middleware personalizzata.</td>
+    </tr>
+  </tbody>
+</table>

--- a/docs/website/i18n/it/docusaurus-plugin-content-docs/version-0.2.3/resources.md
+++ b/docs/website/i18n/it/docusaurus-plugin-content-docs/version-0.2.3/resources.md
@@ -1,0 +1,1690 @@
+---
+sidebar_position: 3
+---
+
+# Risorse
+
+Questa pagina è il riferimento esaustivo per ogni wrapper di risorsa nel pacchetto `pkg/aruba`. Per ogni wrapper troverai:
+
+1. La catena di accessor per raggiungerlo da `arubaClient`
+2. Uno snippet `Create` pronto all'uso
+3. I metodi accessor di risposta disponibili sul wrapper restituito
+
+Per il walkthrough end-to-end del ciclo di vita (come `Create`, `Get`, `Update`, `List`, `Delete` e il polling si integrano) vedi la [Guida al Walkthrough API](./walkthrough).
+
+---
+
+## Convenzioni
+
+Ogni risorsa segue la stessa struttura:
+
+```go
+// 1. Raggiungi il sub-client
+client := arubaClient.FromX().Y()
+
+// 2. Costruisci la richiesta inline e crea
+result, err := client.Create(ctx,
+    aruba.NewX().
+        IntoParent(parentRef).   // scope al progetto / VPC / ecc.
+        Named("my-resource").
+        AddTag("env-prod").
+        WithFoo(...))
+
+// 3. Attendi che le risorse asincrone diventino pronte
+if err := result.WaitUntilReady(ctx); err != nil { … }
+
+// 4. Leggi gli accessor di risposta
+fmt.Println(result.ID(), result.Name(), result.State())
+```
+
+- `aruba.NewX()` — factory constructor per ogni builder di risorsa
+- `IntoFoo(ref)` — lega lo scope del genitore; accetta qualsiasi `aruba.Ref` (wrapper idratato o `aruba.URI("…")`)
+- `WithFoo(...)` — setter fluenti; gli errori sono differiti fino a `Create`/`Update`
+- `WaitUntilReady(ctx, opts...)` — disponibile sulle risorse marcate **async** qui sotto; vedi [Async / Await](./async) per le opzioni complete
+- `aruba.URI(s)` — avvolge un percorso stringa grezzo in un `Ref` (vedi [Guida al Walkthrough API](./walkthrough#5-get-a-specific-resource))
+
+:::info Formato dei tag
+L'API di Aruba valida i valori dei tag contro `^[A-Za-z0-9-]{4,30}$`: **solo caratteri alfanumerici e trattini, lunghezza da 4 a 30**. Due punti, punti, underscore, spazi e altra punteggiatura vengono rifiutati con `400 — One or more validation error occurred`. L'SDK non valida i tag lato client, quindi un tag non valido fallisce solo quando la richiesta raggiunge il server.
+:::
+
+---
+
+## Progetto
+
+```go
+arubaClient.FromProject()
+```
+
+**Operazioni supportate**: `Create`, `List`, `Get`, `Update`, `Delete`
+
+> Il Progetto **non** è asincrono — è pronto in modo sincrono dopo che `Create` ritorna. Non è necessaria alcuna chiamata `WaitUntilReady`.
+
+```go
+proj, err := arubaClient.FromProject().Create(
+    ctx,
+    aruba.NewProject().
+        Named("my-project").
+        WithDescription("Production project").
+        AddTag("env-prod").
+        NotDefault())
+if err != nil {
+    log.Fatalf("Create project: %v", err)
+}
+fmt.Printf("✓ Progetto: %s (ID: %s)\n", proj.Name(), proj.ID())
+```
+
+**Accessor di risposta**:
+- `ID()` — UUID della risorsa
+- `URI()` — percorso completo della risorsa (es. `/projects/abc-123`)
+- `Name()` — nome del progetto
+- `Description()` — descrizione del progetto
+- `IsDefault()` — se questo è il progetto predefinito
+- `Tags()` — lista di tag `[]string`
+- `CreatedAt()`, `UpdatedAt()` — timestamp
+
+:::tip Esempio eseguibile
+Esempio end-to-end completo: [`examples/all-resources/resource_project.go`](https://github.com/Arubacloud/sdk-go/blob/main/examples/all-resources/resource_project.go)
+:::
+
+---
+
+## Audit
+
+```go
+arubaClient.FromAudit().Events()
+```
+
+**Operazioni supportate**: `List`
+
+Gli Audit Event sono in sola lettura. Non esiste un costruttore `Create` — usa `List` con un `Ref` di progetto e opzionalmente `aruba.WithFilter(…)` per interrogare l'audit trail.
+
+```go
+list, err := arubaClient.FromAudit().Events().List(ctx, proj,
+    aruba.WithLimit(50),
+    aruba.WithFilter("action eq 'Create'"))
+if err != nil {
+    log.Fatalf("List events: %v", err)
+}
+for _, e := range list.Items() {
+    fmt.Println(e.ID(), e.Action(), e.Timestamp())
+}
+```
+
+**Accessor di risposta**:
+- `ID()` — UUID dell'evento
+- `URI()` — percorso della risorsa
+- `ResourceURI()` — URI della risorsa a cui l'evento si riferisce
+- `Action()` — stringa dell'azione (es. `"Create"`, `"Delete"`)
+- `Timestamp()` — ora dell'evento
+- `User()` — identificatore utente che ha scatenato l'evento
+- `Raw()` — struct wire sottostante
+
+:::tip Esempio eseguibile
+Eseguito come parte dell'orchestratore: [`examples/all-resources/orchestrator_create.go`](https://github.com/Arubacloud/sdk-go/blob/main/examples/all-resources/orchestrator_create.go)
+:::
+
+---
+
+## Compute
+
+### Cloud Server
+
+```go
+arubaClient.FromCompute().CloudServers()
+```
+
+**Operazioni supportate**: `Create`, `List`, `Get`, `Update`, `Delete`, `PowerOn`, `PowerOff`, `SetPassword`
+**Asincrono**: sì — chiama `WaitUntilReady(ctx)` dopo `Create`.
+
+Un Cloud Server dipende da risorse di rete (VPC, Subnet, Security Group), un Elastic IP, un Boot Volume (Block Storage) e un Key Pair. Crea prima queste risorse e passa i wrapper idratati come parametri `Ref`.
+
+```go
+cs, err := arubaClient.FromCompute().CloudServers().Create(
+    ctx,
+    aruba.NewCloudServer().
+        IntoProject(proj).
+        Named("my-server").
+        AddTag("env-prod").
+        InRegion(aruba.RegionITBGBergamo).
+        InZone(aruba.ZoneITBG1).
+        OfFlavor(aruba.CloudServerFlavorCSO2A4).
+        WithVPC(vpc).
+        AddSubnet(subnet).
+        AddSecurityGroup(sg).
+        WithElasticIP(eip).
+        WithBootVolume(blockStorage).
+        WithKeyPair(keyPair))
+if err != nil {
+    log.Fatalf("Create Cloud Server: %v", err)
+}
+
+if err := cs.WaitUntilReady(ctx); err != nil {
+    log.Fatalf("Cloud Server did not become Ready: %v", err)
+}
+fmt.Printf("✓ Cloud Server: %s (zona: %s, flavor: %s)\n", cs.Name(), cs.Zone(), cs.Flavor())
+```
+
+**Azioni di alimentazione e password** (richiedono un wrapper idratato da `Create`/`Get`):
+
+```go
+if err := cs.PowerOff(ctx); err != nil { log.Fatalf("PowerOff: %v", err) }
+if err := cs.PowerOn(ctx);  err != nil { log.Fatalf("PowerOn: %v", err) }
+if err := cs.SetPassword(ctx, "NewStr0ngP@ss!"); err != nil { log.Fatalf("SetPassword: %v", err) }
+```
+
+**Accessor di risposta**:
+- `ID()`, `URI()`, `Name()`, `Tags()`
+- `CloudServerID()` — ID server assegnato dal provider
+- `Zone()` — zona di disponibilità
+- `Flavor()` — slug del flavor di calcolo
+- `FlavorRaw()` — struct flavor completa
+- `VPC()` — `aruba.Ref` della VPC collegata
+- `BootVolume()` — `aruba.Ref` del volume di boot
+- `KeyPair()` — `aruba.Ref` della key pair
+- `NetworkInterfaces()` — slice di descrittori di interfacce di rete
+- `Template()` — immagine/template usata al boot
+- `State()`, `FailureReason()`, `PreviousState()`, `IsDisabled()`, `DisableReasons()` — da `statusMixin`
+- `WaitUntilReady(ctx, opts...)`, `WaitUntilActive(ctx, opts...)`, `WaitUntilStates(ctx, []types.State{...}, opts...)`, `WaitUntilGone(ctx, opts...)`
+- `Raw()` — struct wire sottostante
+
+:::tip Esempio eseguibile
+Esempio end-to-end completo: [`examples/all-resources/resource_cloud_server.go`](https://github.com/Arubacloud/sdk-go/blob/main/examples/all-resources/resource_cloud_server.go)
+:::
+
+---
+
+### Key Pair
+
+```go
+arubaClient.FromCompute().KeyPairs()
+```
+
+**Operazioni supportate**: `Create`, `List`, `Get`, `Delete`
+**Asincrono**: no.
+
+```go
+kp, err := arubaClient.FromCompute().KeyPairs().Create(
+    ctx,
+    aruba.NewKeyPair().
+        IntoProject(proj).
+        Named("my-keypair").
+        InRegion(aruba.RegionITBGBergamo).
+        WithPublicKey("ssh-rsa AAAAB3NzaC1yc2E..."))
+if err != nil {
+    log.Fatalf("Create KeyPair: %v", err)
+}
+fmt.Printf("✓ KeyPair: %s (ID: %s)\n", kp.Name(), kp.ID())
+```
+
+**Accessor di risposta**:
+- `ID()`, `URI()`, `Name()`, `Tags()`
+- `KeyPairID()` — ID chiave assegnato dal provider
+- `PublicKey()` — stringa della chiave pubblica
+- `Region()` — slug della regione
+- `Raw()` — struct wire sottostante
+
+:::tip Esempio eseguibile
+Esempio end-to-end completo: [`examples/all-resources/resource_key_pair.go`](https://github.com/Arubacloud/sdk-go/blob/main/examples/all-resources/resource_key_pair.go)
+:::
+
+---
+
+## Container
+
+### KaaS (Kubernetes as a Service)
+
+```go
+arubaClient.FromContainer().KaaS()
+```
+
+**Operazioni supportate**: `Create`, `List`, `Get`, `Update`, `Delete`, `DownloadKubeconfig`
+**Asincrono**: sì — chiama `WaitUntilReady(ctx)` dopo `Create`.
+
+```go
+k, err := arubaClient.FromContainer().KaaS().Create(
+    ctx,
+    aruba.NewKaaS().
+        IntoProject(proj).
+        Named("my-cluster").
+        AddTag("env-prod").
+        InRegion(aruba.RegionITBGBergamo).
+        WithVPC(vpc).
+        WithSubnet(subnet).
+        WithSecurityGroup(sg).
+        WithNodeCIDR("10.100.0.0/16", "node-cidr").
+        WithPodCIDR("10.200.0.0/16").
+        WithKubernetesVersion(aruba.KubernetesVersion1323).
+        WithHA(true).
+        WithBillingPeriod(aruba.BillingPeriodHour).
+        AddNodePool(aruba.NewNodePool().
+            Named("default-pool").
+            WithCount(3).
+            OfInstance(aruba.NodePoolInstanceK4A8).
+            InZone(aruba.ZoneITBG1)))
+if err != nil {
+    log.Fatalf("Create KaaS: %v", err)
+}
+
+if err := k.WaitUntilReady(ctx); err != nil {
+    log.Fatalf("KaaS did not become Ready: %v", err)
+}
+fmt.Printf("✓ Cluster KaaS: %s (k8s: %s)\n", k.Name(), k.KubernetesVersion())
+```
+
+**Download del kubeconfig** (richiede un wrapper idratato):
+
+```go
+kubeconfig, err := k.DownloadKubeconfig(ctx)
+if err != nil {
+    log.Fatalf("DownloadKubeconfig: %v", err)
+}
+// kubeconfig è un []byte YAML kubeconfig
+```
+
+**Builder del node pool** — `aruba.NewNodePool()`:
+- `Named(name)` — nome del pool
+- `WithCount(n)` — numero di nodi
+- `OfInstance(flavor)` — flavor dell'istanza nodo
+- `InZone(zone)` — zona di disponibilità
+- `WithAutoscaling(min, max)` — abilita l'autoscaling
+
+**Accessor di risposta**:
+- `ID()`, `URI()`, `Name()`, `Tags()`
+- `KaaSID()` — ID cluster assegnato dal provider
+- `VPC()`, `Subnet()` — `aruba.Ref` alle risorse di rete collegate
+- `SecurityGroupName()` — nome del security group applicato
+- `KubernetesVersion()` — stringa della versione Kubernetes
+- `BillingPeriod()` — cadenza di fatturazione
+- `State()`, `FailureReason()`, `PreviousState()`, `IsDisabled()`, `DisableReasons()`
+- `WaitUntilReady(ctx, opts...)`, `WaitUntilActive(ctx, opts...)`, `WaitUntilStates(ctx, []types.State{...}, opts...)`, `WaitUntilGone(ctx, opts...)`
+- `Raw()` — struct wire sottostante
+
+:::tip Esempio eseguibile
+Esempio end-to-end completo: [`examples/all-resources/resource_kaas.go`](https://github.com/Arubacloud/sdk-go/blob/main/examples/all-resources/resource_kaas.go)
+:::
+
+---
+
+### Container Registry
+
+```go
+arubaClient.FromContainer().ContainerRegistry()
+```
+
+**Operazioni supportate**: `Create`, `List`, `Get`, `Update`, `Delete`
+**Asincrono**: sì — chiama `WaitUntilReady(ctx)` dopo `Create`. Questa risorsa può impiegare 20–40 minuti per convergere — usa un budget di attesa generoso.
+
+```go
+reg, err := arubaClient.FromContainer().ContainerRegistry().Create(
+    ctx,
+    aruba.NewContainerRegistry().
+        IntoProject(proj).
+        Named("my-registry").
+        AddTag("env-prod").
+        WithVPC(vpc).
+        WithSubnet(subnet).
+        WithSecurityGroup(sg).
+        WithElasticIP(eip).
+        WithBlockStorage(blockStorage).
+        WithAdminUsername("admin").
+        OfSize(aruba.ContainerRegistrySizeFlavorSmall).
+        WithBillingPeriod(aruba.BillingPeriodHour))
+if err != nil {
+    log.Fatalf("Create ContainerRegistry: %v", err)
+}
+
+if err := reg.WaitUntilReady(ctx); err != nil {
+    log.Fatalf("ContainerRegistry did not become Ready: %v", err)
+}
+fmt.Printf("✓ Registry: %s (IP pubblico: %s)\n", reg.Name(), reg.PublicIP())
+```
+
+**Accessor di risposta**:
+- `ID()`, `URI()`, `Name()`, `Tags()`
+- `ContainerRegistryID()` — ID registry assegnato dal provider
+- `ElasticIP()` — URI dell'endpoint pubblico
+- `VPC()`, `Subnet()`, `SecurityGroup()`, `BlockStorage()` — `aruba.Ref` alle risorse collegate
+- `AdminUsername()` — utente amministratore del registry
+- `BillingPeriod()` — cadenza di fatturazione
+- `State()`, `FailureReason()`, `PreviousState()`, `IsDisabled()`, `DisableReasons()`
+- `WaitUntilReady(ctx, opts...)`, `WaitUntilActive(ctx, opts...)`, `WaitUntilStates(ctx, []types.State{...}, opts...)`, `WaitUntilGone(ctx, opts...)`
+- `Raw()` — struct wire sottostante
+
+:::tip Esempio eseguibile
+Esempio end-to-end completo: [`examples/all-resources/resource_container_registry.go`](https://github.com/Arubacloud/sdk-go/blob/main/examples/all-resources/resource_container_registry.go)
+:::
+
+---
+
+## Database
+
+### DBaaS (Database as a Service)
+
+```go
+arubaClient.FromDatabase().DBaaS()
+```
+
+**Operazioni supportate**: `Create`, `List`, `Get`, `Update`, `Delete`
+**Asincrono**: sì — chiama `WaitUntilReady(ctx)` dopo `Create`.
+
+```go
+db, err := arubaClient.FromDatabase().DBaaS().Create(
+    ctx,
+    aruba.NewDBaaS().
+        IntoProject(proj).
+        Named("my-database").
+        AddTag("env-prod").
+        InRegion(aruba.RegionITBGBergamo).
+        InZone(aruba.ZoneITBG1).
+        OfEngine(aruba.DatabaseEngineMySQL80).
+        OfFlavor(aruba.DBaaSFlavorDBO2A4).
+        WithSizeGB(20).
+        WithBillingPeriod(aruba.BillingPeriodHour).
+        WithVPC(vpc).
+        WithSubnet(subnet).
+        WithSecurityGroup(sg).
+        WithElasticIP(eip))
+if err != nil {
+    log.Fatalf("Create DBaaS: %v", err)
+}
+
+if err := db.WaitUntilReady(ctx); err != nil {
+    log.Fatalf("DBaaS did not become Ready: %v", err)
+}
+fmt.Printf("✓ DBaaS: %s (engine: %s)\n", db.Name(), db.Engine())
+```
+
+**Accessor di risposta**:
+- `ID()`, `URI()`, `Name()`, `Tags()`
+- `DBaaSID()` — ID istanza assegnato dal provider
+- `Engine()` — identificatore dell'engine (costante `DatabaseEngine`)
+- `EngineRaw()` — struct engine completa
+- `Flavor()` — identificatore del flavor (costante `DBaaSFlavor`)
+- `FlavorRaw()` — struct flavor completa
+- `SizeGB()` — dimensione storage in GB
+- `AutoscalingEnabled()` — bool
+- `VPC()`, `Subnet()`, `SecurityGroup()`, `ElasticIP()` — `aruba.Ref` alle risorse di rete
+- `BillingPeriod()` — cadenza di fatturazione
+- `State()`, `FailureReason()`, `PreviousState()`, `IsDisabled()`, `DisableReasons()`
+- `WaitUntilReady(ctx, opts...)`, `WaitUntilActive(ctx, opts...)`, `WaitUntilStates(ctx, []types.State{...}, opts...)`, `WaitUntilGone(ctx, opts...)`
+- `Raw()` — struct wire sottostante
+
+:::tip Esempio eseguibile
+Esempio end-to-end completo: [`examples/all-resources/resource_dbaas.go`](https://github.com/Arubacloud/sdk-go/blob/main/examples/all-resources/resource_dbaas.go)
+:::
+
+---
+
+### Database
+
+```go
+arubaClient.FromDatabase().Databases()
+```
+
+**Operazioni supportate**: `Create`, `List`, `Get`, `Delete`
+**Asincrono**: sì — chiama `WaitUntilReady(ctx)` dopo `Create`.
+
+```go
+database, err := arubaClient.FromDatabase().Databases().Create(
+    ctx,
+    aruba.NewDatabase().
+        IntoDBaaS(db).
+        Named("my-app-db").
+        AddTag("app-backend"))
+if err != nil {
+    log.Fatalf("Create Database: %v", err)
+}
+
+if err := database.WaitUntilReady(ctx); err != nil {
+    log.Fatalf("Database did not become Ready: %v", err)
+}
+fmt.Printf("✓ Database: %s\n", database.Name())
+```
+
+**Accessor di risposta**:
+- `ID()`, `URI()`, `Name()`, `Tags()`
+- `DatabaseID()` — ID database assegnato dal provider
+- `DBaaSID()` — ID DBaaS genitore
+- `State()`, `FailureReason()`, `PreviousState()`, `IsDisabled()`, `DisableReasons()`
+- `WaitUntilReady(ctx, opts...)`, `WaitUntilActive(ctx, opts...)`, `WaitUntilStates(ctx, []types.State{...}, opts...)`, `WaitUntilGone(ctx, opts...)`
+- `Raw()` — struct wire sottostante
+
+:::tip Esempio eseguibile
+Esempio end-to-end completo: [`examples/all-resources/resource_database.go`](https://github.com/Arubacloud/sdk-go/blob/main/examples/all-resources/resource_database.go)
+:::
+
+---
+
+### Utente
+
+```go
+arubaClient.FromDatabase().Users()
+```
+
+**Operazioni supportate**: `Create`, `List`, `Get`, `Delete`
+**Asincrono**: sì — chiama `WaitUntilReady(ctx)` dopo `Create`.
+
+```go
+user, err := arubaClient.FromDatabase().Users().Create(
+    ctx,
+    aruba.NewUser().
+        IntoDBaaS(db).
+        WithUsername("app_user").
+        WithPassword("Str0ngP@ssword!").
+        AddTag("app-backend"))
+if err != nil {
+    log.Fatalf("Create User: %v", err)
+}
+
+if err := user.WaitUntilReady(ctx); err != nil {
+    log.Fatalf("User did not become Ready: %v", err)
+}
+fmt.Printf("✓ Utente: %s\n", user.Name())
+```
+
+**Accessor di risposta**:
+- `ID()`, `URI()`, `Name()`, `Tags()`
+- `UserID()` — ID utente assegnato dal provider
+- `Username()` — nome utente del database
+- `DBaaSID()` — ID DBaaS genitore
+- `State()`, `FailureReason()`, `PreviousState()`, `IsDisabled()`, `DisableReasons()`
+- `WaitUntilReady(ctx, opts...)`, `WaitUntilActive(ctx, opts...)`, `WaitUntilStates(ctx, []types.State{...}, opts...)`, `WaitUntilGone(ctx, opts...)`
+- `Raw()` — struct wire sottostante
+
+:::tip Esempio eseguibile
+Esempio end-to-end completo: [`examples/all-resources/resource_dbaas_user.go`](https://github.com/Arubacloud/sdk-go/blob/main/examples/all-resources/resource_dbaas_user.go)
+:::
+
+---
+
+### Grant
+
+```go
+arubaClient.FromDatabase().Grants()
+```
+
+**Operazioni supportate**: `Create`, `List`, `Get`, `Delete`
+**Asincrono**: sì — chiama `WaitUntilReady(ctx)` dopo `Create`.
+
+```go
+grant, err := arubaClient.FromDatabase().Grants().Create(
+    ctx,
+    aruba.NewGrant().
+        IntoDatabase(database).
+        Named("app_user-grant").
+        WithPrivileges("ALL"))
+if err != nil {
+    log.Fatalf("Create Grant: %v", err)
+}
+
+if err := grant.WaitUntilReady(ctx); err != nil {
+    log.Fatalf("Grant did not become Ready: %v", err)
+}
+fmt.Printf("✓ Grant: %s (privilegi: %s)\n", grant.Name(), grant.Privileges())
+```
+
+**Accessor di risposta**:
+- `ID()`, `URI()`, `Name()`, `Tags()`
+- `GrantID()` — ID grant assegnato dal provider
+- `DatabaseID()` — ID Database genitore
+- `Privileges()` — stringa dei privilegi
+- `State()`, `FailureReason()`, `PreviousState()`, `IsDisabled()`, `DisableReasons()`
+- `WaitUntilReady(ctx, opts...)`, `WaitUntilActive(ctx, opts...)`, `WaitUntilStates(ctx, []types.State{...}, opts...)`, `WaitUntilGone(ctx, opts...)`
+- `Raw()` — struct wire sottostante
+
+:::tip Esempio eseguibile
+Esempio end-to-end completo: [`examples/all-resources/resource_grant.go`](https://github.com/Arubacloud/sdk-go/blob/main/examples/all-resources/resource_grant.go)
+:::
+
+---
+
+### DBaaS Backup
+
+```go
+arubaClient.FromDatabase().DBaaSBackups()
+```
+
+**Operazioni supportate**: `Create`, `List`, `Get`, `Delete`
+**Asincrono**: sì — chiama `WaitUntilReady(ctx)` dopo `Create`.
+
+```go
+backup, err := arubaClient.FromDatabase().DBaaSBackups().Create(
+    ctx,
+    aruba.NewDBaaSBackup().
+        IntoProject(proj).
+        Named("my-db-backup").
+        FromDBaaS(db).
+        WithBillingPeriod(aruba.BillingPeriodHour).
+        AddTag("backup"))
+if err != nil {
+    log.Fatalf("Create DBaaSBackup: %v", err)
+}
+
+if err := backup.WaitUntilReady(ctx); err != nil {
+    log.Fatalf("DBaaS Backup did not become Ready: %v", err)
+}
+fmt.Printf("✓ DBaaS Backup: %s\n", backup.Name())
+```
+
+**Accessor di risposta**:
+- `ID()`, `URI()`, `Name()`, `Tags()`
+- `DBaaSBackupID()` — ID backup assegnato dal provider
+- `DBaaSURI()` — URI del DBaaS sorgente
+- `DatabaseURI()` — URI del Database sorgente (se applicabile)
+- `SizeGB()` — dimensione backup in GB
+- `Zone()` — zona di disponibilità
+- `BillingPeriod()` — cadenza di fatturazione
+- `State()`, `FailureReason()`, `PreviousState()`, `IsDisabled()`, `DisableReasons()`
+- `WaitUntilReady(ctx, opts...)`, `WaitUntilActive(ctx, opts...)`, `WaitUntilStates(ctx, []types.State{...}, opts...)`, `WaitUntilGone(ctx, opts...)`
+- `Raw()` — struct wire sottostante
+
+:::tip Esempio eseguibile
+Le operazioni DBaaS Backup sono coperte nell'esempio DBaaS: [`examples/all-resources/resource_dbaas.go`](https://github.com/Arubacloud/sdk-go/blob/main/examples/all-resources/resource_dbaas.go)
+:::
+
+---
+
+## Metric
+
+### Alert
+
+```go
+arubaClient.FromMetric().Alerts()
+```
+
+**Operazioni supportate**: `List`
+
+Gli Alert sono in sola lettura. Usa `List` con un `Ref` di progetto per interrogare gli alert attivi.
+
+```go
+list, err := arubaClient.FromMetric().Alerts().List(ctx, proj)
+if err != nil {
+    log.Fatalf("List Alerts: %v", err)
+}
+for _, a := range list.Items() {
+    fmt.Println(a.ID(), a.Name(), a.IsActive())
+}
+```
+
+**Accessor di risposta**:
+- `ID()`, `URI()`, `Name()`
+- `Threshold()` — valore soglia dell'alert
+- `Action()` — azione scatenata dall'alert
+- `IsActive()` — bool
+- `Raw()` — struct wire sottostante
+
+:::tip Esempio eseguibile
+Eseguito come parte dell'orchestratore: [`examples/all-resources/orchestrator_create.go`](https://github.com/Arubacloud/sdk-go/blob/main/examples/all-resources/orchestrator_create.go)
+:::
+
+---
+
+### Metric
+
+```go
+arubaClient.FromMetric().Metrics()
+```
+
+**Operazioni supportate**: `List`
+
+Le metriche sono risultati di query di serie temporali in sola lettura.
+
+```go
+list, err := arubaClient.FromMetric().Metrics().List(ctx, proj,
+    aruba.WithFilter("resource eq '"+cs.URI()+"'"))
+if err != nil {
+    log.Fatalf("List Metrics: %v", err)
+}
+for _, m := range list.Items() {
+    fmt.Println(m.ID(), m.Name())
+}
+```
+
+**Accessor di risposta**:
+- `ID()`, `URI()`, `Name()`
+- `Raw()` — struct wire sottostante
+
+:::tip Esempio eseguibile
+Eseguito come parte dell'orchestratore: [`examples/all-resources/orchestrator_create.go`](https://github.com/Arubacloud/sdk-go/blob/main/examples/all-resources/orchestrator_create.go)
+:::
+
+---
+
+## Network
+
+### VPC
+
+```go
+arubaClient.FromNetwork().VPCs()
+```
+
+**Operazioni supportate**: `Create`, `List`, `Get`, `Update`, `Delete`
+**Asincrono**: sì — chiama `WaitUntilReady(ctx)` dopo `Create`.
+
+```go
+vpc, err := arubaClient.FromNetwork().VPCs().Create(
+    ctx,
+    aruba.NewVPC().
+        IntoProject(proj).
+        Named("my-vpc").
+        AddTag("network").
+        InRegion(aruba.RegionITBGBergamo).
+        NotDefault().
+        WithPreset(false))
+if err != nil {
+    log.Fatalf("Create VPC: %v", err)
+}
+
+if err := vpc.WaitUntilReady(ctx); err != nil {
+    log.Fatalf("VPC did not become Ready: %v", err)
+}
+fmt.Printf("✓ VPC: %s\n", vpc.Name())
+```
+
+**Accessor di risposta**:
+- `ID()`, `URI()`, `Name()`, `Tags()`
+- `VPCID()` — ID VPC assegnato dal provider
+- `Region()` — slug della regione
+- `IsDefault()`, `IsPreset()` — flag
+- `State()`, `FailureReason()`, `PreviousState()`, `IsDisabled()`, `DisableReasons()`
+- `WaitUntilReady(ctx, opts...)`, `WaitUntilActive(ctx, opts...)`, `WaitUntilStates(ctx, []types.State{...}, opts...)`, `WaitUntilGone(ctx, opts...)`
+- `Raw()` — struct wire sottostante
+
+:::tip Esempio eseguibile
+Esempio end-to-end completo: [`examples/all-resources/resource_vpc.go`](https://github.com/Arubacloud/sdk-go/blob/main/examples/all-resources/resource_vpc.go)
+:::
+
+---
+
+### Subnet
+
+```go
+arubaClient.FromNetwork().Subnets()
+```
+
+**Operazioni supportate**: `Create`, `List`, `Get`, `Update`, `Delete`
+**Asincrono**: sì — chiama `WaitUntilReady(ctx)` dopo `Create`.
+
+`OfType` accetta `aruba.SubnetTypeBasic` o `aruba.SubnetTypeAdvanced` (costanti tipizzate — non è necessario alcun cast a stringa).
+
+`aruba.NewSubnetDHCP()` è un sub-builder per la configurazione DHCP. Si allega con `WithDHCP(...)`.
+
+```go
+subnet, err := arubaClient.FromNetwork().Subnets().Create(
+    ctx,
+    aruba.NewSubnet().
+        IntoVPC(vpc).
+        Named("my-subnet").
+        AddTag("network").
+        InRegion(aruba.RegionITBGBergamo).
+        OfType(aruba.SubnetTypeAdvanced).
+        NotDefault().
+        WithCIDR("192.168.1.0/25").
+        WithDHCP(aruba.NewSubnetDHCP().
+            Enabled().
+            WithRange("192.168.1.10", 50).
+            AddRoute("0.0.0.0/0", "192.168.1.1").
+            AddDNS("8.8.8.8").
+            AddDNS("8.8.4.4")))
+if err != nil {
+    log.Fatalf("Create Subnet: %v", err)
+}
+
+if err := subnet.WaitUntilReady(ctx); err != nil {
+    log.Fatalf("Subnet did not become Ready: %v", err)
+}
+fmt.Printf("✓ Subnet: %s (CIDR: %s)\n", subnet.Name(), subnet.CIDR())
+```
+
+**Accessor di risposta**:
+- `ID()`, `URI()`, `Name()`, `Tags()`
+- `SubnetID()` — ID subnet assegnato dal provider
+- `Type()` — tipo di subnet (costante `SubnetType`)
+- `CIDR()` — blocco CIDR
+- `DHCP()` — configurazione DHCP
+- `IsDefault()` — bool
+- `Region()` — slug della regione
+- `State()`, `FailureReason()`, `PreviousState()`, `IsDisabled()`, `DisableReasons()`
+- `WaitUntilReady(ctx, opts...)`, `WaitUntilActive(ctx, opts...)`, `WaitUntilStates(ctx, []types.State{...}, opts...)`, `WaitUntilGone(ctx, opts...)`
+- `Raw()` — struct wire sottostante
+
+:::tip Esempio eseguibile
+Esempio end-to-end completo: [`examples/all-resources/resource_subnet.go`](https://github.com/Arubacloud/sdk-go/blob/main/examples/all-resources/resource_subnet.go)
+:::
+
+---
+
+### Elastic IP
+
+```go
+arubaClient.FromNetwork().ElasticIPs()
+```
+
+**Operazioni supportate**: `Create`, `List`, `Get`, `Update`, `Delete`
+**Asincrono**: sì — chiama `WaitUntilReady(ctx)` dopo `Create`.
+
+```go
+eip, err := arubaClient.FromNetwork().ElasticIPs().Create(
+    ctx,
+    aruba.NewElasticIP().
+        IntoProject(proj).
+        Named("my-eip").
+        AddTag("network").
+        InRegion(aruba.RegionITBGBergamo).
+        WithBillingPeriod(aruba.BillingPeriodHour))
+if err != nil {
+    log.Fatalf("Create ElasticIP: %v", err)
+}
+
+if err := eip.WaitUntilReady(ctx); err != nil {
+    log.Fatalf("ElasticIP did not become Ready: %v", err)
+}
+fmt.Printf("✓ Elastic IP: %s (%s)\n", eip.Name(), eip.Address())
+```
+
+**Accessor di risposta**:
+- `ID()`, `URI()`, `Name()`, `Tags()`
+- `ElasticIPID()` — ID IP assegnato dal provider
+- `Address()` — l'indirizzo IP pubblico allocato
+- `BillingPeriod()` — cadenza di fatturazione
+- `Region()` — slug della regione
+- `State()`, `FailureReason()`, `PreviousState()`, `IsDisabled()`, `DisableReasons()`
+- `WaitUntilReady(ctx, opts...)`, `WaitUntilActive(ctx, opts...)`, `WaitUntilNotUsed(ctx, opts...)`, `WaitUntilUsed(ctx, opts...)`, `WaitUntilStates(ctx, []types.State{...}, opts...)`, `WaitUntilGone(ctx, opts...)`
+- `Raw()` — struct wire sottostante
+
+:::tip Esempio eseguibile
+Esempio end-to-end completo: [`examples/all-resources/resource_elastic_ip.go`](https://github.com/Arubacloud/sdk-go/blob/main/examples/all-resources/resource_elastic_ip.go)
+:::
+
+---
+
+### Security Group
+
+```go
+arubaClient.FromNetwork().SecurityGroups()
+```
+
+**Operazioni supportate**: `Create`, `List`, `Get`, `Update`, `Delete`
+**Asincrono**: sì — chiama `WaitUntilReady(ctx)` dopo `Create`.
+
+```go
+sg, err := arubaClient.FromNetwork().SecurityGroups().Create(
+    ctx,
+    aruba.NewSecurityGroup().
+        IntoVPC(vpc).
+        Named("my-security-group").
+        AddTag("security").
+        NotDefault())
+if err != nil {
+    log.Fatalf("Create SecurityGroup: %v", err)
+}
+
+if err := sg.WaitUntilReady(ctx); err != nil {
+    log.Fatalf("SecurityGroup did not become Active: %v", err)
+}
+fmt.Printf("✓ Security Group: %s (ID: %s)\n", sg.Name(), sg.ID())
+```
+
+**Accessor di risposta**:
+- `ID()`, `URI()`, `Name()`, `Tags()`
+- `SecurityGroupID()` — ID gruppo assegnato dal provider
+- `IsDefault()` — bool
+- `State()`, `FailureReason()`, `PreviousState()`, `IsDisabled()`, `DisableReasons()`
+- `WaitUntilReady(ctx, opts...)`, `WaitUntilActive(ctx, opts...)`, `WaitUntilStates(ctx, []types.State{...}, opts...)`, `WaitUntilGone(ctx, opts...)`
+- `Raw()` — struct wire sottostante
+
+:::tip Esempio eseguibile
+Esempio end-to-end completo: [`examples/all-resources/resource_security_group.go`](https://github.com/Arubacloud/sdk-go/blob/main/examples/all-resources/resource_security_group.go)
+:::
+
+---
+
+### Security Rule
+
+```go
+arubaClient.FromNetwork().SecurityGroupRules()
+```
+
+**Operazioni supportate**: `Create`, `List`, `Get`, `Delete`
+**Asincrono**: sì — `State()` e `FailureReason()` sono disponibili.
+
+`WithDirection` accetta `aruba.RuleDirectionIngress` o `aruba.RuleDirectionEgress`. `WithProtocol` accetta `aruba.RuleProtocolTCP`, `aruba.RuleProtocolUDP`, `aruba.RuleProtocolICMP` o `aruba.RuleProtocolANY`.
+
+> **Avvertenza**: `WithTargetCIDR` e `WithTargetSecurityGroup` si escludono a vicenda. Impostarli entrambi registra un errore al momento del setter che emerge su `Create`.
+
+```go
+rule, err := arubaClient.FromNetwork().SecurityGroupRules().Create(
+    ctx,
+    aruba.NewSecurityRule().
+        IntoSecurityGroup(sg).
+        Named("allow-ssh").
+        AddTag("ssh-key").
+        InRegion(aruba.RegionITBGBergamo).
+        WithDirection(aruba.RuleDirectionIngress).
+        WithProtocol(aruba.RuleProtocolTCP).
+        WithPort("22").
+        WithTargetCIDR("0.0.0.0/0"))
+if err != nil {
+    log.Fatalf("Create SecurityRule: %v", err)
+}
+fmt.Printf("✓ Security Rule: %s\n", rule.Name())
+```
+
+**Accessor di risposta**:
+- `ID()`, `URI()`, `Name()`, `Tags()`
+- `SecurityRuleID()` — ID regola assegnato dal provider
+- `Direction()` — `"Ingress"` o `"Egress"`
+- `Protocol()` — es. `"TCP"`, `"UDP"`, `"ICMP"`
+- `Port()` — numero o intervallo di porte
+- `TargetKind()` — `"Ip"` o `"SecurityGroup"`
+- `TargetValue()` — stringa CIDR o URI del Security Group
+- `Region()` — slug della regione
+- `State()`, `FailureReason()`, `PreviousState()`, `IsDisabled()`, `DisableReasons()`
+- `WaitUntilGone(ctx, opts...)`
+- `Raw()` — struct wire sottostante
+
+:::tip Esempio eseguibile
+Eseguito come parte dell'orchestratore: [`examples/all-resources/orchestrator_create.go`](https://github.com/Arubacloud/sdk-go/blob/main/examples/all-resources/orchestrator_create.go)
+:::
+
+---
+
+### Load Balancer
+
+```go
+arubaClient.FromNetwork().LoadBalancers()
+```
+
+**Operazioni supportate**: `List`, `Get`
+
+I Load Balancer sono in sola lettura tramite questo SDK — vengono creati e gestiti automaticamente dalla piattaforma Aruba Cloud.
+
+```go
+list, err := arubaClient.FromNetwork().LoadBalancers().List(ctx, proj)
+if err != nil {
+    log.Fatalf("List LoadBalancers: %v", err)
+}
+for _, lb := range list.Items() {
+    fmt.Println(lb.ID(), lb.Name(), lb.Address())
+}
+```
+
+**Accessor di risposta**:
+- `ID()`, `URI()`, `Name()`, `Tags()`
+- `LoadBalancerID()` — ID LB assegnato dal provider
+- `Address()` — indirizzo pubblico
+- `VPC()` — `aruba.Ref` alla VPC collegata
+- `Region()` — slug della regione
+- `State()`, `FailureReason()`, `PreviousState()`, `IsDisabled()`, `DisableReasons()`
+- `Raw()` — struct wire sottostante
+
+:::tip Esempio eseguibile
+Eseguito come parte dell'orchestratore: [`examples/all-resources/orchestrator_create.go`](https://github.com/Arubacloud/sdk-go/blob/main/examples/all-resources/orchestrator_create.go)
+:::
+
+---
+
+### VPC Peering
+
+```go
+arubaClient.FromNetwork().VPCPeerings()
+```
+
+**Operazioni supportate**: `Create`, `List`, `Get`, `Update`, `Delete`
+**Asincrono**: sì — chiama `WaitUntilReady(ctx)` dopo `Create`.
+
+```go
+peering, err := arubaClient.FromNetwork().VPCPeerings().Create(
+    ctx,
+    aruba.NewVPCPeering().
+        IntoVPC(vpc).
+        Named("my-peering").
+        AddTag("network").
+        InRegion(aruba.RegionITBGBergamo).
+        WithPeerVPC(aruba.URI("/projects/"+peerProjectID+"/vpcs/"+peerVPCID)))
+if err != nil {
+    log.Fatalf("Create VPCPeering: %v", err)
+}
+
+if err := peering.WaitUntilReady(ctx); err != nil {
+    log.Fatalf("VPCPeering did not become Active: %v", err)
+}
+fmt.Printf("✓ VPC Peering: %s\n", peering.Name())
+```
+
+**Accessor di risposta**:
+- `ID()`, `URI()`, `Name()`, `Tags()`
+- `VPCPeeringID()` — ID peering assegnato dal provider
+- `VPCID()` — ID VPC sorgente
+- `PeerVPC()` — `aruba.Ref` alla VPC peer
+- `State()`, `FailureReason()`, `PreviousState()`, `IsDisabled()`, `DisableReasons()`
+- `WaitUntilReady(ctx, opts...)`, `WaitUntilActive(ctx, opts...)`, `WaitUntilStates(ctx, []types.State{...}, opts...)`, `WaitUntilGone(ctx, opts...)`
+- `Raw()` — struct wire sottostante
+
+:::tip Esempio eseguibile
+Eseguito come parte dell'orchestratore: [`examples/all-resources/orchestrator_create.go`](https://github.com/Arubacloud/sdk-go/blob/main/examples/all-resources/orchestrator_create.go)
+:::
+
+---
+
+### VPC Peering Route
+
+```go
+arubaClient.FromNetwork().VPCPeeringRoutes()
+```
+
+**Operazioni supportate**: `Create`, `List`, `Get`, `Update`, `Delete`
+**Asincrono**: sì — chiama `WaitUntilReady(ctx)` dopo `Create`.
+
+```go
+route, err := arubaClient.FromNetwork().VPCPeeringRoutes().Create(
+    ctx,
+    aruba.NewVPCPeeringRoute().
+        IntoVPCPeering(peering).
+        Named("my-peering-route").
+        AddTag("network").
+        InRegion(aruba.RegionITBGBergamo).
+        WithCIDR("10.0.0.0/8").
+        WithTarget(aruba.URI("/projects/"+projectID+"/vpcs/"+vpcID)))
+if err != nil {
+    log.Fatalf("Create VPCPeeringRoute: %v", err)
+}
+
+if err := route.WaitUntilReady(ctx); err != nil {
+    log.Fatalf("VPCPeeringRoute did not become Active: %v", err)
+}
+fmt.Printf("✓ Peering Route: %s (CIDR: %s)\n", route.Name(), route.CIDR())
+```
+
+**Accessor di risposta**:
+- `ID()`, `URI()`, `Name()`, `Tags()`
+- `CIDR()` — blocco CIDR della route
+- `Target()` — `aruba.Ref` al target della route
+- `VPCPeeringID()` — ID peering genitore
+- `State()`, `FailureReason()`, `PreviousState()`, `IsDisabled()`, `DisableReasons()`
+- `WaitUntilReady(ctx, opts...)`, `WaitUntilActive(ctx, opts...)`, `WaitUntilStates(ctx, []types.State{...}, opts...)`, `WaitUntilGone(ctx, opts...)`
+- `Raw()` — struct wire sottostante
+
+:::tip Esempio eseguibile
+Eseguito come parte dell'orchestratore: [`examples/all-resources/orchestrator_create.go`](https://github.com/Arubacloud/sdk-go/blob/main/examples/all-resources/orchestrator_create.go)
+:::
+
+---
+
+### VPN Tunnel
+
+```go
+arubaClient.FromNetwork().VPNTunnels()
+```
+
+**Operazioni supportate**: `Create`, `List`, `Get`, `Update`, `Delete`
+**Asincrono**: sì — chiama `WaitUntilReady(ctx)` dopo `Create`.
+
+Sub-builder del VPN Tunnel:
+- `aruba.NewVPNIKE()` — parametri IKE fase 1 (`WithEncryption(IKEEncryption)`, `WithHash(IKEHash)`, `WithDHGroup(IKEDHGroup)`, `WithDPDAction(IKEDPDAction)`)
+- `aruba.NewVPNESP()` — parametri ESP fase 2 (`WithEncryption(ESPEncryption)`, `WithHash(ESPHash)`, `WithPFS(ESPPFSGroup)`)
+- `aruba.NewVPNPSK()` — configurazione della pre-shared key (`WithKey(string)`, `WithCloudSite(string)`, `WithOnPremSite(string)`)
+
+```go
+tunnel, err := arubaClient.FromNetwork().VPNTunnels().Create(
+    ctx,
+    aruba.NewVPNTunnel().
+        IntoProject(proj).
+        Named("my-vpn-tunnel").
+        AddTag("vpn-net").
+        InRegion(aruba.RegionITBGBergamo).
+        WithPeerClientPublicIP("203.0.113.1").
+        WithIKESettings(aruba.NewVPNIKE().
+            WithEncryption(aruba.IKEEncryptionAES256).
+            WithHash(aruba.IKEHashSHA256).
+            WithDHGroup(aruba.IKEDHGroup14)).
+        WithESPSettings(aruba.NewVPNESP().
+            WithEncryption(aruba.ESPEncryptionAES256).
+            WithHash(aruba.ESPHashSHA256)).
+        WithPSKSettings(aruba.NewVPNPSK().
+            WithKey("my-pre-shared-key")))
+if err != nil {
+    log.Fatalf("Create VPNTunnel: %v", err)
+}
+
+if err := tunnel.WaitUntilReady(ctx); err != nil {
+    log.Fatalf("VPNTunnel did not become Active: %v", err)
+}
+fmt.Printf("✓ VPN Tunnel: %s (gateway: %s)\n", tunnel.Name(), tunnel.PeerClientPublicIP())
+```
+
+**Accessor di risposta**:
+- `ID()`, `URI()`, `Name()`, `Tags()`
+- `VPNTunnelID()` — ID tunnel assegnato dal provider
+- `PeerClientPublicIP()` — IP del gateway remoto
+- `IKE()` — impostazioni IKE `*aruba.VPNIKE`
+- `ESP()` — impostazioni ESP `*aruba.VPNESP`
+- `PSK()` — impostazioni PSK `*aruba.VPNPSK`
+- `State()`, `FailureReason()`, `PreviousState()`, `IsDisabled()`, `DisableReasons()`
+- `WaitUntilReady(ctx, opts...)`, `WaitUntilActive(ctx, opts...)`, `WaitUntilStates(ctx, []types.State{...}, opts...)`, `WaitUntilGone(ctx, opts...)`
+- `Raw()` — struct wire sottostante
+
+:::tip Esempio eseguibile
+Eseguito come parte dell'orchestratore: [`examples/all-resources/orchestrator_create.go`](https://github.com/Arubacloud/sdk-go/blob/main/examples/all-resources/orchestrator_create.go)
+:::
+
+---
+
+### VPN Route
+
+```go
+arubaClient.FromNetwork().VPNRoutes()
+```
+
+**Operazioni supportate**: `Create`, `List`, `Get`, `Update`, `Delete`
+**Asincrono**: sì — chiama `WaitUntilReady(ctx)` dopo `Create`.
+
+```go
+vpnRoute, err := arubaClient.FromNetwork().VPNRoutes().Create(
+    ctx,
+    aruba.NewVPNRoute().
+        IntoVPNTunnel(tunnel).
+        Named("my-vpn-route").
+        AddTag("vpn-net").
+        InRegion(aruba.RegionITBGBergamo).
+        WithCIDR("10.0.0.0/8").
+        WithTarget(aruba.URI("/projects/"+projectID+"/vpcs/"+vpcID)))
+if err != nil {
+    log.Fatalf("Create VPNRoute: %v", err)
+}
+
+if err := vpnRoute.WaitUntilReady(ctx); err != nil {
+    log.Fatalf("VPNRoute did not become Active: %v", err)
+}
+fmt.Printf("✓ VPN Route: %s (CIDR: %s)\n", vpnRoute.Name(), vpnRoute.CIDR())
+```
+
+**Accessor di risposta**:
+- `ID()`, `URI()`, `Name()`, `Tags()`
+- `CIDR()` — blocco CIDR della route
+- `Target()` — `aruba.Ref` al target della route
+- `VPNTunnelID()` — ID VPN Tunnel genitore
+- `State()`, `FailureReason()`, `PreviousState()`, `IsDisabled()`, `DisableReasons()`
+- `WaitUntilReady(ctx, opts...)`, `WaitUntilActive(ctx, opts...)`, `WaitUntilStates(ctx, []types.State{...}, opts...)`, `WaitUntilGone(ctx, opts...)`
+- `Raw()` — struct wire sottostante
+
+:::tip Esempio eseguibile
+Eseguito come parte dell'orchestratore: [`examples/all-resources/orchestrator_create.go`](https://github.com/Arubacloud/sdk-go/blob/main/examples/all-resources/orchestrator_create.go)
+:::
+
+---
+
+## Schedule
+
+### Job
+
+```go
+arubaClient.FromSchedule().Jobs()
+```
+
+**Operazioni supportate**: `Create`, `List`, `Get`, `Update`, `Delete`
+**Asincrono**: sì — `State()` e `FailureReason()` sono disponibili.
+
+Usa `OneShotAt(t time.Time)` per pianificare un job una tantum, oppure `WithCron(expr string)` per un job ricorrente su una pianificazione cron. Usa `RecurringUntil(t time.Time)` per impostare una data di fine per un job ricorrente.
+
+```go
+// Job una tantum — si esegue una sola volta a un orario specifico
+job, err := arubaClient.FromSchedule().Jobs().Create(
+    ctx,
+    aruba.NewJob().
+        IntoProject(proj).
+        Named("my-one-shot-job").
+        AddTag("automation").
+        OneShotAt(time.Now().Add(10*time.Minute)))
+if err != nil {
+    log.Fatalf("Create Job: %v", err)
+}
+fmt.Printf("✓ Job: %s (tipo: %s)\n", job.Name(), job.JobType())
+
+// Job ricorrente — si esegue secondo una pianificazione cron
+cronJob, err := arubaClient.FromSchedule().Jobs().Create(
+    ctx,
+    aruba.NewJob().
+        IntoProject(proj).
+        Named("my-recurring-job").
+        AddTag("automation").
+        WithCron("0 * * * *"))
+if err != nil {
+    log.Fatalf("Create recurring Job: %v", err)
+}
+fmt.Printf("✓ Job ricorrente: %s (cron: %s)\n", cronJob.Name(), cronJob.Cron())
+```
+
+**Accessor di risposta**:
+- `ID()`, `URI()`, `Name()`, `Tags()`
+- `JobID()` — ID job assegnato dal provider
+- `JobType()` — tipo di job (`types.JobTypeOneShot` o `types.JobTypeRecurring`)
+- `Cron()` — espressione cron (job ricorrenti)
+- `Enabled()` — bool
+- `State()`, `FailureReason()`, `PreviousState()`, `IsDisabled()`, `DisableReasons()`
+- `Raw()` — struct wire sottostante
+
+:::tip Esempio eseguibile
+Esempio end-to-end completo: [`examples/all-resources/resource_job.go`](https://github.com/Arubacloud/sdk-go/blob/main/examples/all-resources/resource_job.go)
+:::
+
+---
+
+## Security
+
+### KMS (Key Management Service)
+
+```go
+arubaClient.FromSecurity().KMS()
+```
+
+**Operazioni supportate**: `Create`, `List`, `Get`, `Update`, `Delete`
+**Asincrono**: sì — chiama `WaitUntilReady(ctx)` dopo `Create`.
+
+```go
+kms, err := arubaClient.FromSecurity().KMS().Create(
+    ctx,
+    aruba.NewKMS().
+        IntoProject(proj).
+        Named("my-kms").
+        AddTag("security").
+        InRegion(aruba.RegionITBGBergamo).
+        WithBillingPeriod(aruba.BillingPeriodHour))
+if err != nil {
+    log.Fatalf("Create KMS: %v", err)
+}
+
+if err := kms.WaitUntilReady(ctx); err != nil {
+    log.Fatalf("KMS did not become Active: %v", err)
+}
+fmt.Printf("✓ KMS: %s (ID: %s)\n", kms.Name(), kms.ID())
+```
+
+**Accessor di risposta**:
+- `ID()`, `URI()`, `Name()`, `Tags()`
+- `KMSID()` — ID istanza KMS assegnato dal provider
+- `BillingPeriod()` — cadenza di fatturazione
+- `State()`, `FailureReason()`, `PreviousState()`, `IsDisabled()`, `DisableReasons()`
+- `WaitUntilReady(ctx, opts...)`, `WaitUntilActive(ctx, opts...)`, `WaitUntilStates(ctx, []types.State{...}, opts...)`, `WaitUntilGone(ctx, opts...)`
+- `Raw()` — struct wire sottostante
+
+:::tip Esempio eseguibile
+Esempio end-to-end completo: [`examples/all-resources/resource_kms.go`](https://github.com/Arubacloud/sdk-go/blob/main/examples/all-resources/resource_kms.go)
+:::
+
+---
+
+### Key (Chiave)
+
+```go
+arubaClient.FromSecurity().Keys()
+```
+
+**Operazioni supportate**: `Create`, `List`, `Get`, `Delete`
+**Asincrono**: sì — `State()` e `FailureReason()` sono disponibili.
+
+`WithAlgorithm` accetta `aruba.KeyAlgorithmAes` o `aruba.KeyAlgorithmRsa` (costanti tipizzate — non è necessario alcun cast a stringa).
+
+```go
+key, err := arubaClient.FromSecurity().Keys().Create(
+    ctx,
+    aruba.NewKey().
+        IntoKMS(kms).
+        Named("my-encryption-key").
+        AddTag("security").
+        WithAlgorithm(aruba.KeyAlgorithmAes))
+if err != nil {
+    log.Fatalf("Create Key: %v", err)
+}
+fmt.Printf("✓ Chiave: %s (algoritmo: %s)\n", key.Name(), key.Algorithm())
+```
+
+**Accessor di risposta**:
+- `ID()`, `URI()`, `Name()`, `Tags()`
+- `KeyID()` — ID chiave assegnato dal provider
+- `Algorithm()` — stringa dell'algoritmo
+- `Type()` — `"Symmetric"` o `"Asymmetric"`
+- `Status()` — stato del ciclo di vita della chiave
+- `CreationSource()` — come è stata creata la chiave
+- `State()`, `FailureReason()`, `PreviousState()`, `IsDisabled()`, `DisableReasons()`
+- `WaitUntilGone(ctx, opts...)`
+- `Raw()` — struct wire sottostante
+
+:::tip Esempio eseguibile
+Le operazioni Key sono coperte nell'esempio KMS: [`examples/all-resources/resource_kms.go`](https://github.com/Arubacloud/sdk-go/blob/main/examples/all-resources/resource_kms.go)
+:::
+
+---
+
+### Kmip
+
+```go
+arubaClient.FromSecurity().Kmips()
+```
+
+**Operazioni supportate**: `Create`, `List`, `Get`, `Delete`
+**Asincrono**: sì — chiama `WaitUntilReady(ctx)` dopo `Create`. `WaitUntilReady` per KMIP ha successo su `"CertificateAvailable"` oppure `"Active"`. `WaitUntilCertificateAvailable` è un alias di `WaitUntilReady`.
+
+```go
+km, err := arubaClient.FromSecurity().Kmips().Create(
+    ctx,
+    aruba.NewKmip().
+        IntoKMS(kms).
+        Named("my-kmip").
+        AddTag("security"))
+if err != nil {
+    log.Fatalf("Create Kmip: %v", err)
+}
+
+if err := km.WaitUntilReady(ctx); err != nil {
+    log.Fatalf("Kmip did not become ready: %v", err)
+}
+fmt.Printf("✓ Kmip: %s\n", km.Name())
+```
+
+**Download del certificato KMIP** (richiede un wrapper idratato):
+
+```go
+cert, err := km.Download(ctx)
+if err != nil {
+    log.Fatalf("Download Kmip certificate: %v", err)
+}
+fmt.Println("Cert:", cert.Cert())
+fmt.Println("Key:",  cert.Key())
+```
+
+**Accessor di risposta**:
+- `ID()`, `URI()`, `Name()`, `Tags()`
+- `KmipID()` — ID KMIP assegnato dal provider
+- `KmipStatus()` — stato specifico KMIP
+- `State()`, `FailureReason()`, `PreviousState()`, `IsDisabled()`, `DisableReasons()`
+- `WaitUntilReady(ctx, opts...)`, `WaitUntilCertificateAvailable(ctx, opts...)`, `WaitUntilStates(ctx, []types.State{...}, opts...)`, `WaitUntilGone(ctx, opts...)`
+- `Raw()` — struct wire sottostante
+
+:::tip Esempio eseguibile
+Le operazioni KMIP sono coperte nell'esempio KMS: [`examples/all-resources/resource_kms.go`](https://github.com/Arubacloud/sdk-go/blob/main/examples/all-resources/resource_kms.go)
+:::
+
+---
+
+## Storage
+
+### Block Storage (Volume)
+
+```go
+arubaClient.FromStorage().Volumes()
+```
+
+**Operazioni supportate**: `Create`, `List`, `Get`, `Update`, `Delete`
+**Asincrono**: sì — chiama `WaitUntilReady(ctx)` dopo `Create`.
+
+`OfType` accetta `aruba.BlockStorageTypeStandard` o `aruba.BlockStorageTypePerformance`. Usa `SetBootable()` per contrassegnare un volume come avviabile; `UnsetBootable()` per rimuovere il contrassegno. Usa `FromImage(imageID)` per specificare un'immagine di base.
+
+```go
+bs, err := arubaClient.FromStorage().Volumes().Create(
+    ctx,
+    aruba.NewBlockStorage().
+        IntoProject(proj).
+        Named("my-volume").
+        AddTag("storage").
+        InRegion(aruba.RegionITBGBergamo).
+        InZone(aruba.ZoneITBG1).
+        WithSizeGB(20).
+        OfType(aruba.BlockStorageTypeStandard).
+        WithBillingPeriod(aruba.BillingPeriodHour).
+        SetBootable().
+        FromImage("LU22-001"))
+if err != nil {
+    log.Fatalf("Create BlockStorage: %v", err)
+}
+
+if err := bs.WaitUntilReady(ctx); err != nil {
+    log.Fatalf("BlockStorage did not become Active: %v", err)
+}
+fmt.Printf("✓ Volume: %s (%d GB)\n", bs.Name(), bs.SizeGB())
+```
+
+Per creare un volume **da uno snapshot**, usa `FromSnapshot(snapshot)` al posto di `FromImage`:
+
+```go
+bs, err := arubaClient.FromStorage().Volumes().Create(
+    ctx,
+    aruba.NewBlockStorage().
+        IntoProject(proj).
+        Named("restored-volume").
+        InRegion(aruba.RegionITBGBergamo).
+        InZone(aruba.ZoneITBG1).
+        WithSizeGB(20).
+        OfType(aruba.BlockStorageTypeStandard).
+        WithBillingPeriod(aruba.BillingPeriodHour).
+        SetBootable().
+        FromSnapshot(snapshot))
+```
+
+**Accessor di risposta**:
+- `ID()`, `URI()`, `Name()`, `Tags()`
+- `BlockStorageID()` — ID volume assegnato dal provider
+- `SizeGB()` — dimensione in GB
+- `Type()` — tipo di storage
+- `Zone()` — zona di disponibilità
+- `BillingPeriod()` — cadenza di fatturazione
+- `Bootable()` — bool
+- `Image()` — riferimento all'immagine
+- `SnapshotURI()` — URI dello snapshot sorgente (se creato da snapshot)
+- `State()`, `FailureReason()`, `PreviousState()`, `IsDisabled()`, `DisableReasons()`
+- `WaitUntilReady(ctx, opts...)`, `WaitUntilActive(ctx, opts...)`, `WaitUntilNotUsed(ctx, opts...)`, `WaitUntilUsed(ctx, opts...)`, `WaitUntilStates(ctx, []types.State{...}, opts...)`, `WaitUntilGone(ctx, opts...)`
+- `Raw()` — struct wire sottostante
+
+:::tip Esempio eseguibile
+Esempio end-to-end completo: [`examples/all-resources/resource_block_storage.go`](https://github.com/Arubacloud/sdk-go/blob/main/examples/all-resources/resource_block_storage.go)
+:::
+
+---
+
+### Snapshot
+
+```go
+arubaClient.FromStorage().Snapshots()
+```
+
+**Operazioni supportate**: `Create`, `List`, `Get`, `Update`, `Delete`
+**Asincrono**: sì — chiama `WaitUntilReady(ctx)` dopo `Create`.
+
+```go
+snap, err := arubaClient.FromStorage().Snapshots().Create(
+    ctx,
+    aruba.NewSnapshot().
+        IntoProject(proj).
+        Named("my-snapshot").
+        AddTag("backup").
+        InRegion(aruba.RegionITBGBergamo).
+        WithBillingPeriod(aruba.BillingPeriodHour).
+        FromVolume(bs))
+if err != nil {
+    log.Fatalf("Create Snapshot: %v", err)
+}
+
+if err := snap.WaitUntilReady(ctx); err != nil {
+    log.Fatalf("Snapshot did not become Active: %v", err)
+}
+fmt.Printf("✓ Snapshot: %s\n", snap.Name())
+```
+
+**Accessor di risposta**:
+- `ID()`, `URI()`, `Name()`, `Tags()`
+- `SnapshotID()` — ID snapshot assegnato dal provider
+- `SizeGB()` — dimensione snapshot in GB
+- `Type()` — tipo di storage
+- `Zone()` — zona di disponibilità
+- `BillingPeriod()` — cadenza di fatturazione
+- `Bootable()` — bool
+- `VolumeURI()` — URI del volume sorgente
+- `State()`, `FailureReason()`, `PreviousState()`, `IsDisabled()`, `DisableReasons()`
+- `WaitUntilReady(ctx, opts...)`, `WaitUntilActive(ctx, opts...)`, `WaitUntilStates(ctx, []types.State{...}, opts...)`, `WaitUntilGone(ctx, opts...)`
+- `Raw()` — struct wire sottostante
+
+:::tip Esempio eseguibile
+Esempio end-to-end completo: [`examples/all-resources/resource_snapshot.go`](https://github.com/Arubacloud/sdk-go/blob/main/examples/all-resources/resource_snapshot.go)
+:::
+
+---
+
+### Storage Backup
+
+```go
+arubaClient.FromStorage().Backups()
+```
+
+**Operazioni supportate**: `Create`, `List`, `Get`, `Delete`
+**Asincrono**: sì — chiama `WaitUntilReady(ctx)` dopo `Create`.
+
+`OfType` accetta `aruba.StorageBackupTypeFull` o `aruba.StorageBackupTypeIncremental`. Usa `FromVolume(vol)` per specificare il volume sorgente.
+
+```go
+backup, err := arubaClient.FromStorage().Backups().Create(
+    ctx,
+    aruba.NewStorageBackup().
+        IntoProject(proj).
+        Named("my-backup").
+        AddTag("backup").
+        FromVolume(bs).
+        OfType(aruba.StorageBackupTypeFull).
+        WithRetentionDays(30).
+        WithBillingPeriod(aruba.BillingPeriodHour))
+if err != nil {
+    log.Fatalf("Create StorageBackup: %v", err)
+}
+
+if err := backup.WaitUntilReady(ctx); err != nil {
+    log.Fatalf("StorageBackup did not become Active: %v", err)
+}
+fmt.Printf("✓ Storage Backup: %s\n", backup.Name())
+```
+
+**Accessor di risposta**:
+- `ID()`, `URI()`, `Name()`, `Tags()`
+- `BackupID()` — ID backup assegnato dal provider
+- `Type()` — tipo di backup
+- `RetentionDays()` — periodo di conservazione in giorni
+- `OriginURI()` — URI del volume sorgente
+- `BillingPeriod()` — cadenza di fatturazione
+- `State()`, `FailureReason()`, `PreviousState()`, `IsDisabled()`, `DisableReasons()`
+- `WaitUntilReady(ctx, opts...)`, `WaitUntilActive(ctx, opts...)`, `WaitUntilStates(ctx, []types.State{...}, opts...)`, `WaitUntilGone(ctx, opts...)`
+- `Raw()` — struct wire sottostante
+
+:::tip Esempio eseguibile
+Esempio end-to-end completo: [`examples/all-resources/resource_storage_backup.go`](https://github.com/Arubacloud/sdk-go/blob/main/examples/all-resources/resource_storage_backup.go)
+:::
+
+---
+
+### Storage Restore
+
+```go
+arubaClient.FromStorage().Restores()
+```
+
+**Operazioni supportate**: `Create`, `List`, `Get`, `Delete`
+**Asincrono**: sì — chiama `WaitUntilReady(ctx)` dopo `Create`.
+
+```go
+restore, err := arubaClient.FromStorage().Restores().Create(
+    ctx,
+    aruba.NewStorageRestore().
+        IntoBackup(backup).
+        Named("my-restore").
+        AddTag("restore").
+        WithTarget(aruba.URI(backup.OriginURI())))
+if err != nil {
+    log.Fatalf("Create StorageRestore: %v", err)
+}
+
+if err := restore.WaitUntilReady(ctx); err != nil {
+    log.Fatalf("StorageRestore did not become Active: %v", err)
+}
+fmt.Printf("✓ Storage Restore: %s\n", restore.Name())
+```
+
+**Accessor di risposta**:
+- `ID()`, `URI()`, `Name()`, `Tags()`
+- `RestoreID()` — ID restore assegnato dal provider
+- `TargetURI()` — URI del volume target
+- `State()`, `FailureReason()`, `PreviousState()`, `IsDisabled()`, `DisableReasons()`
+- `WaitUntilReady(ctx, opts...)`, `WaitUntilActive(ctx, opts...)`, `WaitUntilStates(ctx, []types.State{...}, opts...)`, `WaitUntilGone(ctx, opts...)`
+- `Raw()` — struct wire sottostante
+
+:::tip Esempio eseguibile
+Esempio end-to-end completo: [`examples/all-resources/resource_storage_restore.go`](https://github.com/Arubacloud/sdk-go/blob/main/examples/all-resources/resource_storage_restore.go)
+:::
+
+---
+
+## Opzioni di Chiamata
+
+Passa le opzioni di chiamata come argomenti variadic a qualsiasi chiamata `List`, `Get`, `Create`, `Update` o `Delete`:
+
+| Opzione | Scopo |
+|---------|-------|
+| `aruba.WithFilter(expr)` | Espressione di filtro lato server |
+| `aruba.WithSort(expr)` | Espressione di ordinamento |
+| `aruba.WithLimit(n)` | Dimensione della pagina |
+| `aruba.WithOffset(n)` | Offset di paginazione |
+| `aruba.WithProjection(expr)` | Proiezione dei campi |
+| `aruba.WithAPIVersion(v)` | Sovrascrive la versione API per questa chiamata |
+
+Vedi [Filtri](./filters) per la sintassi di filtro e ordinamento.
+
+---
+
+## Costanti Enum
+
+Tutti i tipi enum sono ri-esportati da `pkg/aruba` — non è necessario alcun import aggiuntivo. L'elenco canonico si trova in `pkg/aruba/aliases.go`.
+
+### Regione e Zona
+
+| Costante | Descrizione |
+|----------|-------------|
+| `aruba.RegionITBGBergamo` | Datacenter di Bergamo (Italia) |
+| `aruba.ZoneITBG1` | Zona di disponibilità Bergamo 1 |
+| `aruba.ZoneITBG2` | Zona di disponibilità Bergamo 2 |
+| `aruba.ZoneITBG3` | Zona di disponibilità Bergamo 3 |
+
+### Fatturazione
+
+| Costante | Descrizione |
+|----------|-------------|
+| `aruba.BillingPeriodHour` | Fatturazione oraria |
+| `aruba.BillingPeriodMonth` | Fatturazione mensile |
+
+### Network
+
+| Costante | Valore |
+|----------|--------|
+| `aruba.RuleDirectionIngress` | `"Ingress"` |
+| `aruba.RuleDirectionEgress` | `"Egress"` |
+| `aruba.RuleProtocolTCP` | `"TCP"` |
+| `aruba.RuleProtocolUDP` | `"UDP"` |
+| `aruba.RuleProtocolICMP` | `"ICMP"` |
+| `aruba.RuleProtocolANY` | (wildcard — qualsiasi protocollo) |
+| `aruba.SubnetTypeBasic` | `"Basic"` |
+| `aruba.SubnetTypeAdvanced` | `"Advanced"` |
+
+### Compute
+
+| Costante | Descrizione |
+|----------|-------------|
+| `aruba.CloudServerFlavorCSO1A2` | 1 vCPU, 2 GB RAM |
+| `aruba.CloudServerFlavorCSO2A4` | 2 vCPU, 4 GB RAM |
+| `aruba.CloudServerFlavorCSO4A8` | 4 vCPU, 8 GB RAM |
+| `aruba.CloudServerFlavorCSO8A16` | 8 vCPU, 16 GB RAM |
+| … (vedi `aliases.go` per l'elenco completo) | |
+
+### Container
+
+| Costante | Descrizione |
+|----------|-------------|
+| `aruba.KubernetesVersion1323` | Kubernetes 1.32.3 |
+| `aruba.KubernetesVersion1332` | Kubernetes 1.33.2 |
+| `aruba.KubernetesVersion1341` | Kubernetes 1.34.1 |
+| `aruba.NodePoolInstanceK2A4` | 2 vCPU, 4 GB RAM |
+| `aruba.NodePoolInstanceK4A8` | 4 vCPU, 8 GB RAM |
+| `aruba.NodePoolInstanceK8A16` | 8 vCPU, 16 GB RAM |
+| … (vedi `aliases.go` per l'elenco completo) | |
+| `aruba.ContainerRegistrySizeFlavorSmall` | Tier utenti concorrenti Small |
+| `aruba.ContainerRegistrySizeFlavorMedium` | Tier utenti concorrenti Medium |
+| `aruba.ContainerRegistrySizeFlavorHighPerf` | Tier ad alte prestazioni |
+
+### Database
+
+| Costante | Descrizione |
+|----------|-------------|
+| `aruba.DatabaseEngineMySQL80` | MySQL 8.0 |
+| `aruba.DatabaseEngineMSSQL2022Web` | SQL Server 2022 Web |
+| `aruba.DatabaseEngineMSSQL2022Standard` | SQL Server 2022 Standard |
+| `aruba.DatabaseEngineMSSQL2022Enterprise` | SQL Server 2022 Enterprise |
+| `aruba.DBaaSFlavorDBO1A2` | 1 vCPU, 2 GB RAM |
+| `aruba.DBaaSFlavorDBO2A4` | 2 vCPU, 4 GB RAM |
+| `aruba.DBaaSFlavorDBO4A8` | 4 vCPU, 8 GB RAM |
+| … (vedi `aliases.go` per l'elenco completo) | |
+
+### Storage
+
+| Costante | Valore |
+|----------|--------|
+| `aruba.BlockStorageTypeStandard` | `"Standard"` |
+| `aruba.BlockStorageTypePerformance` | `"Performance"` |
+| `aruba.StorageBackupTypeFull` | `"Full"` |
+| `aruba.StorageBackupTypeIncremental` | `"Incremental"` |
+
+### Security
+
+| Costante | Valore |
+|----------|--------|
+| `aruba.KeyAlgorithmAes` | `"Aes"` |
+| `aruba.KeyAlgorithmRsa` | `"Rsa"` |
+| `aruba.KeyTypeSymmetric` | `"Symmetric"` |
+| `aruba.KeyTypeAsymmetric` | `"Asymmetric"` |
+| `aruba.ServiceStatusCertificateAvailable` | `"CertificateAvailable"` |
+
+### Crypto VPN
+
+| Costante | Descrizione |
+|----------|-------------|
+| `aruba.IKEEncryptionAES256` | AES-256 CBC (IKE fase 1) |
+| `aruba.IKEHashSHA256` | HMAC-SHA-256 (IKE fase 1) |
+| `aruba.IKEDHGroup14` | Gruppo Diffie-Hellman MODP-2048 |
+| `aruba.ESPEncryptionAES256` | AES-256 CBC (ESP fase 2) |
+| `aruba.ESPHashSHA256` | HMAC-SHA-256 (ESP fase 2) |
+| `aruba.ESPPFSGroupEnable` | PFS abilitato (gruppo DH negoziato) |
+| `aruba.ESPPFSGroupDisable` | PFS disabilitato |
+| … (vedi `aliases.go` per l'elenco completo) | |
+
+### Schedule
+
+| Costante | Valore |
+|----------|--------|
+| `aruba.JobTypeOneShot` | `"OneShot"` |
+| `aruba.JobTypeRecurring` | `"Recurring"` |
+
+---
+
+## Appendice: Tipi Wire Grezzi (`pkg/types`)
+
+I seguenti tipi sono le struct wire di basso livello. Normalmente vi si accede solo tramite `.Raw()` o `.RawRequest()` su un wrapper, o quando si costruiscono integrazioni avanzate con `pkg/async`. Sono anche ri-esportati come alias di tipo `aruba.XxxRequest` / `aruba.XxxResponse` così da poterli referenziare senza un import aggiuntivo.
+
+| Tipo | File | Note |
+|------|------|------|
+| `Response[T]` | `resource.go` | Envelope HTTP generico restituito dagli adapter di basso livello |
+| `ErrorResponse` | `error.go` | Errore strutturato RFC 7807 |
+| `ListResponse` | `resource.go` | Link di paginazione e conteggio totale |
+| `ResourceMetadataRequest` | `resource.go` | Nome + tag per Create |
+| `RegionalResourceMetadataRequest` | `resource.go` | Estende i metadati con Location |
+| `ResourceMetadataResponse` | `resource.go` | ID, URI, Name, timestamp |
+| `ResourceStatus` | `resource.go` | Campo State |
+| `ReferenceResource` | `resource.go` | Link `{uri: "…"}` a un'altra risorsa |
+| `RequestParameters` | `parameters.go` | Struct filter/sort/limit/offset di basso livello (preferire gli helper `CallOption`) |
+| `ProjectRequest` / `ProjectResponse` / `ProjectList` | `project.project.go` | |
+| `VPCRequest` / `VPCResponse` / `VPCList` | `network.vpc.go` | |
+| `SubnetRequest` / `SubnetResponse` / `SubnetList` | `network.subnet.go` | |
+| `SecurityGroupRequest` / `SecurityGroupResponse` | `network.security-group.go` | |
+| `SecurityRuleRequest` / `SecurityRuleResponse` | `network.security-rule.go` | |
+| `ElasticIPRequest` / `ElasticIPResponse` | `network.elastic-ip.go` | |
+| `CloudServerRequest` / `CloudServerResponse` | `compute.cloudserver.go` | |
+| `KeyPairRequest` / `KeyPairResponse` | `compute.keypair.go` | |
+| `KaaSRequest` / `KaaSResponse` / `KaaSUpdateRequest` | `container.kaas.go` | |
+| `ContainerRegistryRequest` / `ContainerRegistryResponse` | `container.containerregistry.go` | |
+| `DBaaSRequest` / `DBaaSResponse` | `database.dbaas.go` | |
+| `KmsRequest` / `KmsResponse` | `security.kms.go` | |
+| `KeyRequest` / `KeyResponse` | `security.kms.go` | |
+| `KmipRequest` / `KmipResponse` / `KmipCertificateResponse` | `security.kms.go` | |
+| `BlockStorageRequest` / `BlockStorageResponse` | `storage.block-storage.go` | |
+| `SnapshotRequest` / `SnapshotResponse` | `storage.snapshot.go` | |
+| `StorageBackupRequest` / `StorageBackupResponse` | `storage.backup.go` | |
+| `JobRequest` / `JobResponse` / `JobList` | `schedule.job.go` | |
+| `AlertResponse` / `AlertsListResponse` | `metrics.alert.go` | |
+| `MetricResponse` / `MetricListResponse` | `metrics.metric.go` | |
+| `AuditEvent` / `AuditEventListResponse` | `audit.event.go` | |
+| `VPCPeeringRequest` / `VPCPeeringResponse` | `network.vpc-peering.go` | |
+| `VPNTunnelRequest` / `VPNTunnelResponse` | `network.vpn-tunnel.go` | |
+| `VPNRouteRequest` / `VPNRouteResponse` | `network.vpn-route.go` | |
+| `LoadBalancerResponse` | `network.load-balancer.go` | |

--- a/docs/website/i18n/it/docusaurus-plugin-content-docs/version-0.2.3/response-handling.md
+++ b/docs/website/i18n/it/docusaurus-plugin-content-docs/version-0.2.3/response-handling.md
@@ -1,0 +1,130 @@
+# Guida alla Gestione delle Risposte
+
+## Panoramica
+
+Il layer wrapper dell'SDK gestisce automaticamente il parsing delle risposte e la segnalazione degli errori. Ogni metodo CRUD restituisce o un wrapper popolato (in caso di successo) o un errore. Raramente è necessario ispezionare direttamente l'envelope HTTP grezzo — ma gli strumenti per farlo sono sempre disponibili.
+
+## Pattern Base
+
+Ogni metodo wrapper restituisce `(wrapper, error)`. L'errore è non-nil sia per errori di rete che per errori a livello API (4xx / 5xx).
+
+```go
+vpc, err := arubaClient.FromNetwork().VPCs().Get(ctx,
+    aruba.URI("/projects/<projectID>/providers/Aruba.Network/vpcs/<vpcID>"),
+)
+if err != nil {
+    log.Fatalf("Get VPC failed: %v", err)
+}
+fmt.Printf("VPC: %s (state: %s)\n", vpc.Name(), vpc.State())
+```
+
+## Errori HTTP Tipizzati
+
+Quando l'API restituisce una risposta 4xx o 5xx, l'SDK la racchiude in `*aruba.HTTPError`. Usa `errors.As` per ispezionare il codice di stato e il corpo dell'errore strutturato:
+
+```go
+import "errors"
+
+vpc, err := arubaClient.FromNetwork().VPCs().Create(ctx, vpc)
+if err != nil {
+    var httpErr *aruba.HTTPError
+    if errors.As(err, &httpErr) {
+        fmt.Printf("API error %d: %s\n", httpErr.StatusCode, httpErr.Error())
+        if httpErr.ErrResp != nil {
+            fmt.Printf("  title:  %s\n", derefStr(httpErr.ErrResp.Title))
+            fmt.Printf("  detail: %s\n", derefStr(httpErr.ErrResp.Detail))
+            for _, ve := range httpErr.ErrResp.Errors {
+                fmt.Printf("  field %s: %s\n", ve.Field, ve.Message)
+            }
+        }
+    } else {
+        // Errore di rete, timeout del contesto, ecc.
+        log.Fatalf("Request failed: %v", err)
+    }
+}
+```
+
+## Pattern Completo di Gestione degli Errori
+
+```go
+proj, err := arubaClient.FromProject().Get(ctx, ref)
+if err != nil {
+    var httpErr *aruba.HTTPError
+    if errors.As(err, &httpErr) {
+        switch httpErr.StatusCode {
+        case 404:
+            return fmt.Errorf("project not found")
+        case 400:
+            return fmt.Errorf("bad request: %s", derefStr(httpErr.ErrResp.Detail))
+        default:
+            return fmt.Errorf("API error (%d): %s", httpErr.StatusCode, httpErr.Error())
+        }
+    }
+    return fmt.Errorf("request failed: %w", err)
+}
+// proj è popolato — usalo direttamente
+fmt.Printf("Project: %s (tags: %v)\n", proj.Name(), proj.Tags())
+```
+
+## Accessori dell'Envelope HTTP
+
+Ogni wrapper prodotto da una chiamata Create / Get / Update / List espone il suo envelope HTTP grezzo:
+
+```go
+// Dopo qualsiasi chiamata CRUD:
+proj, err := arubaClient.FromProject().Create(ctx, p)
+// …
+
+fmt.Println("Status:", proj.StatusCode())
+fmt.Println("Headers:", proj.Headers())
+fmt.Println("Raw body:", string(proj.RawHTTP()))
+fmt.Println("Error body (if any):", proj.RawError())
+```
+
+## Accesso alla Risposta Wire Grezza
+
+Ogni wrapper ha un metodo `Raw()` che restituisce lo struct di risposta tipizzato sottostante da `pkg/types`. È utile per i campi non ancora promossi alla superficie del wrapper:
+
+```go
+vpc, err := arubaClient.FromNetwork().VPCs().Get(ctx, ref)
+if err != nil { /* … */ }
+
+raw := vpc.Raw()                         // struct wire sottostante
+fmt.Println(raw.Properties.IsDefault)    // campo non sul wrapper
+```
+
+## Errori in Fase di Setter
+
+I setter del builder fluente non restituiscono mai errori — li registrano internamente. L'errore emerge alla prima chiamata `Create` o `Update`. Puoi anche controllarlo in anticipo:
+
+```go
+rule := aruba.NewSecurityRule().
+    IntoSecurityGroup(sg).
+    WithTargetCIDR("0.0.0.0/0").
+    WithTargetSecurityGroup(otherSG) // setter in conflitto — registra un errore
+
+if err := rule.Err(); err != nil {
+    log.Fatalf("Bad rule configuration: %v", err)
+}
+```
+
+## Best Practice
+
+1. **Controlla sempre `err` prima** — copre sia gli errori di rete che quelli API.
+2. **Usa `errors.As(err, &httpErr)`** per ottenere dettagli strutturati sugli errori 4xx/5xx.
+3. **Controlla `httpErr.ErrResp.Errors`** per messaggi di validazione a livello di campo sugli errori 400.
+4. **Usa `httpErr.ErrResp.TraceID`** quando apri una richiesta di supporto.
+5. **Usa `.Raw()` con parsimonia** — preferisci gli accessori tipizzati del wrapper.
+6. **Controlla `wrapper.Err()` prima di Create/Update** quando la catena di builder è lunga.
+
+---
+
+```go
+// Helper usato negli esempi sopra
+func derefStr(s *string) string {
+    if s == nil {
+        return ""
+    }
+    return *s
+}
+```

--- a/docs/website/i18n/it/docusaurus-plugin-content-docs/version-0.2.3/version-0.2.3.json
+++ b/docs/website/i18n/it/docusaurus-plugin-content-docs/version-0.2.3/version-0.2.3.json
@@ -1,0 +1,30 @@
+{
+  "version.label": {
+    "message": "0.2.3",
+    "description": "The label for version current"
+  },
+  "sidebar.tutorialSidebar.category.Quick Start": {
+    "message": "Guida Rapida",
+    "description": "The label for category Quick Start in sidebar tutorialSidebar"
+  },
+  "sidebar.tutorialSidebar.category.Resources": {
+    "message": "Risorse",
+    "description": "The label for category Resources in sidebar tutorialSidebar"
+  },
+  "sidebar.tutorialSidebar.category.Types": {
+    "message": "Tipi",
+    "description": "The label for category Types in sidebar tutorialSidebar"
+  },
+  "sidebar.tutorialSidebar.category.Options": {
+    "message": "Opzioni",
+    "description": "The label for category Options in sidebar tutorialSidebar"
+  },
+  "sidebar.tutorialSidebar.category.Response Handling": {
+    "message": "Gestione Risposte",
+    "description": "The label for category Response Handling in sidebar tutorialSidebar"
+  },
+  "sidebar.tutorialSidebar.category.Filters": {
+    "message": "Filtri",
+    "description": "The label for category Filters in sidebar tutorialSidebar"
+  }
+}

--- a/docs/website/i18n/it/docusaurus-plugin-content-docs/version-0.2.3/walkthrough.md
+++ b/docs/website/i18n/it/docusaurus-plugin-content-docs/version-0.2.3/walkthrough.md
@@ -1,0 +1,339 @@
+---
+sidebar_position: 2
+---
+
+# Guida al Walkthrough API
+
+L'SDK Go di Aruba Cloud fornisce un singolo import — `github.com/Arubacloud/sdk-go/pkg/aruba` — che espone un'API fluente con pattern builder per ogni risorsa cloud. Si costruisce la descrizione della risorsa con una catena `aruba.NewX()`, la si passa al metodo del client appropriato (`Create`, `Get`, `Update`, `Delete` o `List`), e si lavora con il wrapper tipizzato restituito.
+
+Le risorse sono organizzate in un **Progetto**, e le risorse figlio referenziano i propri genitori tramite l'interfaccia `aruba.Ref`. Non è mai necessario estrarre o passare manualmente stringhe di ID grezzi: si passa direttamente il wrapper idratato (restituito da `Create` o `Get`) come parametro `Ref` ai metodi builder come `IntoProject(proj)`, `IntoVPC(vpc)` o `IntoSecurityGroup(sg)`.
+
+Questa pagina illustra il ciclo CRUD completo su un esempio minimale — Project + VPC + Subnet. Ogni altra risorsa segue esattamente la stessa struttura. Vedi [Risorse](./resources) per snippet pronti all'uso per tutte le risorse supportate.
+
+---
+
+## 1. Inizializzare il Client
+
+```go
+package main
+
+import (
+    "context"
+    "log"
+    "time"
+
+    "github.com/Arubacloud/sdk-go/pkg/aruba"
+)
+
+func main() {
+    arubaClient, err := aruba.NewClient(aruba.DefaultOptions(clientID, clientSecret))
+    if err != nil {
+        log.Fatalf("Failed to create client: %v", err)
+    }
+
+    ctx, cancel := context.WithTimeout(context.Background(), 30*time.Minute)
+    defer cancel()
+}
+```
+
+`aruba.NewClient` accetta un valore `*aruba.Options`. `aruba.DefaultOptions(clientID, clientSecret)` è il modo più rapido per iniziare; vedi [Opzioni di Configurazione](./options) per credenziali Vault, caching token Redis, logger personalizzati e altro.
+
+Il `aruba.Client` restituito è una facciata che espone sub-client specifici per dominio:
+`FromProject()`, `FromAudit()`, `FromCompute()`, `FromContainer()`, `FromDatabase()`, `FromMetric()`, `FromNetwork()`, `FromSchedule()`, `FromSecurity()`, `FromStorage()`.
+
+---
+
+## 2. Provisioning delle Risorse
+
+Le risorse vengono create inline: si costruisce la richiesta con `aruba.NewX()` e la si passa direttamente a `Create`. Il wrapper restituito porta l'ID e l'URI della risorsa — lo si passa come `Ref` ai builder delle risorse figlio.
+
+### Progetto
+
+Il Progetto è il contenitore di livello superiore. Ogni altra risorsa appartiene a un progetto. È pronto in modo sincrono dopo che `Create` ritorna — non è necessario il polling.
+
+```go
+proj, err := arubaClient.FromProject().Create(
+    ctx,
+    aruba.NewProject().
+        Named("my-project").
+        WithDescription("Creato tramite l'SDK Go di Aruba Cloud").
+        AddTag("go-sdk").
+        NotDefault())
+if err != nil {
+    log.Fatalf("Create project: %v", err)
+}
+fmt.Printf("✓ Progetto creato: %s (ID: %s)\n", proj.Name(), proj.ID())
+```
+
+### VPC
+
+```go
+vpc, err := arubaClient.FromNetwork().VPCs().Create(
+    ctx,
+    aruba.NewVPC().
+        IntoProject(proj).
+        Named("my-vpc").
+        AddTag("network").
+        InRegion(aruba.RegionITBGBergamo).
+        NotDefault().
+        WithPreset(false))
+if err != nil {
+    log.Fatalf("Create VPC: %v", err)
+}
+fmt.Printf("✓ VPC creata: %s\n", vpc.Name())
+
+// La maggior parte delle risorse è asincrona — attendi che raggiungano uno stato stabile.
+// Vedi "7. Attendere la Disponibilità" per le opzioni e i dettagli.
+if err := vpc.WaitUntilReady(ctx); err != nil {
+    log.Fatalf("VPC did not become Active: %v", err)
+}
+```
+
+`IntoProject(proj)` accetta qualsiasi `aruba.Ref` — lega lo scope del progetto senza richiedere l'estrazione di un ID stringa grezzo.
+
+### Subnet
+
+```go
+subnet, err := arubaClient.FromNetwork().Subnets().Create(
+    ctx,
+    aruba.NewSubnet().
+        IntoVPC(vpc).
+        Named("my-subnet").
+        AddTag("network").
+        InRegion(aruba.RegionITBGBergamo).
+        OfType(aruba.SubnetTypeAdvanced).
+        NotDefault().
+        WithCIDR("192.168.1.0/25").
+        WithDHCP(aruba.NewSubnetDHCP().
+            Enabled().
+            WithRange("192.168.1.10", 50).
+            AddRoute("10.0.0.0/8", "192.168.1.1").
+            AddDNS("8.8.8.8").
+            AddDNS("8.8.4.4")))
+if err != nil {
+    log.Fatalf("Create subnet: %v", err)
+}
+fmt.Printf("✓ Subnet creata: %s (CIDR: %s)\n", subnet.Name(), subnet.CIDR())
+
+if err := subnet.WaitUntilReady(ctx); err != nil {
+    log.Fatalf("Subnet did not become Active: %v", err)
+}
+```
+
+`aruba.NewSubnetDHCP()` è un sub-builder per la configurazione DHCP. Si allega alla subnet con `WithDHCP(...)`.
+
+`OfType` accetta `aruba.SubnetTypeBasic` o `aruba.SubnetTypeAdvanced` (costanti tipizzate — nessun cast a stringa necessario).
+
+> Ogni altra risorsa — Security Group, Elastic IP, Block Storage, Cloud Server, cluster KaaS, istanze DBaaS e altro — segue esattamente la stessa struttura `NewX()` → `IntoParent(ref)` → `Create(ctx, ...)` → `WaitUntilReady(ctx)`. Vedi [Risorse](./resources) per l'elenco completo con snippet pronti all'uso.
+
+---
+
+## 3. Aggiornare una Risorsa Esistente
+
+Prima si recupera la risorsa, poi la si muta tramite setter, poi si chiama `Update`. Il wrapper di risposta da `Get` porta tutto lo stato interno (URI padre, riferimenti di rete, ecc.) che viene trasferito automaticamente nella richiesta `Update`.
+
+```go
+// Recupera
+vpc, err = arubaClient.FromNetwork().VPCs().Get(ctx, vpc)
+if err != nil {
+    log.Fatalf("Get VPC: %v", err)
+}
+
+// Muta
+vpc.Named("my-vpc-updated").
+    ReplaceTags("network", "updated")
+
+// Aggiorna
+updated, err := arubaClient.FromNetwork().VPCs().Update(ctx, vpc)
+if err != nil {
+    log.Fatalf("Update VPC: %v", err)
+}
+fmt.Printf("✓ VPC aggiornata: %s\n", updated.Name())
+```
+
+> **Importante**: Chiama sempre `Get` prima di `Update`. Chiamare `Update` su un wrapper appena costruito (senza un precedente `Create` o `Get`) restituisce un errore: `"Update: resource has no ID"`.
+
+---
+
+## 4. Elencare Risorse Esistenti
+
+`List` accetta un `Ref` genitore e restituisce un `*aruba.List[T]`. Si iterano gli elementi con `Items()`:
+
+```go
+list, err := arubaClient.FromNetwork().VPCs().List(ctx, proj)
+if err != nil {
+    log.Fatalf("List VPCs: %v", err)
+}
+fmt.Println("Totale VPC:", list.Total())
+for _, v := range list.Items() {
+    fmt.Println("-", v.Name(), v.ID())
+}
+```
+
+Gli elementi nella lista sono wrapper leggeri — portano l'ID e l'URI della risorsa, così puoi passarli direttamente a `Get`, `Update` o `Delete` come `Ref`:
+
+```go
+for _, v := range list.Items() {
+    full, err := arubaClient.FromNetwork().VPCs().Get(ctx, v)
+    // full ha tutti i campi popolati
+}
+```
+
+Per il filtraggio lato server, ordinamento e paginazione vedi [Filtri](./filters).
+
+---
+
+## 5. Ottenere una Risorsa Specifica
+
+Usa `Get` quando hai un `Ref` (un wrapper idratato, o un elemento di `*aruba.List[T]`):
+
+```go
+vpc, err := arubaClient.FromNetwork().VPCs().Get(ctx, vpc)
+if err != nil {
+    log.Fatalf("Get VPC: %v", err)
+}
+```
+
+### L'escape hatch `aruba.URI(…)`
+
+Quando hai solo un identificatore di risorsa come stringa — ad esempio, letto da una variabile d'ambiente o da una configurazione esterna — avvolgilo in `aruba.URI(…)` per soddisfare l'interfaccia `aruba.Ref`:
+
+```go
+projectID := os.Getenv("PROJECT_ID")
+
+// Bootstrap di un wrapper tipizzato da un ID stringa
+proj, err := arubaClient.FromProject().Get(ctx, aruba.URI("/projects/"+projectID))
+if err != nil {
+    log.Fatalf("Get project: %v", err)
+}
+
+// Ora proj è completamente idratato — usalo come Ref per le risorse figlio
+vpcs, err := arubaClient.FromNetwork().VPCs().List(ctx, proj)
+```
+
+`aruba.URI(s)` restituisce un `Ref` leggero che l'SDK usa per estrarre gli ID degli antenati dai segmenti di percorso URI. Qualsiasi URI di risorsa valido funziona — l'SDK lo analizza internamente.
+
+---
+
+## 6. Eliminazione (Ordine Inverso)
+
+Elimina i figli prima dei genitori. L'API Aruba Cloud restituisce **HTTP 400** quando si tenta di eliminare un genitore che ha ancora risorse figlio attive o in fase di eliminazione — non 409/422. Il pattern sicuro è emettere ogni delete sul figlio, poi attendere che la risorsa sia completamente sparita prima di salire nella catena delle dipendenze.
+
+`WaitUntilGone` blocca finché la risorsa non esiste più — ovvero finché il suo `Get` restituisce HTTP 404. Chiamalo sul wrapper idratato che già possiedi (`Delete` di per sé restituisce solo un `error`, non un wrapper):
+
+```go
+// subnet → VPC → progetto
+if err := arubaClient.FromNetwork().Subnets().Delete(ctx, subnet); err != nil {
+    log.Printf("Delete subnet: %v", err)
+} else if err := subnet.WaitUntilGone(ctx); err != nil {
+    log.Printf("Subnet not gone: %v", err)
+}
+
+if err := arubaClient.FromNetwork().VPCs().Delete(ctx, vpc); err != nil {
+    log.Printf("Delete VPC: %v", err)
+} else if err := vpc.WaitUntilGone(ctx); err != nil {
+    log.Printf("VPC not gone: %v", err)
+}
+
+if err := arubaClient.FromProject().Delete(ctx, proj); err != nil {
+    log.Printf("Delete project: %v", err)
+}
+```
+
+`WaitUntilGone` accetta le stesse `WaitOption` di `WaitUntilReady` (`WithRetries`, `WithBaseDelay`, `WithTimeout`) ed è disponibile su ogni wrapper di risorsa che supporta il polling. `Project` non ha polling — viene eliminato per ultimo, senza figli rimasti su cui attendere.
+
+`Delete` accetta qualsiasi `aruba.Ref` — puoi passare il wrapper idratato direttamente o `aruba.URI(…)` se hai solo il percorso.
+
+Per una sequenza completa di teardown (Security Rule → Security Group → Subnet → VPC → Cloud Server → Block Storage → Progetto) vedi l'[Esempio Completo](#esempio-completo) in basso.
+
+---
+
+## 7. Attendere la Disponibilità
+
+La maggior parte delle operazioni cloud — Create, Update, operazioni di scaling — sono **asincrone**: la chiamata HTTP ritorna rapidamente, ma la risorsa continua a transitare tra stati (`Creating` → `Active`, `Updating` → `Active`) per secondi o minuti in background.
+
+Il metodo `WaitUntilReady` su qualsiasi wrapper di risorsa che incorpora `statusMixin` blocca finché la risorsa raggiunge lo stato `"Active"` (o restituisce un errore in caso di fallimento terminale):
+
+```go
+if err := vpc.WaitUntilReady(ctx); err != nil {
+    log.Fatalf("VPC did not become Active: %v", err)
+}
+```
+
+Tre `WaitOption` permettono di sovrascrivere i valori predefiniti (60 tentativi × 10 s di ritardo base × 600 s di scadenza rigida):
+
+```go
+if err := vpc.WaitUntilReady(ctx,
+    aruba.WithRetries(30),              // max iterazioni di polling (default: 60)
+    aruba.WithBaseDelay(5*time.Second), // ritardo fisso tra i poll (default: 10s)
+    aruba.WithTimeout(3*time.Minute),   // scadenza rigida (default: 600s)
+); err != nil {
+    log.Fatalf("VPC did not become Active: %v", err)
+}
+```
+
+Per `WaitUntilStates(ctx, []types.State{...}, opts...)` (qualsiasi insieme di stati target, non solo `"Active"`), gli accessor di stato (`State()`, `FailureReason()`, `PreviousState()`, `IsDisabled()`, `DisableReasons()`), e il primitivo di basso livello `pkg/async.WaitFor` per il polling concorrente, vedi la guida [Async / Await](./async).
+
+---
+
+## Avvertenze
+
+### Gli errori dei setter sono differiti
+
+I setter del builder non restituiscono mai un errore — lo registrano nel wrapper. L'errore viene restituito dalla prima chiamata `Create` o `Update`, oppure puoi controllarlo in anticipo:
+
+```go
+rule := aruba.NewSecurityRule().
+    IntoSecurityGroup(sg).
+    WithTargetCIDR("0.0.0.0/0").
+    WithTargetSecurityGroup(otherSG) // in conflitto — registrato come errore
+
+if err := rule.Err(); err != nil {
+    log.Fatalf("Bad rule config: %v", err)
+}
+```
+
+> **Avvertenza**: `WithTargetCIDR` e `WithTargetSecurityGroup` si escludono a vicenda. Impostarli entrambi registra un errore al momento del setter che emerge su `Create`.
+
+### `WaitUntilReady` richiede un wrapper idratato
+
+Chiamare `WaitUntilReady` su un wrapper costruito manualmente (senza `Create`/`Get`/`Update`/`List`) restituisce:
+
+```
+WaitUntilStates: refresh callback not set; resource must be produced by an adapter (Create/Get/Update/List) to support polling
+```
+
+Usa sempre il wrapper restituito dalla chiamata API, non il builder della richiesta.
+
+### Errori HTTP tipizzati
+
+Le risposte API non-2xx vengono restituite come `*aruba.HTTPError`. Usa `errors.As` per ispezionarle:
+
+```go
+vpc, err = arubaClient.FromNetwork().VPCs().Create(ctx, vpc)
+if err != nil {
+    var httpErr *aruba.HTTPError
+    if errors.As(err, &httpErr) {
+        log.Printf("API error %d: %s", httpErr.StatusCode, httpErr.Error())
+    } else {
+        log.Fatalf("Network error: %v", err)
+    }
+}
+```
+
+Vedi [Gestione delle Risposte](./response-handling) per la guida completa alla gestione degli errori.
+
+---
+
+## Esempio Completo
+
+La directory `examples/all-resources/` nel repository contiene un esempio end-to-end eseguibile che dimostra tutte le risorse:
+
+```bash
+go run ./examples/all-resources/ -mode=create -clientID=… -clientSecret=…
+go run ./examples/all-resources/ -mode=update -clientID=… -clientSecret=… -projectID=…
+go run ./examples/all-resources/ -mode=delete -clientID=… -clientSecret=… -projectID=…
+
+# Aggiungi -debug per il logging verboso dell'SDK:
+go run ./examples/all-resources/ -mode=create -clientID=… -clientSecret=… -debug
+```

--- a/docs/website/i18n/it/docusaurus-plugin-content-docs/version-0.3.0/async.md
+++ b/docs/website/i18n/it/docusaurus-plugin-content-docs/version-0.3.0/async.md
@@ -1,0 +1,220 @@
+---
+sidebar_position: 3
+---
+
+# Async / Await
+
+La maggior parte delle operazioni API di Aruba Cloud sono **asincrone**: la chiamata HTTP ritorna rapidamente (con un `201 Created` o `200 OK`), ma la risorsa continua a transitare tra stati in background — `Creating` → `Active`, oppure `Updating` → `Active`, oppure `Deleting` → rimossa — per secondi o svariati minuti.
+
+L'SDK espone tre livelli per gestire questa situazione:
+
+| Livello | Quando usarlo |
+|---------|---------------|
+| `WaitUntilReady(ctx)` | 95% dei casi — blocca finché la risorsa è pronta (accetta `Active`, `Running`, `Stopped`, `NotUsed`, `Reserved`, `InUse`, `Used`) |
+| `WaitUntilActive(ctx)` | Quando hai specificamente bisogno solo dello stato `Active` |
+| `WaitUntilStates(ctx, []types.State{...}, opts...)` | Attendi uno o più stati specifici (es. `[]types.State{types.StateStopped}`) |
+| `WaitUntilGone(ctx)` | Dopo `Delete` — blocca finché il `Get` della risorsa restituisce HTTP 404 (rimossa definitivamente) |
+| `pkg/async.WaitFor` + `AsyncClient.Await` | Avanzato — avvia il polling in una goroutine in background, fai altro lavoro, raccogli il risultato in seguito |
+
+---
+
+## `WaitUntilReady`
+
+Dopo qualsiasi `Create`, `Update` o `Get`, chiama `WaitUntilReady` sul wrapper restituito per bloccare finché la risorsa raggiunge uno qualsiasi dei 7 stati stabili: `Active`, `Running`, `Stopped`, `NotUsed`, `Reserved`, `InUse`, o `Used`.
+
+```go
+vpc, err := arubaClient.FromNetwork().VPCs().Create(ctx, vpc)
+if err != nil {
+    log.Fatalf("Create VPC: %v", err)
+}
+
+if err := vpc.WaitUntilReady(ctx); err != nil {
+    log.Fatalf("VPC did not become Ready: %v", err)
+}
+```
+
+`WaitUntilReady` effettua il polling dell'API ripetutamente con un ritardo fisso. Quando la risorsa entra in uno **stato terminale di errore** noto (es. `"Error"`, `"Failed"`), ritorna immediatamente con un errore descrittivo invece di esaurire tutti i tentativi.
+
+`WaitUntilActive` è disponibile quando hai specificamente bisogno dello stato `"Active"` — ad esempio dopo un'operazione di power-on.
+
+Vedi la [Guida al Walkthrough API](./walkthrough) per esempi completi di Create + polling + Update + Delete.
+
+### Personalizzare il comportamento di polling
+
+Tre opzioni di chiamata permettono di sovrascrivere i valori predefiniti:
+
+```go
+if err := vpc.WaitUntilReady(ctx,
+    aruba.WithRetries(30),              // max iterazioni di polling (default: 60)
+    aruba.WithBaseDelay(5*time.Second), // ritardo fisso tra i poll (default: 10s)
+    aruba.WithTimeout(3*time.Minute),   // scadenza rigida (default: 600s)
+); err != nil {
+    log.Fatalf("VPC did not become Ready: %v", err)
+}
+```
+
+Il limite effettivo è `min(retries × baseDelay, timeout)`. Con i valori predefiniti: `min(60×10s, 600s) = 600s`.
+
+Per risorse a lunga esecuzione (Container Registry, DBaaS, KaaS) che possono richiedere 20–40 minuti, usa un budget maggiore:
+
+```go
+longWait := []aruba.WaitOption{
+    aruba.WithTimeout(40 * time.Minute),
+    aruba.WithRetries(240),
+}
+if err := reg.WaitUntilReady(ctx, longWait...); err != nil {
+    log.Fatalf("ContainerRegistry did not become Ready: %v", err)
+}
+```
+
+---
+
+## `WaitUntilStates`
+
+Usa `WaitUntilStates` quando devi attendere uno o più stati specifici — ad esempio, attendere lo stato di stop dopo un'operazione di power-off:
+
+```go
+// Attendi che un Cloud Server si fermi completamente dopo PowerOff
+if err := cs.WaitUntilStates(ctx, []types.State{types.StateStopped}); err != nil {
+    log.Fatalf("Cloud Server did not stop: %v", err)
+}
+```
+
+```go
+// Attendi che un'istanza DBaaS finisca un aggiornamento in corso
+if err := db.WaitUntilActive(ctx,
+    aruba.WithRetries(120),
+    aruba.WithBaseDelay(15*time.Second),
+); err != nil {
+    log.Fatalf("DBaaS did not return to Active after update: %v", err)
+}
+```
+
+Si applica lo stesso comportamento di uscita anticipata per gli stati di errore terminali: se la risorsa raggiunge `"Error"` o `"Failed"` mentre si aspetta `"Stopped"`, la chiamata ritorna immediatamente con un errore che indica sia lo stato attuale che gli stati attesi.
+
+`WaitUntilActive` e `WaitUntilReady` sono wrapper di convenienza attorno a `WaitUntilStates`:
+- `WaitUntilActive(ctx, opts...)` — equivalente a `WaitUntilStates(ctx, []types.State{types.StateActive}, opts...)`
+- `WaitUntilReady(ctx, opts...)` — equivalente a `WaitUntilStates(ctx, []types.State{types.StateActive, types.StateRunning, types.StateStopped, types.StateNotUsed, types.StateReserved, types.StateInUse, types.StateUsed}, opts...)`
+
+---
+
+## `WaitUntilGone`
+
+Usa `WaitUntilGone` dopo una chiamata `Delete` per bloccare finché la risorsa è completamente rimossa — ovvero finché il suo `Get` restituisce HTTP 404:
+
+```go
+if err := arubaClient.FromNetwork().Subnets().Delete(ctx, subnet); err != nil {
+    log.Printf("Delete subnet: %v", err)
+} else if err := subnet.WaitUntilGone(ctx); err != nil {
+    log.Printf("Subnet not gone: %v", err)
+}
+```
+
+`WaitUntilGone` è disponibile su ogni wrapper di risorsa che supporta il polling (vedi [Risorse che Supportano il Polling](#risorse-che-supportano-il-polling) di seguito). Accetta le stesse `WaitOption` di `WaitUntilReady`. Qualsiasi errore da `Get` diverso da HTTP 404 viene trattato come transitorio e ritentato; un 404 segnala il successo.
+
+`Project` non supporta il polling e quindi non ha `WaitUntilGone`. Viene eliminato per ultimo, senza figli rimasti su cui attendere.
+
+---
+
+## Accessor di Stato
+
+Ogni wrapper che supporta il polling espone anche accessor di stato dettagliati. Puoi leggerli in qualsiasi momento dopo una chiamata `Create`, `Get`, `Update` o `List`:
+
+| Metodo | Restituisce | Utilizzo tipico |
+|--------|-------------|-----------------|
+| `State()` | `types.State` — stato corrente | Logging, diramazione condizionale |
+| `PreviousState()` | `types.State` — stato prima dell'ultima transizione | Post-mortem dopo un'attesa fallita |
+| `FailureReason()` | `string` — testo di errore fornito dal server | Mostrare all'utente / log di alert |
+| `IsDisabled()` | `bool` | Bloccare operazioni quando il server disabilita una risorsa |
+| `DisableReasons()` | `[]string` | Spiegare perché una risorsa è disabilitata |
+
+Un pattern comune — chiamare `WaitUntilReady` e, in caso di errore, allegare la motivazione di fallimento del server all'errore:
+
+```go
+if err := vpc.WaitUntilReady(ctx); err != nil {
+    reason := vpc.FailureReason()
+    if reason != "" {
+        log.Fatalf("VPC failed: %v (reason: %s)", err, reason)
+    }
+    log.Fatalf("VPC polling failed: %v", err)
+}
+```
+
+---
+
+## Risorse che Supportano il Polling
+
+I seguenti wrapper di risorse supportano `WaitUntilReady`, `WaitUntilActive`, `WaitUntilStates`, `WaitUntilGone` e gli accessor di stato. Le risorse contrassegnate con un metodo wait speciale espongono un'ulteriore forma nominata.
+
+| Risorsa | Wait speciale | Note |
+|---------|---------------|------|
+| `CloudServer` | — | `WaitUntilReady` → `Active` |
+| `KaaS` | — | `WaitUntilReady` → `Active`; può richiedere 10–20 min |
+| `ContainerRegistry` | — | `WaitUntilReady` → `Active`; può richiedere 20–40 min |
+| `DBaaS` | — | `WaitUntilReady` → `Active`; può richiedere 5–15 min |
+| `Database` | — | |
+| `User` | — | |
+| `Grant` | — | |
+| `VPC` | — | |
+| `Subnet` | — | |
+| `SecurityGroup` | — | |
+| `SecurityRule` | — | |
+| `ElasticIP` | `WaitUntilNotUsed`, `WaitUntilUsed` | Delegano a `WaitUntilStates` |
+| `BlockStorage` | `WaitUntilNotUsed`, `WaitUntilUsed` | Delegano a `WaitUntilStates` |
+| `Snapshot` | — | |
+| `StorageBackup` | — | |
+| `StorageRestore` | — | |
+| `VPCPeering` | — | |
+| `VPCPeeringRoute` | — | |
+| `VPNTunnel` | — | |
+| `VPNRoute` | — | |
+| `KMS` | — | |
+| `Kmip` | `WaitUntilCertificateAvailable` | Waiter personalizzato (Family B — nessun `statusMixin`); fa il polling di `KmipResponse.Status` direttamente rispetto a una mappa esplicita degli stati terminali |
+
+> **Il Progetto non supporta il polling.** È pronto in modo sincrono immediatamente dopo che `Create` ritorna — non è necessaria né disponibile alcuna chiamata `WaitUntilActive`.
+
+---
+
+## Avvertenze
+
+### Wrapper idratato obbligatorio
+
+`WaitUntilReady`, `WaitUntilActive`, `WaitUntilStates` e `WaitUntilGone` funzionano solo su wrapper che sono stati **restituiti da una chiamata adapter** (`Create`, `Get`, `Update` o `List`). Chiamare uno qualsiasi di questi metodi su un builder di richiesta appena costruito restituisce:
+
+```
+WaitUntilStates: refresh callback not set; resource must be produced by an adapter (Create/Get/Update/List) to support polling
+```
+
+Usa sempre il wrapper restituito dalla chiamata API:
+
+```go
+// Corretto — vpc è stato restituito da Create
+vpc, err := arubaClient.FromNetwork().VPCs().Create(ctx, myVPC)
+vpc.WaitUntilReady(ctx)
+
+// Errato — myVPC è un builder di richiesta, non una risposta adapter
+myVPC := aruba.NewVPC().Named("x")
+myVPC.WaitUntilReady(ctx) // restituisce "refresh callback not set"
+```
+
+### Cadenza di polling costante
+
+Il polling usa un **ritardo fisso** (senza backoff esponenziale). Se stai raggiungendo i limiti di rate dell'API, aumenta `WithBaseDelay` invece di aspettarti che l'SDK rallenti automaticamente.
+
+### Cancellazione del context
+
+Tutto il polling rispetta la scadenza e la cancellazione del `ctx`. Se il context scade durante il polling, la chiamata restituisce `ctx.Err()` (tipicamente `context.DeadlineExceeded` o `context.Canceled`).
+
+---
+
+## Avanzato: polling concorrente e personalizzato
+
+`WaitUntilReady`, `WaitUntilActive` e `WaitUntilStates` bloccano la goroutine chiamante. Se devi **avviare più attese in modo concorrente**, o **fare il polling di una condizione arbitraria** (non solo uno stato di risorsa), usa direttamente il pacchetto `pkg/async` di livello inferiore. Quel livello lavora direttamente con `*types.Response[T]` ed è documentato separatamente — vedi [Lavorare a Basso Livello](./working-at-low-level#background-polling-with-pkgasync).
+
+---
+
+## Vedi Anche
+
+- [Guida al Walkthrough API](./walkthrough) — esempio completo del ciclo di vita Create + `WaitUntilReady` + Update + Delete
+- [Gestione delle Risposte](./response-handling) — come `*aruba.HTTPError` si propaga attraverso `WaitUntilReady` quando l'API restituisce 4xx/5xx
+- [Lavorare a Basso Livello](./working-at-low-level) — polling in background con `pkg/async`, accesso ai campi wire non promossi

--- a/docs/website/i18n/it/docusaurus-plugin-content-docs/version-0.3.0/filters.md
+++ b/docs/website/i18n/it/docusaurus-plugin-content-docs/version-0.3.0/filters.md
@@ -1,0 +1,257 @@
+# Guida al Filtraggio
+
+Questa guida spiega come utilizzare i filtri con l'SDK Aruba Cloud Go per interrogare e filtrare le risorse in base a vari criteri.
+
+## Panoramica
+
+L'SDK fornisce un sistema di filtraggio flessibile tramite helper `CallOption`. Passali direttamente a `List` (e ad altre operazioni di lettura) senza costruire struct di parametri intermedi.
+
+```go
+servers, err := arubaClient.FromCompute().CloudServers().List(ctx, proj,
+    aruba.WithFilter("status:eq:Active,cpu:gt:2"),
+    aruba.WithSort("name:asc"),
+    aruba.WithLimit(50),
+)
+```
+
+Opzioni di chiamata disponibili:
+
+| Opzione | Descrizione |
+|---------|-------------|
+| `aruba.WithFilter(expr string)` | Espressione di filtro lato server |
+| `aruba.WithSort(expr string)` | Espressione di ordinamento |
+| `aruba.WithLimit(n int)` | Dimensione della pagina |
+| `aruba.WithOffset(n int)` | Offset di paginazione |
+| `aruba.WithProjection(expr string)` | Proiezione dei campi |
+
+## Formato Filtro
+
+I filtri seguono questo formato: `campo:operatore:valore`
+
+- **Campo**: Il campo della risorsa su cui filtrare (es. `status`, `name`, `cpu`)
+- **Operatore**: L'operatore di confronto (es. `eq`, `gt`, `like`)
+- **Valore**: Il valore con cui confrontare
+
+Più filtri vengono combinati usando:
+- `,` (virgola) per operazioni **AND**
+- `;` (punto e virgola) per operazioni **OR**
+
+## Operatori Supportati
+
+| Operatore | Codice | Descrizione | Esempio |
+|-----------|--------|-------------|---------|
+| Uguale | `eq` | Corrispondenza esatta | `status:eq:Active` |
+| Diverso | `ne` | Non uguale a | `status:ne:Error` |
+| Maggiore | `gt` | Maggiore di | `cpu:gt:2` |
+| Maggiore/Uguale | `gte` | Maggiore o uguale a | `memory:gte:4096` |
+| Minore | `lt` | Minore di | `disk:lt:100` |
+| Minore/Uguale | `lte` | Minore o uguale a | `cpu:lte:8` |
+| In | `in` | Valore in lista | `region:in:us-east,us-west` |
+| Non In | `nin` | Valore non in lista | `status:nin:Error,Failed` |
+| Contiene | `like` | Corrispondenza sottostringa | `name:like:prod` |
+| Inizia Con | `sw` | Corrispondenza prefisso | `name:sw:web-` |
+| Termina Con | `ew` | Corrispondenza suffisso | `name:ew:-prod` |
+
+## Filtri Semplici
+
+### Condizione Singola
+
+```go
+// Elenca i cloud server attivi
+servers, err := arubaClient.FromCompute().CloudServers().List(ctx, proj,
+    aruba.WithFilter("status:eq:Active"),
+)
+```
+
+### Condizioni AND Multiple
+
+```go
+// Server attivi con almeno 2 vCPU e 4 GB di RAM
+servers, err := arubaClient.FromCompute().CloudServers().List(ctx, proj,
+    aruba.WithFilter("status:eq:Active,cpu:gt:2,memory:gte:4096"),
+)
+```
+
+Espressione risultante: `status:eq:Active,cpu:gt:2,memory:gte:4096`
+
+### Condizioni OR
+
+```go
+// Server che sono Attivi O in Avvio
+servers, err := arubaClient.FromCompute().CloudServers().List(ctx, proj,
+    aruba.WithFilter("status:eq:Active;status:eq:Starting"),
+)
+```
+
+Espressione risultante: `status:eq:Active;status:eq:Starting`
+
+### Filtri Complessi (AND + OR)
+
+```go
+// (environment=production AND memory>=4096) OR (tier=premium AND region IN [us-east-1,us-west-2])
+servers, err := arubaClient.FromCompute().CloudServers().List(ctx, proj,
+    aruba.WithFilter("environment:eq:production,memory:gte:4096;tier:eq:premium,region:in:us-east-1,us-west-2"),
+)
+```
+
+## Esempi Pratici
+
+### Filtra Cloud Server Attivi
+
+```go
+// Elenca server attivi con almeno 4 GB di RAM, dimensione pagina 50
+servers, err := arubaClient.FromCompute().CloudServers().List(ctx, proj,
+    aruba.WithFilter("status:eq:Active,memory:gte:4096"),
+    aruba.WithLimit(50),
+)
+if err != nil {
+    log.Fatalf("List failed: %v", err)
+}
+fmt.Printf("Found %d servers\n", servers.Total())
+for _, s := range servers.Items() {
+    fmt.Println("-", s.Name())
+}
+```
+
+### Filtra VPC per Regione
+
+```go
+// Elenca VPC in data center specifici
+vpcs, err := arubaClient.FromNetwork().VPCs().List(ctx, proj,
+    aruba.WithFilter("location:in:ITBG-Bergamo,ITMI-Milan"),
+)
+```
+
+### Filtra per Pattern Nome
+
+```go
+// Tutti i cloud server il cui nome inizia con "web-"
+servers, err := arubaClient.FromCompute().CloudServers().List(ctx, proj,
+    aruba.WithFilter("name:sw:web-"),
+)
+```
+
+### Logica di Business Complessa
+
+```go
+// Server di produzione con risorse elevate O server di sviluppo in regioni specifiche
+servers, err := arubaClient.FromCompute().CloudServers().List(ctx, proj,
+    aruba.WithFilter(
+        "environment:eq:production,cpu:gte:8,memory:gte:16384" +
+        ";environment:eq:development,region:in:ITBG-Bergamo,ITMI-Milan",
+    ),
+)
+```
+
+## Ordinamento
+
+```go
+// Ordina per nome crescente
+servers, err := arubaClient.FromCompute().CloudServers().List(ctx, proj,
+    aruba.WithSort("name:asc"),
+)
+
+// Ordina per data di creazione decrescente
+servers, err = arubaClient.FromCompute().CloudServers().List(ctx, proj,
+    aruba.WithSort("createdAt:desc"),
+)
+```
+
+## Paginazione
+
+```go
+const pageSize = 25
+
+// Prima pagina
+page1, err := arubaClient.FromCompute().CloudServers().List(ctx, proj,
+    aruba.WithLimit(pageSize),
+    aruba.WithOffset(0),
+)
+
+// Seconda pagina
+page2, err := arubaClient.FromCompute().CloudServers().List(ctx, proj,
+    aruba.WithLimit(pageSize),
+    aruba.WithOffset(pageSize),
+)
+
+fmt.Printf("Total resources: %d\n", page1.Total())
+```
+
+## Best Practice
+
+### Usa Filtri Specifici
+
+Sii il più specifico possibile per ridurre la quantità di dati trasferiti:
+
+```go
+// Bene: filtro specifico — solo le risorse necessarie
+servers, err := arubaClient.FromCompute().CloudServers().List(ctx, proj,
+    aruba.WithFilter("status:eq:Active,region:eq:ITBG-Bergamo"),
+)
+
+// Meno efficiente: nessun filtro — recupera tutto
+servers, err = arubaClient.FromCompute().CloudServers().List(ctx, proj)
+```
+
+### Combina Filtro e Paginazione
+
+```go
+servers, err := arubaClient.FromCompute().CloudServers().List(ctx, proj,
+    aruba.WithFilter("environment:eq:production"),
+    aruba.WithLimit(50),
+    aruba.WithOffset(0),
+)
+```
+
+### Valida le Stringhe di Filtro
+
+Stampa la stringa di filtro per debuggare risultati inaspettati:
+
+```go
+filter := "status:eq:Active,cpu:gt:4"
+fmt.Println("Filter:", filter)
+// Output: Filter: status:eq:Active,cpu:gt:4
+
+servers, err := arubaClient.FromCompute().CloudServers().List(ctx, proj,
+    aruba.WithFilter(filter),
+)
+```
+
+## Risoluzione dei Problemi
+
+### Filtro Non Funzionante
+
+**Problema**: Il filtro non restituisce i risultati attesi
+
+**Soluzioni**:
+1. Controlla che i nomi dei campi corrispondano esattamente allo schema API (sensibile alle maiuscole)
+2. Verifica che l'operatore sia appropriato per il tipo di campo
+3. Assicurati che i valori siano nel formato corretto (es. `Active` non `active`)
+4. Stampa la stringa di filtro per il debug
+
+### Risultati Vuoti
+
+**Problema**: Il filtro non restituisce risultati
+
+**Soluzioni**:
+1. Verifica che la logica del filtro sia corretta
+2. Prova filtri più semplici per isolare il problema
+3. Controlla se il campo supporta l'operatore utilizzato
+4. Elenca senza filtri per confermare che le risorse esistano
+
+### Problemi con Filtri Complessi
+
+**Problema**: La logica AND/OR complessa non funziona come previsto
+
+**Soluzioni**:
+1. Scomponi i filtri complessi in parti più semplici
+2. Testa ogni condizione separatamente
+3. Ricorda: virgole (`,`) = AND, punto e virgola (`;`) = OR
+4. Usa le parentesi mentalmente per capire il raggruppamento
+
+```
+// Questo: status:eq:Active,cpu:gt:2;memory:gte:4096
+// Significa: (status = Active AND cpu > 2) OR (memory >= 4096)
+
+// Non: status = Active AND (cpu > 2 OR memory >= 4096)
+```

--- a/docs/website/i18n/it/docusaurus-plugin-content-docs/version-0.3.0/intro.md
+++ b/docs/website/i18n/it/docusaurus-plugin-content-docs/version-0.3.0/intro.md
@@ -1,0 +1,76 @@
+---
+sidebar_position: 1
+---
+
+# Guida Rapida
+
+Benvenuto nell'SDK ufficiale Go per l'API Aruba Cloud. Questo SDK fornisce un modo comodo e potente per gli sviluppatori Go di interagire con l'API Aruba Cloud. L'obiettivo principale è semplificare la gestione delle risorse cloud, permettendoti di creare, leggere, aggiornare ed eliminare programmaticamente risorse come istanze di calcolo, virtual private cloud (VPC), storage a blocchi e altro ancora.
+
+## Installazione
+
+Aggiungi l'SDK al tuo progetto Go:
+
+```bash
+go get github.com/Arubacloud/sdk-go
+```
+
+## Iniziare
+
+Iniziare con l'SDK è semplice. Importa il pacchetto `aruba`, crea un client con le tue credenziali e inizia a effettuare chiamate API usando il pattern builder fluente.
+
+La prima e più fondamentale risorsa in Aruba Cloud è il **Progetto**. Tutte le altre risorse appartengono a un progetto.
+
+Ecco come inizializzare il client SDK e creare il tuo primo progetto:
+
+```go
+package main
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"time"
+
+	"github.com/Arubacloud/sdk-go/pkg/aruba"
+)
+
+func main() {
+	// Le tue credenziali API
+	clientID := "your-client-id"
+	clientSecret := "your-client-secret"
+
+	// 1. Inizializza il client SDK utilizzando le opzioni predefinite
+	arubaClient, err := aruba.NewClient(aruba.DefaultOptions(clientID, clientSecret))
+	if err != nil {
+		log.Fatalf("Failed to create SDK client: %v", err)
+	}
+
+	// Crea un contesto con un timeout
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
+	defer cancel()
+
+	// 2. Crea il Progetto — costruisci inline e passa a Create
+	fmt.Println("Creazione di un nuovo progetto...")
+	proj, err := arubaClient.FromProject().Create(
+		ctx,
+		aruba.NewProject().
+			Named("my-first-project").
+			Tagged("go-sdk", "quick-start").
+			DescribedAs("A project with the Go SDK"))
+	if err != nil {
+		log.Fatalf("Error creating project: %v", err)
+	}
+
+	fmt.Printf("✓ Progetto creato con successo: %s (ID: %s)\n", proj.Name(), proj.ID())
+}
+```
+
+## Prossimi Passi
+
+- Leggi la [Guida al Walkthrough API](./walkthrough) per un percorso completo attraverso il ciclo di vita delle risorse
+- Scopri le [Opzioni di Configurazione](./options) per personalizzare il tuo client SDK
+- Esplora le [Risorse API](./resources) per vedere cosa puoi gestire
+- Comprendi la [Gestione delle Risposte](./response-handling) per una gestione robusta degli errori
+- Scopri il [Filtraggio](./filters) per interrogare le risorse in modo efficiente
+- Leggi [Multitenancy](./multitenancy) per gestire client specifici per tenant
+- Approfondisci [Lavorare a Basso Livello](./working-at-low-level) per accedere ai campi wire e al polling avanzato

--- a/docs/website/i18n/it/docusaurus-plugin-content-docs/version-0.3.0/multitenancy.md
+++ b/docs/website/i18n/it/docusaurus-plugin-content-docs/version-0.3.0/multitenancy.md
@@ -1,0 +1,152 @@
+# Multitenancy
+
+Il package `pkg/multitenant` fornisce un registro in-memory tenant-to-client per l'SDK Aruba Cloud. E utile quando la tua applicazione gestisce piu tenant e ogni tenant richiede un proprio `aruba.Client`.
+
+## Panoramica
+
+Il package espone:
+
+- Un'interfaccia `Multitenant` per creare, salvare, recuperare e pulire i client tenant
+- Un'implementazione predefinita basata su mappa e mutex
+- Un helper per routine di cleanup periodico dei tenant inattivi
+
+File principali:
+
+- `pkg/multitenant/multitenant.go`
+- `pkg/multitenant/cleanup_routine.go`
+
+## Interfaccia Principale
+
+L'interfaccia `Multitenant` supporta queste operazioni:
+
+- `New(tenant string) error`: crea client usando opzioni template
+- `NewFromOptions(tenant string, options *aruba.Options) error`: crea client da opzioni esplicite
+- `Add(tenant string, client aruba.Client)`: aggiunge un client gia inizializzato
+- `Get(tenant string) (aruba.Client, bool)`: recupera client con flag di esistenza
+- `MustGet(tenant string) aruba.Client`: recupera o termina il processo se assente
+- `GetOrNil(tenant string) aruba.Client`: recupera o restituisce `nil`
+- `CleanUp(from time.Duration)`: elimina tenant inattivi
+
+## Creazione del Manager
+
+### Manager vuoto
+
+Usalo quando vuoi aggiungere client manualmente o tramite `NewFromOptions`:
+
+```go
+mt := multitenant.New()
+```
+
+### Manager con template
+
+Usalo quando i tenant condividono una configurazione base comune:
+
+```go
+opts := aruba.DefaultOptions(clientID, clientSecret)
+mt := multitenant.NewWithTemplate(opts)
+
+// In seguito:
+if err := mt.New("tenant-a"); err != nil {
+    // gestisci errore
+}
+```
+
+## Pattern di Utilizzo
+
+### Aggiungere un client esistente
+
+```go
+client, err := aruba.NewClient(aruba.DefaultOptions(clientID, clientSecret))
+if err != nil {
+    // gestisci errore
+}
+
+mt.Add("tenant-a", client)
+```
+
+### Creare da opzioni specifiche tenant
+
+```go
+tenantOpts := aruba.DefaultOptions(tenantClientID, tenantClientSecret)
+if err := mt.NewFromOptions("tenant-a", tenantOpts); err != nil {
+    // gestisci errore
+}
+```
+
+### Recuperare un client
+
+```go
+client, ok := mt.Get("tenant-a")
+if !ok {
+    // tenant non trovato
+}
+```
+
+Se richiedi esistenza obbligatoria:
+
+```go
+client := mt.MustGet("tenant-a")
+```
+
+## Cleanup Automatico
+
+Il package include anche `StartCleanupRoutine` in `cleanup_routine.go`. Esegue `CleanUp` periodicamente in una goroutine in background.
+
+```go
+ctx, cancel := context.WithCancel(context.Background())
+defer cancel()
+
+stopCleanup := multitenant.StartCleanupRoutine(
+    ctx,
+    mt,
+    5*time.Minute,   // intervallo di esecuzione
+    24*time.Hour,    // rimuove tenant inattivi da 24h
+)
+defer stopCleanup()
+```
+
+Valori di default:
+
+- `tickInterval`: 1 ora se zero/negativo
+- `fromDuration`: 24 ore se zero/negativo
+
+## Note
+
+- Implementazione in-memory, locale al processo.
+- Ciclo di vita tenant basato su `lastUsage`.
+- `CleanUp` rimuove anche entry non valide (`nil` entry/client).
+
+## Esempio di Utilizzo (`examples/all-resources/orchestrator_multitenancy.go`)
+
+Per un esempio completo vedi:
+
+- `examples/all-resources/orchestrator_multitenancy.go`
+
+Snippet principale (cache + credenziali Vault per tenant):
+
+```go
+c, ok := r.multiTenantClient.Get(tenant)
+if ok {
+	return c, nil
+}
+
+options := aruba.NewOptions().
+	WithBaseURL(r.config.APIGateway).
+	WithDefaultTokenIssuerURL().
+	WithVaultCredentialsRepository(
+		r.config.VaultAddress,
+		r.config.KVMount,
+		tenant, // tenant -> kvPath (es. ARU-297647)
+		r.config.Namespace,
+		r.config.RolePath,
+		r.config.RoleID,
+		r.config.RoleSecret,
+	)
+
+client, err := aruba.NewClient(options)
+if err != nil {
+	return nil, err
+}
+r.multiTenantClient.Add(tenant, client)
+return client, nil
+```

--- a/docs/website/i18n/it/docusaurus-plugin-content-docs/version-0.3.0/options.md
+++ b/docs/website/i18n/it/docusaurus-plugin-content-docs/version-0.3.0/options.md
@@ -1,0 +1,202 @@
+# Opzioni di Configurazione SDK
+
+L'SDK Aruba Cloud per Go è configurato utilizzando un'API fluente che ti consente di concatenare i setter di opzioni per costruire una configurazione client. Questa guida dettaglia tutte le opzioni disponibili, raggruppate per argomento.
+
+## Iniziare
+
+<p>Il modo più semplice per configurare il client è utilizzare <code>DefaultOptions</code>, che fornisce una configurazione pronta per la produzione per il caso d'uso più comune (autenticazione Client Credentials).</p>
+
+<table>
+  <thead>
+    <tr>
+      <th>Setter Opzione</th>
+      <th>Descrizione</th>
+      <th>Note</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td><code>DefaultOptions(clientID, clientSecret)</code></td>
+      <td>Crea una configurazione standard per l'ambiente di produzione utilizzando il tuo Client ID e Secret API.</td>
+      <td>Questo è il punto di partenza consigliato per la maggior parte delle applicazioni. Imposta l'API di produzione e gli URL dei token e configura l'autenticazione.</td>
+    </tr>
+    <tr>
+      <td><code>NewOptions()</code></td>
+      <td>Crea un nuovo builder di configurazione vuoto. Devi configurare manualmente tutte le impostazioni richieste, inclusa l'autenticazione.</td>
+      <td>Usa questo se hai bisogno di controllo completo sulla configurazione da zero.</td>
+    </tr>
+  </tbody>
+</table>
+
+## Configurazione Generale
+
+<table>
+  <thead>
+    <tr>
+      <th>Setter Opzione</th>
+      <th>Descrizione</th>
+      <th>Note</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td><code>WithBaseURL(baseURL)</code></td>
+      <td>Sovrascrive l'URL API Aruba Cloud predefinito.</td>
+      <td>Il predefinito è <code>https://api.arubacloud.com</code>. Dovresti cambiarlo solo se devi puntare a un ambiente diverso.</td>
+    </tr>
+    <tr>
+      <td><code>WithDefaultBaseURL()</code></td>
+      <td>Un helper che imposta l'URL API al predefinito di produzione.</td>
+      <td>Chiamato da <code>DefaultOptions()</code>.</td>
+    </tr>
+  </tbody>
+</table>
+
+## Autenticazione
+
+<p>L'autenticazione è una parte critica della configurazione. Devi scegliere <b>uno</b> dei seguenti metodi.</p>
+
+<table>
+  <thead>
+    <tr>
+      <th>Setter Opzione</th>
+      <th>Descrizione</th>
+      <th>Note</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td><code>WithClientCredentials(clientID, clientSecret)</code></td>
+      <td><b>(Consigliato)</b> Configura l'SDK per utilizzare il flusso OAuth2 Client Credentials. L'SDK gestirà automaticamente il recupero e il rinnovo del token di accesso.</td>
+      <td><b>Esclusione Reciproca</b>: Non può essere utilizzato con <code>WithToken()</code> o <code>WithVaultCredentialsRepository()</code>. Questo è il metodo standard e più sicuro per l'autenticazione service-to-service.</td>
+    </tr>
+    <tr>
+      <td><code>WithToken(token)</code></td>
+      <td>Configura l'SDK per utilizzare un token di accesso OAuth2 statico preesistente.</td>
+      <td><b>Esclusione Reciproca</b>: Non può essere utilizzato con qualsiasi altra opzione di autenticazione o token issuer.<br/> <b>Avviso</b>: L'SDK <b>non</b> rinnoverà questo token. Una volta scaduto, tutte le chiamate API falliranno. Questo metodo è consigliato solo per client di breve durata o script semplici e atomici.</td>
+    </tr>
+    <tr>
+      <td><code>WithVaultCredentialsRepository(...)</code></td>
+      <td>Configura l'SDK per recuperare <code>clientID</code> e <code>clientSecret</code> da un'istanza HashiCorp Vault. L'SDK utilizzerà quindi queste credenziali per gestire il token di accesso.</td>
+      <td><b>Esclusione Reciproca</b>: Non può essere utilizzato con <code>WithClientCredentials()</code> o <code>WithToken()</code>.<br/> <b>Parametri</b>: <code>vaultURI</code>, <code>kvMount</code>, <code>kvPath</code>, <code>namespace</code>, <code>rolePath</code>, <code>roleID</code>, <code>secretID</code>.</td>
+    </tr>
+    <tr>
+      <td><code>WithTokenIssuerURL(url)</code></td>
+      <td>Sovrascrive l'URL predefinito per l'endpoint del token OAuth2.</td>
+      <td>Il predefinito è <code>https://login.aruba.it/...</code>. Dovresti cambiarlo solo se devi puntare a un endpoint di autenticazione diverso.</td>
+    </tr>
+    <tr>
+      <td><code>WithSecurityScopes(scopes ...)</code></td>
+      <td>Imposta gli scope di sicurezza da richiedere durante l'autenticazione.</td>
+      <td>Sostituisce qualsiasi scope precedentemente impostato.</td>
+    </tr>
+    <tr>
+      <td><code>WithAdditionalSecurityScopes(scopes ...)</code></td>
+      <td>Aggiunge scope di sicurezza aggiuntivi all'elenco esistente.</td>
+      <td>Non sovrascrive gli scope esistenti.</td>
+    </tr>
+  </tbody>
+</table>
+
+## Cache Token (Opzionale)
+
+<p>Per migliorare le prestazioni e la resilienza, l'SDK può memorizzare nella cache il token di accesso in un archivio esterno. Questo è altamente consigliato per le applicazioni di produzione per evitare di recuperare un nuovo token ad ogni avvio.</p>
+
+<table>
+  <thead>
+    <tr>
+      <th>Setter Opzione</th>
+      <th>Descrizione</th>
+      <th>Note</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td><code>WithRedisTokenRepositoryFromURI(redisURI)</code></td>
+      <td>Configura un'istanza Redis come cache persistente per il token di accesso.</td>
+      <td><b>Esclusione Reciproca</b>: Non può essere utilizzato con le opzioni <code>WithFileTokenRepository...</code>.<br/> Il formato URI è <code>redis://&lt;user&gt;:&lt;pass&gt;@&lt;host&gt;:&lt;port&gt;/&lt;db&gt;</code>.</td>
+    </tr>
+    <tr>
+      <td><code>WithFileTokenRepositoryFromBaseDir(baseDir)</code></td>
+      <td>Configura una directory locale per memorizzare il token di accesso in un file JSON.</td>
+      <td><b>Esclusione Reciproca</b>: Non può essere utilizzato con le opzioni <code>WithRedisTokenRepository...</code>. Il processo SDK deve avere i permessi di lettura/scrittura sulla directory specificata.</td>
+    </tr>
+    <tr>
+      <td><code>WithTokenExpirationDriftSeconds(seconds)</code></td>
+      <td>Imposta un buffer di sicurezza (in secondi) per trattare un token come scaduto prima che lo faccia effettivamente.</td>
+      <td>Questo previene condizioni di race dove l'SDK utilizza un token che scade appena prima che la richiesta API venga completata. Il predefinito è 300 secondi (5 minuti). Questa opzione non ha effetto se un meccanismo di cache (Redis o File) non è configurato.</td>
+    </tr>
+    <tr>
+      <td><code>WithStandardRedisTokenRepository()</code></td>
+      <td>Helper per configurare la cache Redis su <code>localhost:6379</code> e imposta lo drift di scadenza standard (300s).</td>
+      <td>Una scorciatoia conveniente per lo sviluppo locale.</td>
+    </tr>
+    <tr>
+      <td><code>WithStandardFileTokenRepository()</code></td>
+      <td>Helper per configurare la cache file in <code>/tmp/sdk-go</code> e imposta lo drift di scadenza standard (300s).</td>
+      <td>Una scorciatoia conveniente per lo sviluppo locale.</td>
+    </tr>
+  </tbody>
+</table>
+
+## Logging
+
+<p>Il logging è disabilitato per impostazione predefinita.</p>
+
+<table>
+  <thead>
+    <tr>
+      <th>Setter Opzione</th>
+      <th>Descrizione</th>
+      <th>Note</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td><code>WithNoLogs()</code></td>
+      <td>Disabilita tutto il logging dell'SDK.</td>
+      <td>Questo è il comportamento predefinito.</td>
+    </tr>
+    <tr>
+      <td><code>WithNativeLogger()</code></td>
+      <td>Abilita il logger integrato dell'SDK, che utilizza il pacchetto standard <code>log</code>.</td>
+      <td>Utile per il debug di base.</td>
+    </tr>
+    <tr>
+      <td><code>WithLoggerType(loggerType)</code></td>
+      <td>Una funzione più generale per impostare il tipo di logger.</td>
+      <td><code>loggerType</code> può essere <code>LoggerNoLog</code> o <code>LoggerNative</code>.</td>
+    </tr>
+    <tr>
+      <td><code>WithCustomLogger(logger)</code></td>
+      <td>Inietta un logger personalizzato che rispetta l'interfaccia <code>ports/logger.Logger</code>.</td>
+      <td>Consente l'integrazione con il framework di logging della tua applicazione (ad esempio, Logrus, Zap). Impostare questo imposta automaticamente il tipo di logger su <code>loggerCustom</code>.</td>
+    </tr>
+  </tbody>
+</table>
+
+## Avanzato / Dipendenze Personalizzate
+
+<p>Queste opzioni sono per casi d'uso avanzati dove devi iniettare i tuoi componenti personalizzati nel flusso di lavoro dell'SDK.</p>
+
+<table>
+  <thead>
+    <tr>
+      <th>Setter Opzione</th>
+      <th>Descrizione</th>
+      <th>Note</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td><code>WithCustomHTTPClient(client)</code></td>
+      <td>Inietta un <code>*http.Client</code> pre-configurato.</td>
+      <td>Utile per impostare timeout personalizzati, transport o altre configurazioni a livello HTTP.</td>
+    </tr>
+    <tr>
+      <td><code>WithCustomMiddleware(middleware)</code></td>
+      <td>Inietta un middleware personalizzato che rispetta l'interfaccia <code>ports/interceptor.Interceptor</code>.</td>
+      <td>Ti consente di aggiungere logica personalizzata (come logging o tracing di richiesta/risposta) nella catena di chiamate HTTP dell'SDK. Il middleware di autenticazione dell'SDK sarà automaticamente collegato alla fine della tua catena di middleware personalizzata.</td>
+    </tr>
+  </tbody>
+</table>

--- a/docs/website/i18n/it/docusaurus-plugin-content-docs/version-0.3.0/resources.md
+++ b/docs/website/i18n/it/docusaurus-plugin-content-docs/version-0.3.0/resources.md
@@ -1,0 +1,1689 @@
+---
+sidebar_position: 3
+---
+
+# Risorse
+
+Questa pagina è il riferimento esaustivo per ogni wrapper di risorsa nel pacchetto `pkg/aruba`. Per ogni wrapper troverai:
+
+1. La catena di accessor per raggiungerlo da `arubaClient`
+2. Uno snippet `Create` pronto all'uso
+3. I metodi accessor di risposta disponibili sul wrapper restituito
+
+Per il walkthrough end-to-end del ciclo di vita (come `Create`, `Get`, `Update`, `List`, `Delete` e il polling si integrano) vedi la [Guida al Walkthrough API](./walkthrough).
+
+---
+
+## Convenzioni
+
+Ogni risorsa segue la stessa struttura:
+
+```go
+// 1. Raggiungi il sub-client
+client := arubaClient.FromX().Y()
+
+// 2. Costruisci la richiesta inline e crea
+result, err := client.Create(ctx,
+    aruba.NewX().
+        IntoParent(parentRef).   // scope al progetto / VPC / ecc.
+        Named("my-resource").
+        Tagged("env-prod").
+        WithFoo(...))
+
+// 3. Attendi che le risorse asincrone diventino pronte
+if err := result.WaitUntilReady(ctx); err != nil { … }
+
+// 4. Leggi gli accessor di risposta
+fmt.Println(result.ID(), result.Name(), result.State())
+```
+
+- `aruba.NewX()` — factory constructor per ogni builder di risorsa
+- `IntoFoo(ref)` — lega lo scope del genitore; accetta qualsiasi `aruba.Ref` (wrapper idratato o `aruba.URI("…")`)
+- `WithFoo(...)` — setter fluenti; gli errori sono differiti fino a `Create`/`Update`
+- `WaitUntilReady(ctx, opts...)` — disponibile sulle risorse marcate **async** qui sotto; vedi [Async / Await](./async) per le opzioni complete
+- `aruba.URI(s)` — avvolge un percorso stringa grezzo in un `Ref` (vedi [Guida al Walkthrough API](./walkthrough#5-get-a-specific-resource))
+
+:::info Formato dei tag
+L'API di Aruba valida i valori dei tag contro `^[A-Za-z0-9-]{4,30}$`: **solo caratteri alfanumerici e trattini, lunghezza da 4 a 30**. Due punti, punti, underscore, spazi e altra punteggiatura vengono rifiutati con `400 — One or more validation error occurred`. L'SDK non valida i valori dei tag lato client, quindi un tag non valido fallisce solo quando la richiesta raggiunge il server.
+:::
+
+---
+
+## Progetto
+
+```go
+arubaClient.FromProject()
+```
+
+**Operazioni supportate**: `Create`, `List`, `Get`, `Update`, `Delete`
+
+> Il Progetto **non** è asincrono — è pronto in modo sincrono dopo che `Create` ritorna. Non è necessaria alcuna chiamata `WaitUntilReady`.
+
+```go
+proj, err := arubaClient.FromProject().Create(
+    ctx,
+    aruba.NewProject().
+        Named("my-project").
+        Tagged("env-prod").
+        DescribedAs("Production project").
+        NotDefault())
+if err != nil {
+    log.Fatalf("Create project: %v", err)
+}
+fmt.Printf("✓ Progetto: %s (ID: %s)\n", proj.Name(), proj.ID())
+```
+
+**Accessor di risposta**:
+- `ID()` — UUID della risorsa
+- `URI()` — percorso completo della risorsa (es. `/projects/abc-123`)
+- `Name()` — nome del progetto
+- `Description()` — descrizione del progetto
+- `IsDefault()` — se questo è il progetto predefinito
+- `Tags()` — lista di tag `[]string`
+- `CreatedAt()`, `UpdatedAt()` — timestamp
+
+:::tip Esempio eseguibile
+Esempio end-to-end completo: [`examples/all-resources/resource_project.go`](https://github.com/Arubacloud/sdk-go/blob/main/examples/all-resources/resource_project.go)
+:::
+
+---
+
+## Audit
+
+```go
+arubaClient.FromAudit().Events()
+```
+
+**Operazioni supportate**: `List`
+
+Gli Audit Event sono in sola lettura. Non esiste un costruttore `Create` — usa `List` con un `Ref` di progetto e opzionalmente `aruba.WithFilter(…)` per interrogare l'audit trail.
+
+```go
+list, err := arubaClient.FromAudit().Events().List(ctx, proj,
+    aruba.WithLimit(50),
+    aruba.WithFilter("action eq 'Create'"))
+if err != nil {
+    log.Fatalf("List events: %v", err)
+}
+for _, e := range list.Items() {
+    fmt.Println(e.ID(), e.Action(), e.Timestamp())
+}
+```
+
+**Accessor di risposta**:
+- `ID()` — UUID dell'evento
+- `URI()` — percorso della risorsa
+- `ResourceURI()` — URI della risorsa a cui l'evento si riferisce
+- `Action()` — stringa dell'azione (es. `"Create"`, `"Delete"`)
+- `Timestamp()` — ora dell'evento
+- `User()` — identificatore utente che ha scatenato l'evento
+- `Raw()` — struct wire sottostante
+
+:::tip Esempio eseguibile
+Eseguito come parte dell'orchestratore: [`examples/all-resources/orchestrator_create.go`](https://github.com/Arubacloud/sdk-go/blob/main/examples/all-resources/orchestrator_create.go)
+:::
+
+---
+
+## Compute
+
+### Cloud Server
+
+```go
+arubaClient.FromCompute().CloudServers()
+```
+
+**Operazioni supportate**: `Create`, `List`, `Get`, `Update`, `Delete`, `PowerOn`, `PowerOff`, `SetPassword`
+**Asincrono**: sì — chiama `WaitUntilReady(ctx)` dopo `Create`.
+
+Un Cloud Server dipende da risorse di rete (VPC, Subnet, Security Group), un Elastic IP, un Boot Volume (Block Storage) e un Key Pair. Crea prima queste risorse e passa i wrapper idratati come parametri `Ref`.
+
+```go
+cs, err := arubaClient.FromCompute().CloudServers().Create(
+    ctx,
+    aruba.NewCloudServer().
+        OfFlavor(aruba.CloudServerFlavorCSO2A4).
+        Named("my-server").
+        Tagged("env-prod").
+        InProject(proj).
+        InRegion(aruba.RegionITBGBergamo).
+        InZone(aruba.ZoneITBG1).
+        BootingFrom(blockStorage).
+        WithVPC(vpc).
+        OnSubnets(subnet).
+        WithSecurityGroups(sg).
+        WithElasticIP(eip).
+        UsingKeyPair(keyPair))
+if err != nil {
+    log.Fatalf("Create Cloud Server: %v", err)
+}
+
+if err := cs.WaitUntilReady(ctx); err != nil {
+    log.Fatalf("Cloud Server did not become Ready: %v", err)
+}
+fmt.Printf("✓ Cloud Server: %s (zona: %s, flavor: %s)\n", cs.Name(), cs.Zone(), cs.Flavor())
+```
+
+**Azioni di alimentazione e password** (richiedono un wrapper idratato da `Create`/`Get`):
+
+```go
+if err := cs.PowerOff(ctx); err != nil { log.Fatalf("PowerOff: %v", err) }
+if err := cs.PowerOn(ctx);  err != nil { log.Fatalf("PowerOn: %v", err) }
+if err := cs.SetPassword(ctx, "NewStr0ngP@ss!"); err != nil { log.Fatalf("SetPassword: %v", err) }
+```
+
+**Accessor di risposta**:
+- `ID()`, `URI()`, `Name()`, `Tags()`
+- `CloudServerID()` — ID server assegnato dal provider
+- `Zone()` — zona di disponibilità
+- `Flavor()` — slug del flavor di calcolo
+- `FlavorRaw()` — struct flavor completa
+- `VPC()` — `aruba.Ref` della VPC collegata
+- `BootVolume()` — `aruba.Ref` del volume di boot
+- `KeyPair()` — `aruba.Ref` della key pair
+- `NetworkInterfaces()` — slice di descrittori di interfacce di rete
+- `Template()` — immagine/template usata al boot
+- `State()`, `FailureReason()`, `PreviousState()`, `IsDisabled()`, `DisableReasons()` — da `statusMixin`
+- `WaitUntilReady(ctx, opts...)`, `WaitUntilActive(ctx, opts...)`, `WaitUntilStates(ctx, []types.State{...}, opts...)`, `WaitUntilGone(ctx, opts...)`
+- `Raw()` — struct wire sottostante
+
+:::tip Esempio eseguibile
+Esempio end-to-end completo: [`examples/all-resources/resource_cloud_server.go`](https://github.com/Arubacloud/sdk-go/blob/main/examples/all-resources/resource_cloud_server.go)
+:::
+
+---
+
+### Key Pair
+
+```go
+arubaClient.FromCompute().KeyPairs()
+```
+
+**Operazioni supportate**: `Create`, `List`, `Get`, `Delete`
+**Asincrono**: no.
+
+```go
+kp, err := arubaClient.FromCompute().KeyPairs().Create(
+    ctx,
+    aruba.NewKeyPair().
+        Named("my-keypair").
+        InProject(proj).
+        InRegion(aruba.RegionITBGBergamo).
+        WithPublicKey("ssh-rsa AAAAB3NzaC1yc2E..."))
+if err != nil {
+    log.Fatalf("Create KeyPair: %v", err)
+}
+fmt.Printf("✓ KeyPair: %s (ID: %s)\n", kp.Name(), kp.ID())
+```
+
+**Accessor di risposta**:
+- `ID()`, `URI()`, `Name()`, `Tags()`
+- `KeyPairID()` — ID chiave assegnato dal provider
+- `PublicKey()` — stringa della chiave pubblica
+- `Region()` — slug della regione
+- `Raw()` — struct wire sottostante
+
+:::tip Esempio eseguibile
+Esempio end-to-end completo: [`examples/all-resources/resource_key_pair.go`](https://github.com/Arubacloud/sdk-go/blob/main/examples/all-resources/resource_key_pair.go)
+:::
+
+---
+
+## Container
+
+### KaaS (Kubernetes as a Service)
+
+```go
+arubaClient.FromContainer().KaaS()
+```
+
+**Operazioni supportate**: `Create`, `List`, `Get`, `Update`, `Delete`, `DownloadKubeconfig`
+**Asincrono**: sì — chiama `WaitUntilReady(ctx)` dopo `Create`.
+
+```go
+k, err := arubaClient.FromContainer().KaaS().Create(
+    ctx,
+    aruba.NewKaaS().
+        Named("my-cluster").
+        Tagged("env-prod").
+        InProject(proj).
+        InRegion(aruba.RegionITBGBergamo).
+        WithKubernetesVersion(aruba.KubernetesVersion1323).
+        WithPodCIDR("10.200.0.0/16").
+        WithNodeCIDR("10.100.0.0/16", "node-cidr").
+        WithVPC(vpc).
+        WithSubnet(subnet).
+        WithSecurityGroup(sg).
+        WithNodePools(aruba.NewNodePool().
+            OfInstance(aruba.NodePoolInstanceK4A8).
+            Named("default-pool").
+            InZone(aruba.ZoneITBG1).
+            WithCount(3)).
+        HighlyAvailable().
+        BilledBy(aruba.BillingPeriodHour))
+if err != nil {
+    log.Fatalf("Create KaaS: %v", err)
+}
+
+if err := k.WaitUntilReady(ctx); err != nil {
+    log.Fatalf("KaaS did not become Ready: %v", err)
+}
+fmt.Printf("✓ Cluster KaaS: %s (k8s: %s)\n", k.Name(), k.KubernetesVersion())
+```
+
+**Download del kubeconfig** (richiede un wrapper idratato):
+
+```go
+kubeconfig, err := k.DownloadKubeconfig(ctx)
+if err != nil {
+    log.Fatalf("DownloadKubeconfig: %v", err)
+}
+// kubeconfig è un []byte YAML kubeconfig
+```
+
+**Builder del node pool** — `aruba.NewNodePool()`:
+- `Named(name)` — nome del pool
+- `WithCount(n)` — numero di nodi
+- `OfInstance(flavor)` — flavor dell'istanza nodo
+- `InZone(zone)` — zona di disponibilità
+- `WithAutoscaling(min, max)` — abilita l'autoscaling
+
+**Accessor di risposta**:
+- `ID()`, `URI()`, `Name()`, `Tags()`
+- `KaaSID()` — ID cluster assegnato dal provider
+- `VPC()`, `Subnet()` — `aruba.Ref` alle risorse di rete collegate
+- `SecurityGroupName()` — nome del security group applicato
+- `KubernetesVersion()` — stringa della versione Kubernetes
+- `BillingPeriod()` — cadenza di fatturazione
+- `State()`, `FailureReason()`, `PreviousState()`, `IsDisabled()`, `DisableReasons()`
+- `WaitUntilReady(ctx, opts...)`, `WaitUntilActive(ctx, opts...)`, `WaitUntilStates(ctx, []types.State{...}, opts...)`, `WaitUntilGone(ctx, opts...)`
+- `Raw()` — struct wire sottostante
+
+:::tip Esempio eseguibile
+Esempio end-to-end completo: [`examples/all-resources/resource_kaas.go`](https://github.com/Arubacloud/sdk-go/blob/main/examples/all-resources/resource_kaas.go)
+:::
+
+---
+
+### Container Registry
+
+```go
+arubaClient.FromContainer().ContainerRegistry()
+```
+
+**Operazioni supportate**: `Create`, `List`, `Get`, `Update`, `Delete`
+**Asincrono**: sì — chiama `WaitUntilReady(ctx)` dopo `Create`. Questa risorsa può richiedere da 20 a 40 minuti per convergere — utilizza un budget di attesa generoso.
+
+```go
+reg, err := arubaClient.FromContainer().ContainerRegistry().Create(
+    ctx,
+    aruba.NewContainerRegistry().
+        OfSize(aruba.ContainerRegistrySizeFlavorSmall).
+        Named("my-registry").
+        Tagged("env-prod").
+        InProject(proj).
+        WithAdminUsername("admin").
+        WithVPC(vpc).
+        WithSubnet(subnet).
+        WithSecurityGroup(sg).
+        WithElasticIP(eip).
+        WithBlockStorage(blockStorage).
+        BilledBy(aruba.BillingPeriodHour))
+if err != nil {
+    log.Fatalf("Create ContainerRegistry: %v", err)
+}
+
+if err := reg.WaitUntilReady(ctx); err != nil {
+    log.Fatalf("ContainerRegistry did not become Ready: %v", err)
+}
+fmt.Printf("✓ Registry: %s (IP pubblico: %s)\n", reg.Name(), reg.PublicIP())
+```
+
+**Accessor di risposta**:
+- `ID()`, `URI()`, `Name()`, `Tags()`
+- `ContainerRegistryID()` — ID registry assegnato dal provider
+- `ElasticIP()` — URI dell'endpoint pubblico
+- `VPC()`, `Subnet()`, `SecurityGroup()`, `BlockStorage()` — `aruba.Ref` alle risorse collegate
+- `AdminUsername()` — utente amministratore del registry
+- `BillingPeriod()` — cadenza di fatturazione
+- `State()`, `FailureReason()`, `PreviousState()`, `IsDisabled()`, `DisableReasons()`
+- `WaitUntilReady(ctx, opts...)`, `WaitUntilActive(ctx, opts...)`, `WaitUntilStates(ctx, []types.State{...}, opts...)`, `WaitUntilGone(ctx, opts...)`
+- `Raw()` — struct wire sottostante
+
+:::tip Esempio eseguibile
+Esempio end-to-end completo: [`examples/all-resources/resource_container_registry.go`](https://github.com/Arubacloud/sdk-go/blob/main/examples/all-resources/resource_container_registry.go)
+:::
+
+---
+
+## Database
+
+### DBaaS (Database as a Service)
+
+```go
+arubaClient.FromDatabase().DBaaS()
+```
+
+**Operazioni supportate**: `Create`, `List`, `Get`, `Update`, `Delete`
+**Asincrono**: sì — chiama `WaitUntilReady(ctx)` dopo `Create`.
+
+```go
+db, err := arubaClient.FromDatabase().DBaaS().Create(
+    ctx,
+    aruba.NewDBaaS().
+        OfEngine(aruba.DatabaseEngineMySQL80).
+        OfFlavor(aruba.DBaaSFlavorDBO2A4).
+        Named("my-database").
+        Tagged("env-prod").
+        InProject(proj).
+        InRegion(aruba.RegionITBGBergamo).
+        InZone(aruba.ZoneITBG1).
+        SizedGB(20).
+        WithVPC(vpc).
+        WithSubnet(subnet).
+        WithSecurityGroup(sg).
+        WithElasticIP(eip).
+        BilledBy(aruba.BillingPeriodHour))
+if err != nil {
+    log.Fatalf("Create DBaaS: %v", err)
+}
+
+if err := db.WaitUntilReady(ctx); err != nil {
+    log.Fatalf("DBaaS did not become Ready: %v", err)
+}
+fmt.Printf("✓ DBaaS: %s (engine: %s)\n", db.Name(), db.Engine())
+```
+
+**Accessor di risposta**:
+- `ID()`, `URI()`, `Name()`, `Tags()`
+- `DBaaSID()` — ID istanza assegnato dal provider
+- `Engine()` — identificatore dell'engine (costante `DatabaseEngine`)
+- `EngineRaw()` — struct engine completa
+- `Flavor()` — identificatore del flavor (costante `DBaaSFlavor`)
+- `FlavorRaw()` — struct flavor completa
+- `SizeGB()` — dimensione storage in GB
+- `AutoscalingEnabled()` — bool
+- `VPC()`, `Subnet()`, `SecurityGroup()`, `ElasticIP()` — `aruba.Ref` alle risorse di rete
+- `BillingPeriod()` — cadenza di fatturazione
+- `State()`, `FailureReason()`, `PreviousState()`, `IsDisabled()`, `DisableReasons()`
+- `WaitUntilReady(ctx, opts...)`, `WaitUntilActive(ctx, opts...)`, `WaitUntilStates(ctx, []types.State{...}, opts...)`, `WaitUntilGone(ctx, opts...)`
+- `Raw()` — struct wire sottostante
+
+:::tip Esempio eseguibile
+Esempio end-to-end completo: [`examples/all-resources/resource_dbaas.go`](https://github.com/Arubacloud/sdk-go/blob/main/examples/all-resources/resource_dbaas.go)
+:::
+
+---
+
+### Database
+
+```go
+arubaClient.FromDatabase().Databases()
+```
+
+**Operazioni supportate**: `Create`, `List`, `Get`, `Delete`
+**Asincrono**: sì — chiama `WaitUntilReady(ctx)` dopo `Create`.
+
+```go
+database, err := arubaClient.FromDatabase().Databases().Create(
+    ctx,
+    aruba.NewDatabase().
+        Named("my-app-db").
+        Tagged("app-backend").
+        InDBaaS(db))
+if err != nil {
+    log.Fatalf("Create Database: %v", err)
+}
+
+if err := database.WaitUntilReady(ctx); err != nil {
+    log.Fatalf("Database did not become Ready: %v", err)
+}
+fmt.Printf("✓ Database: %s\n", database.Name())
+```
+
+**Accessor di risposta**:
+- `ID()`, `URI()`, `Name()`, `Tags()`
+- `DatabaseID()` — ID database assegnato dal provider
+- `DBaaSID()` — ID DBaaS genitore
+- `State()`, `FailureReason()`, `PreviousState()`, `IsDisabled()`, `DisableReasons()`
+- `WaitUntilReady(ctx, opts...)`, `WaitUntilActive(ctx, opts...)`, `WaitUntilStates(ctx, []types.State{...}, opts...)`, `WaitUntilGone(ctx, opts...)`
+- `Raw()` — struct wire sottostante
+
+:::tip Esempio eseguibile
+Esempio end-to-end completo: [`examples/all-resources/resource_database.go`](https://github.com/Arubacloud/sdk-go/blob/main/examples/all-resources/resource_database.go)
+:::
+
+---
+
+### Utente
+
+```go
+arubaClient.FromDatabase().Users()
+```
+
+**Operazioni supportate**: `Create`, `List`, `Get`, `Delete`
+**Asincrono**: sì — chiama `WaitUntilReady(ctx)` dopo `Create`.
+
+```go
+user, err := arubaClient.FromDatabase().Users().Create(
+    ctx,
+    aruba.NewUser().
+        Tagged("app-backend").
+        InDBaaS(db).
+        WithUsername("app_user").
+        WithPassword("Str0ngP@ssword!"))
+if err != nil {
+    log.Fatalf("Create User: %v", err)
+}
+
+if err := user.WaitUntilReady(ctx); err != nil {
+    log.Fatalf("User did not become Ready: %v", err)
+}
+fmt.Printf("✓ Utente: %s\n", user.Name())
+```
+
+**Accessor di risposta**:
+- `ID()`, `URI()`, `Name()`, `Tags()`
+- `UserID()` — ID utente assegnato dal provider
+- `Username()` — nome utente del database
+- `DBaaSID()` — ID DBaaS genitore
+- `State()`, `FailureReason()`, `PreviousState()`, `IsDisabled()`, `DisableReasons()`
+- `WaitUntilReady(ctx, opts...)`, `WaitUntilActive(ctx, opts...)`, `WaitUntilStates(ctx, []types.State{...}, opts...)`, `WaitUntilGone(ctx, opts...)`
+- `Raw()` — struct wire sottostante
+
+:::tip Esempio eseguibile
+Esempio end-to-end completo: [`examples/all-resources/resource_dbaas_user.go`](https://github.com/Arubacloud/sdk-go/blob/main/examples/all-resources/resource_dbaas_user.go)
+:::
+
+---
+
+### Grant
+
+```go
+arubaClient.FromDatabase().Grants()
+```
+
+**Operazioni supportate**: `Create`, `List`, `Get`, `Delete`
+**Asincrono**: sì — chiama `WaitUntilReady(ctx)` dopo `Create`.
+
+```go
+grant, err := arubaClient.FromDatabase().Grants().Create(
+    ctx,
+    aruba.NewGrant().
+        OfRole("liteadmin").
+        InDatabase(database).
+        ForUser("app_user"))
+if err != nil {
+    log.Fatalf("Create Grant: %v", err)
+}
+
+if err := grant.WaitUntilReady(ctx); err != nil {
+    log.Fatalf("Grant did not become Ready: %v", err)
+}
+fmt.Printf("✓ Grant: %s (privilegi: %s)\n", grant.Name(), grant.Privileges())
+```
+
+**Accessor di risposta**:
+- `ID()`, `URI()`, `Name()`, `Tags()`
+- `GrantID()` — ID grant assegnato dal provider
+- `DatabaseID()` — ID Database genitore
+- `Privileges()` — stringa dei privilegi
+- `State()`, `FailureReason()`, `PreviousState()`, `IsDisabled()`, `DisableReasons()`
+- `WaitUntilReady(ctx, opts...)`, `WaitUntilActive(ctx, opts...)`, `WaitUntilStates(ctx, []types.State{...}, opts...)`, `WaitUntilGone(ctx, opts...)`
+- `Raw()` — struct wire sottostante
+
+:::tip Esempio eseguibile
+Esempio end-to-end completo: [`examples/all-resources/resource_grant.go`](https://github.com/Arubacloud/sdk-go/blob/main/examples/all-resources/resource_grant.go)
+:::
+
+---
+
+### DBaaS Backup
+
+```go
+arubaClient.FromDatabase().DBaaSBackups()
+```
+
+**Operazioni supportate**: `Create`, `List`, `Get`, `Delete`
+**Asincrono**: sì — chiama `WaitUntilReady(ctx)` dopo `Create`.
+
+```go
+backup, err := arubaClient.FromDatabase().DBaaSBackups().Create(
+    ctx,
+    aruba.NewDBaaSBackup().
+        Named("my-db-backup").
+        Tagged("backup").
+        InProject(proj).
+        FromDBaaS(db).
+        BilledBy(aruba.BillingPeriodHour))
+if err != nil {
+    log.Fatalf("Create DBaaSBackup: %v", err)
+}
+
+if err := backup.WaitUntilReady(ctx); err != nil {
+    log.Fatalf("DBaaS Backup did not become Ready: %v", err)
+}
+fmt.Printf("✓ DBaaS Backup: %s\n", backup.Name())
+```
+
+**Accessor di risposta**:
+- `ID()`, `URI()`, `Name()`, `Tags()`
+- `DBaaSBackupID()` — ID backup assegnato dal provider
+- `DBaaSURI()` — URI DBaaS sorgente
+- `DatabaseURI()` — URI Database sorgente (se applicabile)
+- `SizeGB()` — dimensione del backup in GB
+- `Zone()` — zona di disponibilità
+- `BillingPeriod()` — cadenza di fatturazione
+- `State()`, `FailureReason()`, `PreviousState()`, `IsDisabled()`, `DisableReasons()`
+- `WaitUntilReady(ctx, opts...)`, `WaitUntilActive(ctx, opts...)`, `WaitUntilStates(ctx, []types.State{...}, opts...)`, `WaitUntilGone(ctx, opts...)`
+- `Raw()` — struct wire sottostante
+
+:::tip Esempio eseguibile
+Le operazioni DBaaS Backup sono coperte nell'esempio DBaaS: [`examples/all-resources/resource_dbaas.go`](https://github.com/Arubacloud/sdk-go/blob/main/examples/all-resources/resource_dbaas.go)
+:::
+
+---
+
+## Metric
+
+### Alert
+
+```go
+arubaClient.FromMetric().Alerts()
+```
+
+**Operazioni supportate**: `List`
+
+Gli Alert sono in sola lettura. Usa `List` con un `Ref` di progetto per interrogare gli alert attivi.
+
+```go
+list, err := arubaClient.FromMetric().Alerts().List(ctx, proj)
+if err != nil {
+    log.Fatalf("List Alerts: %v", err)
+}
+for _, a := range list.Items() {
+    fmt.Println(a.ID(), a.Name(), a.IsActive())
+}
+```
+
+**Accessor di risposta**:
+- `ID()`, `URI()`, `Name()`
+- `Threshold()` — valore soglia dell'alert
+- `Action()` — azione scatenata dall'alert
+- `IsActive()` — bool
+- `Raw()` — struct wire sottostante
+
+:::tip Esempio eseguibile
+Eseguito come parte dell'orchestratore: [`examples/all-resources/orchestrator_create.go`](https://github.com/Arubacloud/sdk-go/blob/main/examples/all-resources/orchestrator_create.go)
+:::
+
+---
+
+### Metric
+
+```go
+arubaClient.FromMetric().Metrics()
+```
+
+**Operazioni supportate**: `List`
+
+Le metriche sono risultati di query su serie temporali in sola lettura.
+
+```go
+list, err := arubaClient.FromMetric().Metrics().List(ctx, proj,
+    aruba.WithFilter("resource eq '"+cs.URI()+"'"))
+if err != nil {
+    log.Fatalf("List Metrics: %v", err)
+}
+for _, m := range list.Items() {
+    fmt.Println(m.ID(), m.Name())
+}
+```
+
+**Accessor di risposta**:
+- `ID()`, `URI()`, `Name()`
+- `Raw()` — struct wire sottostante
+
+:::tip Esempio eseguibile
+Eseguito come parte dell'orchestratore: [`examples/all-resources/orchestrator_create.go`](https://github.com/Arubacloud/sdk-go/blob/main/examples/all-resources/orchestrator_create.go)
+:::
+
+---
+
+## Network
+
+### VPC
+
+```go
+arubaClient.FromNetwork().VPCs()
+```
+
+**Operazioni supportate**: `Create`, `List`, `Get`, `Update`, `Delete`
+**Asincrono**: sì — chiama `WaitUntilReady(ctx)` dopo `Create`.
+
+```go
+vpc, err := arubaClient.FromNetwork().VPCs().Create(
+    ctx,
+    aruba.NewVPC().
+        Named("my-vpc").
+        Tagged("network").
+        InProject(proj).
+        InRegion(aruba.RegionITBGBergamo).
+        NotDefault().
+        WithoutPreset())
+if err != nil {
+    log.Fatalf("Create VPC: %v", err)
+}
+
+if err := vpc.WaitUntilReady(ctx); err != nil {
+    log.Fatalf("VPC did not become Ready: %v", err)
+}
+fmt.Printf("✓ VPC: %s\n", vpc.Name())
+```
+
+**Accessor di risposta**:
+- `ID()`, `URI()`, `Name()`, `Tags()`
+- `VPCID()` — ID VPC assegnato dal provider
+- `Region()` — slug della regione
+- `IsDefault()`, `IsPreset()` — flag
+- `State()`, `FailureReason()`, `PreviousState()`, `IsDisabled()`, `DisableReasons()`
+- `WaitUntilReady(ctx, opts...)`, `WaitUntilActive(ctx, opts...)`, `WaitUntilStates(ctx, []types.State{...}, opts...)`, `WaitUntilGone(ctx, opts...)`
+- `Raw()` — struct wire sottostante
+
+:::tip Esempio eseguibile
+Esempio end-to-end completo: [`examples/all-resources/resource_vpc.go`](https://github.com/Arubacloud/sdk-go/blob/main/examples/all-resources/resource_vpc.go)
+:::
+
+---
+
+### Subnet
+
+```go
+arubaClient.FromNetwork().Subnets()
+```
+
+**Operazioni supportate**: `Create`, `List`, `Get`, `Update`, `Delete`
+**Asincrono**: sì — chiama `WaitUntilReady(ctx)` dopo `Create`.
+
+`OfType` accetta `aruba.SubnetTypeBasic` o `aruba.SubnetTypeAdvanced` (costanti tipizzate — non è necessario alcun cast a stringa).
+
+`aruba.NewSubnetDHCP()` è un sub-builder per la configurazione DHCP. Si allega con `WithDHCP(...)`.
+
+```go
+subnet, err := arubaClient.FromNetwork().Subnets().Create(
+    ctx,
+    aruba.NewSubnet().
+        OfType(aruba.SubnetTypeAdvanced).
+        Named("my-subnet").
+        Tagged("network").
+        InVPC(vpc).
+        InRegion(aruba.RegionITBGBergamo).
+        WithCIDR("192.168.1.0/25").
+        WithDHCP(aruba.NewSubnetDHCP().
+            Enabled().
+            WithRange("192.168.1.10", 50).
+            WithRoutes(aruba.SubnetDHCPRoute{Address: "0.0.0.0/0", Gateway: "192.168.1.1"}).
+            WithDNSServers("8.8.8.8", "8.8.4.4")).
+        NotDefault())
+if err != nil {
+    log.Fatalf("Create Subnet: %v", err)
+}
+
+if err := subnet.WaitUntilReady(ctx); err != nil {
+    log.Fatalf("Subnet did not become Ready: %v", err)
+}
+fmt.Printf("✓ Subnet: %s (CIDR: %s)\n", subnet.Name(), subnet.CIDR())
+```
+
+**Accessor di risposta**:
+- `ID()`, `URI()`, `Name()`, `Tags()`
+- `SubnetID()` — ID subnet assegnato dal provider
+- `Type()` — tipo di subnet (costante `SubnetType`)
+- `CIDR()` — blocco CIDR
+- `DHCP()` — configurazione DHCP
+- `IsDefault()` — bool
+- `Region()` — slug della regione
+- `State()`, `FailureReason()`, `PreviousState()`, `IsDisabled()`, `DisableReasons()`
+- `WaitUntilReady(ctx, opts...)`, `WaitUntilActive(ctx, opts...)`, `WaitUntilStates(ctx, []types.State{...}, opts...)`, `WaitUntilGone(ctx, opts...)`
+- `Raw()` — struct wire sottostante
+
+:::tip Esempio eseguibile
+Esempio end-to-end completo: [`examples/all-resources/resource_subnet.go`](https://github.com/Arubacloud/sdk-go/blob/main/examples/all-resources/resource_subnet.go)
+:::
+
+---
+
+### Elastic IP
+
+```go
+arubaClient.FromNetwork().ElasticIPs()
+```
+
+**Operazioni supportate**: `Create`, `List`, `Get`, `Update`, `Delete`
+**Asincrono**: sì — chiama `WaitUntilReady(ctx)` dopo `Create`.
+
+```go
+eip, err := arubaClient.FromNetwork().ElasticIPs().Create(
+    ctx,
+    aruba.NewElasticIP().
+        Named("my-eip").
+        Tagged("network").
+        InProject(proj).
+        InRegion(aruba.RegionITBGBergamo).
+        BilledBy(aruba.BillingPeriodHour))
+if err != nil {
+    log.Fatalf("Create ElasticIP: %v", err)
+}
+
+if err := eip.WaitUntilReady(ctx); err != nil {
+    log.Fatalf("ElasticIP did not become Ready: %v", err)
+}
+fmt.Printf("✓ Elastic IP: %s (%s)\n", eip.Name(), eip.Address())
+```
+
+**Accessor di risposta**:
+- `ID()`, `URI()`, `Name()`, `Tags()`
+- `ElasticIPID()` — ID IP assegnato dal provider
+- `Address()` — l'indirizzo IP pubblico allocato
+- `BillingPeriod()` — cadenza di fatturazione
+- `Region()` — slug della regione
+- `State()`, `FailureReason()`, `PreviousState()`, `IsDisabled()`, `DisableReasons()`
+- `WaitUntilReady(ctx, opts...)`, `WaitUntilActive(ctx, opts...)`, `WaitUntilNotUsed(ctx, opts...)`, `WaitUntilUsed(ctx, opts...)`, `WaitUntilStates(ctx, []types.State{...}, opts...)`, `WaitUntilGone(ctx, opts...)`
+- `Raw()` — struct wire sottostante
+
+:::tip Esempio eseguibile
+Esempio end-to-end completo: [`examples/all-resources/resource_elastic_ip.go`](https://github.com/Arubacloud/sdk-go/blob/main/examples/all-resources/resource_elastic_ip.go)
+:::
+
+---
+
+### Security Group
+
+```go
+arubaClient.FromNetwork().SecurityGroups()
+```
+
+**Operazioni supportate**: `Create`, `List`, `Get`, `Update`, `Delete`
+**Asincrono**: sì — chiama `WaitUntilReady(ctx)` dopo `Create`.
+
+```go
+sg, err := arubaClient.FromNetwork().SecurityGroups().Create(
+    ctx,
+    aruba.NewSecurityGroup().
+        Named("my-security-group").
+        Tagged("security").
+        InVPC(vpc).
+        NotDefault())
+if err != nil {
+    log.Fatalf("Create SecurityGroup: %v", err)
+}
+
+if err := sg.WaitUntilReady(ctx); err != nil {
+    log.Fatalf("SecurityGroup did not become Active: %v", err)
+}
+fmt.Printf("✓ Security Group: %s (ID: %s)\n", sg.Name(), sg.ID())
+```
+
+**Accessor di risposta**:
+- `ID()`, `URI()`, `Name()`, `Tags()`
+- `SecurityGroupID()` — ID gruppo assegnato dal provider
+- `IsDefault()` — bool
+- `State()`, `FailureReason()`, `PreviousState()`, `IsDisabled()`, `DisableReasons()`
+- `WaitUntilReady(ctx, opts...)`, `WaitUntilActive(ctx, opts...)`, `WaitUntilStates(ctx, []types.State{...}, opts...)`, `WaitUntilGone(ctx, opts...)`
+- `Raw()` — struct wire sottostante
+
+:::tip Esempio eseguibile
+Esempio end-to-end completo: [`examples/all-resources/resource_security_group.go`](https://github.com/Arubacloud/sdk-go/blob/main/examples/all-resources/resource_security_group.go)
+:::
+
+---
+
+### Security Rule
+
+```go
+arubaClient.FromNetwork().SecurityGroupRules()
+```
+
+**Operazioni supportate**: `Create`, `List`, `Get`, `Delete`
+**Asincrono**: sì — `State()` e `FailureReason()` sono disponibili.
+
+`WithDirection` accetta `aruba.RuleDirectionIngress` o `aruba.RuleDirectionEgress`. `WithProtocol` accetta `aruba.RuleProtocolTCP`, `aruba.RuleProtocolUDP`, `aruba.RuleProtocolICMP` o `aruba.RuleProtocolANY`.
+
+> **Avvertenza**: `TargetingCIDR` e `TargetingSecurityGroup` si escludono a vicenda. Impostarli entrambi registra un errore al momento del setter che emerge su `Create`.
+
+```go
+rule, err := arubaClient.FromNetwork().SecurityGroupRules().Create(
+    ctx,
+    aruba.NewSecurityRule().
+        Named("allow-ssh").
+        Tagged("ssh-key").
+        InSecurityGroup(sg).
+        InRegion(aruba.RegionITBGBergamo).
+        WithDirection(aruba.RuleDirectionIngress).
+        WithProtocol(aruba.RuleProtocolTCP).
+        WithPort("22").
+        TargetingCIDR("0.0.0.0/0"))
+if err != nil {
+    log.Fatalf("Create SecurityRule: %v", err)
+}
+fmt.Printf("✓ Security Rule: %s\n", rule.Name())
+```
+
+**Accessor di risposta**:
+- `ID()`, `URI()`, `Name()`, `Tags()`
+- `SecurityRuleID()` — ID regola assegnato dal provider
+- `Direction()` — `"Ingress"` o `"Egress"`
+- `Protocol()` — es. `"TCP"`, `"UDP"`, `"ICMP"`
+- `Port()` — numero o intervallo di porte
+- `TargetKind()` — `"Ip"` o `"SecurityGroup"`
+- `TargetValue()` — stringa CIDR o URI del Security Group
+- `Region()` — slug della regione
+- `State()`, `FailureReason()`, `PreviousState()`, `IsDisabled()`, `DisableReasons()`
+- `WaitUntilGone(ctx, opts...)`
+- `Raw()` — struct wire sottostante
+
+:::tip Esempio eseguibile
+Eseguito come parte dell'orchestratore: [`examples/all-resources/orchestrator_create.go`](https://github.com/Arubacloud/sdk-go/blob/main/examples/all-resources/orchestrator_create.go)
+:::
+
+---
+
+### Load Balancer
+
+```go
+arubaClient.FromNetwork().LoadBalancers()
+```
+
+**Operazioni supportate**: `List`, `Get`
+
+I Load Balancer sono in sola lettura tramite questo SDK — vengono creati e gestiti automaticamente dalla piattaforma Aruba Cloud.
+
+```go
+list, err := arubaClient.FromNetwork().LoadBalancers().List(ctx, proj)
+if err != nil {
+    log.Fatalf("List LoadBalancers: %v", err)
+}
+for _, lb := range list.Items() {
+    fmt.Println(lb.ID(), lb.Name(), lb.Address())
+}
+```
+
+**Accessor di risposta**:
+- `ID()`, `URI()`, `Name()`, `Tags()`
+- `LoadBalancerID()` — ID LB assegnato dal provider
+- `Address()` — indirizzo pubblico
+- `VPC()` — `aruba.Ref` alla VPC collegata
+- `Region()` — slug della regione
+- `State()`, `FailureReason()`, `PreviousState()`, `IsDisabled()`, `DisableReasons()`
+- `Raw()` — struct wire sottostante
+
+:::tip Esempio eseguibile
+Eseguito come parte dell'orchestratore: [`examples/all-resources/orchestrator_create.go`](https://github.com/Arubacloud/sdk-go/blob/main/examples/all-resources/orchestrator_create.go)
+:::
+
+---
+
+### VPC Peering
+
+```go
+arubaClient.FromNetwork().VPCPeerings()
+```
+
+**Operazioni supportate**: `Create`, `List`, `Get`, `Update`, `Delete`
+**Asincrono**: sì — chiama `WaitUntilReady(ctx)` dopo `Create`.
+
+```go
+peering, err := arubaClient.FromNetwork().VPCPeerings().Create(
+    ctx,
+    aruba.NewVPCPeering().
+        Named("my-peering").
+        Tagged("network").
+        InVPC(vpc).
+        InRegion(aruba.RegionITBGBergamo).
+        WithPeerVPC(aruba.URI("/projects/"+peerProjectID+"/vpcs/"+peerVPCID)))
+if err != nil {
+    log.Fatalf("Create VPCPeering: %v", err)
+}
+
+if err := peering.WaitUntilReady(ctx); err != nil {
+    log.Fatalf("VPCPeering did not become Active: %v", err)
+}
+fmt.Printf("✓ VPC Peering: %s\n", peering.Name())
+```
+
+**Accessor di risposta**:
+- `ID()`, `URI()`, `Name()`, `Tags()`
+- `VPCPeeringID()` — ID peering assegnato dal provider
+- `VPCID()` — ID VPC sorgente
+- `PeerVPC()` — `aruba.Ref` alla VPC peer
+- `State()`, `FailureReason()`, `PreviousState()`, `IsDisabled()`, `DisableReasons()`
+- `WaitUntilReady(ctx, opts...)`, `WaitUntilActive(ctx, opts...)`, `WaitUntilStates(ctx, []types.State{...}, opts...)`, `WaitUntilGone(ctx, opts...)`
+- `Raw()` — struct wire sottostante
+
+:::tip Esempio eseguibile
+Eseguito come parte dell'orchestratore: [`examples/all-resources/orchestrator_create.go`](https://github.com/Arubacloud/sdk-go/blob/main/examples/all-resources/orchestrator_create.go)
+:::
+
+---
+
+### VPC Peering Route
+
+```go
+arubaClient.FromNetwork().VPCPeeringRoutes()
+```
+
+**Operazioni supportate**: `Create`, `List`, `Get`, `Update`, `Delete`
+**Asincrono**: sì — chiama `WaitUntilReady(ctx)` dopo `Create`.
+
+```go
+route, err := arubaClient.FromNetwork().VPCPeeringRoutes().Create(
+    ctx,
+    aruba.NewVPCPeeringRoute().
+        Named("my-peering-route").
+        Tagged("network").
+        InVPCPeering(peering).
+        InRegion(aruba.RegionITBGBergamo).
+        WithCIDR("10.0.0.0/8").
+        WithTarget(aruba.URI("/projects/"+projectID+"/vpcs/"+vpcID)))
+if err != nil {
+    log.Fatalf("Create VPCPeeringRoute: %v", err)
+}
+
+if err := route.WaitUntilReady(ctx); err != nil {
+    log.Fatalf("VPCPeeringRoute did not become Active: %v", err)
+}
+fmt.Printf("✓ Peering Route: %s (CIDR: %s)\n", route.Name(), route.CIDR())
+```
+
+**Accessor di risposta**:
+- `ID()`, `URI()`, `Name()`, `Tags()`
+- `CIDR()` — blocco CIDR della route
+- `Target()` — `aruba.Ref` al target della route
+- `VPCPeeringID()` — ID peering genitore
+- `State()`, `FailureReason()`, `PreviousState()`, `IsDisabled()`, `DisableReasons()`
+- `WaitUntilReady(ctx, opts...)`, `WaitUntilActive(ctx, opts...)`, `WaitUntilStates(ctx, []types.State{...}, opts...)`, `WaitUntilGone(ctx, opts...)`
+- `Raw()` — struct wire sottostante
+
+:::tip Esempio eseguibile
+Eseguito come parte dell'orchestratore: [`examples/all-resources/orchestrator_create.go`](https://github.com/Arubacloud/sdk-go/blob/main/examples/all-resources/orchestrator_create.go)
+:::
+
+---
+
+### VPN Tunnel
+
+```go
+arubaClient.FromNetwork().VPNTunnels()
+```
+
+**Operazioni supportate**: `Create`, `List`, `Get`, `Update`, `Delete`
+**Asincrono**: sì — chiama `WaitUntilReady(ctx)` dopo `Create`.
+
+Sub-builder del VPN Tunnel:
+- `aruba.NewVPNIKE()` — parametri IKE fase 1 (`WithEncryption(IKEEncryption)`, `WithHash(IKEHash)`, `WithDHGroup(IKEDHGroup)`, `WithDPDAction(IKEDPDAction)`)
+- `aruba.NewVPNESP()` — parametri ESP fase 2 (`WithEncryption(ESPEncryption)`, `WithHash(ESPHash)`, `WithPFS(ESPPFSGroup)`)
+- `aruba.NewVPNPSK()` — configurazione della pre-shared key (`WithKey(string)`, `WithCloudSite(string)`, `WithOnPremSite(string)`)
+
+```go
+tunnel, err := arubaClient.FromNetwork().VPNTunnels().Create(
+    ctx,
+    aruba.NewVPNTunnel().
+        Named("my-vpn-tunnel").
+        Tagged("vpn-net").
+        InProject(proj).
+        InRegion(aruba.RegionITBGBergamo).
+        WithPeerClientPublicIP("203.0.113.1").
+        WithIKESettings(aruba.NewVPNIKE().
+            WithEncryption(aruba.IKEEncryptionAES256).
+            WithHash(aruba.IKEHashSHA256).
+            WithDHGroup(aruba.IKEDHGroup14)).
+        WithESPSettings(aruba.NewVPNESP().
+            WithEncryption(aruba.ESPEncryptionAES256).
+            WithHash(aruba.ESPHashSHA256)).
+        WithPSKSettings(aruba.NewVPNPSK().
+            WithKey("my-pre-shared-key")))
+if err != nil {
+    log.Fatalf("Create VPNTunnel: %v", err)
+}
+
+if err := tunnel.WaitUntilReady(ctx); err != nil {
+    log.Fatalf("VPNTunnel did not become Active: %v", err)
+}
+fmt.Printf("✓ VPN Tunnel: %s (gateway: %s)\n", tunnel.Name(), tunnel.PeerClientPublicIP())
+```
+
+**Accessor di risposta**:
+- `ID()`, `URI()`, `Name()`, `Tags()`
+- `VPNTunnelID()` — ID tunnel assegnato dal provider
+- `PeerClientPublicIP()` — IP del gateway del peer remoto
+- `IKE()` — impostazioni IKE `*aruba.VPNIKE`
+- `ESP()` — impostazioni ESP `*aruba.VPNESP`
+- `PSK()` — impostazioni PSK `*aruba.VPNPSK`
+- `State()`, `FailureReason()`, `PreviousState()`, `IsDisabled()`, `DisableReasons()`
+- `WaitUntilReady(ctx, opts...)`, `WaitUntilActive(ctx, opts...)`, `WaitUntilStates(ctx, []types.State{...}, opts...)`, `WaitUntilGone(ctx, opts...)`
+- `Raw()` — struct wire sottostante
+
+:::tip Esempio eseguibile
+Eseguito come parte dell'orchestratore: [`examples/all-resources/orchestrator_create.go`](https://github.com/Arubacloud/sdk-go/blob/main/examples/all-resources/orchestrator_create.go)
+:::
+
+---
+
+### VPN Route
+
+```go
+arubaClient.FromNetwork().VPNRoutes()
+```
+
+**Operazioni supportate**: `Create`, `List`, `Get`, `Update`, `Delete`
+**Asincrono**: sì — chiama `WaitUntilReady(ctx)` dopo `Create`.
+
+```go
+vpnRoute, err := arubaClient.FromNetwork().VPNRoutes().Create(
+    ctx,
+    aruba.NewVPNRoute().
+        Named("my-vpn-route").
+        Tagged("vpn-net").
+        InVPNTunnel(tunnel).
+        InRegion(aruba.RegionITBGBergamo).
+        WithCIDR("10.0.0.0/8").
+        WithTarget(aruba.URI("/projects/"+projectID+"/vpcs/"+vpcID)))
+if err != nil {
+    log.Fatalf("Create VPNRoute: %v", err)
+}
+
+if err := vpnRoute.WaitUntilReady(ctx); err != nil {
+    log.Fatalf("VPNRoute did not become Active: %v", err)
+}
+fmt.Printf("✓ VPN Route: %s (CIDR: %s)\n", vpnRoute.Name(), vpnRoute.CIDR())
+```
+
+**Accessor di risposta**:
+- `ID()`, `URI()`, `Name()`, `Tags()`
+- `CIDR()` — blocco CIDR della route
+- `Target()` — `aruba.Ref` al target della route
+- `VPNTunnelID()` — ID VPN Tunnel genitore
+- `State()`, `FailureReason()`, `PreviousState()`, `IsDisabled()`, `DisableReasons()`
+- `WaitUntilReady(ctx, opts...)`, `WaitUntilActive(ctx, opts...)`, `WaitUntilStates(ctx, []types.State{...}, opts...)`, `WaitUntilGone(ctx, opts...)`
+- `Raw()` — struct wire sottostante
+
+:::tip Esempio eseguibile
+Eseguito come parte dell'orchestratore: [`examples/all-resources/orchestrator_create.go`](https://github.com/Arubacloud/sdk-go/blob/main/examples/all-resources/orchestrator_create.go)
+:::
+
+---
+
+## Schedule
+
+### Job
+
+```go
+arubaClient.FromSchedule().Jobs()
+```
+
+**Operazioni supportate**: `Create`, `List`, `Get`, `Update`, `Delete`
+**Asincrono**: sì — `State()` e `FailureReason()` sono disponibili.
+
+Usa `OneShotAt(t time.Time)` per pianificare un job una tantum, o `WithCron(expr string)` per un job ricorrente su schedulazione cron. Usa `RecurringUntil(t time.Time)` per impostare una data di fine per un job ricorrente.
+
+```go
+// Job una tantum — si esegue una sola volta a un orario specifico
+job, err := arubaClient.FromSchedule().Jobs().Create(
+    ctx,
+    aruba.NewJob().
+        Named("my-one-shot-job").
+        Tagged("automation").
+        InProject(proj).
+        OneShotAt(time.Now().Add(10*time.Minute)))
+if err != nil {
+    log.Fatalf("Create Job: %v", err)
+}
+fmt.Printf("✓ Job: %s (tipo: %s)\n", job.Name(), job.JobType())
+
+// Job ricorrente — si esegue secondo una schedulazione cron
+cronJob, err := arubaClient.FromSchedule().Jobs().Create(
+    ctx,
+    aruba.NewJob().
+        Named("my-recurring-job").
+        Tagged("automation").
+        InProject(proj).
+        WithCron("0 * * * *"))
+if err != nil {
+    log.Fatalf("Create recurring Job: %v", err)
+}
+fmt.Printf("✓ Job ricorrente: %s (cron: %s)\n", cronJob.Name(), cronJob.Cron())
+```
+
+**Accessor di risposta**:
+- `ID()`, `URI()`, `Name()`, `Tags()`
+- `JobID()` — ID job assegnato dal provider
+- `JobType()` — tipo di job (`types.JobTypeOneShot` o `types.JobTypeRecurring`)
+- `Cron()` — espressione cron (job ricorrenti)
+- `IsEnabled()` — bool
+- `State()`, `FailureReason()`, `PreviousState()`, `IsDisabled()`, `DisableReasons()`
+- `Raw()` — struct wire sottostante
+
+:::tip Esempio eseguibile
+Esempio end-to-end completo: [`examples/all-resources/resource_job.go`](https://github.com/Arubacloud/sdk-go/blob/main/examples/all-resources/resource_job.go)
+:::
+
+---
+
+## Security
+
+### KMS (Key Management Service)
+
+```go
+arubaClient.FromSecurity().KMS()
+```
+
+**Operazioni supportate**: `Create`, `List`, `Get`, `Update`, `Delete`
+**Asincrono**: sì — chiama `WaitUntilReady(ctx)` dopo `Create`.
+
+```go
+kms, err := arubaClient.FromSecurity().KMS().Create(
+    ctx,
+    aruba.NewKMS().
+        Named("my-kms").
+        Tagged("security").
+        InProject(proj).
+        InRegion(aruba.RegionITBGBergamo).
+        BilledBy(aruba.BillingPeriodHour))
+if err != nil {
+    log.Fatalf("Create KMS: %v", err)
+}
+
+if err := kms.WaitUntilReady(ctx); err != nil {
+    log.Fatalf("KMS did not become Active: %v", err)
+}
+fmt.Printf("✓ KMS: %s (ID: %s)\n", kms.Name(), kms.ID())
+```
+
+**Accessor di risposta**:
+- `ID()`, `URI()`, `Name()`, `Tags()`
+- `KMSID()` — ID istanza KMS assegnato dal provider
+- `BillingPeriod()` — cadenza di fatturazione
+- `State()`, `FailureReason()`, `PreviousState()`, `IsDisabled()`, `DisableReasons()`
+- `WaitUntilReady(ctx, opts...)`, `WaitUntilActive(ctx, opts...)`, `WaitUntilStates(ctx, []types.State{...}, opts...)`, `WaitUntilGone(ctx, opts...)`
+- `Raw()` — struct wire sottostante
+
+:::tip Esempio eseguibile
+Esempio end-to-end completo: [`examples/all-resources/resource_kms.go`](https://github.com/Arubacloud/sdk-go/blob/main/examples/all-resources/resource_kms.go)
+:::
+
+---
+
+### Key (Chiave)
+
+```go
+arubaClient.FromSecurity().Keys()
+```
+
+**Operazioni supportate**: `Create`, `List`, `Get`, `Delete`
+**Asincrono**: sì — `State()` e `FailureReason()` sono disponibili.
+
+`OfAlgorithm` accetta `aruba.KeyAlgorithmAes` o `aruba.KeyAlgorithmRsa` (costanti tipizzate — non è necessario alcun cast a stringa).
+
+```go
+key, err := arubaClient.FromSecurity().Keys().Create(
+    ctx,
+    aruba.NewKey().
+        OfAlgorithm(aruba.KeyAlgorithmAes).
+        Named("my-encryption-key").
+        Tagged("security").
+        InKMS(kms))
+if err != nil {
+    log.Fatalf("Create Key: %v", err)
+}
+fmt.Printf("✓ Chiave: %s (algoritmo: %s)\n", key.Name(), key.Algorithm())
+```
+
+**Accessor di risposta**:
+- `ID()`, `URI()`, `Name()`, `Tags()`
+- `KeyID()` — ID chiave assegnato dal provider
+- `Algorithm()` — stringa dell'algoritmo
+- `Type()` — `"Symmetric"` o `"Asymmetric"`
+- `Status()` — stato del ciclo di vita della chiave
+- `CreationSource()` — come è stata creata la chiave
+- `State()`, `FailureReason()`, `PreviousState()`, `IsDisabled()`, `DisableReasons()`
+- `WaitUntilGone(ctx, opts...)`
+- `Raw()` — struct wire sottostante
+
+:::tip Esempio eseguibile
+Le operazioni Key sono coperte nell'esempio KMS: [`examples/all-resources/resource_kms.go`](https://github.com/Arubacloud/sdk-go/blob/main/examples/all-resources/resource_kms.go)
+:::
+
+---
+
+### Kmip
+
+```go
+arubaClient.FromSecurity().Kmips()
+```
+
+**Operazioni supportate**: `Create`, `List`, `Get`, `Delete`
+**Asincrono**: sì — chiama `WaitUntilReady(ctx)` dopo `Create`. `WaitUntilReady` del KMIP ha successo su `"CertificateAvailable"` o `"Active"`. `WaitUntilCertificateAvailable` è un alias per `WaitUntilReady`.
+
+```go
+km, err := arubaClient.FromSecurity().Kmips().Create(
+    ctx,
+    aruba.NewKmip().
+        Named("my-kmip").
+        Tagged("security").
+        InKMS(kms))
+if err != nil {
+    log.Fatalf("Create Kmip: %v", err)
+}
+
+if err := km.WaitUntilReady(ctx); err != nil {
+    log.Fatalf("Kmip did not become ready: %v", err)
+}
+fmt.Printf("✓ Kmip: %s\n", km.Name())
+```
+
+**Download del certificato KMIP** (richiede un wrapper idratato):
+
+```go
+cert, err := km.Download(ctx)
+if err != nil {
+    log.Fatalf("Download Kmip certificate: %v", err)
+}
+fmt.Println("Cert:", cert.Cert())
+fmt.Println("Key:",  cert.Key())
+```
+
+**Accessor di risposta**:
+- `ID()`, `URI()`, `Name()`, `Tags()`
+- `KmipID()` — ID KMIP assegnato dal provider
+- `KmipStatus()` — stato specifico KMIP
+- `State()`, `FailureReason()`, `PreviousState()`, `IsDisabled()`, `DisableReasons()`
+- `WaitUntilReady(ctx, opts...)`, `WaitUntilCertificateAvailable(ctx, opts...)`, `WaitUntilStates(ctx, []types.State{...}, opts...)`, `WaitUntilGone(ctx, opts...)`
+- `Raw()` — struct wire sottostante
+
+:::tip Esempio eseguibile
+Le operazioni KMIP sono coperte nell'esempio KMS: [`examples/all-resources/resource_kms.go`](https://github.com/Arubacloud/sdk-go/blob/main/examples/all-resources/resource_kms.go)
+:::
+
+---
+
+## Storage
+
+### Block Storage (Volume)
+
+```go
+arubaClient.FromStorage().Volumes()
+```
+
+**Operazioni supportate**: `Create`, `List`, `Get`, `Update`, `Delete`
+**Asincrono**: sì — chiama `WaitUntilReady(ctx)` dopo `Create`.
+
+`OfType` accetta `aruba.BlockStorageTypeStandard` o `aruba.BlockStorageTypePerformance`. Usa `AsBootable()` per contrassegnare un volume come avviabile; `NotBootable()` per disattivarlo. Usa `FromImage(imageID)` per specificare un'immagine di base.
+
+```go
+bs, err := arubaClient.FromStorage().Volumes().Create(
+    ctx,
+    aruba.NewBlockStorage().
+        OfType(aruba.BlockStorageTypeStandard).
+        Named("my-volume").
+        Tagged("storage").
+        InProject(proj).
+        InRegion(aruba.RegionITBGBergamo).
+        InZone(aruba.ZoneITBG1).
+        SizedGB(20).
+        FromImage("LU22-001").
+        AsBootable().
+        BilledBy(aruba.BillingPeriodHour))
+if err != nil {
+    log.Fatalf("Create BlockStorage: %v", err)
+}
+
+if err := bs.WaitUntilReady(ctx); err != nil {
+    log.Fatalf("BlockStorage did not become Active: %v", err)
+}
+fmt.Printf("✓ Volume: %s (%d GB)\n", bs.Name(), bs.SizeGB())
+```
+
+Per creare un volume **da uno snapshot**, usa `FromSnapshot(snapshot)` al posto di `FromImage`:
+
+```go
+bs, err := arubaClient.FromStorage().Volumes().Create(
+    ctx,
+    aruba.NewBlockStorage().
+        OfType(aruba.BlockStorageTypeStandard).
+        Named("restored-volume").
+        InProject(proj).
+        InRegion(aruba.RegionITBGBergamo).
+        InZone(aruba.ZoneITBG1).
+        SizedGB(20).
+        FromSnapshot(snapshot).
+        AsBootable().
+        BilledBy(aruba.BillingPeriodHour))
+```
+
+**Accessor di risposta**:
+- `ID()`, `URI()`, `Name()`, `Tags()`
+- `BlockStorageID()` — ID volume assegnato dal provider
+- `SizeGB()` — dimensione in GB
+- `Type()` — tipo di storage
+- `Zone()` — zona di disponibilità
+- `BillingPeriod()` — cadenza di fatturazione
+- `IsBootable()` — bool
+- `Image()` — riferimento all'immagine
+- `SnapshotURI()` — URI dello snapshot sorgente (se creato da snapshot)
+- `State()`, `FailureReason()`, `PreviousState()`, `IsDisabled()`, `DisableReasons()`
+- `WaitUntilReady(ctx, opts...)`, `WaitUntilActive(ctx, opts...)`, `WaitUntilNotUsed(ctx, opts...)`, `WaitUntilUsed(ctx, opts...)`, `WaitUntilStates(ctx, []types.State{...}, opts...)`, `WaitUntilGone(ctx, opts...)`
+- `Raw()` — struct wire sottostante
+
+:::tip Esempio eseguibile
+Esempio end-to-end completo: [`examples/all-resources/resource_block_storage.go`](https://github.com/Arubacloud/sdk-go/blob/main/examples/all-resources/resource_block_storage.go)
+:::
+
+---
+
+### Snapshot
+
+```go
+arubaClient.FromStorage().Snapshots()
+```
+
+**Operazioni supportate**: `Create`, `List`, `Get`, `Update`, `Delete`
+**Asincrono**: sì — chiama `WaitUntilReady(ctx)` dopo `Create`.
+
+```go
+snap, err := arubaClient.FromStorage().Snapshots().Create(
+    ctx,
+    aruba.NewSnapshot().
+        Named("my-snapshot").
+        Tagged("backup").
+        InProject(proj).
+        InRegion(aruba.RegionITBGBergamo).
+        FromVolume(bs).
+        BilledBy(aruba.BillingPeriodHour))
+if err != nil {
+    log.Fatalf("Create Snapshot: %v", err)
+}
+
+if err := snap.WaitUntilReady(ctx); err != nil {
+    log.Fatalf("Snapshot did not become Active: %v", err)
+}
+fmt.Printf("✓ Snapshot: %s\n", snap.Name())
+```
+
+**Accessor di risposta**:
+- `ID()`, `URI()`, `Name()`, `Tags()`
+- `SnapshotID()` — ID snapshot assegnato dal provider
+- `SizeGB()` — dimensione snapshot in GB
+- `Type()` — tipo di storage
+- `Zone()` — zona di disponibilità
+- `BillingPeriod()` — cadenza di fatturazione
+- `Bootable()` — bool
+- `VolumeURI()` — URI del volume sorgente
+- `State()`, `FailureReason()`, `PreviousState()`, `IsDisabled()`, `DisableReasons()`
+- `WaitUntilReady(ctx, opts...)`, `WaitUntilActive(ctx, opts...)`, `WaitUntilStates(ctx, []types.State{...}, opts...)`, `WaitUntilGone(ctx, opts...)`
+- `Raw()` — struct wire sottostante
+
+:::tip Esempio eseguibile
+Esempio end-to-end completo: [`examples/all-resources/resource_snapshot.go`](https://github.com/Arubacloud/sdk-go/blob/main/examples/all-resources/resource_snapshot.go)
+:::
+
+---
+
+### Storage Backup
+
+```go
+arubaClient.FromStorage().Backups()
+```
+
+**Operazioni supportate**: `Create`, `List`, `Get`, `Delete`
+**Asincrono**: sì — chiama `WaitUntilReady(ctx)` dopo `Create`.
+
+`OfType` accetta `aruba.StorageBackupTypeFull` o `aruba.StorageBackupTypeIncremental`. Usa `FromVolume(vol)` per specificare il volume sorgente.
+
+```go
+backup, err := arubaClient.FromStorage().Backups().Create(
+    ctx,
+    aruba.NewStorageBackup().
+        OfType(aruba.StorageBackupTypeFull).
+        Named("my-backup").
+        Tagged("backup").
+        InProject(proj).
+        RetainedForDays(30).
+        FromVolume(bs).
+        BilledBy(aruba.BillingPeriodHour))
+if err != nil {
+    log.Fatalf("Create StorageBackup: %v", err)
+}
+
+if err := backup.WaitUntilReady(ctx); err != nil {
+    log.Fatalf("StorageBackup did not become Active: %v", err)
+}
+fmt.Printf("✓ Storage Backup: %s\n", backup.Name())
+```
+
+**Accessor di risposta**:
+- `ID()`, `URI()`, `Name()`, `Tags()`
+- `BackupID()` — ID backup assegnato dal provider
+- `Type()` — tipo di backup
+- `RetentionDays()` — periodo di conservazione in giorni
+- `OriginURI()` — URI del volume sorgente
+- `BillingPeriod()` — cadenza di fatturazione
+- `State()`, `FailureReason()`, `PreviousState()`, `IsDisabled()`, `DisableReasons()`
+- `WaitUntilReady(ctx, opts...)`, `WaitUntilActive(ctx, opts...)`, `WaitUntilStates(ctx, []types.State{...}, opts...)`, `WaitUntilGone(ctx, opts...)`
+- `Raw()` — struct wire sottostante
+
+:::tip Esempio eseguibile
+Esempio end-to-end completo: [`examples/all-resources/resource_storage_backup.go`](https://github.com/Arubacloud/sdk-go/blob/main/examples/all-resources/resource_storage_backup.go)
+:::
+
+---
+
+### Storage Restore
+
+```go
+arubaClient.FromStorage().Restores()
+```
+
+**Operazioni supportate**: `Create`, `List`, `Get`, `Delete`
+**Asincrono**: sì — chiama `WaitUntilReady(ctx)` dopo `Create`.
+
+```go
+restore, err := arubaClient.FromStorage().Restores().Create(
+    ctx,
+    aruba.NewStorageRestore().
+        Named("my-restore").
+        Tagged("restore").
+        FromBackup(backup).
+        WithTarget(aruba.URI(backup.OriginURI())))
+if err != nil {
+    log.Fatalf("Create StorageRestore: %v", err)
+}
+
+if err := restore.WaitUntilReady(ctx); err != nil {
+    log.Fatalf("StorageRestore did not become Active: %v", err)
+}
+fmt.Printf("✓ Storage Restore: %s\n", restore.Name())
+```
+
+**Accessor di risposta**:
+- `ID()`, `URI()`, `Name()`, `Tags()`
+- `RestoreID()` — ID restore assegnato dal provider
+- `TargetURI()` — URI del volume target
+- `State()`, `FailureReason()`, `PreviousState()`, `IsDisabled()`, `DisableReasons()`
+- `WaitUntilReady(ctx, opts...)`, `WaitUntilActive(ctx, opts...)`, `WaitUntilStates(ctx, []types.State{...}, opts...)`, `WaitUntilGone(ctx, opts...)`
+- `Raw()` — struct wire sottostante
+
+:::tip Esempio eseguibile
+Esempio end-to-end completo: [`examples/all-resources/resource_storage_restore.go`](https://github.com/Arubacloud/sdk-go/blob/main/examples/all-resources/resource_storage_restore.go)
+:::
+
+---
+
+## Opzioni di Chiamata
+
+Passa le opzioni di chiamata come argomenti variadic a qualsiasi chiamata `List`, `Get`, `Create`, `Update` o `Delete`:
+
+| Opzione | Scopo |
+|---------|-------|
+| `aruba.WithFilter(expr)` | Espressione di filtro lato server |
+| `aruba.WithSort(expr)` | Espressione di ordinamento |
+| `aruba.WithLimit(n)` | Dimensione della pagina |
+| `aruba.WithOffset(n)` | Offset di paginazione |
+| `aruba.WithProjection(expr)` | Proiezione dei campi |
+| `aruba.WithAPIVersion(v)` | Sovrascrive la versione API per questa chiamata |
+
+Vedi [Filtri](./filters) per la sintassi di filtro e ordinamento.
+
+---
+
+## Costanti Enum
+
+Tutti i tipi enum sono ri-esportati da `pkg/aruba` — non è necessario alcun import aggiuntivo. L'elenco canonico si trova in `pkg/aruba/aliases.go`.
+
+### Regione e Zona
+
+| Costante | Descrizione |
+|----------|-------------|
+| `aruba.RegionITBGBergamo` | Datacenter di Bergamo (Italia) |
+| `aruba.ZoneITBG1` | Zona di disponibilità Bergamo 1 |
+| `aruba.ZoneITBG2` | Zona di disponibilità Bergamo 2 |
+| `aruba.ZoneITBG3` | Zona di disponibilità Bergamo 3 |
+
+### Fatturazione
+
+| Costante | Descrizione |
+|----------|-------------|
+| `aruba.BillingPeriodHour` | Fatturazione oraria |
+| `aruba.BillingPeriodMonth` | Fatturazione mensile |
+
+### Network
+
+| Costante | Valore |
+|----------|--------|
+| `aruba.RuleDirectionIngress` | `"Ingress"` |
+| `aruba.RuleDirectionEgress` | `"Egress"` |
+| `aruba.RuleProtocolTCP` | `"TCP"` |
+| `aruba.RuleProtocolUDP` | `"UDP"` |
+| `aruba.RuleProtocolICMP` | `"ICMP"` |
+| `aruba.RuleProtocolANY` | (wildcard — qualsiasi protocollo) |
+| `aruba.SubnetTypeBasic` | `"Basic"` |
+| `aruba.SubnetTypeAdvanced` | `"Advanced"` |
+
+### Compute
+
+| Costante | Descrizione |
+|----------|-------------|
+| `aruba.CloudServerFlavorCSO1A2` | 1 vCPU, 2 GB RAM |
+| `aruba.CloudServerFlavorCSO2A4` | 2 vCPU, 4 GB RAM |
+| `aruba.CloudServerFlavorCSO4A8` | 4 vCPU, 8 GB RAM |
+| `aruba.CloudServerFlavorCSO8A16` | 8 vCPU, 16 GB RAM |
+| … (vedi `aliases.go` per l'elenco completo) | |
+
+### Container
+
+| Costante | Descrizione |
+|----------|-------------|
+| `aruba.KubernetesVersion1323` | Kubernetes 1.32.3 |
+| `aruba.KubernetesVersion1332` | Kubernetes 1.33.2 |
+| `aruba.KubernetesVersion1341` | Kubernetes 1.34.1 |
+| `aruba.NodePoolInstanceK2A4` | 2 vCPU, 4 GB RAM |
+| `aruba.NodePoolInstanceK4A8` | 4 vCPU, 8 GB RAM |
+| `aruba.NodePoolInstanceK8A16` | 8 vCPU, 16 GB RAM |
+| … (vedi `aliases.go` per l'elenco completo) | |
+| `aruba.ContainerRegistrySizeFlavorSmall` | Livello utenti concorrenti piccolo |
+| `aruba.ContainerRegistrySizeFlavorMedium` | Livello utenti concorrenti medio |
+| `aruba.ContainerRegistrySizeFlavorHighPerf` | Livello ad alte prestazioni |
+
+### Database
+
+| Costante | Descrizione |
+|----------|-------------|
+| `aruba.DatabaseEngineMySQL80` | MySQL 8.0 |
+| `aruba.DatabaseEngineMSSQL2022Web` | SQL Server 2022 Web |
+| `aruba.DatabaseEngineMSSQL2022Standard` | SQL Server 2022 Standard |
+| `aruba.DatabaseEngineMSSQL2022Enterprise` | SQL Server 2022 Enterprise |
+| `aruba.DBaaSFlavorDBO1A2` | 1 vCPU, 2 GB RAM |
+| `aruba.DBaaSFlavorDBO2A4` | 2 vCPU, 4 GB RAM |
+| `aruba.DBaaSFlavorDBO4A8` | 4 vCPU, 8 GB RAM |
+| … (vedi `aliases.go` per l'elenco completo) | |
+
+### Storage
+
+| Costante | Valore |
+|----------|--------|
+| `aruba.BlockStorageTypeStandard` | `"Standard"` |
+| `aruba.BlockStorageTypePerformance` | `"Performance"` |
+| `aruba.StorageBackupTypeFull` | `"Full"` |
+| `aruba.StorageBackupTypeIncremental` | `"Incremental"` |
+
+### Security
+
+| Costante | Valore |
+|----------|--------|
+| `aruba.KeyAlgorithmAes` | `"Aes"` |
+| `aruba.KeyAlgorithmRsa` | `"Rsa"` |
+| `aruba.KeyTypeSymmetric` | `"Symmetric"` |
+| `aruba.KeyTypeAsymmetric` | `"Asymmetric"` |
+| `aruba.ServiceStatusCertificateAvailable` | `"CertificateAvailable"` |
+
+### Crittografia VPN
+
+| Costante | Descrizione |
+|----------|-------------|
+| `aruba.IKEEncryptionAES256` | AES-256 CBC (IKE fase 1) |
+| `aruba.IKEHashSHA256` | HMAC-SHA-256 (IKE fase 1) |
+| `aruba.IKEDHGroup14` | Gruppo Diffie-Hellman MODP-2048 |
+| `aruba.ESPEncryptionAES256` | AES-256 CBC (ESP fase 2) |
+| `aruba.ESPHashSHA256` | HMAC-SHA-256 (ESP fase 2) |
+| `aruba.ESPPFSGroupEnable` | PFS abilitato (gruppo DH negoziato) |
+| `aruba.ESPPFSGroupDisable` | PFS disabilitato |
+| … (vedi `aliases.go` per gli elenchi completi) | |
+
+### Schedule
+
+| Costante | Valore |
+|----------|--------|
+| `aruba.JobTypeOneShot` | `"OneShot"` |
+| `aruba.JobTypeRecurring` | `"Recurring"` |
+
+---
+
+## Appendice: Tipi Wire Grezzi (`pkg/types`)
+
+I seguenti tipi sono le struct wire di basso livello. Normalmente vi si accede solo tramite `.Raw()` o `.RawRequest()` su un wrapper, o quando si costruiscono integrazioni avanzate con `pkg/async`. Sono anche ri-esportati come alias di tipo `aruba.XxxRequest` / `aruba.XxxResponse` così da poterli referenziare senza un import aggiuntivo.
+
+| Tipo | File | Note |
+|------|------|------|
+| `Response[T]` | `resource.go` | Envelope HTTP generico restituito dagli adapter di basso livello |
+| `ErrorResponse` | `error.go` | Errore strutturato RFC 7807 |
+| `ListResponse` | `resource.go` | Link di paginazione e conteggio totale |
+| `ResourceMetadataRequest` | `resource.go` | Nome + tag per Create |
+| `RegionalResourceMetadataRequest` | `resource.go` | Estende i metadati con Location |
+| `ResourceMetadataResponse` | `resource.go` | ID, URI, Name, timestamp |
+| `ResourceStatus` | `resource.go` | Campo State |
+| `ReferenceResource` | `resource.go` | Link `{uri: "…"}` a un'altra risorsa |
+| `RequestParameters` | `parameters.go` | Struct filter/sort/limit/offset di basso livello (preferire gli helper `CallOption`) |
+| `ProjectRequest` / `ProjectResponse` / `ProjectList` | `project.project.go` | |
+| `VPCRequest` / `VPCResponse` / `VPCList` | `network.vpc.go` | |
+| `SubnetRequest` / `SubnetResponse` / `SubnetList` | `network.subnet.go` | |
+| `SecurityGroupRequest` / `SecurityGroupResponse` | `network.security-group.go` | |
+| `SecurityRuleRequest` / `SecurityRuleResponse` | `network.security-rule.go` | |
+| `ElasticIPRequest` / `ElasticIPResponse` | `network.elastic-ip.go` | |
+| `CloudServerRequest` / `CloudServerResponse` | `compute.cloudserver.go` | |
+| `KeyPairRequest` / `KeyPairResponse` | `compute.keypair.go` | |
+| `KaaSRequest` / `KaaSResponse` / `KaaSUpdateRequest` | `container.kaas.go` | |
+| `ContainerRegistryRequest` / `ContainerRegistryResponse` | `container.containerregistry.go` | |
+| `DBaaSRequest` / `DBaaSResponse` | `database.dbaas.go` | |
+| `KmsRequest` / `KmsResponse` | `security.kms.go` | |
+| `KeyRequest` / `KeyResponse` | `security.kms.go` | |
+| `KmipRequest` / `KmipResponse` / `KmipCertificateResponse` | `security.kms.go` | |
+| `BlockStorageRequest` / `BlockStorageResponse` | `storage.block-storage.go` | |
+| `SnapshotRequest` / `SnapshotResponse` | `storage.snapshot.go` | |
+| `StorageBackupRequest` / `StorageBackupResponse` | `storage.backup.go` | |
+| `JobRequest` / `JobResponse` / `JobList` | `schedule.job.go` | |
+| `AlertResponse` / `AlertsListResponse` | `metrics.alert.go` | |
+| `MetricResponse` / `MetricListResponse` | `metrics.metric.go` | |
+| `AuditEvent` / `AuditEventListResponse` | `audit.event.go` | |
+| `VPCPeeringRequest` / `VPCPeeringResponse` | `network.vpc-peering.go` | |
+| `VPNTunnelRequest` / `VPNTunnelResponse` | `network.vpn-tunnel.go` | |
+| `VPNRouteRequest` / `VPNRouteResponse` | `network.vpn-route.go` | |
+| `LoadBalancerResponse` | `network.load-balancer.go` | |

--- a/docs/website/i18n/it/docusaurus-plugin-content-docs/version-0.3.0/response-handling.md
+++ b/docs/website/i18n/it/docusaurus-plugin-content-docs/version-0.3.0/response-handling.md
@@ -1,0 +1,178 @@
+# Guida alla Gestione delle Risposte
+
+## Panoramica
+
+Il layer wrapper dell'SDK gestisce automaticamente il parsing delle risposte e la segnalazione degli errori. Ogni metodo CRUD restituisce o un wrapper popolato (in caso di successo) o un errore. Raramente è necessario ispezionare direttamente l'envelope HTTP grezzo — ma gli strumenti per farlo sono sempre disponibili.
+
+## Pattern Base
+
+Ogni metodo wrapper restituisce `(wrapper, error)`. L'errore è non-nil sia per errori di rete che per errori a livello API (4xx / 5xx).
+
+```go
+vpc, err := arubaClient.FromNetwork().VPCs().Get(ctx,
+    aruba.URI("/projects/<projectID>/providers/Aruba.Network/vpcs/<vpcID>"),
+)
+if err != nil {
+    log.Fatalf("Get VPC failed: %v", err)
+}
+fmt.Printf("VPC: %s (state: %s)\n", vpc.Name(), vpc.State())
+```
+
+## Errori HTTP Tipizzati
+
+Quando l'API restituisce una risposta 4xx o 5xx, l'SDK la racchiude in `*aruba.HTTPError`. Usa `errors.As` per ispezionare il codice di stato e il corpo dell'errore strutturato:
+
+```go
+import "errors"
+
+vpc, err := arubaClient.FromNetwork().VPCs().Get(ctx, ref)
+if err != nil {
+    var httpErr *aruba.HTTPError
+    if errors.As(err, &httpErr) {
+        fmt.Printf("API error %d: %s\n", httpErr.StatusCode, httpErr.Error())
+        if httpErr.ErrResp != nil {
+            fmt.Printf("  title:  %s\n", derefStr(httpErr.ErrResp.Title))
+            fmt.Printf("  detail: %s\n", derefStr(httpErr.ErrResp.Detail))
+            for _, ve := range httpErr.ErrResp.Errors {
+                fmt.Printf("  field %s: %s\n", ve.Field, ve.Message)
+            }
+        }
+    } else {
+        // Errore di rete, timeout del contesto, ecc.
+        log.Fatalf("Request failed: %v", err)
+    }
+}
+```
+
+## Pattern Completo di Gestione degli Errori
+
+```go
+proj, err := arubaClient.FromProject().Get(ctx, ref)
+if err != nil {
+    var httpErr *aruba.HTTPError
+    if errors.As(err, &httpErr) {
+        switch httpErr.StatusCode {
+        case 404:
+            return fmt.Errorf("project not found")
+        case 400:
+            return fmt.Errorf("bad request: %s", derefStr(httpErr.ErrResp.Detail))
+        default:
+            return fmt.Errorf("API error (%d): %s", httpErr.StatusCode, httpErr.Error())
+        }
+    }
+    return fmt.Errorf("request failed: %w", err)
+}
+// proj è popolato — usalo direttamente
+fmt.Printf("Project: %s (tags: %v)\n", proj.Name(), proj.Tags())
+```
+
+## Accessori dell'Envelope HTTP
+
+Ogni wrapper prodotto da una chiamata Create / Get / Update / List espone il suo envelope HTTP grezzo:
+
+```go
+// Dopo qualsiasi chiamata CRUD:
+proj, err := arubaClient.FromProject().Create(ctx, p)
+// …
+
+fmt.Println("Status:", proj.StatusCode())
+fmt.Println("Headers:", proj.Headers())
+rawResp, rawBody := proj.RawHTTP()
+fmt.Println("Raw body:", string(rawBody))
+fmt.Println("HTTP status:", rawResp.StatusCode)
+fmt.Println("Error body (if any):", proj.RawError())
+```
+
+## Accesso alla Risposta Wire Grezza
+
+Ogni wrapper ha un metodo `Raw()` che restituisce lo struct di risposta tipizzato sottostante da `pkg/types`. È utile per i campi non ancora promossi alla superficie del wrapper:
+
+```go
+vpc, err := arubaClient.FromNetwork().VPCs().Get(ctx, ref)
+if err != nil { /* … */ }
+
+raw := vpc.Raw()                         // struct wire sottostante
+fmt.Println(raw.Properties.IsDefault)    // campo non sul wrapper
+```
+
+### Convenienza JSON / YAML
+
+Per flag CLI come `--output json` / `--output yaml`, ogni wrapper espone slice di byte già serializzate:
+
+```go
+fmt.Println(string(vpc.RawJSON()))   // payload codificato in JSON
+fmt.Println(string(vpc.RawYAML()))   // payload codificato in YAML
+```
+
+Restituisce `nil` se il wrapper non è ancora stato popolato (receiver a valore zero).
+
+## Risposte List
+
+`List[T]` espone la stessa superficie di introspezione dei wrapper per risorsa singola, senza mai dover importare `pkg/types`:
+
+```go
+vpcList, err := arubaClient.FromNetwork().VPCs().List(ctx, proj)
+if err != nil { /* … */ }
+
+// Paginazione e conteggi — accessor tipizzati sul wrapper.
+fmt.Println("server total:", vpcList.Total())
+if vpcList.HasNext() {
+    nextPage, _ := vpcList.Next(ctx)
+    _ = nextPage
+}
+
+// Envelope HTTP — stessi accessor dei wrapper per risorsa singola.
+fmt.Println("status:", vpcList.StatusCode())
+fmt.Println("trace-id:", vpcList.Headers().Get("X-Trace-Id"))
+_, body := vpcList.RawHTTP()
+fmt.Println("raw body bytes:", len(body))
+```
+
+### Convenienza JSON / YAML
+
+Anche `List[T]` espone `RawJSON()` e `RawYAML()` per il payload della lista tipizzata:
+
+```go
+fmt.Println(string(vpcList.RawJSON()))   // payload codificato in JSON
+fmt.Println(string(vpcList.RawYAML()))   // payload codificato in YAML
+```
+
+Restituisce `nil` quando la lista non ha payload (`Raw() == nil`).
+
+> **Accedere a campi non promossi.** Se hai bisogno di un campo non esposto dalla superficie del wrapper, vedi [Lavorare a Basso Livello](./working-at-low-level) — copre il cast alla struct wire tipizzata e gli altri escape hatch che richiedono l'import di `pkg/types`.
+
+## Errori in Fase di Setter
+
+I setter del builder fluente non restituiscono mai errori — li registrano internamente. L'errore emerge alla prima chiamata `Create` o `Update`. Puoi anche controllarlo in anticipo:
+
+```go
+rule := aruba.NewSecurityRule().
+    InSecurityGroup(sg).
+    TargetingCIDR("0.0.0.0/0").
+    TargetingSecurityGroup(otherSG) // setter in conflitto — registra un errore
+
+if err := rule.Err(); err != nil {
+    log.Fatalf("Bad rule configuration: %v", err)
+}
+```
+
+## Best Practice
+
+1. **Controlla sempre `err` prima** — copre sia gli errori di rete che quelli API.
+2. **Usa `errors.As(err, &httpErr)`** per ottenere dettagli strutturati sugli errori 4xx/5xx.
+3. **Controlla `httpErr.ErrResp.Errors`** per messaggi di validazione a livello di campo sugli errori 400.
+4. **Usa `httpErr.ErrResp.TraceID`** quando apri una richiesta di supporto.
+5. **Usa `.Raw()` con parsimonia** — preferisci gli accessor tipizzati del wrapper.
+6. **Controlla `wrapper.Err()` prima di Create/Update** quando la catena di builder è lunga.
+
+---
+
+```go
+// Helper usato negli esempi sopra
+func derefStr(s *string) string {
+    if s == nil {
+        return ""
+    }
+    return *s
+}
+```

--- a/docs/website/i18n/it/docusaurus-plugin-content-docs/version-0.3.0/version-0.3.0.json
+++ b/docs/website/i18n/it/docusaurus-plugin-content-docs/version-0.3.0/version-0.3.0.json
@@ -1,0 +1,30 @@
+{
+  "version.label": {
+    "message": "0.3.0",
+    "description": "The label for version current"
+  },
+  "sidebar.tutorialSidebar.category.Quick Start": {
+    "message": "Guida Rapida",
+    "description": "The label for category Quick Start in sidebar tutorialSidebar"
+  },
+  "sidebar.tutorialSidebar.category.Resources": {
+    "message": "Risorse",
+    "description": "The label for category Resources in sidebar tutorialSidebar"
+  },
+  "sidebar.tutorialSidebar.category.Types": {
+    "message": "Tipi",
+    "description": "The label for category Types in sidebar tutorialSidebar"
+  },
+  "sidebar.tutorialSidebar.category.Options": {
+    "message": "Opzioni",
+    "description": "The label for category Options in sidebar tutorialSidebar"
+  },
+  "sidebar.tutorialSidebar.category.Response Handling": {
+    "message": "Gestione Risposte",
+    "description": "The label for category Response Handling in sidebar tutorialSidebar"
+  },
+  "sidebar.tutorialSidebar.category.Filters": {
+    "message": "Filtri",
+    "description": "The label for category Filters in sidebar tutorialSidebar"
+  }
+}

--- a/docs/website/i18n/it/docusaurus-plugin-content-docs/version-0.3.0/walkthrough.md
+++ b/docs/website/i18n/it/docusaurus-plugin-content-docs/version-0.3.0/walkthrough.md
@@ -1,0 +1,338 @@
+---
+sidebar_position: 2
+---
+
+# Guida al Walkthrough API
+
+L'SDK Go di Aruba Cloud fornisce un singolo import — `github.com/Arubacloud/sdk-go/pkg/aruba` — che espone un'API fluente con pattern builder per ogni risorsa cloud. Si costruisce la descrizione della risorsa con una catena `aruba.NewX()`, la si passa al metodo del client appropriato (`Create`, `Get`, `Update`, `Delete` o `List`), e si lavora con il wrapper tipizzato restituito.
+
+Le risorse sono organizzate in un **Progetto**, e le risorse figlio referenziano i propri genitori tramite l'interfaccia `aruba.Ref`. Non è mai necessario estrarre o passare manualmente stringhe di ID grezzi: si passa direttamente il wrapper idratato (restituito da `Create` o `Get`) come parametro `Ref` ai metodi builder come `InProject(proj)`, `InVPC(vpc)` o `InSecurityGroup(sg)`.
+
+Questa pagina illustra il ciclo CRUD completo su un esempio minimale — Project + VPC + Subnet. Ogni altra risorsa segue esattamente la stessa struttura. Vedi [Risorse](./resources) per snippet pronti all'uso per tutte le risorse supportate.
+
+---
+
+## 1. Inizializzare il Client
+
+```go
+package main
+
+import (
+    "context"
+    "log"
+    "time"
+
+    "github.com/Arubacloud/sdk-go/pkg/aruba"
+)
+
+func main() {
+    arubaClient, err := aruba.NewClient(aruba.DefaultOptions(clientID, clientSecret))
+    if err != nil {
+        log.Fatalf("Failed to create client: %v", err)
+    }
+
+    ctx, cancel := context.WithTimeout(context.Background(), 30*time.Minute)
+    defer cancel()
+}
+```
+
+`aruba.NewClient` accetta un valore `*aruba.Options`. `aruba.DefaultOptions(clientID, clientSecret)` è il modo più rapido per iniziare; vedi [Opzioni di Configurazione](./options) per credenziali Vault, caching token Redis, logger personalizzati e altro.
+
+Il `aruba.Client` restituito è una facciata che espone sub-client specifici per dominio:
+`FromProject()`, `FromAudit()`, `FromCompute()`, `FromContainer()`, `FromDatabase()`, `FromMetric()`, `FromNetwork()`, `FromSchedule()`, `FromSecurity()`, `FromStorage()`.
+
+---
+
+## 2. Provisioning delle Risorse
+
+Le risorse vengono create inline: si costruisce la richiesta con `aruba.NewX()` e la si passa direttamente a `Create`. Il wrapper restituito porta l'ID e l'URI della risorsa — lo si passa come `Ref` ai builder delle risorse figlio.
+
+### Progetto
+
+Il Progetto è il contenitore di livello superiore. Ogni altra risorsa appartiene a un progetto. È pronto in modo sincrono dopo che `Create` ritorna — non è necessario il polling.
+
+```go
+proj, err := arubaClient.FromProject().Create(
+    ctx,
+    aruba.NewProject().
+        Named("my-project").
+        Tagged("go-sdk").
+        DescribedAs("Created via the Aruba Cloud Go SDK").
+        NotDefault())
+if err != nil {
+    log.Fatalf("Create project: %v", err)
+}
+fmt.Printf("✓ Progetto creato: %s (ID: %s)\n", proj.Name(), proj.ID())
+```
+
+### VPC
+
+```go
+vpc, err := arubaClient.FromNetwork().VPCs().Create(
+    ctx,
+    aruba.NewVPC().
+        Named("my-vpc").
+        Tagged("network").
+        InProject(proj).
+        InRegion(aruba.RegionITBGBergamo).
+        NotDefault().
+        WithoutPreset())
+if err != nil {
+    log.Fatalf("Create VPC: %v", err)
+}
+fmt.Printf("✓ VPC creata: %s\n", vpc.Name())
+
+// La maggior parte delle risorse è asincrona — attendi che raggiungano uno stato stabile.
+// Vedi "7. Attendere la Disponibilità" per le opzioni e i dettagli.
+if err := vpc.WaitUntilReady(ctx); err != nil {
+    log.Fatalf("VPC did not become Active: %v", err)
+}
+```
+
+`InProject(proj)` accetta qualsiasi `aruba.Ref` — lega lo scope del progetto senza richiedere l'estrazione di un ID stringa grezzo.
+
+### Subnet
+
+```go
+subnet, err := arubaClient.FromNetwork().Subnets().Create(
+    ctx,
+    aruba.NewSubnet().
+        OfType(aruba.SubnetTypeAdvanced).
+        Named("my-subnet").
+        Tagged("network").
+        InVPC(vpc).
+        InRegion(aruba.RegionITBGBergamo).
+        WithCIDR("192.168.1.0/25").
+        WithDHCP(aruba.NewSubnetDHCP().
+            Enabled().
+            WithRange("192.168.1.10", 50).
+            WithRoutes(aruba.SubnetDHCPRoute{Address: "10.0.0.0/8", Gateway: "192.168.1.1"}).
+            WithDNSServers("8.8.8.8", "8.8.4.4")).
+        NotDefault())
+if err != nil {
+    log.Fatalf("Create subnet: %v", err)
+}
+fmt.Printf("✓ Subnet creata: %s (CIDR: %s)\n", subnet.Name(), subnet.CIDR())
+
+if err := subnet.WaitUntilReady(ctx); err != nil {
+    log.Fatalf("Subnet did not become Active: %v", err)
+}
+```
+
+`aruba.NewSubnetDHCP()` è un sub-builder per la configurazione DHCP. Si allega alla subnet con `WithDHCP(...)`.
+
+`OfType` accetta `aruba.SubnetTypeBasic` o `aruba.SubnetTypeAdvanced` (costanti tipizzate — nessun cast a stringa necessario).
+
+> Ogni altra risorsa — Security Group, Elastic IP, Block Storage, Cloud Server, cluster KaaS, istanze DBaaS e altro — segue esattamente la stessa struttura `NewX()` → `IntoParent(ref)` → `Create(ctx, ...)` → `WaitUntilReady(ctx)`. Vedi [Risorse](./resources) per l'elenco completo con snippet pronti all'uso.
+
+---
+
+## 3. Aggiornare una Risorsa Esistente
+
+Prima si recupera la risorsa, poi la si muta tramite setter, poi si chiama `Update`. Il wrapper di risposta da `Get` porta tutto lo stato interno (URI padre, riferimenti di rete, ecc.) che viene trasferito automaticamente nella richiesta `Update`.
+
+```go
+// Recupera
+vpc, err = arubaClient.FromNetwork().VPCs().Get(ctx, vpc)
+if err != nil {
+    log.Fatalf("Get VPC: %v", err)
+}
+
+// Muta
+vpc.Named("my-vpc-updated").
+    RetaggedAs("network", "updated")
+
+// Aggiorna
+updated, err := arubaClient.FromNetwork().VPCs().Update(ctx, vpc)
+if err != nil {
+    log.Fatalf("Update VPC: %v", err)
+}
+fmt.Printf("✓ VPC aggiornata: %s\n", updated.Name())
+```
+
+> **Importante**: Chiama sempre `Get` prima di `Update`. Chiamare `Update` su un wrapper appena costruito (senza un precedente `Create` o `Get`) restituisce un errore: `"Update: resource has no ID"`.
+
+---
+
+## 4. Elencare Risorse Esistenti
+
+`List` accetta un `Ref` genitore e restituisce un `*aruba.List[T]`. Si iterano gli elementi con `Items()`:
+
+```go
+list, err := arubaClient.FromNetwork().VPCs().List(ctx, proj)
+if err != nil {
+    log.Fatalf("List VPCs: %v", err)
+}
+fmt.Println("Totale VPC:", list.Total())
+for _, v := range list.Items() {
+    fmt.Println("-", v.Name(), v.ID())
+}
+```
+
+Gli elementi nella lista sono wrapper leggeri — portano l'ID e l'URI della risorsa, così puoi passarli direttamente a `Get`, `Update` o `Delete` come `Ref`:
+
+```go
+for _, v := range list.Items() {
+    full, err := arubaClient.FromNetwork().VPCs().Get(ctx, v)
+    // full ha tutti i campi popolati
+}
+```
+
+Per il filtraggio lato server, ordinamento e paginazione vedi [Filtri](./filters).
+
+---
+
+## 5. Ottenere una Risorsa Specifica
+
+Usa `Get` quando hai un `Ref` (un wrapper idratato, o un elemento di `*aruba.List[T]`):
+
+```go
+vpc, err := arubaClient.FromNetwork().VPCs().Get(ctx, vpc)
+if err != nil {
+    log.Fatalf("Get VPC: %v", err)
+}
+```
+
+### L'escape hatch `aruba.URI(…)`
+
+Quando hai solo un identificatore di risorsa come stringa — ad esempio, letto da una variabile d'ambiente o da una configurazione esterna — avvolgilo in `aruba.URI(…)` per soddisfare l'interfaccia `aruba.Ref`:
+
+```go
+projectID := os.Getenv("PROJECT_ID")
+
+// Bootstrap di un wrapper tipizzato da un ID stringa
+proj, err := arubaClient.FromProject().Get(ctx, aruba.URI("/projects/"+projectID))
+if err != nil {
+    log.Fatalf("Get project: %v", err)
+}
+
+// Ora proj è completamente idratato — usalo come Ref per le risorse figlio
+vpcs, err := arubaClient.FromNetwork().VPCs().List(ctx, proj)
+```
+
+`aruba.URI(s)` restituisce un `Ref` leggero che l'SDK usa per estrarre gli ID degli antenati dai segmenti di percorso URI. Qualsiasi URI di risorsa valido funziona — l'SDK lo analizza internamente.
+
+---
+
+## 6. Eliminazione (Ordine Inverso)
+
+Elimina i figli prima dei genitori. L'API Aruba Cloud restituisce **HTTP 400** quando si tenta di eliminare un genitore che ha ancora risorse figlio attive o in fase di eliminazione — non 409/422. Il pattern sicuro è emettere ogni delete sul figlio, poi attendere che la risorsa sia completamente sparita prima di salire nella catena delle dipendenze.
+
+`WaitUntilGone` blocca finché la risorsa non esiste più — ovvero finché il suo `Get` restituisce HTTP 404. Chiamalo sul wrapper idratato già disponibile (`Delete` stesso restituisce solo un `error`, senza wrapper):
+
+```go
+// subnet → VPC → progetto
+if err := arubaClient.FromNetwork().Subnets().Delete(ctx, subnet); err != nil {
+    log.Printf("Delete subnet: %v", err)
+} else if err := subnet.WaitUntilGone(ctx); err != nil {
+    log.Printf("Subnet not gone: %v", err)
+}
+
+if err := arubaClient.FromNetwork().VPCs().Delete(ctx, vpc); err != nil {
+    log.Printf("Delete VPC: %v", err)
+} else if err := vpc.WaitUntilGone(ctx); err != nil {
+    log.Printf("VPC not gone: %v", err)
+}
+
+if err := arubaClient.FromProject().Delete(ctx, proj); err != nil {
+    log.Printf("Delete project: %v", err)
+}
+```
+
+`WaitUntilGone` accetta le stesse `WaitOption` di `WaitUntilReady` (`WithRetries`, `WithBaseDelay`, `WithTimeout`) ed è disponibile su ogni wrapper di risorsa che supporta il polling. `Project` non ha polling — viene eliminato per ultimo, senza figli rimasti su cui attendere.
+
+`Delete` accetta qualsiasi `aruba.Ref` — puoi passare il wrapper idratato direttamente o `aruba.URI(…)` se hai solo il percorso.
+
+Per una sequenza completa di teardown (Security Rule → Security Group → Subnet → VPC → Cloud Server → Block Storage → Progetto) vedi l'[Esempio Completo](#esempio-completo) in basso.
+
+---
+
+## 7. Attendere la Disponibilità
+
+La maggior parte delle operazioni cloud — Create, Update, operazioni di scaling — sono **asincrone**: la chiamata HTTP ritorna rapidamente, ma la risorsa continua a transitare tra stati (`Creating` → `Active`, `Updating` → `Active`) per secondi o minuti in background.
+
+Il metodo `WaitUntilReady` su qualsiasi wrapper di risorsa che incorpora `statusMixin` blocca finché la risorsa raggiunge lo stato `"Active"` (o restituisce un errore in caso di fallimento terminale):
+
+```go
+if err := vpc.WaitUntilReady(ctx); err != nil {
+    log.Fatalf("VPC did not become Active: %v", err)
+}
+```
+
+Tre `WaitOption` permettono di sovrascrivere i valori predefiniti (60 tentativi × 10 s di ritardo base × 600 s di scadenza rigida):
+
+```go
+if err := vpc.WaitUntilReady(ctx,
+    aruba.WithRetries(30),              // max iterazioni di polling (default: 60)
+    aruba.WithBaseDelay(5*time.Second), // ritardo fisso tra i poll (default: 10s)
+    aruba.WithTimeout(3*time.Minute),   // scadenza rigida (default: 600s)
+); err != nil {
+    log.Fatalf("VPC did not become Active: %v", err)
+}
+```
+
+Per `WaitUntilStates(ctx, []types.State{...}, opts...)` (qualsiasi insieme di stati target, non solo `"Active"`), gli accessor di stato (`State()`, `FailureReason()`, `PreviousState()`, `IsDisabled()`, `DisableReasons()`), e il primitivo di basso livello `pkg/async.WaitFor` per il polling concorrente, vedi la guida [Async / Await](./async).
+
+---
+
+## Avvertenze
+
+### Gli errori dei setter sono differiti
+
+I setter del builder non restituiscono mai un errore — lo registrano nel wrapper. L'errore viene restituito dalla prima chiamata `Create` o `Update`, oppure puoi controllarlo in anticipo:
+
+```go
+rule := aruba.NewSecurityRule().
+    InSecurityGroup(sg).
+    TargetingCIDR("0.0.0.0/0").
+    TargetingSecurityGroup(otherSG) // in conflitto — registrato come errore
+
+if err := rule.Err(); err != nil {
+    log.Fatalf("Bad rule config: %v", err)
+}
+```
+
+> **Avvertenza**: `TargetingCIDR` e `TargetingSecurityGroup` si escludono a vicenda. Impostarli entrambi registra un errore al momento del setter che emerge su `Create`.
+
+### `WaitUntilReady` richiede un wrapper idratato
+
+Chiamare `WaitUntilReady` su un wrapper costruito manualmente (senza `Create`/`Get`/`Update`/`List`) restituisce:
+
+```
+WaitUntilStates: refresh callback not set; resource must be produced by an adapter (Create/Get/Update/List) to support polling
+```
+
+Usa sempre il wrapper restituito dalla chiamata API, non il builder della richiesta.
+
+### Errori HTTP tipizzati
+
+Le risposte API non-2xx vengono restituite come `*aruba.HTTPError`. Usa `errors.As` per ispezionarle:
+
+```go
+vpc, err = arubaClient.FromNetwork().VPCs().Create(ctx, vpc)
+if err != nil {
+    var httpErr *aruba.HTTPError
+    if errors.As(err, &httpErr) {
+        log.Printf("API error %d: %s", httpErr.StatusCode, httpErr.Error())
+    } else {
+        log.Fatalf("Network error: %v", err)
+    }
+}
+```
+
+Vedi [Gestione delle Risposte](./response-handling) per la guida completa alla gestione degli errori.
+
+---
+
+## Esempio Completo
+
+La directory `examples/all-resources/` nel repository contiene un esempio end-to-end eseguibile che dimostra tutte le risorse:
+
+```bash
+go run ./examples/all-resources/ -mode=create -clientID=… -clientSecret=…
+go run ./examples/all-resources/ -mode=update -clientID=… -clientSecret=… -projectID=…
+go run ./examples/all-resources/ -mode=delete -clientID=… -clientSecret=… -projectID=…
+
+# Aggiungi -debug per il logging verboso dell'SDK:
+go run ./examples/all-resources/ -mode=create -clientID=… -clientSecret=… -debug
+```

--- a/docs/website/i18n/it/docusaurus-plugin-content-docs/version-0.3.0/working-at-low-level.md
+++ b/docs/website/i18n/it/docusaurus-plugin-content-docs/version-0.3.0/working-at-low-level.md
@@ -1,0 +1,268 @@
+# Lavorare a Basso Livello
+
+## Perché questa pagina esiste
+
+L'SDK è progettato attorno a un **principio di import singolo**: importare solo `github.com/Arubacloud/sdk-go/pkg/aruba` copre circa il 99,9% dei casi d'uso reali.
+
+La superficie wrapper — accessor tipizzati, helper `WaitUntil*`, `RawJSON()` / `RawYAML()` — è progettata in modo che raramente sia necessario accedere direttamente alle struct wire sottostanti. Per lo 0,1% dei casi in cui è necessario farlo, questa pagina raccoglie tutte le vie di uscita che richiedono un secondo import.
+
+> Questi pattern sono **intenzionali e supportati** — sono vie di uscita, non workaround. Quando incontri un caso non coperto dalla superficie wrapper, usa questi invece di aprire una feature request.
+
+---
+
+## Accedere ai campi wire non promossi con `Raw()`
+
+Ogni wrapper espone un metodo `Raw()` che restituisce la struct `*types.XxxResponse` sottostante. Usalo quando hai bisogno di un campo non ancora promosso alla superficie del wrapper:
+
+```go
+import (
+    "github.com/Arubacloud/sdk-go/pkg/aruba"
+    "github.com/Arubacloud/sdk-go/pkg/types"
+)
+
+vpc, err := arubaClient.FromNetwork().VPCs().Get(ctx, ref)
+if err != nil { /* … */ }
+
+raw := vpc.Raw()                          // *types.VPCResponse
+fmt.Println(raw.Properties.IsDefault)     // campo non promosso al wrapper
+```
+
+Per le liste, `Raw()` restituisce `any` e devi fare il type assert al tipo lista concreto:
+
+```go
+vpcList, err := arubaClient.FromNetwork().VPCs().List(ctx, proj)
+if err != nil { /* … */ }
+
+raw := vpcList.Raw().(*types.VPCList)     // richiede l'import di pkg/types
+fmt.Println("server total:", raw.Total)   // equivalente a vpcList.Total() — mostrato per illustrazione
+fmt.Println("self link:", raw.Self)
+```
+
+> **Preferisci gli accessor del wrapper per la serializzazione.** Se il tuo obiettivo è l'output JSON o YAML, usa `vpc.RawJSON()` / `vpc.RawYAML()` (o i metodi equivalenti su `List[T]`) — senza bisogno di importare `pkg/types`.
+>
+> ```go
+> fmt.Println(string(vpcList.RawJSON()))  // JSON senza pkg/types
+> fmt.Println(string(vpcList.RawYAML()))  // YAML senza pkg/types
+> ```
+
+---
+
+## Ispezionare gli errori di validazione strutturati
+
+`*aruba.HTTPError` è il tipo di errore per tutte le risposte 4xx/5xx. Il suo campo `ErrResp` è un `*types.ErrorResponse` e contiene dettagli strutturati RFC 7807 — inclusa una slice `[]types.ValidationError` per gli errori 400 a livello di campo:
+
+```go
+import (
+    "errors"
+    "github.com/Arubacloud/sdk-go/pkg/aruba"
+    "github.com/Arubacloud/sdk-go/pkg/types"
+)
+
+_, err := arubaClient.FromNetwork().VPCs().Create(ctx, vpc)
+if err != nil {
+    var httpErr *aruba.HTTPError
+    if errors.As(err, &httpErr) && httpErr.ErrResp != nil {
+        fmt.Printf("title:  %s\n", derefStr(httpErr.ErrResp.Title))
+        fmt.Printf("detail: %s\n", derefStr(httpErr.ErrResp.Detail))
+
+        // Errori di validazione a livello di campo — richiedono types.ValidationError
+        for _, ve := range httpErr.ErrResp.Errors {
+            fmt.Printf("  campo %s: %s\n", ve.Field, ve.Message)
+        }
+
+        // TraceID per le richieste di supporto
+        fmt.Printf("trace-id: %s\n", derefStr(httpErr.ErrResp.TraceID))
+    }
+}
+```
+
+### `MetadataValidationError`
+
+Un `*types.MetadataValidationError` viene restituito (insieme a un wrapper non-nil) quando una risposta API manca dei campi di metadati obbligatori (`id` o `uri`). Usa `errors.As` per rilevarlo:
+
+```go
+import (
+    "errors"
+    "github.com/Arubacloud/sdk-go/pkg/aruba"
+    "github.com/Arubacloud/sdk-go/pkg/types"
+)
+
+result, err := arubaClient.FromNetwork().VPCs().Create(ctx, vpc)
+if err != nil {
+    var mvErr *types.MetadataValidationError
+    if errors.As(err, &mvErr) {
+        // result è non-nil e parzialmente idratato; mvErr elenca i campi mancanti
+        fmt.Printf("metadati incompleti: %v\n", mvErr)
+        fmt.Printf("ID finora: %s\n", result.ID())
+    }
+}
+```
+
+---
+
+## Iterare `LinkedResources()`
+
+Ogni wrapper di risorsa espone `LinkedResources()` che restituisce `[]types.LinkedResource`. Ogni elemento ha un `URI string` e un `StrictCorrelation bool`:
+
+```go
+import (
+    "github.com/Arubacloud/sdk-go/pkg/aruba"
+    "github.com/Arubacloud/sdk-go/pkg/types"
+)
+
+vpc, err := arubaClient.FromNetwork().VPCs().Get(ctx, ref)
+if err != nil { /* … */ }
+
+for _, lr := range vpc.LinkedResources() {
+    fmt.Println("linked URI:", lr.URI)
+    if lr.StrictCorrelation {
+        fmt.Println("  → correlazione stretta (lifecycle-linked)")
+    }
+}
+```
+
+> Se hai bisogno solo delle stringhe URI — ad esempio per passarle a un'altra chiamata SDK come `aruba.URI(lr.URI)` — non hai bisogno di `types.LinkedResource`:
+>
+> ```go
+> for _, lr := range vpc.LinkedResources() {
+>     ref := aruba.URI(lr.URI)   // senza import di pkg/types
+>     _ = ref
+> }
+> ```
+
+---
+
+## Ispezionare i body delle richieste prima dell'invio
+
+Ogni wrapper espone `RawRequest()` che restituisce la struct di richiesta a livello wire (`*types.XxxRequest`). È utile per il debug o per passare la richiesta a un altro strumento:
+
+```go
+import (
+    "encoding/json"
+    "github.com/Arubacloud/sdk-go/pkg/aruba"
+    "github.com/Arubacloud/sdk-go/pkg/types"
+)
+
+vpc := aruba.NewVPC().
+    Named("my-vpc").
+    InProject(proj).
+    InRegion(aruba.RegionITBGBergamo).
+    AsDefault()
+
+req := vpc.RawRequest()               // types.VPCRequest — richiede import di pkg/types
+b, _ := json.MarshalIndent(req, "", "  ")
+fmt.Println(string(b))
+```
+
+---
+
+## Polling in background con `pkg/async` {#background-polling-with-pkgasync}
+
+`WaitUntilReady`, `WaitUntilActive` e `WaitUntilStates` bloccano la goroutine chiamante. Se devi **avviare più attese in modo concorrente**, o **fare il polling di una condizione arbitraria** (non solo uno stato di risorsa), usa direttamente il pacchetto `pkg/async` di livello inferiore.
+
+`pkg/async` è un pacchetto pubblico — importalo insieme a `pkg/aruba`:
+
+```go
+import (
+    "github.com/Arubacloud/sdk-go/pkg/aruba"
+    "github.com/Arubacloud/sdk-go/pkg/async"
+    "github.com/Arubacloud/sdk-go/pkg/types"
+)
+```
+
+### `WaitFor` — avvia un future in background
+
+`async.WaitFor` avvia immediatamente una goroutine di polling e restituisce un `*async.AsyncClient[T]` (un future). Chiami `.Await(ctx)` in seguito per bloccare e ottenere il risultato:
+
+```go
+// Avvia il polling di VPC1 e VPC2 in modo concorrente
+futureVPC1 := async.DefaultWaitFor(ctx,
+    func(ctx context.Context) (*types.Response[types.VPCResponse], error) {
+        return arubaClient.FromNetwork().VPCs().Get(ctx, vpc1)
+    },
+    func(resp *types.Response[types.VPCResponse]) (bool, error) {
+        if resp == nil || resp.Data == nil {
+            return false, nil
+        }
+        var state types.State
+        if resp.Data.Properties != nil && resp.Data.Properties.Status != nil &&
+            resp.Data.Properties.Status.State != nil {
+            state = *resp.Data.Properties.Status.State
+        }
+        return state == types.StateActive, nil
+    },
+)
+
+futureVPC2 := async.DefaultWaitFor(ctx, /* stesso pattern per vpc2 */)
+
+// Blocca e attendi entrambi i risultati
+resp1, err1 := futureVPC1.Await(ctx)
+resp2, err2 := futureVPC2.Await(ctx)
+```
+
+`DefaultWaitFor` usa i valori predefiniti del pacchetto: `DefaultRetries=60`, `DefaultBaseDelay=10s`, `DefaultTimeout=600s`. Usa `async.WaitFor(ctx, retries, baseDelay, timeout, call, check)` per sovrascriverli.
+
+### Firma di `WaitFor`
+
+```go
+func WaitFor[T any](
+    ctx         context.Context,
+    retries     int,
+    baseDelay   time.Duration,
+    timeout     time.Duration,
+    call        func(ctx context.Context) (*types.Response[T], error),
+    check       func(*types.Response[T]) (bool, error),
+) *AsyncClient[T]
+```
+
+- `call` — la funzione di polling, chiamata una volta per ogni iterazione.
+- `check` — restituisce `(true, nil)` per segnalare il successo, `(true, error)` per segnalare un fallimento terminale, `(false, nil)` per continuare il polling.
+- Se `check` è `nil`, qualsiasi `response.Data` non-nil viene trattato come successo.
+
+### `AsyncClient.Await`
+
+```go
+func (f *AsyncClient[T]) Await(ctx context.Context) (*types.Response[T], error)
+```
+
+Blocca finché la goroutine in background invia il suo risultato oppure il `ctx` viene cancellato. Chiamate successive restituiscono il risultato **in cache** immediatamente — sicuro da chiamare più volte.
+
+> `pkg/async` lavora direttamente con le struct wire di `pkg/types`. Questo è l'unico livello dell'SDK dove interagirai direttamente con `types.Response[T]` e i tipi `types.*Response`.
+
+---
+
+## Cosa NON richiede `pkg/types`
+
+I seguenti elementi sono tutti disponibili con un singolo import di `pkg/aruba` — senza bisogno di un secondo import:
+
+| Cosa ti serve | Superficie `pkg/aruba` |
+|---|---|
+| Costanti di stato (`StateActive`, `StateStopped`, …) | `aruba.StateActive`, `aruba.StateStopped`, … |
+| Costanti regione / zona | `aruba.RegionITBGBergamo`, `aruba.ZoneITBG1`, … |
+| Periodo di fatturazione | `aruba.BillingPeriodHour`, `aruba.BillingPeriodMonth`, … |
+| Tutti gli enum compute, storage, network, security | Vedi `pkg/aruba/aliases.go` |
+| Attendere transizioni di stato | `wrapper.WaitUntilReady(ctx)`, `WaitUntilActive`, `WaitUntilStates` |
+| Serializzare una risposta in JSON / YAML | `wrapper.RawJSON()`, `wrapper.RawYAML()` |
+| Introspezione dell'envelope HTTP | `wrapper.StatusCode()`, `.Headers()`, `.RawHTTP()`, `.RawError()` |
+| Paginazione | `list.Total()`, `.HasNext()`, `.Next(ctx)`, `.All(ctx, yield)` |
+| Dettagli errore HTTP | `*aruba.HTTPError` — `StatusCode`, `ErrResp.Title`, `ErrResp.Detail`, `ErrResp.TraceID` |
+
+---
+
+## Vedi Anche
+
+- [Gestione delle Risposte](./response-handling) — errori HTTP tipizzati, accessor envelope, `RawJSON`/`RawYAML`
+- [Async / Await](./async) — `WaitUntilReady`, `WaitUntilStates`, opzioni di polling
+- [Guida al Walkthrough API](./walkthrough) — esempio completo del ciclo di vita Create + polling + Update + Delete
+
+---
+
+```go
+// Helper usato negli esempi sopra
+func derefStr(s *string) string {
+    if s == nil {
+        return ""
+    }
+    return *s
+}
+```

--- a/docs/website/i18n/it/docusaurus-plugin-content-docs/version-1.0.0/async.md
+++ b/docs/website/i18n/it/docusaurus-plugin-content-docs/version-1.0.0/async.md
@@ -1,0 +1,220 @@
+---
+sidebar_position: 3
+---
+
+# Async / Await
+
+La maggior parte delle operazioni API di Aruba Cloud sono **asincrone**: la chiamata HTTP ritorna rapidamente (con un `201 Created` o `200 OK`), ma la risorsa continua a transitare tra stati in background — `Creating` → `Active`, oppure `Updating` → `Active`, oppure `Deleting` → rimossa — per secondi o svariati minuti.
+
+L'SDK espone tre livelli per gestire questa situazione:
+
+| Livello | Quando usarlo |
+|---------|---------------|
+| `WaitUntilReady(ctx)` | 95% dei casi — blocca finché la risorsa è pronta (accetta `Active`, `Running`, `Stopped`, `NotUsed`, `Reserved`, `InUse`, `Used`) |
+| `WaitUntilActive(ctx)` | Quando hai specificamente bisogno solo dello stato `Active` |
+| `WaitUntilStates(ctx, []types.State{...}, opts...)` | Attendi uno o più stati specifici (es. `[]types.State{types.StateStopped}`) |
+| `WaitUntilGone(ctx)` | Dopo `Delete` — blocca finché il `Get` della risorsa restituisce HTTP 404 (completamente rimossa) |
+| `pkg/async.WaitFor` + `AsyncClient.Await` | Avanzato — avvia il polling in una goroutine in background, fai altro lavoro, raccogli il risultato in seguito |
+
+---
+
+## `WaitUntilReady`
+
+Dopo qualsiasi `Create`, `Update` o `Get`, chiama `WaitUntilReady` sul wrapper restituito per bloccare finché la risorsa raggiunge uno qualsiasi dei 7 stati stabili: `Active`, `Running`, `Stopped`, `NotUsed`, `Reserved`, `InUse`, o `Used`.
+
+```go
+vpc, err := arubaClient.FromNetwork().VPCs().Create(ctx, vpc)
+if err != nil {
+    log.Fatalf("Create VPC: %v", err)
+}
+
+if err := vpc.WaitUntilReady(ctx); err != nil {
+    log.Fatalf("VPC did not become ready: %v", err)
+}
+```
+
+`WaitUntilReady` effettua il polling dell'API ripetutamente con un ritardo fisso. Quando la risorsa entra in uno **stato terminale di errore** noto (es. `"Error"`, `"Failed"`), ritorna immediatamente con un errore descrittivo invece di esaurire tutti i tentativi.
+
+`WaitUntilActive` è disponibile quando hai specificamente bisogno dello stato `"Active"` — ad esempio dopo un'operazione di power-on.
+
+Vedi la [Guida al Walkthrough API](./walkthrough) per esempi completi di Create + polling + Update + Delete.
+
+### Personalizzare il comportamento di polling
+
+Tre opzioni di chiamata permettono di sovrascrivere i valori predefiniti:
+
+```go
+if err := vpc.WaitUntilReady(ctx,
+    aruba.WithRetries(30),              // max iterazioni di polling (default: 60)
+    aruba.WithBaseDelay(5*time.Second), // ritardo fisso tra i poll (default: 10s)
+    aruba.WithTimeout(3*time.Minute),   // scadenza rigida (default: 600s)
+); err != nil {
+    log.Fatalf("VPC did not become ready: %v", err)
+}
+```
+
+Il limite effettivo è `min(retries × baseDelay, timeout)`. Con i valori predefiniti: `min(60×10s, 600s) = 600s`.
+
+Per risorse a lunga esecuzione (Container Registry, DBaaS, KaaS) che possono richiedere 20–40 minuti, usa un budget maggiore:
+
+```go
+longWait := []aruba.WaitOption{
+    aruba.WithTimeout(40 * time.Minute),
+    aruba.WithRetries(240),
+}
+if err := reg.WaitUntilReady(ctx, longWait...); err != nil {
+    log.Fatalf("ContainerRegistry did not become ready: %v", err)
+}
+```
+
+---
+
+## `WaitUntilStates`
+
+Usa `WaitUntilStates` quando devi attendere uno o più stati specifici — ad esempio, attendere lo stato di stop dopo un'operazione di power-off:
+
+```go
+// Attendi che un Cloud Server si fermi completamente dopo PowerOff
+if err := cs.WaitUntilStates(ctx, []types.State{types.StateStopped}); err != nil {
+    log.Fatalf("Cloud Server did not stop: %v", err)
+}
+```
+
+```go
+// Attendi che un'istanza DBaaS finisca un aggiornamento in corso
+if err := db.WaitUntilActive(ctx,
+    aruba.WithRetries(120),
+    aruba.WithBaseDelay(15*time.Second),
+); err != nil {
+    log.Fatalf("DBaaS did not return to Active after update: %v", err)
+}
+```
+
+Si applica lo stesso comportamento di uscita anticipata per gli stati di errore terminali: se la risorsa raggiunge `"Error"` o `"Failed"` mentre si aspetta `"Stopped"`, la chiamata ritorna immediatamente con un errore che indica sia lo stato attuale che gli stati attesi.
+
+`WaitUntilActive` e `WaitUntilReady` sono wrapper di convenienza attorno a `WaitUntilStates`:
+- `WaitUntilActive(ctx, opts...)` — equivalente a `WaitUntilStates(ctx, []types.State{types.StateActive}, opts...)`
+- `WaitUntilReady(ctx, opts...)` — equivalente a `WaitUntilStates(ctx, []types.State{types.StateActive, types.StateRunning, types.StateStopped, types.StateNotUsed, types.StateReserved, types.StateInUse, types.StateUsed}, opts...)`
+
+---
+
+## `WaitUntilGone`
+
+Usa `WaitUntilGone` dopo una chiamata `Delete` per bloccare finché la risorsa è completamente rimossa — ovvero finché il suo `Get` restituisce HTTP 404:
+
+```go
+if err := arubaClient.FromNetwork().Subnets().Delete(ctx, subnet); err != nil {
+    log.Printf("Delete subnet: %v", err)
+} else if err := subnet.WaitUntilGone(ctx); err != nil {
+    log.Printf("Subnet not gone: %v", err)
+}
+```
+
+`WaitUntilGone` è disponibile su ogni wrapper di risorsa che supporta il polling (vedi [Risorse che Supportano il Polling](#risorse-che-supportano-il-polling) in basso). Accetta le stesse `WaitOption` di `WaitUntilReady`. Qualsiasi errore da `Get` diverso da HTTP 404 viene trattato come transitorio e riprovato; un 404 segnala il successo.
+
+`Project` non ha supporto al polling e quindi nessun `WaitUntilGone`. Viene eliminato per ultimo, senza figli da attendere.
+
+---
+
+## Accessor di Stato
+
+Ogni wrapper che supporta il polling espone anche accessor di stato dettagliati. Puoi leggerli in qualsiasi momento dopo una chiamata `Create`, `Get`, `Update` o `List`:
+
+| Metodo | Restituisce | Utilizzo tipico |
+|--------|-------------|-----------------|
+| `State()` | `types.State` — stato corrente | Logging, diramazione condizionale |
+| `PreviousState()` | `types.State` — stato prima dell'ultima transizione | Post-mortem dopo un'attesa fallita |
+| `FailureReason()` | `string` — testo di errore fornito dal server | Mostrare all'utente / log di alert |
+| `IsDisabled()` | `bool` | Bloccare operazioni quando il server disabilita una risorsa |
+| `DisableReasons()` | `[]string` | Spiegare perché una risorsa è disabilitata |
+
+Un pattern comune — chiamare `WaitUntilReady` e, in caso di errore, allegare la motivazione di fallimento del server all'errore:
+
+```go
+if err := vpc.WaitUntilReady(ctx); err != nil {
+    reason := vpc.FailureReason()
+    if reason != "" {
+        log.Fatalf("VPC failed: %v (reason: %s)", err, reason)
+    }
+    log.Fatalf("VPC polling failed: %v", err)
+}
+```
+
+---
+
+## Risorse che Supportano il Polling
+
+I seguenti wrapper di risorse supportano `WaitUntilReady`, `WaitUntilActive`, `WaitUntilStates`, `WaitUntilGone` e gli accessor di stato. Le risorse contrassegnate con un metodo wait speciale espongono un'ulteriore forma nominata.
+
+| Risorsa | Wait speciale | Note |
+|---------|---------------|------|
+| `CloudServer` | — | `WaitUntilReady` → `Active` |
+| `KaaS` | — | `WaitUntilReady` → `Active`; può richiedere 10–20 min |
+| `ContainerRegistry` | — | `WaitUntilReady` → `Active`; può richiedere 20–40 min |
+| `DBaaS` | — | `WaitUntilReady` → `Active`; può richiedere 5–15 min |
+| `Database` | — | |
+| `User` | — | |
+| `Grant` | — | |
+| `VPC` | — | |
+| `Subnet` | — | |
+| `SecurityGroup` | — | |
+| `SecurityRule` | — | |
+| `ElasticIP` | `WaitUntilNotUsed`, `WaitUntilUsed` | Delegano a `WaitUntilStates` |
+| `BlockStorage` | `WaitUntilNotUsed`, `WaitUntilUsed` | Delegano a `WaitUntilStates` |
+| `Snapshot` | — | |
+| `StorageBackup` | — | |
+| `StorageRestore` | — | |
+| `VPCPeering` | — | |
+| `VPCPeeringRoute` | — | |
+| `VPNTunnel` | — | |
+| `VPNRoute` | — | |
+| `KMS` | — | |
+| `Kmip` | `WaitUntilCertificateAvailable` | Waiter personalizzato (Family B — nessun `statusMixin`); fa il polling di `KmipResponse.Status` direttamente |
+
+> **Il Progetto non supporta il polling.** È pronto in modo sincrono immediatamente dopo che `Create` ritorna — non è necessaria né disponibile alcuna chiamata `WaitUntilActive`.
+
+---
+
+## Avvertenze
+
+### Wrapper idratato obbligatorio
+
+`WaitUntilReady`, `WaitUntilActive`, `WaitUntilStates` e `WaitUntilGone` funzionano solo su wrapper che sono stati **restituiti da una chiamata adapter** (`Create`, `Get`, `Update` o `List`). Chiamare uno qualsiasi di questi metodi su un builder di richiesta appena costruito restituisce:
+
+```
+WaitUntilStates: refresh callback not set; resource must be produced by an adapter (Create/Get/Update/List) to support polling
+```
+
+Usa sempre il wrapper restituito dalla chiamata API:
+
+```go
+// Corretto — vpc è stato restituito da Create
+vpc, err := arubaClient.FromNetwork().VPCs().Create(ctx, myVPC)
+vpc.WaitUntilReady(ctx)
+
+// Errato — myVPC è un builder di richiesta, non una risposta adapter
+myVPC := aruba.NewVPC().Named("x")
+myVPC.WaitUntilReady(ctx) // restituisce "refresh callback not set"
+```
+
+### Cadenza di polling costante
+
+Il polling usa un **ritardo fisso** (senza backoff esponenziale). Se stai raggiungendo i limiti di rate dell'API, aumenta `WithBaseDelay` invece di aspettarti che l'SDK rallenti automaticamente.
+
+### Cancellazione del context
+
+Tutto il polling rispetta la scadenza e la cancellazione del `ctx`. Se il context scade durante il polling, la chiamata restituisce `ctx.Err()` (tipicamente `context.DeadlineExceeded` o `context.Canceled`).
+
+---
+
+## Avanzato: polling concorrente e personalizzato
+
+`WaitUntilReady`, `WaitUntilActive` e `WaitUntilStates` bloccano la goroutine chiamante. Quando devi **avviare più attese in modo concorrente**, o **fare il polling di una condizione arbitraria** (non solo uno stato di risorsa), scendi al livello di `pkg/async`. Quel layer lavora direttamente con `*types.Response[T]` ed è documentato separatamente — consulta [Lavorare a Basso Livello](./working-at-low-level#background-polling-with-pkgasync).
+
+---
+
+## Vedi Anche
+
+- [Guida al Walkthrough API](./walkthrough) — esempio completo del ciclo di vita Create + `WaitUntilReady` + Update + Delete
+- [Gestione delle Risposte](./response-handling) — come `*aruba.HTTPError` si propaga attraverso `WaitUntilReady` quando l'API restituisce 4xx/5xx
+- [Lavorare a Basso Livello](./working-at-low-level) — polling in background con `pkg/async`, accesso ai campi wire non promossi

--- a/docs/website/i18n/it/docusaurus-plugin-content-docs/version-1.0.0/filters.md
+++ b/docs/website/i18n/it/docusaurus-plugin-content-docs/version-1.0.0/filters.md
@@ -1,0 +1,257 @@
+# Guida al Filtraggio
+
+Questa guida spiega come utilizzare i filtri con l'SDK Aruba Cloud Go per interrogare e filtrare le risorse in base a vari criteri.
+
+## Panoramica
+
+L'SDK fornisce un sistema di filtraggio flessibile tramite helper `CallOption`. Passali direttamente a `List` (e ad altre operazioni di lettura) senza costruire struct di parametri intermedi.
+
+```go
+servers, err := arubaClient.FromCompute().CloudServers().List(ctx, proj,
+    aruba.WithFilter("status:eq:Active,cpu:gt:2"),
+    aruba.WithSort("name:asc"),
+    aruba.WithLimit(50),
+)
+```
+
+Opzioni di chiamata disponibili:
+
+| Opzione | Descrizione |
+|---------|-------------|
+| `aruba.WithFilter(expr string)` | Espressione di filtro lato server |
+| `aruba.WithSort(expr string)` | Espressione di ordinamento |
+| `aruba.WithLimit(n int)` | Dimensione della pagina |
+| `aruba.WithOffset(n int)` | Offset di paginazione |
+| `aruba.WithProjection(expr string)` | Proiezione dei campi |
+
+## Formato Filtro
+
+I filtri seguono questo formato: `campo:operatore:valore`
+
+- **Campo**: Il campo della risorsa su cui filtrare (es. `status`, `name`, `cpu`)
+- **Operatore**: L'operatore di confronto (es. `eq`, `gt`, `like`)
+- **Valore**: Il valore con cui confrontare
+
+Più filtri vengono combinati usando:
+- `,` (virgola) per operazioni **AND**
+- `;` (punto e virgola) per operazioni **OR**
+
+## Operatori Supportati
+
+| Operatore | Codice | Descrizione | Esempio |
+|-----------|--------|-------------|---------|
+| Uguale | `eq` | Corrispondenza esatta | `status:eq:Active` |
+| Diverso | `ne` | Non uguale a | `status:ne:Error` |
+| Maggiore | `gt` | Maggiore di | `cpu:gt:2` |
+| Maggiore/Uguale | `gte` | Maggiore o uguale a | `memory:gte:4096` |
+| Minore | `lt` | Minore di | `disk:lt:100` |
+| Minore/Uguale | `lte` | Minore o uguale a | `cpu:lte:8` |
+| In | `in` | Valore in lista | `region:in:us-east,us-west` |
+| Non In | `nin` | Valore non in lista | `status:nin:Error,Failed` |
+| Contiene | `like` | Corrispondenza sottostringa | `name:like:prod` |
+| Inizia Con | `sw` | Corrispondenza prefisso | `name:sw:web-` |
+| Termina Con | `ew` | Corrispondenza suffisso | `name:ew:-prod` |
+
+## Filtri Semplici
+
+### Condizione Singola
+
+```go
+// Elenca i cloud server attivi
+servers, err := arubaClient.FromCompute().CloudServers().List(ctx, proj,
+    aruba.WithFilter("status:eq:Active"),
+)
+```
+
+### Condizioni AND Multiple
+
+```go
+// Server attivi con almeno 2 vCPU e 4 GB di RAM
+servers, err := arubaClient.FromCompute().CloudServers().List(ctx, proj,
+    aruba.WithFilter("status:eq:Active,cpu:gt:2,memory:gte:4096"),
+)
+```
+
+Espressione risultante: `status:eq:Active,cpu:gt:2,memory:gte:4096`
+
+### Condizioni OR
+
+```go
+// Server che sono Attivi O in Avvio
+servers, err := arubaClient.FromCompute().CloudServers().List(ctx, proj,
+    aruba.WithFilter("status:eq:Active;status:eq:Starting"),
+)
+```
+
+Espressione risultante: `status:eq:Active;status:eq:Starting`
+
+### Filtri Complessi (AND + OR)
+
+```go
+// (environment=production AND memory>=4096) OR (tier=premium AND region IN [us-east-1,us-west-2])
+servers, err := arubaClient.FromCompute().CloudServers().List(ctx, proj,
+    aruba.WithFilter("environment:eq:production,memory:gte:4096;tier:eq:premium,region:in:us-east-1,us-west-2"),
+)
+```
+
+## Esempi Pratici
+
+### Filtra Cloud Server Attivi
+
+```go
+// Elenca server attivi con almeno 4 GB di RAM, dimensione pagina 50
+servers, err := arubaClient.FromCompute().CloudServers().List(ctx, proj,
+    aruba.WithFilter("status:eq:Active,memory:gte:4096"),
+    aruba.WithLimit(50),
+)
+if err != nil {
+    log.Fatalf("List failed: %v", err)
+}
+fmt.Printf("Found %d servers\n", servers.Total())
+for _, s := range servers.Items() {
+    fmt.Println("-", s.Name())
+}
+```
+
+### Filtra VPC per Regione
+
+```go
+// Elenca VPC in data center specifici
+vpcs, err := arubaClient.FromNetwork().VPCs().List(ctx, proj,
+    aruba.WithFilter("location:in:ITBG-Bergamo,ITMI-Milan"),
+)
+```
+
+### Filtra per Pattern Nome
+
+```go
+// Tutti i cloud server il cui nome inizia con "web-"
+servers, err := arubaClient.FromCompute().CloudServers().List(ctx, proj,
+    aruba.WithFilter("name:sw:web-"),
+)
+```
+
+### Logica di Business Complessa
+
+```go
+// Server di produzione con risorse elevate O server di sviluppo in regioni specifiche
+servers, err := arubaClient.FromCompute().CloudServers().List(ctx, proj,
+    aruba.WithFilter(
+        "environment:eq:production,cpu:gte:8,memory:gte:16384" +
+        ";environment:eq:development,region:in:ITBG-Bergamo,ITMI-Milan",
+    ),
+)
+```
+
+## Ordinamento
+
+```go
+// Ordina per nome crescente
+servers, err := arubaClient.FromCompute().CloudServers().List(ctx, proj,
+    aruba.WithSort("name:asc"),
+)
+
+// Ordina per data di creazione decrescente
+servers, err = arubaClient.FromCompute().CloudServers().List(ctx, proj,
+    aruba.WithSort("createdAt:desc"),
+)
+```
+
+## Paginazione
+
+```go
+const pageSize = 25
+
+// Prima pagina
+page1, err := arubaClient.FromCompute().CloudServers().List(ctx, proj,
+    aruba.WithLimit(pageSize),
+    aruba.WithOffset(0),
+)
+
+// Seconda pagina
+page2, err := arubaClient.FromCompute().CloudServers().List(ctx, proj,
+    aruba.WithLimit(pageSize),
+    aruba.WithOffset(pageSize),
+)
+
+fmt.Printf("Total resources: %d\n", page1.Total())
+```
+
+## Best Practice
+
+### Usa Filtri Specifici
+
+Sii il più specifico possibile per ridurre la quantità di dati trasferiti:
+
+```go
+// Bene: filtro specifico — solo le risorse necessarie
+servers, err := arubaClient.FromCompute().CloudServers().List(ctx, proj,
+    aruba.WithFilter("status:eq:Active,region:eq:ITBG-Bergamo"),
+)
+
+// Meno efficiente: nessun filtro — recupera tutto
+servers, err = arubaClient.FromCompute().CloudServers().List(ctx, proj)
+```
+
+### Combina Filtro e Paginazione
+
+```go
+servers, err := arubaClient.FromCompute().CloudServers().List(ctx, proj,
+    aruba.WithFilter("environment:eq:production"),
+    aruba.WithLimit(50),
+    aruba.WithOffset(0),
+)
+```
+
+### Valida le Stringhe di Filtro
+
+Stampa la stringa di filtro per debuggare risultati inaspettati:
+
+```go
+filter := "status:eq:Active,cpu:gt:4"
+fmt.Println("Filter:", filter)
+// Output: Filter: status:eq:Active,cpu:gt:4
+
+servers, err := arubaClient.FromCompute().CloudServers().List(ctx, proj,
+    aruba.WithFilter(filter),
+)
+```
+
+## Risoluzione dei Problemi
+
+### Filtro Non Funzionante
+
+**Problema**: Il filtro non restituisce i risultati attesi
+
+**Soluzioni**:
+1. Controlla che i nomi dei campi corrispondano esattamente allo schema API (sensibile alle maiuscole)
+2. Verifica che l'operatore sia appropriato per il tipo di campo
+3. Assicurati che i valori siano nel formato corretto (es. `Active` non `active`)
+4. Stampa la stringa di filtro per il debug
+
+### Risultati Vuoti
+
+**Problema**: Il filtro non restituisce risultati
+
+**Soluzioni**:
+1. Verifica che la logica del filtro sia corretta
+2. Prova filtri più semplici per isolare il problema
+3. Controlla se il campo supporta l'operatore utilizzato
+4. Elenca senza filtri per confermare che le risorse esistano
+
+### Problemi con Filtri Complessi
+
+**Problema**: La logica AND/OR complessa non funziona come previsto
+
+**Soluzioni**:
+1. Scomponi i filtri complessi in parti più semplici
+2. Testa ogni condizione separatamente
+3. Ricorda: virgole (`,`) = AND, punto e virgola (`;`) = OR
+4. Usa le parentesi mentalmente per capire il raggruppamento
+
+```
+// Questo: status:eq:Active,cpu:gt:2;memory:gte:4096
+// Significa: (status = Active AND cpu > 2) OR (memory >= 4096)
+
+// Non: status = Active AND (cpu > 2 OR memory >= 4096)
+```

--- a/docs/website/i18n/it/docusaurus-plugin-content-docs/version-1.0.0/intro.md
+++ b/docs/website/i18n/it/docusaurus-plugin-content-docs/version-1.0.0/intro.md
@@ -1,0 +1,76 @@
+---
+sidebar_position: 1
+---
+
+# Guida Rapida
+
+Benvenuto nell'SDK ufficiale Go per l'API Aruba Cloud. Questo SDK fornisce un modo comodo e potente per gli sviluppatori Go di interagire con l'API Aruba Cloud. L'obiettivo principale è semplificare la gestione delle risorse cloud, permettendoti di creare, leggere, aggiornare ed eliminare programmaticamente risorse come istanze di calcolo, virtual private cloud (VPC), storage a blocchi e altro ancora.
+
+## Installazione
+
+Aggiungi l'SDK al tuo progetto Go:
+
+```bash
+go get github.com/Arubacloud/sdk-go
+```
+
+## Iniziare
+
+Iniziare con l'SDK è semplice. Importa il pacchetto `aruba`, crea un client con le tue credenziali e inizia a effettuare chiamate API usando il pattern builder fluente.
+
+La prima e più fondamentale risorsa in Aruba Cloud è il **Progetto**. Tutte le altre risorse appartengono a un progetto.
+
+Ecco come inizializzare il client SDK e creare il tuo primo progetto:
+
+```go
+package main
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"time"
+
+	"github.com/Arubacloud/sdk-go/pkg/aruba"
+)
+
+func main() {
+	// Le tue credenziali API
+	clientID := "your-client-id"
+	clientSecret := "your-client-secret"
+
+	// 1. Inizializza il client SDK utilizzando le opzioni predefinite
+	arubaClient, err := aruba.NewClient(aruba.DefaultOptions(clientID, clientSecret))
+	if err != nil {
+		log.Fatalf("Failed to create SDK client: %v", err)
+	}
+
+	// Crea un contesto con un timeout
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
+	defer cancel()
+
+	// 2. Crea il Progetto — costruisci inline e passa a Create
+	fmt.Println("Creating a new project...")
+	proj, err := arubaClient.FromProject().Create(
+		ctx,
+		aruba.NewProject().
+			Named("my-first-project").
+			Tagged("go-sdk", "quick-start").
+			DescribedAs("Un progetto creato con l'SDK Go"))
+	if err != nil {
+		log.Fatalf("Error creating project: %v", err)
+	}
+
+	fmt.Printf("✓ Progetto creato con successo: %s (ID: %s)\n", proj.Name(), proj.ID())
+}
+```
+
+## Prossimi Passi
+
+- Leggi la [Guida al Walkthrough API](./walkthrough) per un percorso completo attraverso il ciclo di vita delle risorse
+- Scopri le [Opzioni di Configurazione](./options) per personalizzare il tuo client SDK
+- Esplora le [Risorse API](./resources) per vedere cosa puoi gestire
+- Comprendi la [Gestione delle Risposte](./response-handling) per una gestione robusta degli errori
+- Scopri il [Filtraggio](./filters) per interrogare le risorse in modo efficiente
+- Leggi [Multitenancy](./multitenancy) per gestire client specifici per tenant
+- Vedi [Utilizzo a Basso Livello](./working-at-low-level) per funzionalità avanzate (`pkg/types`, `pkg/async`)

--- a/docs/website/i18n/it/docusaurus-plugin-content-docs/version-1.0.0/multitenancy.md
+++ b/docs/website/i18n/it/docusaurus-plugin-content-docs/version-1.0.0/multitenancy.md
@@ -1,0 +1,152 @@
+# Multitenancy
+
+Il package `pkg/multitenant` fornisce un registro in-memory tenant-to-client per l'SDK Aruba Cloud. E utile quando la tua applicazione gestisce piu tenant e ogni tenant richiede un proprio `aruba.Client`.
+
+## Panoramica
+
+Il package espone:
+
+- Un'interfaccia `Multitenant` per creare, salvare, recuperare e pulire i client tenant
+- Un'implementazione predefinita basata su mappa e mutex
+- Un helper per routine di cleanup periodico dei tenant inattivi
+
+File principali:
+
+- `pkg/multitenant/multitenant.go`
+- `pkg/multitenant/cleanup_routine.go`
+
+## Interfaccia Principale
+
+L'interfaccia `Multitenant` supporta queste operazioni:
+
+- `New(tenant string) error`: crea client usando opzioni template
+- `NewFromOptions(tenant string, options *aruba.Options) error`: crea client da opzioni esplicite
+- `Add(tenant string, client aruba.Client)`: aggiunge un client gia inizializzato
+- `Get(tenant string) (aruba.Client, bool)`: recupera client con flag di esistenza
+- `MustGet(tenant string) aruba.Client`: recupera o termina il processo se assente
+- `GetOrNil(tenant string) aruba.Client`: recupera o restituisce `nil`
+- `CleanUp(from time.Duration)`: elimina tenant inattivi
+
+## Creazione del Manager
+
+### Manager vuoto
+
+Usalo quando vuoi aggiungere client manualmente o tramite `NewFromOptions`:
+
+```go
+mt := multitenant.New()
+```
+
+### Manager con template
+
+Usalo quando i tenant condividono una configurazione base comune:
+
+```go
+opts := aruba.DefaultOptions(clientID, clientSecret)
+mt := multitenant.NewWithTemplate(opts)
+
+// In seguito:
+if err := mt.New("tenant-a"); err != nil {
+    // gestisci errore
+}
+```
+
+## Pattern di Utilizzo
+
+### Aggiungere un client esistente
+
+```go
+client, err := aruba.NewClient(aruba.DefaultOptions(clientID, clientSecret))
+if err != nil {
+    // gestisci errore
+}
+
+mt.Add("tenant-a", client)
+```
+
+### Creare da opzioni specifiche tenant
+
+```go
+tenantOpts := aruba.DefaultOptions(tenantClientID, tenantClientSecret)
+if err := mt.NewFromOptions("tenant-a", tenantOpts); err != nil {
+    // gestisci errore
+}
+```
+
+### Recuperare un client
+
+```go
+client, ok := mt.Get("tenant-a")
+if !ok {
+    // tenant non trovato
+}
+```
+
+Se richiedi esistenza obbligatoria:
+
+```go
+client := mt.MustGet("tenant-a")
+```
+
+## Cleanup Automatico
+
+Il package include anche `StartCleanupRoutine` in `cleanup_routine.go`. Esegue `CleanUp` periodicamente in una goroutine in background.
+
+```go
+ctx, cancel := context.WithCancel(context.Background())
+defer cancel()
+
+stopCleanup := multitenant.StartCleanupRoutine(
+    ctx,
+    mt,
+    5*time.Minute,   // intervallo di esecuzione
+    24*time.Hour,    // rimuove tenant inattivi da 24h
+)
+defer stopCleanup()
+```
+
+Valori di default:
+
+- `tickInterval`: 1 ora se zero/negativo
+- `fromDuration`: 24 ore se zero/negativo
+
+## Note
+
+- Implementazione in-memory, locale al processo.
+- Ciclo di vita tenant basato su `lastUsage`.
+- `CleanUp` rimuove anche entry non valide (`nil` entry/client).
+
+## Esempio di Utilizzo (`examples/all-resources/orchestrator_multitenancy.go`)
+
+Per un esempio completo vedi:
+
+- `examples/all-resources/orchestrator_multitenancy.go`
+
+Snippet principale (cache + credenziali Vault per tenant):
+
+```go
+c, ok := r.multiTenantClient.Get(tenant)
+if ok {
+	return c, nil
+}
+
+options := aruba.NewOptions().
+	WithBaseURL(r.config.APIGateway).
+	WithDefaultTokenIssuerURL().
+	WithVaultCredentialsRepository(
+		r.config.VaultAddress,
+		r.config.KVMount,
+		tenant, // tenant -> kvPath (es. ARU-297647)
+		r.config.Namespace,
+		r.config.RolePath,
+		r.config.RoleID,
+		r.config.RoleSecret,
+	)
+
+client, err := aruba.NewClient(options)
+if err != nil {
+	return nil, err
+}
+r.multiTenantClient.Add(tenant, client)
+return client, nil
+```

--- a/docs/website/i18n/it/docusaurus-plugin-content-docs/version-1.0.0/options.md
+++ b/docs/website/i18n/it/docusaurus-plugin-content-docs/version-1.0.0/options.md
@@ -1,0 +1,257 @@
+# Opzioni di Configurazione SDK
+
+L'SDK Aruba Cloud per Go è configurato mediante un'API fluente che consente di concatenare i setter di opzioni per costruire una configurazione client. Questa guida dettaglia tutte le opzioni disponibili, raggruppate per argomento.
+
+## Iniziare
+
+<p>Il modo più semplice per configurare il client è utilizzare <code>DefaultOptions</code>, che fornisce una configurazione pronta per la produzione per il caso d'uso più comune (autenticazione Client Credentials).</p>
+
+<table>
+  <thead>
+    <tr>
+      <th>Setter Opzione</th>
+      <th>Descrizione</th>
+      <th>Note</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td><code>DefaultOptions(clientID, clientSecret)</code></td>
+      <td>Crea una configurazione standard per l'ambiente di produzione utilizzando il Client ID e il Secret API.</td>
+      <td>Questo è il punto di partenza consigliato per la maggior parte delle applicazioni. Imposta l'API di produzione e gli URL dei token e configura l'autenticazione.</td>
+    </tr>
+    <tr>
+      <td><code>NewOptions()</code></td>
+      <td>Crea un nuovo builder di configurazione vuoto. È necessario configurare manualmente tutte le impostazioni richieste, inclusa l'autenticazione.</td>
+      <td>Usa questa opzione se hai bisogno di controllo completo sulla configurazione da zero.</td>
+    </tr>
+  </tbody>
+</table>
+
+## Configurazione Generale
+
+<table>
+  <thead>
+    <tr>
+      <th>Setter Opzione</th>
+      <th>Descrizione</th>
+      <th>Note</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td><code>WithBaseURL(baseURL)</code></td>
+      <td>Sovrascrive l'URL API Aruba Cloud predefinito.</td>
+      <td>Il valore predefinito è <code>https://api.arubacloud.com</code>. Modificalo solo se devi puntare a un ambiente diverso.</td>
+    </tr>
+    <tr>
+      <td><code>WithDefaultBaseURL()</code></td>
+      <td>Helper che imposta l'URL API al valore predefinito di produzione.</td>
+      <td>Chiamato da <code>DefaultOptions()</code>.</td>
+    </tr>
+  </tbody>
+</table>
+
+## Autenticazione
+
+<p>L'autenticazione è una parte critica della configurazione. È necessario scegliere <b>uno</b> dei seguenti metodi.</p>
+
+<table>
+  <thead>
+    <tr>
+      <th>Setter Opzione</th>
+      <th>Descrizione</th>
+      <th>Note</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td><code>WithDefaultTokenManagerSchema(clientID, clientSecret)</code></td>
+      <td>Configura l'autenticazione Client Credentials standard con l'URL del token issuer predefinito e senza caching persistente. Chiamato internamente da <code>DefaultOptions()</code>.</td>
+      <td>Da usare quando si vuole ripristinare il token manager alle impostazioni di fabbrica prima di applicare sovrascritture selettive.</td>
+    </tr>
+    <tr>
+      <td><code>WithClientCredentials(clientID, clientSecret)</code></td>
+      <td><b>(Consigliato)</b> Configura l'SDK per utilizzare il flusso OAuth2 Client Credentials. L'SDK gestirà automaticamente il recupero e il rinnovo del token di accesso.</td>
+      <td><b>Esclusione reciproca</b>: non può essere usato con <code>WithToken()</code> o <code>WithVaultCredentialsRepository()</code>. È il metodo standard e più sicuro per l'autenticazione service-to-service.</td>
+    </tr>
+    <tr>
+      <td><code>WithToken(token)</code></td>
+      <td>Configura l'SDK per utilizzare un token di accesso OAuth2 statico preesistente.</td>
+      <td><b>Esclusione reciproca</b>: non può essere usato con nessun'altra opzione di autenticazione o token issuer.<br/>
+      <b>Avviso</b>: L'SDK <b>non</b> rinnoverà questo token. Una volta scaduto, tutte le chiamate API falliranno. Questo metodo è consigliato solo per client di breve durata o script semplici e atomici.</td>
+    </tr>
+    <tr>
+      <td><code>WithVaultCredentialsRepository(...)</code></td>
+      <td>Configura l'SDK per recuperare <code>clientID</code> e <code>clientSecret</code> da un'istanza HashiCorp Vault. L'SDK utilizzerà poi queste credenziali per gestire il token di accesso.</td>
+      <td><b>Esclusione reciproca</b>: non può essere usato con <code>WithClientCredentials()</code> o <code>WithToken()</code>.<br/>
+      <b>Parametri</b>: <code>vaultURI</code>, <code>kvMount</code>, <code>kvPath</code>, <code>namespace</code>,
+      <code>rolePath</code>, <code>roleID</code>, <code>secretID</code>.</td>
+    </tr>
+    <tr>
+      <td><code>WithTokenIssuerURL(url)</code></td>
+      <td>Sovrascrive l'URL predefinito per l'endpoint del token OAuth2.</td>
+      <td>Il valore predefinito è <code>https://mylogin.aruba.it/auth/realms/cmp-new-apikey/protocol/openid-connect/token</code>. Modificalo solo se devi puntare a un endpoint di autenticazione diverso.</td>
+    </tr>
+    <tr>
+      <td><code>WithSecurityScopes(scopes ...)</code></td>
+      <td>Imposta gli scope di sicurezza da richiedere durante l'autenticazione.</td>
+      <td>Sostituisce qualsiasi scope precedentemente configurato.</td>
+    </tr>
+    <tr>
+      <td><code>WithAdditionalSecurityScopes(scopes ...)</code></td>
+      <td>Aggiunge scope di sicurezza supplementari all'elenco esistente.</td>
+      <td>Non sovrascrive gli scope già presenti.</td>
+    </tr>
+  </tbody>
+</table>
+
+## Caching del Token (Opzionale)
+
+<p>Per migliorare le prestazioni e la resilienza, l'SDK può memorizzare nella cache il token di accesso su uno store esterno. È fortemente consigliato nelle applicazioni di produzione per evitare di richiedere un nuovo token a ogni avvio.</p>
+
+<table>
+  <thead>
+    <tr>
+      <th>Setter Opzione</th>
+      <th>Descrizione</th>
+      <th>Note</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td><code>WithRedisTokenRepositoryFromURI(redisURI)</code></td>
+      <td>Configura un'istanza Redis come cache persistente per il token di accesso, specificando l'URI completo.</td>
+      <td><b>Esclusione reciproca</b>: non può essere usato con le opzioni <code>WithFileTokenRepository...</code>.<br/>
+      Il formato URI è <code>redis://&lt;user&gt;:&lt;pass&gt;@&lt;host&gt;:&lt;port&gt;/&lt;db&gt;</code>.</td>
+    </tr>
+    <tr>
+      <td><code>WithRedisTokenRepositoryFromStandardURI()</code></td>
+      <td>Configura il caching Redis usando l'URI locale standard (<code>redis://admin:admin@localhost:6379/0</code>).</td>
+      <td>Scorciatoia per lo sviluppo locale. Non imposta il drift di scadenza; abbinare con
+      <code>WithStandardTokenExpirationDriftSeconds()</code> o usare <code>WithStandardRedisTokenRepository()</code>.</td>
+    </tr>
+    <tr>
+      <td><code>WithFileTokenRepositoryFromBaseDir(baseDir)</code></td>
+      <td>Configura una directory locale per memorizzare il token di accesso in un file JSON.</td>
+      <td><b>Esclusione reciproca</b>: non può essere usato con le opzioni <code>WithRedisTokenRepository...</code>. Il processo SDK deve avere i permessi di lettura/scrittura sulla directory specificata.</td>
+    </tr>
+    <tr>
+      <td><code>WithFileTokenRepositoryFromStandardBaseDir()</code></td>
+      <td>Configura il caching su file in <code>/tmp/sdk-go</code>.</td>
+      <td>Scorciatoia per lo sviluppo locale. Non imposta il drift di scadenza; abbinare con
+      <code>WithStandardTokenExpirationDriftSeconds()</code> o usare <code>WithStandardFileTokenRepository()</code>.</td>
+    </tr>
+    <tr>
+      <td><code>WithTokenExpirationDriftSeconds(seconds)</code></td>
+      <td>Imposta un buffer di sicurezza (in secondi) per considerare un token scaduto prima che lo sia effettivamente.</td>
+      <td>Previene race condition in cui l'SDK usa un token che scade appena prima del completamento della richiesta API. Il valore predefinito è 300 secondi (5 minuti). Questa opzione non ha effetto se non è configurato un meccanismo di caching (Redis o File).</td>
+    </tr>
+    <tr>
+      <td><code>WithStandardTokenExpirationDriftSeconds()</code></td>
+      <td>Imposta il drift di scadenza a 300 secondi (5 minuti).</td>
+      <td>Equivalente a <code>WithTokenExpirationDriftSeconds(300)</code>.</td>
+    </tr>
+    <tr>
+      <td><code>WithStandardRedisTokenRepository()</code></td>
+      <td>Helper che configura il caching Redis su <code>localhost:6379</code> e imposta il drift di scadenza standard (300s).</td>
+      <td>Scorciatoia comoda per lo sviluppo locale.</td>
+    </tr>
+    <tr>
+      <td><code>WithStandardFileTokenRepository()</code></td>
+      <td>Helper che configura il caching su file in <code>/tmp/sdk-go</code> e imposta il drift di scadenza standard (300s).</td>
+      <td>Scorciatoia comoda per lo sviluppo locale.</td>
+    </tr>
+  </tbody>
+</table>
+
+## Logging
+
+<p>Il logging è disabilitato per impostazione predefinita.</p>
+
+<table>
+  <thead>
+    <tr>
+      <th>Setter Opzione</th>
+      <th>Descrizione</th>
+      <th>Note</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td><code>WithDefaultLogger()</code></td>
+      <td>Ripristina il logger al valore predefinito dell'SDK (nessun log). Chiamato da <code>DefaultOptions()</code>.</td>
+      <td>Da usare quando si vuole ripristinare esplicitamente il logging dopo aver configurato un logger personalizzato.</td>
+    </tr>
+    <tr>
+      <td><code>WithNoLogs()</code></td>
+      <td>Disabilita tutto il logging dell'SDK.</td>
+      <td>Questo è il comportamento predefinito.</td>
+    </tr>
+    <tr>
+      <td><code>WithNativeLogger()</code></td>
+      <td>Abilita il logger integrato dell'SDK, che utilizza il pacchetto standard <code>log</code>.</td>
+      <td>Utile per il debug di base.</td>
+    </tr>
+    <tr>
+      <td><code>WithLoggerType(loggerType)</code></td>
+      <td>Funzione più generale per impostare il tipo di logger.</td>
+      <td><code>loggerType</code> può essere <code>LoggerNoLog</code> o <code>LoggerNative</code>.</td>
+    </tr>
+    <tr>
+      <td><code>WithCustomLogger(logger)</code></td>
+      <td>Inietta un logger personalizzato che rispetta l'interfaccia <code>ports/logger.Logger</code>.</td>
+      <td>Consente l'integrazione con il framework di logging dell'applicazione (ad esempio, Logrus, Zap). Impostando questo valore, il tipo di logger viene automaticamente impostato su <code>loggerCustom</code>.</td>
+    </tr>
+  </tbody>
+</table>
+
+## Identità del Client HTTP
+
+<p>L'SDK imposta automaticamente un header <code>User-Agent</code> su ogni richiesta in uscita, in modo che i log di accesso API possano essere attribuiti alla versione dell'SDK. Per impostazione predefinita il valore dell'header è <code>sdk-go@&lt;version&gt;</code>
+(ad esempio <code>sdk-go@1.0.0</code>), derivato dalla costante <code>aruba.Version</code> definita in
+<code>pkg/aruba/version.go</code>.</p>
+
+<table>
+  <thead>
+    <tr>
+      <th>Setter Opzione</th>
+      <th>Descrizione</th>
+      <th>Note</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td><code>WithUserAgent(ua)</code></td>
+      <td>Sovrascrive il valore predefinito dell'header <code>User-Agent</code> inviato con ogni richiesta.</td>
+      <td>Da usare quando si costruisce uno strumento sopra l'SDK e si vuole che i log API mostrino l'identità del proprio strumento invece di (o in aggiunta a) la versione grezza dell'SDK. Esempio:
+      <code>WithUserAgent("acloud-cli@1.0.0")</code>.</td>
+    </tr>
+  </tbody>
+</table>
+
+## Avanzato / Dipendenze Personalizzate
+
+<p>Queste opzioni sono destinate a casi d'uso avanzati in cui è necessario iniettare componenti personalizzati nel flusso di lavoro dell'SDK.</p>
+
+<table>
+  <thead>
+    <tr>
+      <th>Setter Opzione</th>
+      <th>Descrizione</th>
+      <th>Note</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td><code>WithCustomHTTPClient(client)</code></td>
+      <td>Inietta un <code>*http.Client</code> pre-configurato.</td>
+      <td>Utile per impostare timeout personalizzati, transport o altre configurazioni a livello HTTP.</td>
+    </tr>
+    <tr>
+      <td><code>WithCustomMiddleware(middleware)</code></td>
+      <td>Inietta un middleware personalizzato che rispetta l'interfaccia <code>ports/interceptor.Interceptor</code>.</td>
+      <td>Consente di aggiungere logica personalizzata (come logging o tracing di richiesta/risposta) nella catena di chiamate HTTP dell'SDK. Il middleware di autenticazione dell'SDK verrà automaticamente collegato alla fine della catena di middleware personalizzata.</td>
+    </tr>
+  </tbody>
+</table>

--- a/docs/website/i18n/it/docusaurus-plugin-content-docs/version-1.0.0/resources.md
+++ b/docs/website/i18n/it/docusaurus-plugin-content-docs/version-1.0.0/resources.md
@@ -1,0 +1,1917 @@
+---
+sidebar_position: 3
+---
+
+# Risorse
+
+Questa pagina è il riferimento esaustivo per ogni wrapper di risorsa nel pacchetto `pkg/aruba`. Per ogni wrapper troverai:
+
+1. La catena di accessor per raggiungerlo da `arubaClient`
+2. Uno snippet `Create` pronto all'uso
+3. I metodi accessor di risposta disponibili sul wrapper restituito
+
+Per il walkthrough end-to-end del ciclo di vita (come `Create`, `Get`, `Update`, `List`, `Delete` e il polling si integrano) vedi la [Guida al Walkthrough API](./walkthrough).
+
+---
+
+## Convenzioni
+
+Ogni risorsa segue la stessa struttura:
+
+```go
+// 1. Raggiungi il sub-client
+client := arubaClient.FromX().Y()
+
+// 2. Costruisci la richiesta inline e crea
+result, err := client.Create(ctx,
+    aruba.NewX().
+        IntoParent(parentRef).   // scope al progetto / VPC / ecc.
+        Named("my-resource").
+        Tagged("env-prod").
+        WithFoo(...))
+
+// 3. Attendi che le risorse asincrone diventino pronte
+if err := result.WaitUntilReady(ctx); err != nil { … }
+
+// 4. Leggi gli accessor di risposta
+fmt.Println(result.ID(), result.Name(), result.State())
+```
+
+- `aruba.NewX()` — factory constructor per ogni builder di risorsa
+- `IntoFoo(ref)` — lega lo scope del genitore; accetta qualsiasi `aruba.Ref` (wrapper idratato o `aruba.URI("…")`)
+- `WithFoo(...)` — setter fluenti; gli errori sono differiti fino a `Create`/`Update`
+- `WaitUntilReady(ctx, opts...)` — disponibile sulle risorse marcate **async** qui sotto; vedi [Async / Await](./async) per le opzioni complete
+- `aruba.URI(s)` — avvolge un percorso stringa grezzo in un `Ref` (vedi [Guida al Walkthrough API](./walkthrough#5-ottenere-una-risorsa-specifica))
+
+:::info Formato dei tag
+L'API di Aruba valida i valori dei tag contro `^[A-Za-z0-9-]{4,30}$`: **solo caratteri alfanumerici e trattini, lunghezza da 4 a 30**. Due punti, punti, underscore, spazi e altra punteggiatura vengono rifiutati con `400 — One or more validation error occurred`. L'SDK non valida i tag lato client, quindi un tag non valido fallisce solo quando la richiesta raggiunge il server.
+:::
+
+### Lettura dello stato del wrapper
+
+Ogni wrapper promuove i campi di risposta più usati a accessor piatti. Preferiscili rispetto a `wrapper.Raw().Properties.X`:
+
+```go
+fmt.Println(result.ID())        // UUID
+fmt.Println(result.Name())      // nome della risorsa
+fmt.Println(result.State())     // stato del ciclo di vita
+fmt.Println(result.Region())    // slug della regione
+fmt.Println(result.RawJSON())   // payload JSON wire completo (per --output json)
+fmt.Println(result.RawYAML())   // payload YAML wire completo (per --output yaml)
+```
+
+Gli scalari specifici della risorsa (es. `cs.Subnets()`, `vpnRoute.CloudSubnetCIDR()`, `kaas.PodCIDR()`) sono documentati nella sezione **Accessor di risposta** di ogni risorsa qui sotto. Vedi [Gestione delle risposte](./response-handling#lettura-dello-stato-del-wrapper) per la tassonomia completa degli accessor.
+
+Ogni sezione di risorsa elenca anche i suoi **Setter** (metodi builder concatenabili raggruppati per l'ordine canonico della catena da `ai/CONVENTIONS.md`) e un collegamento all'esempio eseguibile in `examples/all-resources/`.
+
+---
+
+## Progetto
+
+```go
+arubaClient.FromProject()
+```
+
+**Operazioni supportate**: `Create`, `List`, `Get`, `Update`, `Delete`
+
+> Il Progetto **non** è asincrono — è pronto in modo sincrono dopo che `Create` ritorna. Non è necessaria alcuna chiamata `WaitUntilReady`.
+
+```go
+proj, err := arubaClient.FromProject().Create(
+    ctx,
+    aruba.NewProject().
+        Named("my-project").
+        Tagged("env-prod").
+        DescribedAs("Progetto di produzione").
+        NotDefault())
+if err != nil {
+    log.Fatalf("Create project: %v", err)
+}
+fmt.Printf("✓ Progetto: %s (ID: %s)\n", proj.Name(), proj.ID())
+```
+
+**Accessor di risposta**:
+- `ID()` — UUID della risorsa
+- `URI()` — percorso completo della risorsa (es. `/projects/abc-123`)
+- `Name()` — nome del progetto
+- `Description()` — descrizione del progetto
+- `IsDefault()` — se questo è il progetto predefinito
+- `Tags()` — lista di tag `[]string`
+- `CreatedAt()`, `UpdatedAt()` — timestamp
+- `Raw()` — struct wire sottostante `*types.ProjectResponse`
+- `RawJSON()` / `RawYAML()` — payload serializzato per i flag `--output json/yaml`
+- `RawRequest()` — `types.ProjectRequest` per i flussi round-trip `Get → Update`
+
+**Setter**:
+- *Name*: `Named(string)`
+- *Labels*: `Tagged(...string)`, `Untagged(...string)`, `RetaggedAs(...string)`
+- *Descriptive scalars*: `DescribedAs(string)`
+- *Boolean state*: `AsDefault()`, `NotDefault()`
+
+:::tip Esempio eseguibile
+Esempio end-to-end completo: [`examples/all-resources/resource_project.go`](https://github.com/Arubacloud/sdk-go/blob/main/examples/all-resources/resource_project.go)
+:::
+
+---
+
+## Audit
+
+```go
+arubaClient.FromAudit().Events()
+```
+
+**Operazioni supportate**: `List`
+
+Gli Audit Event sono in sola lettura. Non esiste un costruttore `Create` — usa `List` con un `Ref` di progetto e opzionalmente `aruba.WithFilter(…)` per interrogare l'audit trail.
+
+```go
+list, err := arubaClient.FromAudit().Events().List(ctx, proj,
+    aruba.WithLimit(50),
+    aruba.WithFilter("action eq 'Create'"))
+if err != nil {
+    log.Fatalf("List events: %v", err)
+}
+for _, e := range list.Items() {
+    fmt.Println(e.ID(), e.Action(), e.Timestamp())
+}
+```
+
+**Accessor di risposta**:
+- `ID()` — UUID dell'evento
+- `URI()` — percorso della risorsa
+- `ResourceURI()` — URI della risorsa a cui l'evento si riferisce
+- `Action()` — stringa dell'azione (es. `"Create"`, `"Delete"`)
+- `Timestamp()` — ora dell'evento
+- `User()` — identificatore utente che ha scatenato l'evento
+- `Raw()` — struct wire sottostante
+
+:::tip Esempio eseguibile
+Eseguito come parte dell'orchestratore: [`examples/all-resources/orchestrator_create.go`](https://github.com/Arubacloud/sdk-go/blob/main/examples/all-resources/orchestrator_create.go)
+:::
+
+---
+
+## Compute
+
+### Cloud Server
+
+```go
+arubaClient.FromCompute().CloudServers()
+```
+
+**Operazioni supportate**: `Create`, `List`, `Get`, `Update`, `Delete`, `PowerOn`, `PowerOff`, `SetPassword`
+**Asincrono**: sì — chiama `WaitUntilReady(ctx)` dopo `Create`.
+
+Un Cloud Server dipende da risorse di rete (VPC, Subnet, Security Group), un Elastic IP, un Boot Volume (Block Storage) e un Key Pair. Crea prima queste risorse e passa i wrapper idratati come parametri `Ref`.
+
+```go
+cs, err := arubaClient.FromCompute().CloudServers().Create(
+    ctx,
+    aruba.NewCloudServer().
+        OfFlavor(aruba.CloudServerFlavorCSO2A4).
+        Named("my-server").
+        Tagged("env-prod").
+        InProject(proj).
+        InRegion(aruba.RegionITBGBergamo).
+        InZone(aruba.ZoneITBG1).
+        BootingFrom(blockStorage).
+        WithVPC(vpc).
+        OnSubnets(subnet).
+        WithSecurityGroups(sg).
+        WithElasticIP(eip).
+        UsingKeyPair(keyPair))
+if err != nil {
+    log.Fatalf("Create Cloud Server: %v", err)
+}
+
+if err := cs.WaitUntilReady(ctx); err != nil {
+    log.Fatalf("Cloud Server did not become Ready: %v", err)
+}
+fmt.Printf("✓ Cloud Server: %s (zona: %s, flavor: %s)\n", cs.Name(), cs.Zone(), cs.Flavor())
+```
+
+**Azioni di alimentazione e password** (richiedono un wrapper idratato da `Create`/`Get`):
+
+```go
+if err := cs.PowerOff(ctx); err != nil { log.Fatalf("PowerOff: %v", err) }
+if err := cs.PowerOn(ctx);  err != nil { log.Fatalf("PowerOn: %v", err) }
+if err := cs.SetPassword(ctx, "NewStr0ngP@ss!"); err != nil { log.Fatalf("SetPassword: %v", err) }
+```
+
+**Accessor di risposta**:
+- `ID()`, `URI()`, `Name()`, `Tags()`
+- `CloudServerID()` — ID server assegnato dal provider
+- `Zone()` — zona di disponibilità
+- `Flavor()` — slug del flavor di calcolo
+- `FlavorRaw()` — struct flavor completa
+- `VPC()` — `aruba.Ref` della VPC collegata
+- `BootVolume()` — `aruba.Ref` del volume di boot
+- `KeyPair()` — `aruba.Ref` della key pair
+- `NetworkInterfaces()` — slice di descrittori di interfacce di rete
+- `Template()` — immagine/template usata al boot
+- `State()`, `FailureReason()`, `PreviousState()`, `IsDisabled()`, `DisableReasons()` — da `statusMixin`
+- `WaitUntilReady(ctx, opts...)`, `WaitUntilActive(ctx, opts...)`, `WaitUntilStates(ctx, []types.State{...}, opts...)`, `WaitUntilGone(ctx, opts...)`
+- `Raw()` — struct wire sottostante
+
+**Setter**:
+- *Classifier*: `OfFlavor(CloudServerFlavor)`
+- *Name*: `Named(string)`
+- *Labels*: `Tagged(...string)`, `Untagged(...string)`, `RetaggedAs(...string)`
+- *Containment*: `InProject(Ref)`
+- *Geography*: `InRegion(Region)`, `InZone(Zone)`
+- *Descriptive scalars*: `WithUserData(string)`
+- *Origin*: `BootingFrom(Ref)`
+- *Attached config*: `WithVPC(Ref)`, `WithSecurityGroups(...Ref)`, `WithElasticIP(Ref)`
+- *Network placement*: `OnSubnets(...Ref)`
+- *Active relationship*: `UsingKeyPair(Ref)`
+- *Boolean state*: `WithVPCPreset()`, `WithoutVPCPreset()`
+- *Billing*: `BilledBy(BillingPeriod)`
+
+:::tip Esempio eseguibile
+Esempio end-to-end completo: [`examples/all-resources/resource_cloud_server.go`](https://github.com/Arubacloud/sdk-go/blob/main/examples/all-resources/resource_cloud_server.go)
+:::
+
+---
+
+### Key Pair
+
+```go
+arubaClient.FromCompute().KeyPairs()
+```
+
+**Operazioni supportate**: `Create`, `List`, `Get`, `Delete`
+**Asincrono**: no.
+
+```go
+kp, err := arubaClient.FromCompute().KeyPairs().Create(
+    ctx,
+    aruba.NewKeyPair().
+        Named("my-keypair").
+        InProject(proj).
+        InRegion(aruba.RegionITBGBergamo).
+        WithPublicKey("ssh-rsa AAAAB3NzaC1yc2E..."))
+if err != nil {
+    log.Fatalf("Create KeyPair: %v", err)
+}
+fmt.Printf("✓ KeyPair: %s (ID: %s)\n", kp.Name(), kp.ID())
+```
+
+**Accessor di risposta**:
+- `ID()`, `URI()`, `Name()`, `Tags()`
+- `KeyPairID()` — ID chiave assegnato dal provider
+- `PublicKey()` — stringa della chiave pubblica
+- `Region()` — slug della regione
+- `Raw()` — struct wire sottostante
+
+**Setter**:
+- *Name*: `Named(string)`
+- *Labels*: `Tagged(...string)`, `Untagged(...string)`, `RetaggedAs(...string)`
+- *Containment*: `InProject(Ref)`
+- *Geography*: `InRegion(Region)`
+- *Descriptive scalars*: `WithPublicKey(string)`
+
+:::tip Esempio eseguibile
+Esempio end-to-end completo: [`examples/all-resources/resource_key_pair.go`](https://github.com/Arubacloud/sdk-go/blob/main/examples/all-resources/resource_key_pair.go)
+:::
+
+---
+
+## Container
+
+### KaaS (Kubernetes as a Service)
+
+```go
+arubaClient.FromContainer().KaaS()
+```
+
+**Operazioni supportate**: `Create`, `List`, `Get`, `Update`, `Delete`, `DownloadKubeconfig`
+**Asincrono**: sì — chiama `WaitUntilReady(ctx)` dopo `Create`.
+
+```go
+k, err := arubaClient.FromContainer().KaaS().Create(
+    ctx,
+    aruba.NewKaaS().
+        Named("my-cluster").
+        Tagged("env-prod").
+        InProject(proj).
+        InRegion(aruba.RegionITBGBergamo).
+        WithKubernetesVersion(aruba.KubernetesVersion1323).
+        WithPodCIDR("10.200.0.0/16").
+        WithNodeCIDR("10.100.0.0/16", "node-cidr").
+        WithVPC(vpc).
+        WithSubnet(subnet).
+        WithSecurityGroup(sg).
+        WithNodePools(aruba.NewNodePool().
+            OfInstance(aruba.NodePoolInstanceK4A8).
+            Named("default-pool").
+            InZone(aruba.ZoneITBG1).
+            WithCount(3)).
+        HighlyAvailable().
+        BilledBy(aruba.BillingPeriodHour))
+if err != nil {
+    log.Fatalf("Create KaaS: %v", err)
+}
+
+if err := k.WaitUntilReady(ctx); err != nil {
+    log.Fatalf("KaaS did not become Ready: %v", err)
+}
+fmt.Printf("✓ Cluster KaaS: %s (k8s: %s)\n", k.Name(), k.KubernetesVersion())
+```
+
+**Download del kubeconfig** (richiede un wrapper idratato):
+
+```go
+kubeconfig, err := k.DownloadKubeconfig(ctx)
+if err != nil {
+    log.Fatalf("DownloadKubeconfig: %v", err)
+}
+// kubeconfig è un []byte YAML kubeconfig
+```
+
+**Builder del node pool** — `aruba.NewNodePool()`:
+- `Named(name)` — nome del pool
+- `WithCount(n)` — numero di nodi
+- `OfInstance(flavor)` — flavor dell'istanza nodo
+- `InZone(zone)` — zona di disponibilità
+- `WithAutoscaling(min, max)` — abilita l'autoscaling
+
+**Accessor di risposta**:
+- `ID()`, `URI()`, `Name()`, `Tags()`
+- `KaaSID()` — ID cluster assegnato dal provider
+- `VPC()`, `Subnet()` — `aruba.Ref` alle risorse di rete collegate
+- `SecurityGroupName()` — nome del security group applicato
+- `KubernetesVersion()` — stringa della versione Kubernetes
+- `BillingPeriod()` — cadenza di fatturazione
+- `State()`, `FailureReason()`, `PreviousState()`, `IsDisabled()`, `DisableReasons()`
+- `WaitUntilReady(ctx, opts...)`, `WaitUntilActive(ctx, opts...)`, `WaitUntilStates(ctx, []types.State{...}, opts...)`, `WaitUntilGone(ctx, opts...)`
+- `Raw()` — struct wire sottostante
+
+**Setter**:
+- *Name*: `Named(string)`
+- *Labels*: `Tagged(...string)`, `Untagged(...string)`, `RetaggedAs(...string)`
+- *Containment*: `InProject(Ref)`
+- *Geography*: `InRegion(Region)`
+- *Descriptive scalars*: `WithKubernetesVersion(KubernetesVersion)`, `WithPodCIDR(string)`, `WithMaxStorageQuotaGB(int)`, `WithIdentity(string, string)`
+- *Attached config*: `WithVPC(Ref)`, `WithSubnet(Ref)`, `WithSecurityGroup(Ref)`, `WithNodeCIDR(string, string)`, `WithNodePools(...*NodePool)`, `WithoutNodePools()`, `ReplaceNodePools(...*NodePool)`
+- *Boolean state*: `HighlyAvailable()`
+- *Billing*: `BilledBy(BillingPeriod)`
+
+:::tip Esempio eseguibile
+Esempio end-to-end completo: [`examples/all-resources/resource_kaas.go`](https://github.com/Arubacloud/sdk-go/blob/main/examples/all-resources/resource_kaas.go)
+:::
+
+---
+
+### Container Registry
+
+```go
+arubaClient.FromContainer().ContainerRegistry()
+```
+
+**Operazioni supportate**: `Create`, `List`, `Get`, `Update`, `Delete`
+**Asincrono**: sì — chiama `WaitUntilReady(ctx)` dopo `Create`. Questa risorsa può impiegare 20–40 minuti per convergere — utilizza un budget di attesa generoso.
+
+```go
+reg, err := arubaClient.FromContainer().ContainerRegistry().Create(
+    ctx,
+    aruba.NewContainerRegistry().
+        OfSize(aruba.ContainerRegistrySizeFlavorSmall).
+        Named("my-registry").
+        Tagged("env-prod").
+        InProject(proj).
+        WithAdminUsername("admin").
+        WithVPC(vpc).
+        WithSubnet(subnet).
+        WithSecurityGroup(sg).
+        WithElasticIP(eip).
+        WithBlockStorage(blockStorage).
+        BilledBy(aruba.BillingPeriodHour))
+if err != nil {
+    log.Fatalf("Create ContainerRegistry: %v", err)
+}
+
+if err := reg.WaitUntilReady(ctx); err != nil {
+    log.Fatalf("ContainerRegistry did not become Ready: %v", err)
+}
+fmt.Printf("✓ Registry: %s (IP pubblico: %s)\n", reg.Name(), reg.PublicIP())
+```
+
+**Accessor di risposta**:
+- `ID()`, `URI()`, `Name()`, `Tags()`
+- `ContainerRegistryID()` — ID registry assegnato dal provider
+- `ElasticIP()` — URI dell'endpoint pubblico
+- `VPC()`, `Subnet()`, `SecurityGroup()`, `BlockStorage()` — `aruba.Ref` alle risorse collegate
+- `AdminUsername()` — utente amministratore del registry
+- `BillingPeriod()` — cadenza di fatturazione
+- `State()`, `FailureReason()`, `PreviousState()`, `IsDisabled()`, `DisableReasons()`
+- `WaitUntilReady(ctx, opts...)`, `WaitUntilActive(ctx, opts...)`, `WaitUntilStates(ctx, []types.State{...}, opts...)`, `WaitUntilGone(ctx, opts...)`
+- `Raw()` — struct wire sottostante
+
+**Setter**:
+- *Classifier*: `OfSize(ContainerRegistrySizeFlavor)`
+- *Name*: `Named(string)`
+- *Labels*: `Tagged(...string)`, `Untagged(...string)`, `RetaggedAs(...string)`
+- *Containment*: `InProject(Ref)`
+- *Geography*: `InRegion(Region)`
+- *Descriptive scalars*: `WithAdminUsername(string)`
+- *Attached config*: `WithElasticIP(Ref)`, `WithVPC(Ref)`, `WithSubnet(Ref)`, `WithSecurityGroup(Ref)`, `WithBlockStorage(Ref)`
+- *Billing*: `BilledBy(BillingPeriod)`
+
+:::tip Esempio eseguibile
+Esempio end-to-end completo: [`examples/all-resources/resource_container_registry.go`](https://github.com/Arubacloud/sdk-go/blob/main/examples/all-resources/resource_container_registry.go)
+:::
+
+---
+
+## Database
+
+### DBaaS (Database as a Service)
+
+```go
+arubaClient.FromDatabase().DBaaS()
+```
+
+**Operazioni supportate**: `Create`, `List`, `Get`, `Update`, `Delete`
+**Asincrono**: sì — chiama `WaitUntilReady(ctx)` dopo `Create`.
+
+```go
+db, err := arubaClient.FromDatabase().DBaaS().Create(
+    ctx,
+    aruba.NewDBaaS().
+        OfEngine(aruba.DatabaseEngineMySQL80).
+        OfFlavor(aruba.DBaaSFlavorDBO2A4).
+        Named("my-database").
+        Tagged("env-prod").
+        InProject(proj).
+        InRegion(aruba.RegionITBGBergamo).
+        InZone(aruba.ZoneITBG1).
+        SizedGB(20).
+        WithVPC(vpc).
+        WithSubnet(subnet).
+        WithSecurityGroup(sg).
+        WithElasticIP(eip).
+        BilledBy(aruba.BillingPeriodHour))
+if err != nil {
+    log.Fatalf("Create DBaaS: %v", err)
+}
+
+if err := db.WaitUntilReady(ctx); err != nil {
+    log.Fatalf("DBaaS did not become Ready: %v", err)
+}
+fmt.Printf("✓ DBaaS: %s (engine: %s)\n", db.Name(), db.Engine())
+```
+
+**Accessor di risposta**:
+- `ID()`, `URI()`, `Name()`, `Tags()`
+- `DBaaSID()` — ID istanza assegnato dal provider
+- `Engine()` — identificatore dell'engine (costante `DatabaseEngine`)
+- `EngineRaw()` — struct engine completa
+- `Flavor()` — identificatore del flavor (costante `DBaaSFlavor`)
+- `FlavorRaw()` — struct flavor completa
+- `SizeGB()` — dimensione dello storage in GB
+- `AutoscalingEnabled()` — bool
+- `VPC()`, `Subnet()`, `SecurityGroup()`, `ElasticIP()` — `aruba.Ref` alle risorse di rete
+- `BillingPeriod()` — cadenza di fatturazione
+- `State()`, `FailureReason()`, `PreviousState()`, `IsDisabled()`, `DisableReasons()`
+- `WaitUntilReady(ctx, opts...)`, `WaitUntilActive(ctx, opts...)`, `WaitUntilStates(ctx, []types.State{...}, opts...)`, `WaitUntilGone(ctx, opts...)`
+- `Raw()` — struct wire sottostante
+
+**Setter**:
+- *Classifier*: `OfEngine(DatabaseEngine)`, `OfFlavor(DBaaSFlavor)`
+- *Name*: `Named(string)`
+- *Labels*: `Tagged(...string)`, `Untagged(...string)`, `RetaggedAs(...string)`
+- *Containment*: `InProject(Ref)`
+- *Geography*: `InRegion(Region)`, `InZone(Zone)`
+- *Descriptive scalars*: `SizedGB(int)`, `WithAutoscaling(min, max int)`, `WithoutAutoscaling()`
+- *Attached config*: `WithVPC(Ref)`, `WithSubnet(Ref)`, `WithSecurityGroup(Ref)`, `WithElasticIP(Ref)`
+- *Billing*: `BilledBy(BillingPeriod)`
+
+:::tip Esempio eseguibile
+Esempio end-to-end completo: [`examples/all-resources/resource_dbaas.go`](https://github.com/Arubacloud/sdk-go/blob/main/examples/all-resources/resource_dbaas.go)
+:::
+
+---
+
+### Database
+
+```go
+arubaClient.FromDatabase().Databases()
+```
+
+**Operazioni supportate**: `Create`, `List`, `Get`, `Delete`
+**Asincrono**: sì — chiama `WaitUntilReady(ctx)` dopo `Create`.
+
+```go
+database, err := arubaClient.FromDatabase().Databases().Create(
+    ctx,
+    aruba.NewDatabase().
+        Named("my-app-db").
+        Tagged("app-backend").
+        InDBaaS(db))
+if err != nil {
+    log.Fatalf("Create Database: %v", err)
+}
+
+if err := database.WaitUntilReady(ctx); err != nil {
+    log.Fatalf("Database did not become Ready: %v", err)
+}
+fmt.Printf("✓ Database: %s\n", database.Name())
+```
+
+**Accessor di risposta**:
+- `ID()`, `URI()`, `Name()`, `Tags()`
+- `DatabaseID()` — ID database assegnato dal provider
+- `DBaaSID()` — ID DBaaS padre
+- `State()`, `FailureReason()`, `PreviousState()`, `IsDisabled()`, `DisableReasons()`
+- `WaitUntilReady(ctx, opts...)`, `WaitUntilActive(ctx, opts...)`, `WaitUntilStates(ctx, []types.State{...}, opts...)`, `WaitUntilGone(ctx, opts...)`
+- `Raw()` — struct wire sottostante
+
+**Setter**:
+- *Name*: `Named(string)`
+- *Containment*: `InDBaaS(Ref)`
+
+:::tip Esempio eseguibile
+Esempio end-to-end completo: [`examples/all-resources/resource_database.go`](https://github.com/Arubacloud/sdk-go/blob/main/examples/all-resources/resource_database.go)
+:::
+
+---
+
+### User
+
+```go
+arubaClient.FromDatabase().Users()
+```
+
+**Operazioni supportate**: `Create`, `List`, `Get`, `Delete`
+**Asincrono**: sì — chiama `WaitUntilReady(ctx)` dopo `Create`.
+
+```go
+user, err := arubaClient.FromDatabase().Users().Create(
+    ctx,
+    aruba.NewUser().
+        Tagged("app-backend").
+        InDBaaS(db).
+        WithUsername("app_user").
+        WithPassword("Str0ngP@ssword!"))
+if err != nil {
+    log.Fatalf("Create User: %v", err)
+}
+
+if err := user.WaitUntilReady(ctx); err != nil {
+    log.Fatalf("User did not become Ready: %v", err)
+}
+fmt.Printf("✓ Utente: %s\n", user.Name())
+```
+
+**Accessor di risposta**:
+- `ID()`, `URI()`, `Name()`, `Tags()`
+- `UserID()` — ID utente assegnato dal provider
+- `Username()` — nome utente del database
+- `DBaaSID()` — ID DBaaS padre
+- `State()`, `FailureReason()`, `PreviousState()`, `IsDisabled()`, `DisableReasons()`
+- `WaitUntilReady(ctx, opts...)`, `WaitUntilActive(ctx, opts...)`, `WaitUntilStates(ctx, []types.State{...}, opts...)`, `WaitUntilGone(ctx, opts...)`
+- `Raw()` — struct wire sottostante
+
+**Setter**:
+- *Name*: `WithUsername(string)`
+- *Containment*: `InDBaaS(Ref)`
+- *Descriptive scalars*: `WithPassword(string)`
+
+:::tip Esempio eseguibile
+Esempio end-to-end completo: [`examples/all-resources/resource_dbaas_user.go`](https://github.com/Arubacloud/sdk-go/blob/main/examples/all-resources/resource_dbaas_user.go)
+:::
+
+---
+
+### Grant
+
+```go
+arubaClient.FromDatabase().Grants()
+```
+
+**Operazioni supportate**: `Create`, `List`, `Get`, `Delete`
+**Asincrono**: sì — chiama `WaitUntilReady(ctx)` dopo `Create`.
+
+```go
+grant, err := arubaClient.FromDatabase().Grants().Create(
+    ctx,
+    aruba.NewGrant().
+        OfRole("liteadmin").
+        InDatabase(database).
+        ForUser("app_user"))
+if err != nil {
+    log.Fatalf("Create Grant: %v", err)
+}
+
+if err := grant.WaitUntilReady(ctx); err != nil {
+    log.Fatalf("Grant did not become Ready: %v", err)
+}
+fmt.Printf("✓ Grant: %s (privilegi: %s)\n", grant.Name(), grant.Privileges())
+```
+
+**Accessor di risposta**:
+- `ID()`, `URI()`, `Name()`, `Tags()`
+- `GrantID()` — ID grant assegnato dal provider
+- `DatabaseID()` — ID Database padre
+- `Privileges()` — stringa dei privilegi
+- `State()`, `FailureReason()`, `PreviousState()`, `IsDisabled()`, `DisableReasons()`
+- `WaitUntilReady(ctx, opts...)`, `WaitUntilActive(ctx, opts...)`, `WaitUntilStates(ctx, []types.State{...}, opts...)`, `WaitUntilGone(ctx, opts...)`
+- `Raw()` — struct wire sottostante
+
+**Setter**:
+- *Containment*: `InDatabase(Ref)`
+- *Active relationship*: `ForUser(string)`, `OfRole(string)`
+
+:::tip Esempio eseguibile
+Esempio end-to-end completo: [`examples/all-resources/resource_grant.go`](https://github.com/Arubacloud/sdk-go/blob/main/examples/all-resources/resource_grant.go)
+:::
+
+---
+
+### DBaaS Backup
+
+```go
+arubaClient.FromDatabase().DBaaSBackups()
+```
+
+**Operazioni supportate**: `Create`, `List`, `Get`, `Delete`
+**Asincrono**: sì — chiama `WaitUntilReady(ctx)` dopo `Create`.
+
+```go
+backup, err := arubaClient.FromDatabase().DBaaSBackups().Create(
+    ctx,
+    aruba.NewDBaaSBackup().
+        Named("my-db-backup").
+        Tagged("backup").
+        InProject(proj).
+        FromDBaaS(db).
+        BilledBy(aruba.BillingPeriodHour))
+if err != nil {
+    log.Fatalf("Create DBaaSBackup: %v", err)
+}
+
+if err := backup.WaitUntilReady(ctx); err != nil {
+    log.Fatalf("DBaaS Backup did not become Ready: %v", err)
+}
+fmt.Printf("✓ DBaaS Backup: %s\n", backup.Name())
+```
+
+**Accessor di risposta**:
+- `ID()`, `URI()`, `Name()`, `Tags()`
+- `DBaaSBackupID()` — ID backup assegnato dal provider
+- `DBaaSURI()` — URI del DBaaS sorgente
+- `DatabaseURI()` — URI del Database sorgente (se applicabile)
+- `SizeGB()` — dimensione del backup in GB
+- `Zone()` — zona di disponibilità
+- `BillingPeriod()` — cadenza di fatturazione
+- `State()`, `FailureReason()`, `PreviousState()`, `IsDisabled()`, `DisableReasons()`
+- `WaitUntilReady(ctx, opts...)`, `WaitUntilActive(ctx, opts...)`, `WaitUntilStates(ctx, []types.State{...}, opts...)`, `WaitUntilGone(ctx, opts...)`
+- `Raw()` — struct wire sottostante
+
+**Setter**:
+- *Name*: `Named(string)`
+- *Labels*: `Tagged(...string)`, `Untagged(...string)`, `RetaggedAs(...string)`
+- *Containment*: `InProject(Ref)`, `FromDBaaS(Ref)`, `FromDatabase(Ref)`
+- *Geography*: `InRegion(Region)`, `InZone(Zone)`
+- *Billing*: `BilledBy(BillingPeriod)`
+
+:::tip Esempio eseguibile
+Le operazioni di DBaaS Backup sono trattate nell'esempio DBaaS: [`examples/all-resources/resource_dbaas.go`](https://github.com/Arubacloud/sdk-go/blob/main/examples/all-resources/resource_dbaas.go)
+:::
+
+---
+
+## Metric
+
+### Alert
+
+```go
+arubaClient.FromMetric().Alerts()
+```
+
+**Operazioni supportate**: `List`
+
+Gli Alert sono in sola lettura. Usa `List` con un `Ref` di progetto per interrogare gli alert attivi.
+
+```go
+list, err := arubaClient.FromMetric().Alerts().List(ctx, proj)
+if err != nil {
+    log.Fatalf("List Alerts: %v", err)
+}
+for _, a := range list.Items() {
+    fmt.Println(a.ID(), a.Name(), a.IsActive())
+}
+```
+
+**Accessor di risposta**:
+- `ID()`, `URI()`, `Name()`
+- `Threshold()` — valore soglia dell'alert
+- `Action()` — azione scatenata all'alert
+- `IsActive()` — bool
+- `Raw()` — struct wire sottostante
+
+:::tip Esempio eseguibile
+Eseguito come parte dell'orchestratore: [`examples/all-resources/orchestrator_create.go`](https://github.com/Arubacloud/sdk-go/blob/main/examples/all-resources/orchestrator_create.go)
+:::
+
+---
+
+### Metric
+
+```go
+arubaClient.FromMetric().Metrics()
+```
+
+**Operazioni supportate**: `List`
+
+Le Metric sono risultati di query di serie temporali in sola lettura.
+
+```go
+list, err := arubaClient.FromMetric().Metrics().List(ctx, proj,
+    aruba.WithFilter("resource eq '"+cs.URI()+"'"))
+if err != nil {
+    log.Fatalf("List Metrics: %v", err)
+}
+for _, m := range list.Items() {
+    fmt.Println(m.ID(), m.Name())
+}
+```
+
+**Accessor di risposta**:
+- `ID()`, `URI()`, `Name()`
+- `Raw()` — struct wire sottostante
+
+:::tip Esempio eseguibile
+Eseguito come parte dell'orchestratore: [`examples/all-resources/orchestrator_create.go`](https://github.com/Arubacloud/sdk-go/blob/main/examples/all-resources/orchestrator_create.go)
+:::
+
+---
+
+## Network
+
+### VPC
+
+```go
+arubaClient.FromNetwork().VPCs()
+```
+
+**Operazioni supportate**: `Create`, `List`, `Get`, `Update`, `Delete`
+**Asincrono**: sì — chiama `WaitUntilReady(ctx)` dopo `Create`.
+
+```go
+vpc, err := arubaClient.FromNetwork().VPCs().Create(
+    ctx,
+    aruba.NewVPC().
+        Named("my-vpc").
+        Tagged("network").
+        InProject(proj).
+        InRegion(aruba.RegionITBGBergamo).
+        NotDefault().
+        WithoutPreset())
+if err != nil {
+    log.Fatalf("Create VPC: %v", err)
+}
+
+if err := vpc.WaitUntilReady(ctx); err != nil {
+    log.Fatalf("VPC did not become Ready: %v", err)
+}
+fmt.Printf("✓ VPC: %s\n", vpc.Name())
+```
+
+**Accessor di risposta**:
+- `ID()`, `URI()`, `Name()`, `Tags()`
+- `VPCID()` — ID VPC assegnato dal provider
+- `Region()` — slug della regione
+- `IsDefault()`, `IsPreset()` — flag
+- `State()`, `FailureReason()`, `PreviousState()`, `IsDisabled()`, `DisableReasons()`
+- `WaitUntilReady(ctx, opts...)`, `WaitUntilActive(ctx, opts...)`, `WaitUntilStates(ctx, []types.State{...}, opts...)`, `WaitUntilGone(ctx, opts...)`
+- `Raw()` — struct wire sottostante
+
+**Setter**:
+- *Name*: `Named(string)`
+- *Labels*: `Tagged(...string)`, `Untagged(...string)`, `RetaggedAs(...string)`
+- *Containment*: `InProject(Ref)`
+- *Geography*: `InRegion(Region)`
+- *Boolean state*: `AsDefault()`, `NotDefault()`, `WithPreset()`, `WithoutPreset()`
+
+:::tip Esempio eseguibile
+Esempio end-to-end completo: [`examples/all-resources/resource_vpc.go`](https://github.com/Arubacloud/sdk-go/blob/main/examples/all-resources/resource_vpc.go)
+:::
+
+---
+
+### Subnet
+
+```go
+arubaClient.FromNetwork().Subnets()
+```
+
+**Operazioni supportate**: `Create`, `List`, `Get`, `Update`, `Delete`
+**Asincrono**: sì — chiama `WaitUntilReady(ctx)` dopo `Create`.
+
+`OfType` accetta `aruba.SubnetTypeBasic` o `aruba.SubnetTypeAdvanced` (costanti tipizzate — nessun cast a stringa necessario).
+
+`aruba.NewSubnetDHCP()` è un sub-builder per la configurazione DHCP. Collegalo con `WithDHCP(...)`.
+
+```go
+subnet, err := arubaClient.FromNetwork().Subnets().Create(
+    ctx,
+    aruba.NewSubnet().
+        OfType(aruba.SubnetTypeAdvanced).
+        Named("my-subnet").
+        Tagged("network").
+        InVPC(vpc).
+        InRegion(aruba.RegionITBGBergamo).
+        WithCIDR("192.168.1.0/25").
+        WithDHCP(aruba.NewSubnetDHCP().
+            Enabled().
+            WithRange("192.168.1.10", 50).
+            WithRoutes(aruba.SubnetDHCPRouteCommon{Address: "0.0.0.0/0", Gateway: "192.168.1.1"}).
+            WithDNSServers("8.8.8.8", "8.8.4.4")).
+        NotDefault())
+if err != nil {
+    log.Fatalf("Create Subnet: %v", err)
+}
+
+if err := subnet.WaitUntilReady(ctx); err != nil {
+    log.Fatalf("Subnet did not become Ready: %v", err)
+}
+fmt.Printf("✓ Subnet: %s (CIDR: %s)\n", subnet.Name(), subnet.CIDR())
+```
+
+**Accessor di risposta**:
+- `ID()`, `URI()`, `Name()`, `Tags()`
+- `SubnetID()` — ID subnet assegnato dal provider
+- `Type()` — tipo di subnet (costante `SubnetType`)
+- `CIDR()` — blocco CIDR
+- `DHCP()` — configurazione DHCP
+- `IsDefault()` — bool
+- `Region()` — slug della regione
+- `State()`, `FailureReason()`, `PreviousState()`, `IsDisabled()`, `DisableReasons()`
+- `WaitUntilReady(ctx, opts...)`, `WaitUntilActive(ctx, opts...)`, `WaitUntilStates(ctx, []types.State{...}, opts...)`, `WaitUntilGone(ctx, opts...)`
+- `Raw()` — struct wire sottostante
+
+**Setter**:
+- *Classifier*: `OfType(SubnetType)`
+- *Name*: `Named(string)`
+- *Labels*: `Tagged(...string)`, `Untagged(...string)`, `RetaggedAs(...string)`
+- *Containment*: `InVPC(Ref)`
+- *Geography*: `InRegion(Region)`
+- *Descriptive scalars*: `WithCIDR(string)`
+- *Attached config*: `WithDHCP(*SubnetDHCPCommon)`
+- *Boolean state*: `AsDefault()`, `NotDefault()`
+
+:::tip Esempio eseguibile
+Esempio end-to-end completo: [`examples/all-resources/resource_subnet.go`](https://github.com/Arubacloud/sdk-go/blob/main/examples/all-resources/resource_subnet.go)
+:::
+
+---
+
+### Elastic IP
+
+```go
+arubaClient.FromNetwork().ElasticIPs()
+```
+
+**Operazioni supportate**: `Create`, `List`, `Get`, `Update`, `Delete`
+**Asincrono**: sì — chiama `WaitUntilReady(ctx)` dopo `Create`.
+
+```go
+eip, err := arubaClient.FromNetwork().ElasticIPs().Create(
+    ctx,
+    aruba.NewElasticIP().
+        Named("my-eip").
+        Tagged("network").
+        InProject(proj).
+        InRegion(aruba.RegionITBGBergamo).
+        BilledBy(aruba.BillingPeriodHour))
+if err != nil {
+    log.Fatalf("Create ElasticIP: %v", err)
+}
+
+if err := eip.WaitUntilReady(ctx); err != nil {
+    log.Fatalf("ElasticIP did not become Ready: %v", err)
+}
+fmt.Printf("✓ Elastic IP: %s (%s)\n", eip.Name(), eip.Address())
+```
+
+**Accessor di risposta**:
+- `ID()`, `URI()`, `Name()`, `Tags()`
+- `ElasticIPID()` — ID IP assegnato dal provider
+- `Address()` — indirizzo IP pubblico allocato
+- `BillingPeriod()` — cadenza di fatturazione
+- `Region()` — slug della regione
+- `State()`, `FailureReason()`, `PreviousState()`, `IsDisabled()`, `DisableReasons()`
+- `WaitUntilReady(ctx, opts...)`, `WaitUntilActive(ctx, opts...)`, `WaitUntilNotUsed(ctx, opts...)`, `WaitUntilUsed(ctx, opts...)`, `WaitUntilStates(ctx, []types.State{...}, opts...)`, `WaitUntilGone(ctx, opts...)`
+- `Raw()` — struct wire sottostante
+
+**Setter**:
+- *Name*: `Named(string)`
+- *Labels*: `Tagged(...string)`, `Untagged(...string)`, `RetaggedAs(...string)`
+- *Containment*: `InProject(Ref)`
+- *Geography*: `InRegion(Region)`
+- *Billing*: `BilledBy(BillingPeriod)`
+
+:::tip Esempio eseguibile
+Esempio end-to-end completo: [`examples/all-resources/resource_elastic_ip.go`](https://github.com/Arubacloud/sdk-go/blob/main/examples/all-resources/resource_elastic_ip.go)
+:::
+
+---
+
+### Security Group
+
+```go
+arubaClient.FromNetwork().SecurityGroups()
+```
+
+**Operazioni supportate**: `Create`, `List`, `Get`, `Update`, `Delete`
+**Asincrono**: sì — chiama `WaitUntilReady(ctx)` dopo `Create`.
+
+```go
+sg, err := arubaClient.FromNetwork().SecurityGroups().Create(
+    ctx,
+    aruba.NewSecurityGroup().
+        Named("my-security-group").
+        Tagged("security").
+        InVPC(vpc).
+        NotDefault())
+if err != nil {
+    log.Fatalf("Create SecurityGroup: %v", err)
+}
+
+if err := sg.WaitUntilReady(ctx); err != nil {
+    log.Fatalf("SecurityGroup did not become Active: %v", err)
+}
+fmt.Printf("✓ Security Group: %s (ID: %s)\n", sg.Name(), sg.ID())
+```
+
+**Accessor di risposta**:
+- `ID()`, `URI()`, `Name()`, `Tags()`
+- `SecurityGroupID()` — ID gruppo assegnato dal provider
+- `IsDefault()` — bool
+- `State()`, `FailureReason()`, `PreviousState()`, `IsDisabled()`, `DisableReasons()`
+- `WaitUntilReady(ctx, opts...)`, `WaitUntilActive(ctx, opts...)`, `WaitUntilStates(ctx, []types.State{...}, opts...)`, `WaitUntilGone(ctx, opts...)`
+- `Raw()` — struct wire sottostante
+
+**Setter**:
+- *Name*: `Named(string)`
+- *Labels*: `Tagged(...string)`, `Untagged(...string)`, `RetaggedAs(...string)`
+- *Containment*: `InVPC(Ref)`
+- *Boolean state*: `AsDefault()`, `NotDefault()`
+
+:::tip Esempio eseguibile
+Esempio end-to-end completo: [`examples/all-resources/resource_security_group.go`](https://github.com/Arubacloud/sdk-go/blob/main/examples/all-resources/resource_security_group.go)
+:::
+
+---
+
+### Security Rule
+
+```go
+arubaClient.FromNetwork().SecurityGroupRules()
+```
+
+**Operazioni supportate**: `Create`, `List`, `Get`, `Delete`
+**Asincrono**: sì — `State()` e `FailureReason()` sono disponibili.
+
+`WithDirection` accetta `aruba.RuleDirectionIngress` o `aruba.RuleDirectionEgress`. `WithProtocol` accetta `aruba.RuleProtocolTCP`, `aruba.RuleProtocolUDP`, `aruba.RuleProtocolICMP` o `aruba.RuleProtocolANY`.
+
+> **Avvertenza**: `TargetingCIDR` e `TargetingSecurityGroup` sono mutuamente esclusivi. Impostare entrambi registra un errore al momento del setter, che emerge al momento di `Create`.
+
+```go
+rule, err := arubaClient.FromNetwork().SecurityGroupRules().Create(
+    ctx,
+    aruba.NewSecurityRule().
+        Named("allow-ssh").
+        Tagged("ssh-key").
+        InSecurityGroup(sg).
+        InRegion(aruba.RegionITBGBergamo).
+        WithDirection(aruba.RuleDirectionIngress).
+        WithProtocol(aruba.RuleProtocolTCP).
+        WithPort("22").
+        TargetingCIDR("0.0.0.0/0"))
+if err != nil {
+    log.Fatalf("Create SecurityRule: %v", err)
+}
+fmt.Printf("✓ Security Rule: %s\n", rule.Name())
+```
+
+**Accessor di risposta**:
+- `ID()`, `URI()`, `Name()`, `Tags()`
+- `SecurityRuleID()` — ID regola assegnato dal provider
+- `Direction()` — `"Ingress"` o `"Egress"`
+- `Protocol()` — es. `"TCP"`, `"UDP"`, `"ICMP"`
+- `Port()` — numero di porta o intervallo
+- `TargetKind()` — `"Ip"` o `"SecurityGroup"`
+- `TargetValue()` — stringa CIDR o URI del Security Group
+- `Region()` — slug della regione
+- `State()`, `FailureReason()`, `PreviousState()`, `IsDisabled()`, `DisableReasons()`
+- `WaitUntilGone(ctx, opts...)`
+- `Raw()` — struct wire sottostante
+
+**Setter**:
+- *Name*: `Named(string)`
+- *Labels*: `Tagged(...string)`, `Untagged(...string)`, `RetaggedAs(...string)`
+- *Containment*: `InSecurityGroup(Ref)`
+- *Geography*: `InRegion(Region)`
+- *Descriptive scalars*: `WithDirection(RuleDirection)`, `WithProtocol(RuleProtocol)`, `WithPort(string)`
+- *Active relationship*: `TargetingCIDR(string)`, `TargetingSecurityGroup(Ref)`
+
+:::tip Esempio eseguibile
+Eseguito come parte dell'orchestratore: [`examples/all-resources/orchestrator_create.go`](https://github.com/Arubacloud/sdk-go/blob/main/examples/all-resources/orchestrator_create.go)
+:::
+
+---
+
+### Load Balancer
+
+```go
+arubaClient.FromNetwork().LoadBalancers()
+```
+
+**Operazioni supportate**: `List`, `Get`
+
+I Load Balancer sono in sola lettura tramite questo SDK — vengono creati e gestiti automaticamente dalla piattaforma Aruba Cloud.
+
+```go
+list, err := arubaClient.FromNetwork().LoadBalancers().List(ctx, proj)
+if err != nil {
+    log.Fatalf("List LoadBalancers: %v", err)
+}
+for _, lb := range list.Items() {
+    fmt.Println(lb.ID(), lb.Name(), lb.Address())
+}
+```
+
+**Accessor di risposta**:
+- `ID()`, `URI()`, `Name()`, `Tags()`
+- `LoadBalancerID()` — ID LB assegnato dal provider
+- `Address()` — indirizzo pubblico
+- `VPC()` — `aruba.Ref` alla VPC collegata
+- `Region()` — slug della regione
+- `State()`, `FailureReason()`, `PreviousState()`, `IsDisabled()`, `DisableReasons()`
+- `Raw()` — struct wire sottostante
+
+:::tip Esempio eseguibile
+Eseguito come parte dell'orchestratore: [`examples/all-resources/orchestrator_create.go`](https://github.com/Arubacloud/sdk-go/blob/main/examples/all-resources/orchestrator_create.go)
+:::
+
+---
+
+### VPC Peering
+
+```go
+arubaClient.FromNetwork().VPCPeerings()
+```
+
+**Operazioni supportate**: `Create`, `List`, `Get`, `Update`, `Delete`
+**Asincrono**: sì — chiama `WaitUntilReady(ctx)` dopo `Create`.
+
+```go
+peering, err := arubaClient.FromNetwork().VPCPeerings().Create(
+    ctx,
+    aruba.NewVPCPeering().
+        Named("my-peering").
+        Tagged("network").
+        InVPC(vpc).
+        InRegion(aruba.RegionITBGBergamo).
+        WithPeerVPC(aruba.URI("/projects/"+peerProjectID+"/vpcs/"+peerVPCID)))
+if err != nil {
+    log.Fatalf("Create VPCPeering: %v", err)
+}
+
+if err := peering.WaitUntilReady(ctx); err != nil {
+    log.Fatalf("VPCPeering did not become Active: %v", err)
+}
+fmt.Printf("✓ VPC Peering: %s\n", peering.Name())
+```
+
+**Accessor di risposta**:
+- `ID()`, `URI()`, `Name()`, `Tags()`
+- `VPCPeeringID()` — ID peering assegnato dal provider
+- `VPCID()` — ID VPC sorgente
+- `PeerVPC()` — `aruba.Ref` alla VPC peer
+- `State()`, `FailureReason()`, `PreviousState()`, `IsDisabled()`, `DisableReasons()`
+- `WaitUntilReady(ctx, opts...)`, `WaitUntilActive(ctx, opts...)`, `WaitUntilStates(ctx, []types.State{...}, opts...)`, `WaitUntilGone(ctx, opts...)`
+- `Raw()` — struct wire sottostante
+
+**Setter**:
+- *Name*: `Named(string)`
+- *Labels*: `Tagged(...string)`, `Untagged(...string)`, `RetaggedAs(...string)`
+- *Containment*: `InVPC(Ref)`
+- *Geography*: `InRegion(Region)`
+- *Active relationship*: `PeeredWith(Ref)`
+
+:::tip Esempio eseguibile
+Eseguito come parte dell'orchestratore: [`examples/all-resources/orchestrator_create.go`](https://github.com/Arubacloud/sdk-go/blob/main/examples/all-resources/orchestrator_create.go)
+:::
+
+---
+
+### VPC Peering Route
+
+```go
+arubaClient.FromNetwork().VPCPeeringRoutes()
+```
+
+**Operazioni supportate**: `Create`, `List`, `Get`, `Update`, `Delete`
+**Asincrono**: sì — chiama `WaitUntilReady(ctx)` dopo `Create`.
+
+```go
+route, err := arubaClient.FromNetwork().VPCPeeringRoutes().Create(
+    ctx,
+    aruba.NewVPCPeeringRoute().
+        Named("my-peering-route").
+        Tagged("network").
+        InVPCPeering(peering).
+        InRegion(aruba.RegionITBGBergamo).
+        WithCIDR("10.0.0.0/8").
+        WithTarget(aruba.URI("/projects/"+projectID+"/vpcs/"+vpcID)))
+if err != nil {
+    log.Fatalf("Create VPCPeeringRoute: %v", err)
+}
+
+if err := route.WaitUntilReady(ctx); err != nil {
+    log.Fatalf("VPCPeeringRoute did not become Active: %v", err)
+}
+fmt.Printf("✓ Peering Route: %s (CIDR: %s)\n", route.Name(), route.CIDR())
+```
+
+**Accessor di risposta**:
+- `ID()`, `URI()`, `Name()`, `Tags()`
+- `CIDR()` — blocco CIDR della route
+- `Target()` — `aruba.Ref` al target della route
+- `VPCPeeringID()` — ID peering padre
+- `State()`, `FailureReason()`, `PreviousState()`, `IsDisabled()`, `DisableReasons()`
+- `WaitUntilReady(ctx, opts...)`, `WaitUntilActive(ctx, opts...)`, `WaitUntilStates(ctx, []types.State{...}, opts...)`, `WaitUntilGone(ctx, opts...)`
+- `Raw()` — struct wire sottostante
+
+**Setter**:
+- *Name*: `Named(string)`
+- *Labels*: `Tagged(...string)`, `Untagged(...string)`, `RetaggedAs(...string)`
+- *Containment*: `InVPCPeering(Ref)`
+- *Geography*: `InRegion(Region)`
+- *Descriptive scalars*: `WithLocalCIDR(string)`, `WithRemoteCIDR(string)`
+- *Billing*: `BilledBy(BillingPeriod)`
+
+:::tip Esempio eseguibile
+Eseguito come parte dell'orchestratore: [`examples/all-resources/orchestrator_create.go`](https://github.com/Arubacloud/sdk-go/blob/main/examples/all-resources/orchestrator_create.go)
+:::
+
+---
+
+### VPN Tunnel
+
+```go
+arubaClient.FromNetwork().VPNTunnels()
+```
+
+**Operazioni supportate**: `Create`, `List`, `Get`, `Update`, `Delete`
+**Asincrono**: sì — chiama `WaitUntilReady(ctx)` dopo `Create`.
+
+Sub-builder del VPN Tunnel:
+- `aruba.NewVPNIKE()` — parametri fase 1 IKE (`WithEncryption(IKEEncryption)`, `WithHash(IKEHash)`, `WithDHGroup(IKEDHGroup)`, `WithDPDAction(IKEDPDAction)`)
+- `aruba.NewVPNESP()` — parametri fase 2 ESP (`WithEncryption(ESPEncryption)`, `WithHash(ESPHash)`, `WithPFS(ESPPFSGroup)`)
+- `aruba.NewVPNPSK()` — configurazione pre-shared key (`WithKey(string)`, `WithCloudSite(string)`, `WithOnPremSite(string)`)
+
+```go
+tunnel, err := arubaClient.FromNetwork().VPNTunnels().Create(
+    ctx,
+    aruba.NewVPNTunnel().
+        Named("my-vpn-tunnel").
+        Tagged("vpn-net").
+        InProject(proj).
+        InRegion(aruba.RegionITBGBergamo).
+        WithPeerClientPublicIP("203.0.113.1").
+        WithIKESettings(aruba.NewVPNIKE().
+            WithEncryption(aruba.IKEEncryptionAES256).
+            WithHash(aruba.IKEHashSHA256).
+            WithDHGroup(aruba.IKEDHGroup14)).
+        WithESPSettings(aruba.NewVPNESP().
+            WithEncryption(aruba.ESPEncryptionAES256).
+            WithHash(aruba.ESPHashSHA256)).
+        WithPSKSettings(aruba.NewVPNPSK().
+            WithKey("my-pre-shared-key")))
+if err != nil {
+    log.Fatalf("Create VPNTunnel: %v", err)
+}
+
+if err := tunnel.WaitUntilReady(ctx); err != nil {
+    log.Fatalf("VPNTunnel did not become Active: %v", err)
+}
+fmt.Printf("✓ VPN Tunnel: %s (gateway: %s)\n", tunnel.Name(), tunnel.PeerClientPublicIP())
+```
+
+**Accessor di risposta**:
+- `ID()`, `URI()`, `Name()`, `Tags()`
+- `VPNTunnelID()` — ID tunnel assegnato dal provider
+- `PeerClientPublicIP()` — IP gateway del peer remoto
+- `IKE()` — impostazioni IKE `*aruba.VPNIKE`
+- `ESP()` — impostazioni ESP `*aruba.VPNESP`
+- `PSK()` — impostazioni PSK `*aruba.VPNPSK`
+- `State()`, `FailureReason()`, `PreviousState()`, `IsDisabled()`, `DisableReasons()`
+- `WaitUntilReady(ctx, opts...)`, `WaitUntilActive(ctx, opts...)`, `WaitUntilStates(ctx, []types.State{...}, opts...)`, `WaitUntilGone(ctx, opts...)`
+- `Raw()` — struct wire sottostante
+
+**Setter**:
+- *Classifier*: `OfType(VPNType)`
+- *Name*: `Named(string)`
+- *Labels*: `Tagged(...string)`, `Untagged(...string)`, `RetaggedAs(...string)`
+- *Containment*: `InProject(Ref)`
+- *Geography*: `InRegion(Region)`
+- *Descriptive scalars*: `WithVPNClientProtocol(VPNClientProtocol)`, `WithPeerClientPublicIP(string)`
+- *Attached config*: `WithIPConfig(*VPNIPConfig)`, `WithIKESettings(*VPNIKE)`, `WithESPSettings(*VPNESP)`, `WithPSKSettings(*VPNPSK)`
+- *Billing*: `BilledBy(BillingPeriod)`
+
+:::tip Esempio eseguibile
+Eseguito come parte dell'orchestratore: [`examples/all-resources/orchestrator_create.go`](https://github.com/Arubacloud/sdk-go/blob/main/examples/all-resources/orchestrator_create.go)
+:::
+
+---
+
+### VPN Route
+
+```go
+arubaClient.FromNetwork().VPNRoutes()
+```
+
+**Operazioni supportate**: `Create`, `List`, `Get`, `Update`, `Delete`
+**Asincrono**: sì — chiama `WaitUntilReady(ctx)` dopo `Create`.
+
+```go
+vpnRoute, err := arubaClient.FromNetwork().VPNRoutes().Create(
+    ctx,
+    aruba.NewVPNRoute().
+        Named("my-vpn-route").
+        Tagged("vpn-net").
+        InVPNTunnel(tunnel).
+        InRegion(aruba.RegionITBGBergamo).
+        WithCIDR("10.0.0.0/8").
+        WithTarget(aruba.URI("/projects/"+projectID+"/vpcs/"+vpcID)))
+if err != nil {
+    log.Fatalf("Create VPNRoute: %v", err)
+}
+
+if err := vpnRoute.WaitUntilReady(ctx); err != nil {
+    log.Fatalf("VPNRoute did not become Active: %v", err)
+}
+fmt.Printf("✓ VPN Route: %s (CIDR: %s)\n", vpnRoute.Name(), vpnRoute.CIDR())
+```
+
+**Accessor di risposta**:
+- `ID()`, `URI()`, `Name()`, `Tags()`
+- `CIDR()` — blocco CIDR della route
+- `Target()` — `aruba.Ref` al target della route
+- `VPNTunnelID()` — ID VPN Tunnel padre
+- `State()`, `FailureReason()`, `PreviousState()`, `IsDisabled()`, `DisableReasons()`
+- `WaitUntilReady(ctx, opts...)`, `WaitUntilActive(ctx, opts...)`, `WaitUntilStates(ctx, []types.State{...}, opts...)`, `WaitUntilGone(ctx, opts...)`
+- `Raw()` — struct wire sottostante
+
+**Setter**:
+- *Name*: `Named(string)`
+- *Labels*: `Tagged(...string)`, `Untagged(...string)`, `RetaggedAs(...string)`
+- *Containment*: `InVPNTunnel(Ref)`
+- *Geography*: `InRegion(Region)`
+- *Descriptive scalars*: `WithCloudSubnet(string)`, `WithOnPremSubnet(string)`
+
+:::tip Esempio eseguibile
+Eseguito come parte dell'orchestratore: [`examples/all-resources/orchestrator_create.go`](https://github.com/Arubacloud/sdk-go/blob/main/examples/all-resources/orchestrator_create.go)
+:::
+
+---
+
+## Schedule
+
+### Job
+
+```go
+arubaClient.FromSchedule().Jobs()
+```
+
+**Operazioni supportate**: `Create`, `List`, `Get`, `Update`, `Delete`
+**Asincrono**: sì — `State()` e `FailureReason()` sono disponibili.
+
+Usa `OneShotAt(t time.Time)` per pianificare un job one-shot, oppure `WithCron(expr string)` per un job ricorrente con una pianificazione cron. Usa `RecurringUntil(t time.Time)` per impostare una data di fine per un job ricorrente.
+
+```go
+// Job one-shot — eseguito una sola volta a un orario specifico
+job, err := arubaClient.FromSchedule().Jobs().Create(
+    ctx,
+    aruba.NewJob().
+        Named("my-one-shot-job").
+        Tagged("automation").
+        InProject(proj).
+        OneShotAt(time.Now().Add(10*time.Minute)))
+if err != nil {
+    log.Fatalf("Create Job: %v", err)
+}
+fmt.Printf("✓ Job: %s (tipo: %s)\n", job.Name(), job.JobType())
+
+// Job ricorrente — eseguito secondo una pianificazione cron
+cronJob, err := arubaClient.FromSchedule().Jobs().Create(
+    ctx,
+    aruba.NewJob().
+        Named("my-recurring-job").
+        Tagged("automation").
+        InProject(proj).
+        WithCron("0 * * * *"))
+if err != nil {
+    log.Fatalf("Create recurring Job: %v", err)
+}
+fmt.Printf("✓ Job ricorrente: %s (cron: %s)\n", cronJob.Name(), cronJob.Cron())
+```
+
+**Accessor di risposta**:
+- `ID()`, `URI()`, `Name()`, `Tags()`
+- `JobID()` — ID job assegnato dal provider
+- `JobType()` — tipo di job (`types.JobTypeOneShot` o `types.JobTypeRecurring`)
+- `Cron()` — espressione cron (job ricorrenti)
+- `IsEnabled()` — bool
+- `State()`, `FailureReason()`, `PreviousState()`, `IsDisabled()`, `DisableReasons()`
+- `Raw()` — struct wire sottostante
+
+**Setter**:
+- *Classifier*: `OfType(JobType)`
+- *Name*: `Named(string)`
+- *Labels*: `Tagged(...string)`, `Untagged(...string)`, `RetaggedAs(...string)`
+- *Containment*: `InProject(Ref)`
+- *Geography*: `InRegion(Region)`
+- *Descriptive scalars*: `OneShotAt(time.Time)`, `StartingAt(time.Time)`, `WithCron(string)`, `RecurringUntil(time.Time)`, `WithSteps(...*JobStep)`
+- *Boolean state*: `Enabled()`, `Disabled()`
+
+:::tip Esempio eseguibile
+Esempio end-to-end completo: [`examples/all-resources/resource_job.go`](https://github.com/Arubacloud/sdk-go/blob/main/examples/all-resources/resource_job.go)
+:::
+
+---
+
+## Security
+
+### KMS (Key Management Service)
+
+```go
+arubaClient.FromSecurity().KMS()
+```
+
+**Operazioni supportate**: `Create`, `List`, `Get`, `Update`, `Delete`
+**Asincrono**: sì — chiama `WaitUntilReady(ctx)` dopo `Create`.
+
+```go
+kms, err := arubaClient.FromSecurity().KMS().Create(
+    ctx,
+    aruba.NewKMS().
+        Named("my-kms").
+        Tagged("security").
+        InProject(proj).
+        InRegion(aruba.RegionITBGBergamo).
+        BilledBy(aruba.BillingPeriodHour))
+if err != nil {
+    log.Fatalf("Create KMS: %v", err)
+}
+
+if err := kms.WaitUntilReady(ctx); err != nil {
+    log.Fatalf("KMS did not become Active: %v", err)
+}
+fmt.Printf("✓ KMS: %s (ID: %s)\n", kms.Name(), kms.ID())
+```
+
+**Accessor di risposta**:
+- `ID()`, `URI()`, `Name()`, `Tags()`
+- `KMSID()` — ID istanza KMS assegnato dal provider
+- `BillingPeriod()` — cadenza di fatturazione
+- `State()`, `FailureReason()`, `PreviousState()`, `IsDisabled()`, `DisableReasons()`
+- `WaitUntilReady(ctx, opts...)`, `WaitUntilActive(ctx, opts...)`, `WaitUntilStates(ctx, []types.State{...}, opts...)`, `WaitUntilGone(ctx, opts...)`
+- `Raw()` — struct wire sottostante
+
+**Setter**:
+- *Name*: `Named(string)`
+- *Labels*: `Tagged(...string)`, `Untagged(...string)`, `RetaggedAs(...string)`
+- *Containment*: `InProject(Ref)`
+- *Geography*: `InRegion(Region)`
+- *Billing*: `BilledBy(BillingPeriod)`
+
+:::tip Esempio eseguibile
+Esempio end-to-end completo: [`examples/all-resources/resource_kms.go`](https://github.com/Arubacloud/sdk-go/blob/main/examples/all-resources/resource_kms.go)
+:::
+
+---
+
+### Key
+
+```go
+arubaClient.FromSecurity().Keys()
+```
+
+**Operazioni supportate**: `Create`, `List`, `Get`, `Delete`
+**Asincrono**: sì — `State()` e `FailureReason()` sono disponibili.
+
+`OfAlgorithm` accetta `aruba.KeyAlgorithmAes` o `aruba.KeyAlgorithmRsa` (costanti tipizzate — nessun cast a stringa necessario).
+
+```go
+key, err := arubaClient.FromSecurity().Keys().Create(
+    ctx,
+    aruba.NewKey().
+        OfAlgorithm(aruba.KeyAlgorithmAes).
+        Named("my-encryption-key").
+        Tagged("security").
+        InKMS(kms))
+if err != nil {
+    log.Fatalf("Create Key: %v", err)
+}
+fmt.Printf("✓ Chiave: %s (algoritmo: %s)\n", key.Name(), key.Algorithm())
+```
+
+**Accessor di risposta**:
+- `ID()`, `URI()`, `Name()`, `Tags()`
+- `KeyID()` — ID chiave assegnato dal provider
+- `Algorithm()` — stringa dell'algoritmo
+- `Type()` — `"Symmetric"` o `"Asymmetric"`
+- `Status()` — stato del ciclo di vita della chiave
+- `CreationSource()` — come è stata creata la chiave
+- `State()`, `FailureReason()`, `PreviousState()`, `IsDisabled()`, `DisableReasons()`
+- `WaitUntilGone(ctx, opts...)`
+- `Raw()` — struct wire sottostante
+
+**Setter**:
+- *Classifier*: `OfAlgorithm(KeyAlgorithm)`
+- *Name*: `Named(string)`
+- *Containment*: `InKMS(Ref)`
+
+:::tip Esempio eseguibile
+Le operazioni sulle chiavi sono trattate nell'esempio KMS: [`examples/all-resources/resource_kms.go`](https://github.com/Arubacloud/sdk-go/blob/main/examples/all-resources/resource_kms.go)
+:::
+
+---
+
+### Kmip
+
+```go
+arubaClient.FromSecurity().Kmips()
+```
+
+**Operazioni supportate**: `Create`, `List`, `Get`, `Delete`
+**Asincrono**: sì — chiama `WaitUntilReady(ctx)` dopo `Create`. `WaitUntilReady` del KMIP ha successo su `"CertificateAvailable"` o `"Active"`. `WaitUntilCertificateAvailable` è un alias per `WaitUntilReady`.
+
+```go
+km, err := arubaClient.FromSecurity().Kmips().Create(
+    ctx,
+    aruba.NewKmip().
+        Named("my-kmip").
+        Tagged("security").
+        InKMS(kms))
+if err != nil {
+    log.Fatalf("Create Kmip: %v", err)
+}
+
+if err := km.WaitUntilReady(ctx); err != nil {
+    log.Fatalf("Kmip did not become ready: %v", err)
+}
+fmt.Printf("✓ Kmip: %s\n", km.Name())
+```
+
+**Download del certificato KMIP** (richiede un wrapper idratato):
+
+```go
+cert, err := km.Download(ctx)
+if err != nil {
+    log.Fatalf("Download Kmip certificate: %v", err)
+}
+fmt.Println("Cert:", cert.Cert())
+fmt.Println("Key:",  cert.Key())
+```
+
+**Accessor di risposta**:
+- `ID()`, `URI()`, `Name()`, `Tags()`
+- `KmipID()` — ID KMIP assegnato dal provider
+- `KmipStatus()` — stato specifico del KMIP
+- `State()`, `FailureReason()`, `PreviousState()`, `IsDisabled()`, `DisableReasons()`
+- `WaitUntilReady(ctx, opts...)`, `WaitUntilCertificateAvailable(ctx, opts...)`, `WaitUntilStates(ctx, []types.State{...}, opts...)`, `WaitUntilGone(ctx, opts...)`
+- `Raw()` — struct wire sottostante
+
+**Setter**:
+- *Name*: `Named(string)`
+- *Containment*: `InKMS(Ref)`
+
+:::tip Esempio eseguibile
+Le operazioni KMIP sono trattate nell'esempio KMS: [`examples/all-resources/resource_kms.go`](https://github.com/Arubacloud/sdk-go/blob/main/examples/all-resources/resource_kms.go)
+:::
+
+---
+
+## Storage
+
+### Block Storage (Volume)
+
+```go
+arubaClient.FromStorage().Volumes()
+```
+
+**Operazioni supportate**: `Create`, `List`, `Get`, `Update`, `Delete`
+**Asincrono**: sì — chiama `WaitUntilReady(ctx)` dopo `Create`.
+
+`OfType` accetta `aruba.BlockStorageTypeStandard` o `aruba.BlockStorageTypePerformance`. Usa `AsBootable()` per contrassegnare un volume come avviabile; `NotBootable()` per annullare l'impostazione. Usa `FromImage(imageID)` per specificare un'immagine di base.
+
+```go
+bs, err := arubaClient.FromStorage().Volumes().Create(
+    ctx,
+    aruba.NewBlockStorage().
+        OfType(aruba.BlockStorageTypeStandard).
+        Named("my-volume").
+        Tagged("storage").
+        InProject(proj).
+        InRegion(aruba.RegionITBGBergamo).
+        InZone(aruba.ZoneITBG1).
+        SizedGB(20).
+        FromImage("LU22-001").
+        AsBootable().
+        BilledBy(aruba.BillingPeriodHour))
+if err != nil {
+    log.Fatalf("Create BlockStorage: %v", err)
+}
+
+if err := bs.WaitUntilReady(ctx); err != nil {
+    log.Fatalf("BlockStorage did not become Active: %v", err)
+}
+fmt.Printf("✓ Volume: %s (%d GB)\n", bs.Name(), bs.SizeGB())
+```
+
+Per creare un volume **da uno snapshot**, usa `FromSnapshot(snapshot)` invece di `FromImage`:
+
+```go
+bs, err := arubaClient.FromStorage().Volumes().Create(
+    ctx,
+    aruba.NewBlockStorage().
+        OfType(aruba.BlockStorageTypeStandard).
+        Named("restored-volume").
+        InProject(proj).
+        InRegion(aruba.RegionITBGBergamo).
+        InZone(aruba.ZoneITBG1).
+        SizedGB(20).
+        FromSnapshot(snapshot).
+        AsBootable().
+        BilledBy(aruba.BillingPeriodHour))
+```
+
+**Accessor di risposta**:
+- `ID()`, `URI()`, `Name()`, `Tags()`
+- `BlockStorageID()` — ID volume assegnato dal provider
+- `SizeGB()` — dimensione in GB
+- `Type()` — tipo di storage
+- `Zone()` — zona di disponibilità
+- `BillingPeriod()` — cadenza di fatturazione
+- `IsBootable()` — bool
+- `Image()` — riferimento all'immagine
+- `SnapshotURI()` — URI dello snapshot sorgente (se creato da snapshot)
+- `State()`, `FailureReason()`, `PreviousState()`, `IsDisabled()`, `DisableReasons()`
+- `WaitUntilReady(ctx, opts...)`, `WaitUntilActive(ctx, opts...)`, `WaitUntilNotUsed(ctx, opts...)`, `WaitUntilUsed(ctx, opts...)`, `WaitUntilStates(ctx, []types.State{...}, opts...)`, `WaitUntilGone(ctx, opts...)`
+- `Raw()` — struct wire sottostante
+
+**Setter**:
+- *Classifier*: `OfType(BlockStorageType)`
+- *Name*: `Named(string)`
+- *Labels*: `Tagged(...string)`, `Untagged(...string)`, `RetaggedAs(...string)`
+- *Containment*: `InProject(Ref)`
+- *Geography*: `InRegion(Region)`, `InZone(Zone)`
+- *Descriptive scalars*: `SizedGB(int)`
+- *Origin*: `FromImage(string)`, `FromSnapshot(Ref)`
+- *Boolean state*: `AsBootable()`, `NotBootable()`
+- *Billing*: `BilledBy(BillingPeriod)`
+
+:::tip Esempio eseguibile
+Esempio end-to-end completo: [`examples/all-resources/resource_block_storage.go`](https://github.com/Arubacloud/sdk-go/blob/main/examples/all-resources/resource_block_storage.go)
+:::
+
+---
+
+### Snapshot
+
+```go
+arubaClient.FromStorage().Snapshots()
+```
+
+**Operazioni supportate**: `Create`, `List`, `Get`, `Update`, `Delete`
+**Asincrono**: sì — chiama `WaitUntilReady(ctx)` dopo `Create`.
+
+```go
+snap, err := arubaClient.FromStorage().Snapshots().Create(
+    ctx,
+    aruba.NewSnapshot().
+        Named("my-snapshot").
+        Tagged("backup").
+        InProject(proj).
+        InRegion(aruba.RegionITBGBergamo).
+        FromVolume(bs).
+        BilledBy(aruba.BillingPeriodHour))
+if err != nil {
+    log.Fatalf("Create Snapshot: %v", err)
+}
+
+if err := snap.WaitUntilReady(ctx); err != nil {
+    log.Fatalf("Snapshot did not become Active: %v", err)
+}
+fmt.Printf("✓ Snapshot: %s\n", snap.Name())
+```
+
+**Accessor di risposta**:
+- `ID()`, `URI()`, `Name()`, `Tags()`
+- `SnapshotID()` — ID snapshot assegnato dal provider
+- `SizeGB()` — dimensione dello snapshot in GB
+- `Type()` — tipo di storage
+- `Zone()` — zona di disponibilità
+- `BillingPeriod()` — cadenza di fatturazione
+- `Bootable()` — bool
+- `VolumeURI()` — URI del volume sorgente
+- `State()`, `FailureReason()`, `PreviousState()`, `IsDisabled()`, `DisableReasons()`
+- `WaitUntilReady(ctx, opts...)`, `WaitUntilActive(ctx, opts...)`, `WaitUntilStates(ctx, []types.State{...}, opts...)`, `WaitUntilGone(ctx, opts...)`
+- `Raw()` — struct wire sottostante
+
+**Setter**:
+- *Name*: `Named(string)`
+- *Labels*: `Tagged(...string)`, `Untagged(...string)`, `RetaggedAs(...string)`
+- *Containment*: `InProject(Ref)`
+- *Geography*: `InRegion(Region)`
+- *Origin*: `FromVolume(Ref)`
+- *Billing*: `BilledBy(BillingPeriod)`
+
+:::tip Esempio eseguibile
+Esempio end-to-end completo: [`examples/all-resources/resource_snapshot.go`](https://github.com/Arubacloud/sdk-go/blob/main/examples/all-resources/resource_snapshot.go)
+:::
+
+---
+
+### Storage Backup
+
+```go
+arubaClient.FromStorage().Backups()
+```
+
+**Operazioni supportate**: `Create`, `List`, `Get`, `Delete`
+**Asincrono**: sì — chiama `WaitUntilReady(ctx)` dopo `Create`.
+
+`OfType` accetta `aruba.StorageBackupTypeFull` o `aruba.StorageBackupTypeIncremental`. Usa `FromVolume(vol)` per specificare il volume sorgente.
+
+```go
+backup, err := arubaClient.FromStorage().Backups().Create(
+    ctx,
+    aruba.NewStorageBackup().
+        OfType(aruba.StorageBackupTypeFull).
+        Named("my-backup").
+        Tagged("backup").
+        InProject(proj).
+        RetainedForDays(30).
+        FromVolume(bs).
+        BilledBy(aruba.BillingPeriodHour))
+if err != nil {
+    log.Fatalf("Create StorageBackup: %v", err)
+}
+
+if err := backup.WaitUntilReady(ctx); err != nil {
+    log.Fatalf("StorageBackup did not become Active: %v", err)
+}
+fmt.Printf("✓ Storage Backup: %s\n", backup.Name())
+```
+
+**Accessor di risposta**:
+- `ID()`, `URI()`, `Name()`, `Tags()`
+- `BackupID()` — ID backup assegnato dal provider
+- `Type()` — tipo di backup
+- `RetentionDays()` — periodo di conservazione in giorni
+- `OriginURI()` — URI del volume sorgente
+- `BillingPeriod()` — cadenza di fatturazione
+- `State()`, `FailureReason()`, `PreviousState()`, `IsDisabled()`, `DisableReasons()`
+- `WaitUntilReady(ctx, opts...)`, `WaitUntilActive(ctx, opts...)`, `WaitUntilStates(ctx, []types.State{...}, opts...)`, `WaitUntilGone(ctx, opts...)`
+- `Raw()` — struct wire sottostante
+
+**Setter**:
+- *Classifier*: `OfType(StorageBackupType)`
+- *Name*: `Named(string)`
+- *Labels*: `Tagged(...string)`, `Untagged(...string)`, `RetaggedAs(...string)`
+- *Containment*: `InProject(Ref)`
+- *Geography*: `InRegion(Region)`
+- *Descriptive scalars*: `RetainedForDays(int)`
+- *Origin*: `FromVolume(Ref)`
+- *Billing*: `BilledBy(BillingPeriod)`
+
+:::tip Esempio eseguibile
+Esempio end-to-end completo: [`examples/all-resources/resource_storage_backup.go`](https://github.com/Arubacloud/sdk-go/blob/main/examples/all-resources/resource_storage_backup.go)
+:::
+
+---
+
+### Storage Restore
+
+```go
+arubaClient.FromStorage().Restores()
+```
+
+**Operazioni supportate**: `Create`, `List`, `Get`, `Delete`
+**Asincrono**: sì — chiama `WaitUntilReady(ctx)` dopo `Create`.
+
+```go
+restore, err := arubaClient.FromStorage().Restores().Create(
+    ctx,
+    aruba.NewStorageRestore().
+        Named("my-restore").
+        Tagged("restore").
+        FromBackup(backup).
+        WithTarget(aruba.URI(backup.OriginURI())))
+if err != nil {
+    log.Fatalf("Create StorageRestore: %v", err)
+}
+
+if err := restore.WaitUntilReady(ctx); err != nil {
+    log.Fatalf("StorageRestore did not become Active: %v", err)
+}
+fmt.Printf("✓ Storage Restore: %s\n", restore.Name())
+```
+
+**Accessor di risposta**:
+- `ID()`, `URI()`, `Name()`, `Tags()`
+- `RestoreID()` — ID restore assegnato dal provider
+- `TargetURI()` — URI del volume di destinazione
+- `State()`, `FailureReason()`, `PreviousState()`, `IsDisabled()`, `DisableReasons()`
+- `WaitUntilReady(ctx, opts...)`, `WaitUntilActive(ctx, opts...)`, `WaitUntilStates(ctx, []types.State{...}, opts...)`, `WaitUntilGone(ctx, opts...)`
+- `Raw()` — struct wire sottostante
+
+**Setter**:
+- *Name*: `Named(string)`
+- *Labels*: `Tagged(...string)`, `Untagged(...string)`, `RetaggedAs(...string)`
+- *Containment*: `FromBackup(Ref)`
+- *Geography*: `InRegion(Region)`
+- *Origin*: `ToVolume(Ref)`
+
+:::tip Esempio eseguibile
+Esempio end-to-end completo: [`examples/all-resources/resource_storage_restore.go`](https://github.com/Arubacloud/sdk-go/blob/main/examples/all-resources/resource_storage_restore.go)
+:::
+
+---
+
+## Opzioni di chiamata
+
+Passa le opzioni di chiamata come argomenti variadic a qualsiasi chiamata `List`, `Get`, `Create`, `Update` o `Delete`:
+
+| Opzione | Scopo |
+|--------|---------|
+| `aruba.WithFilter(expr)` | Espressione filtro lato server |
+| `aruba.WithSort(expr)` | Espressione di ordinamento |
+| `aruba.WithLimit(n)` | Dimensione della pagina |
+| `aruba.WithOffset(n)` | Offset di paginazione |
+| `aruba.WithProjection(expr)` | Proiezione dei campi |
+| `aruba.WithAPIVersion(v)` | Sovrascrive la versione API per questa chiamata |
+
+Vedi [Filtri](./filters) per la sintassi dei filtri e degli ordinamenti.
+
+---
+
+## Costanti enum
+
+Tutti i tipi enum sono ri-esportati da `pkg/aruba` — nessun import aggiuntivo necessario. L'elenco canonico si trova in `pkg/aruba/aliases.go`.
+
+### Regione e Zona
+
+| Costante | Descrizione |
+|----------|-------------|
+| `aruba.RegionITBGBergamo` | Datacenter di Bergamo (Italia) |
+| `aruba.ZoneITBG1` | Zona di disponibilità Bergamo 1 |
+| `aruba.ZoneITBG2` | Zona di disponibilità Bergamo 2 |
+| `aruba.ZoneITBG3` | Zona di disponibilità Bergamo 3 |
+
+### Fatturazione
+
+| Costante | Descrizione |
+|----------|-------------|
+| `aruba.BillingPeriodHour` | Fatturazione oraria |
+| `aruba.BillingPeriodMonth` | Fatturazione mensile |
+
+### Network
+
+| Costante | Valore |
+|----------|-------|
+| `aruba.RuleDirectionIngress` | `"Ingress"` |
+| `aruba.RuleDirectionEgress` | `"Egress"` |
+| `aruba.RuleProtocolTCP` | `"TCP"` |
+| `aruba.RuleProtocolUDP` | `"UDP"` |
+| `aruba.RuleProtocolICMP` | `"ICMP"` |
+| `aruba.RuleProtocolANY` | (wildcard — qualsiasi protocollo) |
+| `aruba.SubnetTypeBasic` | `"Basic"` |
+| `aruba.SubnetTypeAdvanced` | `"Advanced"` |
+
+### Compute
+
+| Costante | Descrizione |
+|----------|-------------|
+| `aruba.CloudServerFlavorCSO1A2` | 1 vCPU, 2 GB RAM |
+| `aruba.CloudServerFlavorCSO2A4` | 2 vCPU, 4 GB RAM |
+| `aruba.CloudServerFlavorCSO4A8` | 4 vCPU, 8 GB RAM |
+| `aruba.CloudServerFlavorCSO8A16` | 8 vCPU, 16 GB RAM |
+| … (vedi `aliases.go` per l'elenco completo) | |
+
+### Container
+
+| Costante | Descrizione |
+|----------|-------------|
+| `aruba.KubernetesVersion1323` | Kubernetes 1.32.3 |
+| `aruba.KubernetesVersion1332` | Kubernetes 1.33.2 |
+| `aruba.KubernetesVersion1341` | Kubernetes 1.34.1 |
+| `aruba.NodePoolInstanceK2A4` | 2 vCPU, 4 GB RAM |
+| `aruba.NodePoolInstanceK4A8` | 4 vCPU, 8 GB RAM |
+| `aruba.NodePoolInstanceK8A16` | 8 vCPU, 16 GB RAM |
+| … (vedi `aliases.go` per l'elenco completo) | |
+| `aruba.ContainerRegistrySizeFlavorSmall` | Livello small di utenti concorrenti |
+| `aruba.ContainerRegistrySizeFlavorMedium` | Livello medium di utenti concorrenti |
+| `aruba.ContainerRegistrySizeFlavorHighPerf` | Livello ad alte prestazioni |
+
+### Database
+
+| Costante | Descrizione |
+|----------|-------------|
+| `aruba.DatabaseEngineMySQL80` | MySQL 8.0 |
+| `aruba.DatabaseEngineMSSQL2022Web` | SQL Server 2022 Web |
+| `aruba.DatabaseEngineMSSQL2022Standard` | SQL Server 2022 Standard |
+| `aruba.DatabaseEngineMSSQL2022Enterprise` | SQL Server 2022 Enterprise |
+| `aruba.DBaaSFlavorDBO1A2` | 1 vCPU, 2 GB RAM |
+| `aruba.DBaaSFlavorDBO2A4` | 2 vCPU, 4 GB RAM |
+| `aruba.DBaaSFlavorDBO4A8` | 4 vCPU, 8 GB RAM |
+| … (vedi `aliases.go` per l'elenco completo) | |
+
+### Storage
+
+| Costante | Valore |
+|----------|-------|
+| `aruba.BlockStorageTypeStandard` | `"Standard"` |
+| `aruba.BlockStorageTypePerformance` | `"Performance"` |
+| `aruba.StorageBackupTypeFull` | `"Full"` |
+| `aruba.StorageBackupTypeIncremental` | `"Incremental"` |
+
+### Security
+
+| Costante | Valore |
+|----------|-------|
+| `aruba.KeyAlgorithmAes` | `"Aes"` |
+| `aruba.KeyAlgorithmRsa` | `"Rsa"` |
+| `aruba.KeyTypeSymmetric` | `"Symmetric"` |
+| `aruba.KeyTypeAsymmetric` | `"Asymmetric"` |
+| `aruba.ServiceStatusCertificateAvailable` | `"CertificateAvailable"` |
+
+### Crittografia VPN
+
+| Costante | Descrizione |
+|----------|-------------|
+| `aruba.IKEEncryptionAES256` | AES-256 CBC (IKE fase 1) |
+| `aruba.IKEHashSHA256` | HMAC-SHA-256 (IKE fase 1) |
+| `aruba.IKEDHGroup14` | Gruppo Diffie-Hellman MODP-2048 |
+| `aruba.ESPEncryptionAES256` | AES-256 CBC (ESP fase 2) |
+| `aruba.ESPHashSHA256` | HMAC-SHA-256 (ESP fase 2) |
+| `aruba.ESPPFSGroupEnable` | PFS abilitato (gruppo DH negoziato) |
+| `aruba.ESPPFSGroupDisable` | PFS disabilitato |
+| … (vedi `aliases.go` per gli elenchi completi) | |
+
+### Schedule
+
+| Costante | Valore |
+|----------|-------|
+| `aruba.JobTypeOneShot` | `"OneShot"` |
+| `aruba.JobTypeRecurring` | `"Recurring"` |
+
+---
+
+## Appendice: Tipi wire grezzi (`pkg/types`)
+
+I seguenti tipi sono le struct wire di basso livello sottostanti. Normalmente vi si accede solo tramite `.Raw()` o `.RawRequest()` su un wrapper, oppure quando si costruiscono integrazioni avanzate con `pkg/async`. Sono anche ri-esportati come alias di tipo `aruba.XxxRequest` / `aruba.XxxResponse` in modo da poterli referenziare senza un import aggiuntivo.
+
+| Tipo | File | Note |
+|------|------|-------|
+| `Response[T]` | `resource.go` | Envelope HTTP generico restituito dagli adapter di basso livello |
+| `ErrorResponse` | `error.go` | Errore strutturato RFC 7807 |
+| `ListResponse` | `resource.go` | Link di paginazione e conteggio totale |
+| `ResourceMetadataRequest` | `resource.go` | Nome + tag per Create |
+| `RegionalResourceMetadataRequest` | `resource.go` | Estende i metadati con Location |
+| `ResourceMetadataResponse` | `resource.go` | ID, URI, Name, timestamp |
+| `ResourceStatusResponse` | `resource.go` | Campo State |
+| `ReferenceResourceCommon` | `resource.go` | `{uri: "…"}` link a un'altra risorsa |
+| `RequestParameters` | `parameters.go` | Struct filtro/ordinamento/limit/offset di basso livello (preferire gli helper `CallOption`) |
+| `ProjectRequest` / `ProjectResponse` / `ProjectListResponse` | `project.project.go` | |
+| `VPCRequest` / `VPCResponse` / `VPCListResponse` | `network.vpc.go` | |
+| `SubnetRequest` / `SubnetResponse` / `SubnetListResponse` | `network.subnet.go` | |
+| `SecurityGroupRequest` / `SecurityGroupResponse` | `network.security-group.go` | |
+| `SecurityRuleRequest` / `SecurityRuleResponse` | `network.security-rule.go` | |
+| `ElasticIPRequest` / `ElasticIPResponse` | `network.elastic-ip.go` | |
+| `CloudServerRequest` / `CloudServerResponse` | `compute.cloudserver.go` | |
+| `KeyPairRequest` / `KeyPairResponse` | `compute.keypair.go` | |
+| `KaaSRequest` / `KaaSResponse` / `KaaSUpdateRequest` | `container.kaas.go` | |
+| `ContainerRegistryRequest` / `ContainerRegistryResponse` | `container.containerregistry.go` | |
+| `DBaaSRequest` / `DBaaSResponse` | `database.dbaas.go` | |
+| `KmsRequest` / `KmsResponse` | `security.kms.go` | |
+| `KeyRequest` / `KeyResponse` | `security.kms.go` | |
+| `KmipRequest` / `KmipResponse` / `KmipCertificateResponse` | `security.kms.go` | |
+| `BlockStorageRequest` / `BlockStorageResponse` | `storage.block-storage.go` | |
+| `SnapshotRequest` / `SnapshotResponse` | `storage.snapshot.go` | |
+| `StorageBackupRequest` / `StorageBackupResponse` | `storage.backup.go` | |
+| `JobRequest` / `JobResponse` / `JobListResponse` | `schedule.job.go` | |
+| `AlertResponse` / `AlertsListResponse` | `metrics.alert.go` | |
+| `MetricResponse` / `MetricListResponse` | `metrics.metric.go` | |
+| `AuditEvent` / `AuditEventListResponse` | `audit.event.go` | |
+| `VPCPeeringRequest` / `VPCPeeringResponse` | `network.vpc-peering.go` | |
+| `VPNTunnelRequest` / `VPNTunnelResponse` | `network.vpn-tunnel.go` | |
+| `VPNRouteRequest` / `VPNRouteResponse` | `network.vpn-route.go` | |
+| `LoadBalancerResponse` | `network.load-balancer.go` | |

--- a/docs/website/i18n/it/docusaurus-plugin-content-docs/version-1.0.0/response-handling.md
+++ b/docs/website/i18n/it/docusaurus-plugin-content-docs/version-1.0.0/response-handling.md
@@ -1,0 +1,235 @@
+# Guida alla Gestione delle Risposte
+
+## Panoramica
+
+Il layer wrapper dell'SDK gestisce automaticamente il parsing delle risposte e la segnalazione degli errori. Ogni metodo CRUD restituisce o un wrapper popolato (in caso di successo) o un errore. Raramente è necessario ispezionare direttamente l'envelope HTTP grezzo — ma gli strumenti per farlo sono sempre disponibili quando servono.
+
+## Pattern Base
+
+Ogni metodo wrapper restituisce `(wrapper, error)`. L'errore è non-nil sia per errori di rete che per errori a livello API (4xx / 5xx).
+
+```go
+vpc, err := arubaClient.FromNetwork().VPCs().Get(ctx,
+    aruba.URI("/projects/<projectID>/providers/Aruba.Network/vpcs/<vpcID>"),
+)
+if err != nil {
+    log.Fatalf("Get VPC failed: %v", err)
+}
+fmt.Printf("VPC: %s (state: %s)\n", vpc.Name(), vpc.State())
+```
+
+## Errori HTTP Tipizzati
+
+Quando l'API restituisce una risposta 4xx o 5xx, l'SDK la racchiude in `*aruba.HTTPError`. Usa `errors.As` per ispezionare il codice di stato e il corpo dell'errore strutturato:
+
+```go
+import "errors"
+
+vpc, err := arubaClient.FromNetwork().VPCs().Get(ctx, ref)
+if err != nil {
+    var httpErr *aruba.HTTPError
+    if errors.As(err, &httpErr) {
+        fmt.Printf("API error %d: %s\n", httpErr.StatusCode, httpErr.Error())
+        if httpErr.ErrResp != nil {
+            fmt.Printf("  title:  %s\n", derefStr(httpErr.ErrResp.Title))
+            fmt.Printf("  detail: %s\n", derefStr(httpErr.ErrResp.Detail))
+            for _, ve := range httpErr.ErrResp.Errors {
+                fmt.Printf("  field %s: %s\n", ve.Field, ve.Message)
+            }
+        }
+    } else {
+        // Errore di rete, timeout del contesto, ecc.
+        log.Fatalf("Request failed: %v", err)
+    }
+}
+```
+
+## Pattern Completo di Gestione degli Errori
+
+```go
+proj, err := arubaClient.FromProject().Get(ctx, ref)
+if err != nil {
+    var httpErr *aruba.HTTPError
+    if errors.As(err, &httpErr) {
+        switch httpErr.StatusCode {
+        case 404:
+            return fmt.Errorf("project not found")
+        case 400:
+            return fmt.Errorf("bad request: %s", derefStr(httpErr.ErrResp.Detail))
+        default:
+            return fmt.Errorf("API error (%d): %s", httpErr.StatusCode, httpErr.Error())
+        }
+    }
+    return fmt.Errorf("request failed: %w", err)
+}
+// proj è popolato — usalo direttamente
+fmt.Printf("Project: %s (tags: %v)\n", proj.Name(), proj.Tags())
+```
+
+## Accessor dell'Envelope HTTP
+
+Ogni wrapper prodotto da una chiamata Create / Get / Update / List espone il proprio envelope HTTP grezzo:
+
+```go
+// Dopo qualsiasi chiamata CRUD:
+proj, err := arubaClient.FromProject().Create(ctx, p)
+// …
+
+fmt.Println("Status:", proj.StatusCode())
+fmt.Println("Headers:", proj.Headers())
+rawResp, rawBody := proj.RawHTTP()
+fmt.Println("Raw body:", string(rawBody))
+fmt.Println("HTTP status:", rawResp.StatusCode)
+fmt.Println("Error body (if any):", proj.RawError())
+```
+
+## Accesso alla Risposta Wire Grezza
+
+Ogni wrapper dispone di un metodo `Raw()` che restituisce la struct di risposta tipizzata sottostante da `pkg/types`. È utile per accedere ai campi non ancora promossi alla superficie del wrapper:
+
+```go
+vpc, err := arubaClient.FromNetwork().VPCs().Get(ctx, ref)
+if err != nil { /* … */ }
+
+raw := vpc.Raw()                         // struct wire sottostante
+fmt.Println(raw.Properties.IsDefault)    // campo non presente sul wrapper
+```
+
+### Comodità JSON / YAML
+
+Per i flag CLI-style `--output json` / `--output yaml`, ogni wrapper espone slice di byte pre-serializzate:
+
+```go
+fmt.Println(string(vpc.RawJSON()))   // payload codificato in JSON
+fmt.Println(string(vpc.RawYAML()))   // payload codificato in YAML
+```
+
+Restituisce `nil` se il wrapper non è ancora stato popolato (receiver con valore zero).
+
+## Risposte di Lista
+
+`List[T]` espone la stessa superficie di introspezione dei wrapper a singola risorsa, il tutto senza dover importare `pkg/types`:
+
+```go
+vpcList, err := arubaClient.FromNetwork().VPCs().List(ctx, proj)
+if err != nil { /* … */ }
+
+// Paginazione e conteggi — accessor tipizzati sul wrapper.
+fmt.Println("server total:", vpcList.Total())
+if vpcList.HasNext() {
+    nextPage, _ := vpcList.Next(ctx)
+    _ = nextPage
+}
+
+// Envelope HTTP — stessi accessor dei wrapper a singola risorsa.
+fmt.Println("status:", vpcList.StatusCode())
+fmt.Println("trace-id:", vpcList.Headers().Get("X-Trace-Id"))
+_, body := vpcList.RawHTTP()
+fmt.Println("raw body bytes:", len(body))
+```
+
+### Comodità JSON / YAML
+
+`List[T]` espone anch'esso `RawJSON()` e `RawYAML()` per il payload della lista tipizzata:
+
+```go
+fmt.Println(string(vpcList.RawJSON()))   // payload codificato in JSON
+fmt.Println(string(vpcList.RawYAML()))   // payload codificato in YAML
+```
+
+Restituisce `nil` quando la lista non ha payload (`Raw() == nil`).
+
+> **Accedere ai campi non promossi.** Se hai bisogno di un campo non esposto dalla superficie del wrapper, vedi [Lavorare a Basso Livello](./working-at-low-level) —
+> illustra il cast alla struct wire tipizzata e le poche altre vie d'uscita che richiedono l'import di `pkg/types`.
+
+## Errori in Fase di Setter
+
+I setter del builder fluente non restituiscono mai errori — li registrano internamente. L'errore emerge alla prima chiamata `Create` o `Update`. È anche possibile verificare in anticipo:
+
+```go
+rule := aruba.NewSecurityRule().
+    InSecurityGroup(sg).
+    TargetingCIDR("0.0.0.0/0").
+    TargetingSecurityGroup(otherSG) // setter in conflitto — registra un errore
+
+if err := rule.Err(); err != nil {
+    log.Fatalf("Bad rule configuration: %v", err)
+}
+```
+
+## Lettura dello Stato del Wrapper
+
+Ogni wrapper di tipo Family-A promuove i campi di risposta più utilizzati a getter piatti. È sempre preferibile utilizzare questi getter invece di accedere direttamente a `wrapper.Raw().Properties.X`:
+
+```go
+cs, err := arubaClient.FromCompute().CloudServers().Get(ctx, ref)
+if err != nil { /* … */ }
+
+// Preferisci i getter piatti
+fmt.Println(cs.Name())          // nome della risorsa
+fmt.Println(cs.State())         // stato del ciclo di vita (Active, Creating, …)
+fmt.Println(cs.ID())            // UUID
+fmt.Println(cs.Region())        // slug della regione
+fmt.Println(cs.Subnets())       // []string degli URI delle subnet
+fmt.Println(cs.ElasticIP())     // URI dell'Elastic IP, se impostato al momento della creazione
+fmt.Println(cs.UserData())      // cloud-init / user-data, se impostato al momento della creazione
+
+// Ricorri a Raw() solo per i campi non ancora promossi
+raw := cs.Raw()
+fmt.Println(raw.Properties.SomeUnpromotedField)
+```
+
+### Livelli standard dei getter
+
+| Categoria | Getter di esempio |
+|---|---|
+| Identità | `ID()`, `URI()`, `CloudServerID()` |
+| Denominazione | `Name()`, `Tags()` |
+| Geografia | `Region()`, `Zone()` |
+| Derivazione | `Project()`, `CreatedAt()`, `UpdatedAt()`, `Version()` |
+| Ciclo di vita | `State()`, `IsDisabled()`, `DisableReasons()`, `FailureReason()` |
+| Risorse collegate | `LinkedResources()` |
+| Envelope grezzo | `Raw()`, `RawJSON()`, `RawYAML()`, `RawRequest()`, `StatusCode()`, `Headers()`, `RawError()` |
+| Specifici della risorsa | es. `cs.Subnets()`, `vpnRoute.CloudSubnetCIDR()`, `kaas.PodCIDR()` |
+
+### `RawJSON()` / `RawYAML()` per l'output CLI
+
+I metodi `RawJSON()` e `RawYAML()` sono pensati per i flag CLI-style `--output json` / `--output yaml`. Serializzano la struct wire sottostante, non solo i campi promossi:
+
+```go
+cs, _ := arubaClient.FromCompute().CloudServers().Get(ctx, ref)
+fmt.Println(string(cs.RawJSON()))   // payload JSON completo
+fmt.Println(string(cs.RawYAML()))   // payload YAML completo
+```
+
+### `RawRequest()` per aggiornamenti round-trip
+
+`RawRequest()` produce un valore `types.<X>Request` che rappresenta lo stato corrente completo del wrapper — utile nei flussi `Get → modifica → Update`:
+
+```go
+cs, _ := arubaClient.FromCompute().CloudServers().Get(ctx, ref)
+// Il wrapper contiene già tutti i campi lato server; basta sovrascrivere ciò che è cambiato.
+cs.Named("new-name")
+_, err = arubaClient.FromCompute().CloudServers().Update(ctx, cs)
+```
+
+## Best Practice
+
+1. **Controlla sempre `err` prima** — copre sia gli errori di rete che quelli API.
+2. **Usa `errors.As(err, &httpErr)`** per ottenere dettagli strutturati sugli errori 4xx/5xx.
+3. **Controlla `httpErr.ErrResp.Errors`** per messaggi di validazione a livello di campo sugli errori 400.
+4. **Usa `httpErr.ErrResp.TraceID`** quando apri una richiesta di supporto.
+5. **Usa `.Raw()` con parsimonia** — preferisci gli accessor tipizzati del wrapper.
+6. **Controlla `wrapper.Err()` prima di Create/Update** quando la catena di builder è lunga.
+
+---
+
+```go
+// Helper usato negli esempi sopra
+func derefStr(s *string) string {
+    if s == nil {
+        return ""
+    }
+    return *s
+}
+```

--- a/docs/website/i18n/it/docusaurus-plugin-content-docs/version-1.0.0/version-1.0.0.json
+++ b/docs/website/i18n/it/docusaurus-plugin-content-docs/version-1.0.0/version-1.0.0.json
@@ -1,0 +1,30 @@
+{
+  "version.label": {
+    "message": "1.0.0",
+    "description": "The label for version current"
+  },
+  "sidebar.tutorialSidebar.category.Quick Start": {
+    "message": "Guida Rapida",
+    "description": "The label for category Quick Start in sidebar tutorialSidebar"
+  },
+  "sidebar.tutorialSidebar.category.Resources": {
+    "message": "Risorse",
+    "description": "The label for category Resources in sidebar tutorialSidebar"
+  },
+  "sidebar.tutorialSidebar.category.Types": {
+    "message": "Tipi",
+    "description": "The label for category Types in sidebar tutorialSidebar"
+  },
+  "sidebar.tutorialSidebar.category.Options": {
+    "message": "Opzioni",
+    "description": "The label for category Options in sidebar tutorialSidebar"
+  },
+  "sidebar.tutorialSidebar.category.Response Handling": {
+    "message": "Gestione Risposte",
+    "description": "The label for category Response Handling in sidebar tutorialSidebar"
+  },
+  "sidebar.tutorialSidebar.category.Filters": {
+    "message": "Filtri",
+    "description": "The label for category Filters in sidebar tutorialSidebar"
+  }
+}

--- a/docs/website/i18n/it/docusaurus-plugin-content-docs/version-1.0.0/walkthrough.md
+++ b/docs/website/i18n/it/docusaurus-plugin-content-docs/version-1.0.0/walkthrough.md
@@ -1,0 +1,340 @@
+---
+sidebar_position: 2
+---
+
+# Guida al Walkthrough API
+
+L'SDK Go di Aruba Cloud fornisce un singolo import — `github.com/Arubacloud/sdk-go/pkg/aruba` — che espone un'API fluente con pattern builder per ogni risorsa cloud. Si costruisce la descrizione della risorsa con una catena `aruba.NewX()`, la si passa al metodo del client appropriato (`Create`, `Get`, `Update`, `Delete` o `List`), e si lavora con il wrapper tipizzato restituito.
+
+Le risorse sono organizzate in un **Progetto**, e le risorse figlio referenziano i propri genitori tramite l'interfaccia `aruba.Ref`. Non è mai necessario estrarre o passare manualmente stringhe di ID grezzi: si passa direttamente il wrapper idratato (restituito da `Create` o `Get`) come parametro `Ref` ai metodi builder come `InProject(proj)`, `InVPC(vpc)` o `InSecurityGroup(sg)`.
+
+Questa pagina illustra il ciclo CRUD completo su un esempio minimale — Project + VPC + Subnet. Ogni altra risorsa segue esattamente la stessa struttura. Vedi [Risorse](./resources) per snippet pronti all'uso per tutte le risorse supportate.
+
+---
+
+## 1. Inizializzare il Client
+
+```go
+package main
+
+import (
+    "context"
+    "log"
+    "time"
+
+    "github.com/Arubacloud/sdk-go/pkg/aruba"
+)
+
+func main() {
+    arubaClient, err := aruba.NewClient(aruba.DefaultOptions(clientID, clientSecret))
+    if err != nil {
+        log.Fatalf("Failed to create client: %v", err)
+    }
+
+    ctx, cancel := context.WithTimeout(context.Background(), 30*time.Minute)
+    defer cancel()
+}
+```
+
+`aruba.NewClient` accetta un valore `*aruba.Options`. `aruba.DefaultOptions(clientID, clientSecret)` è il modo più rapido per iniziare; vedi [Opzioni di Configurazione](./options) per credenziali Vault, caching token Redis, logger personalizzati e altro.
+
+Il `aruba.Client` restituito è una facciata che espone sub-client specifici per dominio:
+`FromProject()`, `FromAudit()`, `FromCompute()`, `FromContainer()`, `FromDatabase()`, `FromMetric()`, `FromNetwork()`, `FromSchedule()`, `FromSecurity()`, `FromStorage()`.
+
+---
+
+## 2. Provisioning delle Risorse
+
+Le risorse vengono create inline: si costruisce la richiesta con `aruba.NewX()` e la si passa direttamente a `Create`. Il wrapper restituito porta l'ID e l'URI della risorsa — lo si passa come `Ref` ai builder delle risorse figlio.
+
+### Progetto
+
+Il Progetto è il contenitore di livello superiore. Ogni altra risorsa appartiene a un progetto. È pronto in modo sincrono dopo che `Create` ritorna — non è necessario il polling.
+
+```go
+proj, err := arubaClient.FromProject().Create(
+    ctx,
+    aruba.NewProject().
+        Named("my-project").
+        Tagged("go-sdk").
+        DescribedAs("Creato tramite l'SDK Go di Aruba Cloud").
+        NotDefault())
+if err != nil {
+    log.Fatalf("Create project: %v", err)
+}
+fmt.Printf("✓ Progetto creato: %s (ID: %s)\n", proj.Name(), proj.ID())
+```
+
+### VPC
+
+```go
+vpc, err := arubaClient.FromNetwork().VPCs().Create(
+    ctx,
+    aruba.NewVPC().
+        Named("my-vpc").
+        Tagged("network").
+        InProject(proj).
+        InRegion(aruba.RegionITBGBergamo).
+        NotDefault().
+        WithoutPreset())
+if err != nil {
+    log.Fatalf("Create VPC: %v", err)
+}
+fmt.Printf("✓ VPC creata: %s\n", vpc.Name())
+
+// La maggior parte delle risorse è asincrona — attendi che raggiungano uno stato stabile.
+// Vedi "7. Attendere la Disponibilità" per le opzioni e i dettagli.
+if err := vpc.WaitUntilReady(ctx); err != nil {
+    log.Fatalf("VPC did not become ready: %v", err)
+}
+```
+
+`InProject(proj)` accetta qualsiasi `aruba.Ref` — lega lo scope del progetto senza richiedere l'estrazione di un ID stringa grezzo.
+
+### Subnet
+
+```go
+subnet, err := arubaClient.FromNetwork().Subnets().Create(
+    ctx,
+    aruba.NewSubnet().
+        OfType(aruba.SubnetTypeAdvanced).
+        Named("my-subnet").
+        Tagged("network").
+        InVPC(vpc).
+        InRegion(aruba.RegionITBGBergamo).
+        WithCIDR("192.168.1.0/25").
+        WithDHCP(aruba.NewSubnetDHCP().
+            Enabled().
+            WithRange("192.168.1.10", 50).
+            WithRoutes(aruba.SubnetDHCPRouteCommon{Address: "10.0.0.0/8", Gateway: "192.168.1.1"}).
+            WithDNSServers("8.8.8.8", "8.8.4.4")).
+        NotDefault())
+if err != nil {
+    log.Fatalf("Create subnet: %v", err)
+}
+fmt.Printf("✓ Subnet creata: %s (CIDR: %s)\n", subnet.Name(), subnet.CIDR())
+
+if err := subnet.WaitUntilReady(ctx); err != nil {
+    log.Fatalf("Subnet did not become ready: %v", err)
+}
+```
+
+`aruba.NewSubnetDHCP()` è un sub-builder per la configurazione DHCP. Si allega alla subnet con `WithDHCP(...)`.
+
+`OfType` accetta `aruba.SubnetTypeBasic` o `aruba.SubnetTypeAdvanced`.
+
+> Ogni altra risorsa — Security Group, Elastic IP, Block Storage, Cloud Server, cluster KaaS, istanze DBaaS e altro — segue esattamente la stessa struttura `NewX()` → `IntoParent(ref)` → `Create(ctx, ...)` → `WaitUntilReady(ctx)`. Vedi [Risorse](./resources) per l'elenco completo con snippet pronti all'uso.
+
+---
+
+## 3. Aggiornare una Risorsa Esistente
+
+Prima si recupera la risorsa, poi la si muta tramite setter, poi si chiama `Update`. Il wrapper di risposta da `Get` porta tutto lo stato interno (URI padre, riferimenti di rete, ecc.) che viene trasferito automaticamente nella richiesta `Update`.
+
+```go
+// Recupera
+vpc, err = arubaClient.FromNetwork().VPCs().Get(ctx, vpc)
+if err != nil {
+    log.Fatalf("Get VPC: %v", err)
+}
+
+// Muta
+vpc.Named("my-vpc-updated").
+    RetaggedAs("network", "updated")
+
+// Aggiorna
+updated, err := arubaClient.FromNetwork().VPCs().Update(ctx, vpc)
+if err != nil {
+    log.Fatalf("Update VPC: %v", err)
+}
+fmt.Printf("✓ VPC aggiornata: %s\n", updated.Name())
+```
+
+> **Importante**: Chiama sempre `Get` prima di `Update`. Chiamare `Update` su un wrapper appena costruito (senza un precedente `Create` o `Get`) restituisce un errore: `"Update: resource has no ID"`.
+
+---
+
+## 4. Elencare Risorse Esistenti
+
+`List` accetta un `Ref` genitore e restituisce un `*aruba.List[T]`. Si iterano gli elementi con `Items()`:
+
+```go
+list, err := arubaClient.FromNetwork().VPCs().List(ctx, proj)
+if err != nil {
+    log.Fatalf("List VPCs: %v", err)
+}
+fmt.Println("Totale VPC:", list.Total())
+for _, v := range list.Items() {
+    fmt.Println("-", v.Name(), v.ID())
+}
+```
+
+Gli elementi nella lista sono wrapper leggeri — portano l'ID e l'URI della risorsa, così puoi passarli direttamente a `Get`, `Update` o `Delete` come `Ref`:
+
+```go
+for _, v := range list.Items() {
+    full, err := arubaClient.FromNetwork().VPCs().Get(ctx, v)
+    // full ha tutti i campi popolati
+}
+```
+
+Per il filtraggio lato server, ordinamento e paginazione vedi [Filtri](./filters).
+
+---
+
+## 5. Ottenere una Risorsa Specifica
+
+Usa `Get` quando hai un `Ref` (un wrapper idratato, o un elemento di `*aruba.List[T]`):
+
+```go
+vpc, err := arubaClient.FromNetwork().VPCs().Get(ctx, vpc)
+if err != nil {
+    log.Fatalf("Get VPC: %v", err)
+}
+```
+
+### L'escape hatch `aruba.URI(…)`
+
+Quando hai solo un identificatore di risorsa come stringa — ad esempio, letto da una variabile d'ambiente o da una configurazione esterna — avvolgilo in `aruba.URI(…)` per soddisfare l'interfaccia `aruba.Ref`:
+
+```go
+projectID := os.Getenv("PROJECT_ID")
+
+// Bootstrap di un wrapper tipizzato da un ID stringa
+proj, err := arubaClient.FromProject().Get(ctx, aruba.URI("/projects/"+projectID))
+if err != nil {
+    log.Fatalf("Get project: %v", err)
+}
+
+// Ora proj è completamente idratato — usalo come Ref per le risorse figlio
+vpcs, err := arubaClient.FromNetwork().VPCs().List(ctx, proj)
+```
+
+`aruba.URI(s)` restituisce un `Ref` leggero che l'SDK usa per estrarre gli ID degli antenati dai segmenti di percorso URI. Qualsiasi URI di risorsa valido funziona — l'SDK lo analizza internamente.
+
+---
+
+## 6. Eliminazione (Ordine Inverso)
+
+Elimina i figli prima dei genitori. L'API Aruba Cloud restituisce **HTTP 400** quando si tenta di eliminare un genitore che ha ancora risorse figlio attive o in fase di eliminazione — non 409/422. Il pattern sicuro è emettere ogni delete sul figlio, poi attendere che la risorsa sia completamente sparita prima di salire nella catena delle dipendenze.
+
+`WaitUntilGone` blocca finché la risorsa non esiste più — ovvero finché il suo `Get` restituisce HTTP 404. Chiamalo sul wrapper idratato che già possiedi (`Delete` restituisce solo un `error`, nessun wrapper):
+
+```go
+// subnet → VPC → progetto
+if err := arubaClient.FromNetwork().Subnets().Delete(ctx, subnet); err != nil {
+    log.Printf("Delete subnet: %v", err)
+} else if err := subnet.WaitUntilGone(ctx); err != nil {
+    log.Printf("Subnet not gone: %v", err)
+}
+
+if err := arubaClient.FromNetwork().VPCs().Delete(ctx, vpc); err != nil {
+    log.Printf("Delete VPC: %v", err)
+} else if err := vpc.WaitUntilGone(ctx); err != nil {
+    log.Printf("VPC not gone: %v", err)
+}
+
+if err := arubaClient.FromProject().Delete(ctx, proj); err != nil {
+    log.Printf("Delete project: %v", err)
+}
+```
+
+`WaitUntilGone` accetta le stesse `WaitOption` di `WaitUntilReady` (`WithRetries`, `WithBaseDelay`, `WithTimeout`) ed è disponibile su ogni wrapper di risorsa che supporta il polling. `Project` non ha polling — viene eliminato per ultimo, senza figli da attendere.
+
+`Delete` accetta qualsiasi `aruba.Ref` — puoi passare il wrapper idratato direttamente o `aruba.URI(…)` se hai solo il percorso.
+
+Per una sequenza completa di teardown (Security Rule → Security Group → Subnet → VPC → Cloud Server → Block Storage → Progetto) vedi l'[Esempio Completo](#esempio-completo) in basso.
+
+---
+
+## 7. Attendere la Disponibilità
+
+La maggior parte delle operazioni cloud — Create, Update, operazioni di scaling — sono **asincrone**: la chiamata HTTP ritorna rapidamente, ma la risorsa continua a transitare tra stati (`Creating` → `Active`, `Updating` → `Active`) per secondi o minuti in background.
+
+Il metodo `WaitUntilReady` su qualsiasi wrapper che incorpora `statusMixin` blocca finché la risorsa raggiunge uno qualsiasi dei 7 stati stabili (`Active`, `Running`, `Stopped`, `NotUsed`, `Reserved`, `InUse`, `Used`) o restituisce un errore in caso di fallimento terminale:
+
+```go
+if err := vpc.WaitUntilReady(ctx); err != nil {
+    log.Fatalf("VPC did not become ready: %v", err)
+}
+```
+
+Usa `WaitUntilActive` quando hai specificamente bisogno solo dello stato `"Active"` — ad esempio dopo un'operazione di power-on.
+
+Tre `WaitOption` permettono di sovrascrivere i valori predefiniti (60 tentativi × 10 s di ritardo base × 600 s di scadenza rigida):
+
+```go
+if err := vpc.WaitUntilReady(ctx,
+    aruba.WithRetries(30),              // max iterazioni di polling (default: 60)
+    aruba.WithBaseDelay(5*time.Second), // ritardo fisso tra i poll (default: 10s)
+    aruba.WithTimeout(3*time.Minute),   // scadenza rigida (default: 600s)
+); err != nil {
+    log.Fatalf("VPC did not become ready: %v", err)
+}
+```
+
+Per `WaitUntilStates` (qualsiasi insieme di stati target), gli accessor di stato (`State()`, `FailureReason()`, `PreviousState()`, `IsDisabled()`, `DisableReasons()`), e il primitivo di basso livello `pkg/async.WaitFor` per il polling concorrente, vedi la guida [Async / Await](./async).
+
+---
+
+## Avvertenze
+
+### Gli errori dei setter sono differiti
+
+I setter del builder non restituiscono mai un errore — lo registrano nel wrapper. L'errore viene restituito dalla prima chiamata `Create` o `Update`, oppure puoi controllarlo in anticipo:
+
+```go
+rule := aruba.NewSecurityRule().
+    InSecurityGroup(sg).
+    TargetingCIDR("0.0.0.0/0").
+    TargetingSecurityGroup(otherSG) // in conflitto — registrato come errore
+
+if err := rule.Err(); err != nil {
+    log.Fatalf("Bad rule config: %v", err)
+}
+```
+
+> **Avvertenza**: `TargetingCIDR` e `TargetingSecurityGroup` si escludono a vicenda. Impostarli entrambi registra un errore al momento del setter che emerge su `Create`.
+
+### `WaitUntilReady` / `WaitUntilActive` richiedono un wrapper idratato
+
+Chiamare `WaitUntilReady` o `WaitUntilActive` su un wrapper costruito manualmente (senza `Create`/`Get`/`Update`/`List`) restituisce:
+
+```
+WaitUntilStates: refresh callback not set; resource must be produced by an adapter (Create/Get/Update/List) to support polling
+```
+
+Usa sempre il wrapper restituito dalla chiamata API, non il builder della richiesta.
+
+### Errori HTTP tipizzati
+
+Le risposte API non-2xx vengono restituite come `*aruba.HTTPError`. Usa `errors.As` per ispezionarle:
+
+```go
+vpc, err = arubaClient.FromNetwork().VPCs().Create(ctx, vpc)
+if err != nil {
+    var httpErr *aruba.HTTPError
+    if errors.As(err, &httpErr) {
+        log.Printf("API error %d: %s", httpErr.StatusCode, httpErr.Error())
+    } else {
+        log.Fatalf("Network error: %v", err)
+    }
+}
+```
+
+Vedi [Gestione delle Risposte](./response-handling) per la guida completa alla gestione degli errori.
+
+---
+
+## Esempio Completo
+
+La directory `examples/all-resources/` nel repository contiene un esempio end-to-end eseguibile che dimostra tutte le risorse:
+
+```bash
+go run ./examples/all-resources/ -mode=create -clientID=… -clientSecret=…
+go run ./examples/all-resources/ -mode=update -clientID=… -clientSecret=… -projectID=…
+go run ./examples/all-resources/ -mode=delete -clientID=… -clientSecret=… -projectID=…
+
+# Aggiungi -debug per il logging verboso dell'SDK:
+go run ./examples/all-resources/ -mode=create -clientID=… -clientSecret=… -debug
+```

--- a/docs/website/i18n/it/docusaurus-plugin-content-docs/version-1.0.0/working-at-low-level.md
+++ b/docs/website/i18n/it/docusaurus-plugin-content-docs/version-1.0.0/working-at-low-level.md
@@ -1,0 +1,268 @@
+# Lavorare a Basso Livello
+
+## Perché questa pagina esiste
+
+L'SDK è progettato attorno a un **principio di import singolo**: importare solo `github.com/Arubacloud/sdk-go/pkg/aruba` copre circa il 99,9% dei casi d'uso reali.
+
+La superficie wrapper — accessor tipizzati, helper `WaitUntil*`, `RawJSON()` / `RawYAML()` — è progettata in modo che raramente sia necessario accedere direttamente alle struct wire sottostanti. Per lo 0,1% dei casi in cui è necessario farlo, questa pagina raccoglie tutte le vie di uscita che richiedono un secondo import.
+
+> Questi pattern sono **intenzionali e supportati** — sono vie di uscita, non workaround. Quando incontri un caso non coperto dalla superficie wrapper, usa questi invece di aprire una feature request.
+
+---
+
+## Accedere ai campi wire non promossi con `Raw()`
+
+Ogni wrapper espone un metodo `Raw()` che restituisce la struct `*types.XxxResponse` sottostante. Usalo quando hai bisogno di un campo non ancora promosso alla superficie del wrapper:
+
+```go
+import (
+    "github.com/Arubacloud/sdk-go/pkg/aruba"
+    "github.com/Arubacloud/sdk-go/pkg/types"
+)
+
+vpc, err := arubaClient.FromNetwork().VPCs().Get(ctx, ref)
+if err != nil { /* … */ }
+
+raw := vpc.Raw()                          // *types.VPCResponse
+fmt.Println(raw.Properties.IsDefault)     // campo non promosso al wrapper
+```
+
+Per le liste, `Raw()` restituisce `any` e devi fare il type assert al tipo lista concreto:
+
+```go
+vpcList, err := arubaClient.FromNetwork().VPCs().List(ctx, proj)
+if err != nil { /* … */ }
+
+raw := vpcList.Raw().(*types.VPCListResponse)     // richiede l'import di pkg/types
+fmt.Println("server total:", raw.Total)   // equivalente a vpcList.Total() — mostrato per illustrazione
+fmt.Println("self link:", raw.Self)
+```
+
+> **Preferisci gli accessor del wrapper per la serializzazione.** Se il tuo obiettivo è l'output JSON o YAML, usa `vpc.RawJSON()` / `vpc.RawYAML()` (o i metodi equivalenti su `List[T]`) — senza bisogno di importare `pkg/types`.
+>
+> ```go
+> fmt.Println(string(vpcList.RawJSON()))  // JSON senza pkg/types
+> fmt.Println(string(vpcList.RawYAML()))  // YAML senza pkg/types
+> ```
+
+---
+
+## Ispezionare gli errori di validazione strutturati
+
+`*aruba.HTTPError` è il tipo di errore per tutte le risposte 4xx/5xx. Il suo campo `ErrResp` è un `*types.ErrorResponse` e contiene dettagli strutturati RFC 7807 — inclusa una slice `[]types.ValidationError` per gli errori 400 a livello di campo:
+
+```go
+import (
+    "errors"
+    "github.com/Arubacloud/sdk-go/pkg/aruba"
+    "github.com/Arubacloud/sdk-go/pkg/types"
+)
+
+_, err := arubaClient.FromNetwork().VPCs().Create(ctx, vpc)
+if err != nil {
+    var httpErr *aruba.HTTPError
+    if errors.As(err, &httpErr) && httpErr.ErrResp != nil {
+        fmt.Printf("title:  %s\n", derefStr(httpErr.ErrResp.Title))
+        fmt.Printf("detail: %s\n", derefStr(httpErr.ErrResp.Detail))
+
+        // Errori di validazione a livello di campo — richiedono types.ValidationError
+        for _, ve := range httpErr.ErrResp.Errors {
+            fmt.Printf("  campo %s: %s\n", ve.Field, ve.Message)
+        }
+
+        // TraceID per le richieste di supporto
+        fmt.Printf("trace-id: %s\n", derefStr(httpErr.ErrResp.TraceID))
+    }
+}
+```
+
+### `MetadataValidationError`
+
+Un `*types.MetadataValidationError` viene restituito (insieme a un wrapper non-nil) quando una risposta API manca dei campi di metadati obbligatori (`id` o `uri`). Usa `errors.As` per rilevarlo:
+
+```go
+import (
+    "errors"
+    "github.com/Arubacloud/sdk-go/pkg/aruba"
+    "github.com/Arubacloud/sdk-go/pkg/types"
+)
+
+result, err := arubaClient.FromNetwork().VPCs().Create(ctx, vpc)
+if err != nil {
+    var mvErr *types.MetadataValidationError
+    if errors.As(err, &mvErr) {
+        // result è non-nil e parzialmente idratato; mvErr elenca i campi mancanti
+        fmt.Printf("metadati incompleti: %v\n", mvErr)
+        fmt.Printf("ID finora: %s\n", result.ID())
+    }
+}
+```
+
+---
+
+## Iterare `LinkedResources()`
+
+Ogni wrapper di risorsa espone `LinkedResources()` che restituisce `[]types.LinkedResourceCommon`. Ogni elemento ha un `URI string` e un `StrictCorrelation bool`:
+
+```go
+import (
+    "github.com/Arubacloud/sdk-go/pkg/aruba"
+    "github.com/Arubacloud/sdk-go/pkg/types"
+)
+
+vpc, err := arubaClient.FromNetwork().VPCs().Get(ctx, ref)
+if err != nil { /* … */ }
+
+for _, lr := range vpc.LinkedResources() {
+    fmt.Println("linked URI:", lr.URI)
+    if lr.StrictCorrelation {
+        fmt.Println("  → correlazione stretta (lifecycle-linked)")
+    }
+}
+```
+
+> Se hai bisogno solo delle stringhe URI — ad esempio per passarle a un'altra chiamata SDK come `aruba.URI(lr.URI)` — non hai bisogno di `types.LinkedResourceCommon`:
+>
+> ```go
+> for _, lr := range vpc.LinkedResources() {
+>     ref := aruba.URI(lr.URI)   // senza import di pkg/types
+>     _ = ref
+> }
+> ```
+
+---
+
+## Ispezionare i body delle richieste prima dell'invio
+
+Ogni wrapper espone `RawRequest()` che restituisce la struct di richiesta a livello wire (`*types.XxxRequest`). È utile per il debug o per passare la richiesta a un altro strumento:
+
+```go
+import (
+    "encoding/json"
+    "github.com/Arubacloud/sdk-go/pkg/aruba"
+    "github.com/Arubacloud/sdk-go/pkg/types"
+)
+
+vpc := aruba.NewVPC().
+    Named("my-vpc").
+    InProject(proj).
+    InRegion(aruba.RegionITBGBergamo).
+    AsDefault()
+
+req := vpc.RawRequest()               // types.VPCRequest — richiede import di pkg/types
+b, _ := json.MarshalIndent(req, "", "  ")
+fmt.Println(string(b))
+```
+
+---
+
+## Polling in background con `pkg/async` {#background-polling-with-pkgasync}
+
+`WaitUntilReady`, `WaitUntilActive` e `WaitUntilStates` bloccano la goroutine chiamante. Se devi **avviare più attese in modo concorrente**, o **fare il polling di una condizione arbitraria** (non solo uno stato di risorsa), usa direttamente il pacchetto `pkg/async` di livello inferiore.
+
+`pkg/async` è un pacchetto pubblico — importalo insieme a `pkg/aruba`:
+
+```go
+import (
+    "github.com/Arubacloud/sdk-go/pkg/aruba"
+    "github.com/Arubacloud/sdk-go/pkg/async"
+    "github.com/Arubacloud/sdk-go/pkg/types"
+)
+```
+
+### `WaitFor` — avvia un future in background
+
+`async.WaitFor` avvia immediatamente una goroutine di polling e restituisce un `*async.AsyncClient[T]` (un future). Chiami `.Await(ctx)` in seguito per bloccare e ottenere il risultato:
+
+```go
+// Avvia il polling di VPC1 e VPC2 in modo concorrente
+futureVPC1 := async.DefaultWaitFor(ctx,
+    func(ctx context.Context) (*types.Response[types.VPCResponse], error) {
+        return arubaClient.FromNetwork().VPCs().Get(ctx, vpc1)
+    },
+    func(resp *types.Response[types.VPCResponse]) (bool, error) {
+        if resp == nil || resp.Data == nil {
+            return false, nil
+        }
+        var state types.State
+        if resp.Data.Properties != nil && resp.Data.Properties.Status != nil &&
+            resp.Data.Properties.Status.State != nil {
+            state = *resp.Data.Properties.Status.State
+        }
+        return state == types.StateActive, nil
+    },
+)
+
+futureVPC2 := async.DefaultWaitFor(ctx, /* stesso pattern per vpc2 */)
+
+// Blocca e attendi entrambi i risultati
+resp1, err1 := futureVPC1.Await(ctx)
+resp2, err2 := futureVPC2.Await(ctx)
+```
+
+`DefaultWaitFor` usa i valori predefiniti del pacchetto: `DefaultRetries=60`, `DefaultBaseDelay=10s`, `DefaultTimeout=600s`. Usa `async.WaitFor(ctx, retries, baseDelay, timeout, call, check)` per sovrascriverli.
+
+### Firma di `WaitFor`
+
+```go
+func WaitFor[T any](
+    ctx         context.Context,
+    retries     int,
+    baseDelay   time.Duration,
+    timeout     time.Duration,
+    call        func(ctx context.Context) (*types.Response[T], error),
+    check       func(*types.Response[T]) (bool, error),
+) *AsyncClient[T]
+```
+
+- `call` — la funzione di polling, chiamata una volta per ogni iterazione.
+- `check` — restituisce `(true, nil)` per segnalare il successo, `(true, error)` per segnalare un fallimento terminale, `(false, nil)` per continuare il polling.
+- Se `check` è `nil`, qualsiasi `response.Data` non-nil viene trattato come successo.
+
+### `AsyncClient.Await`
+
+```go
+func (f *AsyncClient[T]) Await(ctx context.Context) (*types.Response[T], error)
+```
+
+Blocca finché la goroutine in background invia il suo risultato oppure il `ctx` viene cancellato. Chiamate successive restituiscono il risultato **in cache** immediatamente — sicuro da chiamare più volte.
+
+> `pkg/async` lavora direttamente con le struct wire di `pkg/types`. Questo è l'unico livello dell'SDK dove interagirai direttamente con `types.Response[T]` e i tipi `types.*Response`.
+
+---
+
+## Cosa NON richiede `pkg/types`
+
+I seguenti elementi sono tutti disponibili con un singolo import di `pkg/aruba` — senza bisogno di un secondo import:
+
+| Cosa ti serve | Superficie `pkg/aruba` |
+|---|---|
+| Costanti di stato (`StateActive`, `StateStopped`, …) | `aruba.StateActive`, `aruba.StateStopped`, … |
+| Costanti regione / zona | `aruba.RegionITBGBergamo`, `aruba.ZoneITBG1`, … |
+| Periodo di fatturazione | `aruba.BillingPeriodHour`, `aruba.BillingPeriodMonth`, … |
+| Tutti gli enum compute, storage, network, security | Vedi `pkg/aruba/aliases.go` |
+| Attendere transizioni di stato | `wrapper.WaitUntilReady(ctx)`, `WaitUntilActive`, `WaitUntilStates` |
+| Serializzare una risposta in JSON / YAML | `wrapper.RawJSON()`, `wrapper.RawYAML()` |
+| Introspezione dell'envelope HTTP | `wrapper.StatusCode()`, `.Headers()`, `.RawHTTP()`, `.RawError()` |
+| Paginazione | `list.Total()`, `.HasNext()`, `.Next(ctx)`, `.All(ctx, yield)` |
+| Dettagli errore HTTP | `*aruba.HTTPError` — `StatusCode`, `ErrResp.Title`, `ErrResp.Detail`, `ErrResp.TraceID` |
+
+---
+
+## Vedi Anche
+
+- [Gestione delle Risposte](./response-handling) — errori HTTP tipizzati, accessor envelope, `RawJSON`/`RawYAML`
+- [Async / Await](./async) — `WaitUntilReady`, `WaitUntilStates`, opzioni di polling
+- [Guida al Walkthrough API](./walkthrough) — esempio completo del ciclo di vita Create + polling + Update + Delete
+
+---
+
+```go
+// Helper usato negli esempi sopra
+func derefStr(s *string) string {
+    if s == nil {
+        return ""
+    }
+    return *s
+}
+```


### PR DESCRIPTION
## Summary

- Add full Italian translations for **v0.2.3** (8 docs + sidebar JSON)
- Add full Italian translations for **v0.3.0** (9 docs including new `working-at-low-level.md` + sidebar JSON)
- Add full Italian translations for **v1.0.0** (9 docs + sidebar JSON; this version was cut from `main` while the branch was being prepared)
- Resync **3 drifted files** in `current/` (`options.md`, `resources.md`, `response-handling.md`) that were 60–80 lines behind English

## Translation strategy

Matches the established v0.2.2 Italian pattern:
- Prose, headings, admonition titles/bodies, code comments, and user-facing `fmt.Printf` strings → translated
- Code identifiers, imports, builder method names, `log.Fatalf` error strings, admonition keywords → kept in English
- API changes between versions faithfully reflected (e.g. `WaitUntilGone`, `NotDefault()`, `Tagged()`, type renames `VPCList→VPCListResponse`, `LinkedResource→LinkedResourceCommon`)

## Test plan

- [ ] `cd docs/website && npm install && npm run build` succeeds with no broken-link errors
- [ ] `npm run start -- --locale it` serves correctly for all versions
- [ ] Version switcher shows `0.2.3`, `0.3.0`, `1.0.0` in Italian without English fallback banners
- [ ] `working-at-low-level.md` is present and readable in Italian for v0.3.0 and v1.0.0
- [ ] File parity verified: each IT version dir contains exactly the same `.md` files as its English counterpart

🤖 Generated with [Claude Code](https://claude.com/claude-code)