### PR TITLE
feat(aruba): expose CreatedBy/UpdatedBy/CreatedUser/UpdatedUser getters on wrappers

### DIFF
--- a/ai/ARCHITECTURE.md
+++ b/ai/ARCHITECTURE.md
@@ -357,7 +357,7 @@ Every Family-A wrapper exposes a standard set of read accessors so callers never
 | **Identity** | `ID()`, `URI()`, `<Resource>ID()` | `responseMetadataMixin` + wrapper |
 | **Naming** | `Name()`, `Tags()` | `metadataMixin` |
 | **Geography** | `Region()`, `Zone()` (zonal only) | `regionalMixin` / `zonalMixin` |
-| **Lineage** | `Project()`, `CreatedAt()`, `UpdatedAt()`, `Version()` | `responseMetadataMixin` |
+| **Lineage** | `Project()`, `CreatedAt()`, `UpdatedAt()`, `Version()`, `CreatedBy()`, `UpdatedBy()`, `CreatedUser()`, `UpdatedUser()` | `responseMetadataMixin` |
 | **Lifecycle** | `State()`, `IsDisabled()`, `DisableReasons()`, `FailureReason()`, `PreviousState()` | `statusMixin` |
 | **Linked** | `LinkedResources()` | `linkedMixin` |
 | **Raw envelope** | `Raw()`, `RawJSON()`, `RawYAML()`, `RawRequest()`, `RawHTTP()`, `StatusCode()`, `Headers()`, `RawError()` | wrapper + `httpEnvelopeMixin` |

--- a/ai/CONVENTIONS.md
+++ b/ai/CONVENTIONS.md
@@ -194,6 +194,8 @@ Setter signatures take the alias type, not `string`.
 
 Every Family-A wrapper exposes a standard set of read accessors. Callers should always use these instead of reaching into `wrapper.Raw().Properties.X`.
 
+**Audit actor getters** — `CreatedBy()`, `UpdatedBy()`, `CreatedUser()`, `UpdatedUser()` are promoted from `responseMetadataMixin` onto all Family-A wrappers. They return `""` when the server does not populate the field (e.g. after a `Create` whose response omits `updatedBy`). Family-B wrappers whose wire types carry `createdBy` directly (Database, User, Grant) define their own `CreatedBy()` which shadows the mixin.
+
 **Naming rules:**
 - Simple scalar field from `Properties`: use the field name directly — `Name()`, `State()`, `Region()`.
 - URI of a linked resource: `<LinkedResource>URI()` (e.g. `VPNTunnelURI()`, `AssociatedResourceURI()`).

--- a/docs/website/docs/resources.md
+++ b/docs/website/docs/resources.md
@@ -98,6 +98,8 @@ fmt.Printf("✓ Project: %s (ID: %s)\n", proj.Name(), proj.ID())
 - `IsDefault()` — whether this is the default project
 - `Tags()` — `[]string` tag list
 - `CreatedAt()`, `UpdatedAt()` — timestamps
+- `CreatedBy()`, `UpdatedBy()` — actor identifier (e.g. `aru-297647`) of the creator/last updater
+- `CreatedUser()`, `UpdatedUser()` — display name of the creator/last updater
 - `Raw()` — underlying `*types.ProjectResponse` wire struct
 - `RawJSON()` / `RawYAML()` — serialized payload for `--output json/yaml` flags
 - `RawRequest()` — `types.ProjectRequest` for round-trip `Get → Update` flows

--- a/docs/website/docs/response-handling.md
+++ b/docs/website/docs/response-handling.md
@@ -190,7 +190,7 @@ fmt.Println(raw.Properties.SomeUnpromotedField)
 | Identity | `ID()`, `URI()`, `CloudServerID()` |
 | Naming | `Name()`, `Tags()` |
 | Geography | `Region()`, `Zone()` |
-| Lineage | `Project()`, `CreatedAt()`, `UpdatedAt()`, `Version()` |
+| Lineage | `Project()`, `CreatedAt()`, `UpdatedAt()`, `Version()`, `CreatedBy()`, `UpdatedBy()`, `CreatedUser()`, `UpdatedUser()` |
 | Lifecycle | `State()`, `IsDisabled()`, `DisableReasons()`, `FailureReason()` |
 | Linked resources | `LinkedResources()` |
 | Raw envelope | `Raw()`, `RawJSON()`, `RawYAML()`, `RawRequest()`, `StatusCode()`, `Headers()`, `RawError()` |

--- a/docs/website/i18n/it/docusaurus-plugin-content-docs/current/resources.md
+++ b/docs/website/i18n/it/docusaurus-plugin-content-docs/current/resources.md
@@ -98,6 +98,8 @@ fmt.Printf("✓ Progetto: %s (ID: %s)\n", proj.Name(), proj.ID())
 - `IsDefault()` — se questo è il progetto predefinito
 - `Tags()` — lista di tag `[]string`
 - `CreatedAt()`, `UpdatedAt()` — timestamp
+- `CreatedBy()`, `UpdatedBy()` — identificatore dell'attore che ha creato/aggiornato la risorsa (es. `aru-297647`)
+- `CreatedUser()`, `UpdatedUser()` — nome visualizzato dell'utente che ha creato/aggiornato la risorsa
 - `Raw()` — struct wire sottostante `*types.ProjectResponse`
 - `RawJSON()` / `RawYAML()` — payload serializzato per i flag `--output json/yaml`
 - `RawRequest()` — `types.ProjectRequest` per i flussi round-trip `Get → Update`

--- a/docs/website/i18n/it/docusaurus-plugin-content-docs/current/response-handling.md
+++ b/docs/website/i18n/it/docusaurus-plugin-content-docs/current/response-handling.md
@@ -186,7 +186,7 @@ fmt.Println(raw.Properties.SomeUnpromotedField)
 | Identità | `ID()`, `URI()`, `CloudServerID()` |
 | Denominazione | `Name()`, `Tags()` |
 | Geografia | `Region()`, `Zone()` |
-| Derivazione | `Project()`, `CreatedAt()`, `UpdatedAt()`, `Version()` |
+| Derivazione | `Project()`, `CreatedAt()`, `UpdatedAt()`, `Version()`, `CreatedBy()`, `UpdatedBy()`, `CreatedUser()`, `UpdatedUser()` |
 | Ciclo di vita | `State()`, `IsDisabled()`, `DisableReasons()`, `FailureReason()` |
 | Risorse collegate | `LinkedResources()` |
 | Envelope grezzo | `Raw()`, `RawJSON()`, `RawYAML()`, `RawRequest()`, `StatusCode()`, `Headers()`, `RawError()` |

--- a/examples/all-resources/common.go
+++ b/examples/all-resources/common.go
@@ -469,20 +469,17 @@ func summaryRow(label, name, id string, extras ...string) string {
 	return fmt.Sprintf("- %s: %s (ID: %s)", label, name, tail)
 }
 
-// eipRow returns a summary line for an ElasticIP (which may be nil).
-func eipRow(label string, eip *aruba.ElasticIP) string {
-	if eip != nil {
-		return summaryRow(label, eip.Name(), eip.ID())
+// auditExtras returns a slice of "key=value" strings for CreatedBy and CreatedAt.
+// Empty or zero values are omitted so summaryRow output stays clean.
+func auditExtras(createdBy string, createdAt time.Time) []string {
+	var extras []string
+	if createdBy != "" {
+		extras = append(extras, "createdBy="+createdBy)
 	}
-	return summaryRow(label, "", "")
-}
-
-// bsRow returns a summary line for a BlockStorage (which may be nil).
-func bsRow(label string, bs *aruba.BlockStorage) string {
-	if bs != nil {
-		return summaryRow(label, bs.Name(), bs.ID())
+	if !createdAt.IsZero() {
+		extras = append(extras, "createdAt="+createdAt.UTC().Format(time.RFC3339))
 	}
-	return summaryRow(label, "", "")
+	return extras
 }
 
 // printResourceSummary prints a summary of all created resources.
@@ -492,148 +489,195 @@ func printResourceSummary(resources *ResourceCollection) {
 
 	// Project
 	if resources.Project != nil {
-		fmt.Println(summaryRow("Project", resources.Project.Name(), resources.Project.ID()))
+		fmt.Println(summaryRow("Project", resources.Project.Name(), resources.Project.ID(),
+			auditExtras(resources.Project.CreatedBy(), resources.Project.CreatedAt())...))
 	} else {
 		fmt.Println(summaryRow("Project", "", ""))
 	}
 
 	// Elastic IPs
-	fmt.Println(eipRow("ElasticIP (Cloud Server)", resources.CloudServerEIP))
-	fmt.Println(eipRow("ElasticIP (DBaaS)", resources.DBaaSEIP))
-	fmt.Println(eipRow("ElasticIP (Container Registry)", resources.ContainerRegistryEIP))
-	fmt.Println(eipRow("ElasticIP (VPN Tunnel)", resources.VPNTunnelEIP))
+	for _, pair := range []struct {
+		label string
+		eip   *aruba.ElasticIP
+	}{
+		{"ElasticIP (Cloud Server)", resources.CloudServerEIP},
+		{"ElasticIP (DBaaS)", resources.DBaaSEIP},
+		{"ElasticIP (Container Registry)", resources.ContainerRegistryEIP},
+		{"ElasticIP (VPN Tunnel)", resources.VPNTunnelEIP},
+	} {
+		if pair.eip != nil {
+			fmt.Println(summaryRow(pair.label, pair.eip.Name(), pair.eip.ID(),
+				auditExtras(pair.eip.CreatedBy(), pair.eip.CreatedAt())...))
+		} else {
+			fmt.Println(summaryRow(pair.label, "", ""))
+		}
+	}
 
 	// Block Storages
-	fmt.Println(bsRow("BlockStorage (Cloud Server)", resources.CloudServerBlockStorage))
-	fmt.Println(bsRow("BlockStorage (Container Registry)", resources.ContainerRegistryStorage))
-	fmt.Println(bsRow("BlockStorage (Restore Target)", resources.RestoreTargetStorage))
+	for _, pair := range []struct {
+		label string
+		bs    *aruba.BlockStorage
+	}{
+		{"BlockStorage (Cloud Server)", resources.CloudServerBlockStorage},
+		{"BlockStorage (Container Registry)", resources.ContainerRegistryStorage},
+		{"BlockStorage (Restore Target)", resources.RestoreTargetStorage},
+	} {
+		if pair.bs != nil {
+			fmt.Println(summaryRow(pair.label, pair.bs.Name(), pair.bs.ID(),
+				auditExtras(pair.bs.CreatedBy(), pair.bs.CreatedAt())...))
+		} else {
+			fmt.Println(summaryRow(pair.label, "", ""))
+		}
+	}
 
 	// Snapshot / Backup / Restore
 	if resources.Snapshot != nil {
-		fmt.Println(summaryRow("Snapshot", resources.Snapshot.Name(), resources.Snapshot.ID()))
+		fmt.Println(summaryRow("Snapshot", resources.Snapshot.Name(), resources.Snapshot.ID(),
+			auditExtras(resources.Snapshot.CreatedBy(), resources.Snapshot.CreatedAt())...))
 	} else {
 		fmt.Println(summaryRow("Snapshot", "", ""))
 	}
 	if resources.Backup != nil {
-		fmt.Println(summaryRow("Storage Backup", resources.Backup.Name(), resources.Backup.BackupID()))
+		fmt.Println(summaryRow("Storage Backup", resources.Backup.Name(), resources.Backup.BackupID(),
+			auditExtras(resources.Backup.CreatedBy(), resources.Backup.CreatedAt())...))
 	} else {
 		fmt.Println(summaryRow("Storage Backup", "", ""))
 	}
 	if resources.Restore != nil {
-		fmt.Println(summaryRow("Storage Restore", resources.Restore.Name(), resources.Restore.RestoreID()))
+		fmt.Println(summaryRow("Storage Restore", resources.Restore.Name(), resources.Restore.RestoreID(),
+			auditExtras(resources.Restore.CreatedBy(), resources.Restore.CreatedAt())...))
 	} else {
 		fmt.Println(summaryRow("Storage Restore", "", ""))
 	}
 
 	// Network
 	if resources.VPC != nil {
-		fmt.Println(summaryRow("VPC", resources.VPC.Name(), resources.VPC.ID()))
+		fmt.Println(summaryRow("VPC", resources.VPC.Name(), resources.VPC.ID(),
+			auditExtras(resources.VPC.CreatedBy(), resources.VPC.CreatedAt())...))
 	} else {
 		fmt.Println(summaryRow("VPC", "", ""))
 	}
 	if resources.SubnetAdvanced != nil {
-		fmt.Println(summaryRow("Subnet (Advanced)", resources.SubnetAdvanced.Name(), resources.SubnetAdvanced.ID()))
+		fmt.Println(summaryRow("Subnet (Advanced)", resources.SubnetAdvanced.Name(), resources.SubnetAdvanced.ID(),
+			auditExtras(resources.SubnetAdvanced.CreatedBy(), resources.SubnetAdvanced.CreatedAt())...))
 	} else {
 		fmt.Println(summaryRow("Subnet (Advanced)", "", ""))
 	}
 	if resources.SubnetBasic != nil {
-		fmt.Println(summaryRow("Subnet (Basic)", resources.SubnetBasic.Name(), resources.SubnetBasic.ID()))
+		fmt.Println(summaryRow("Subnet (Basic)", resources.SubnetBasic.Name(), resources.SubnetBasic.ID(),
+			auditExtras(resources.SubnetBasic.CreatedBy(), resources.SubnetBasic.CreatedAt())...))
 	} else {
 		fmt.Println(summaryRow("Subnet (Basic)", "", ""))
 	}
 
 	// Security
 	if resources.SecurityGroup != nil {
-		fmt.Println(summaryRow("Security Group", resources.SecurityGroup.Name(), resources.SecurityGroup.ID()))
+		fmt.Println(summaryRow("Security Group", resources.SecurityGroup.Name(), resources.SecurityGroup.ID(),
+			auditExtras(resources.SecurityGroup.CreatedBy(), resources.SecurityGroup.CreatedAt())...))
 	} else {
 		fmt.Println(summaryRow("Security Group", "", ""))
 	}
 	for _, r := range resources.SecurityRulesIngress {
 		if r != nil {
-			fmt.Println(summaryRow("Security Rule (Ingress/"+r.Name()+")", r.Name(), r.ID()))
+			fmt.Println(summaryRow("Security Rule (Ingress/"+r.Name()+")", r.Name(), r.ID(),
+				auditExtras(r.CreatedBy(), r.CreatedAt())...))
 		}
 	}
 	if resources.SecurityRuleEgress != nil {
-		fmt.Println(summaryRow("Security Rule (Egress)", resources.SecurityRuleEgress.Name(), resources.SecurityRuleEgress.ID()))
+		fmt.Println(summaryRow("Security Rule (Egress)", resources.SecurityRuleEgress.Name(), resources.SecurityRuleEgress.ID(),
+			auditExtras(resources.SecurityRuleEgress.CreatedBy(), resources.SecurityRuleEgress.CreatedAt())...))
 	} else {
 		fmt.Println(summaryRow("Security Rule (Egress)", "", ""))
 	}
 
 	// SSH Key Pair
 	if resources.KeyPair != nil {
-		fmt.Println(summaryRow("SSH Key Pair", resources.KeyPair.Name(), resources.KeyPair.KeyPairID()))
+		fmt.Println(summaryRow("SSH Key Pair", resources.KeyPair.Name(), resources.KeyPair.KeyPairID(),
+			auditExtras(resources.KeyPair.CreatedBy(), resources.KeyPair.CreatedAt())...))
 	} else {
 		fmt.Println(summaryRow("SSH Key Pair", "", ""))
 	}
 
 	// Database stack
 	if resources.DBaaS != nil {
-		fmt.Println(summaryRow("DBaaS", resources.DBaaS.Name(), resources.DBaaS.DBaaSID()))
+		fmt.Println(summaryRow("DBaaS", resources.DBaaS.Name(), resources.DBaaS.DBaaSID(),
+			auditExtras(resources.DBaaS.CreatedBy(), resources.DBaaS.CreatedAt())...))
 	} else {
 		fmt.Println(summaryRow("DBaaS", "", ""))
 	}
 	if resources.Database != nil && resources.Database.ID() != "" {
-		fmt.Printf("- DBaaS Database: %s\n", resources.Database.Name())
+		fmt.Println(summaryRow("DBaaS Database", resources.Database.Name(), resources.Database.ID(),
+			auditExtras(resources.Database.CreatedBy(), resources.Database.CreatedAt())...))
 	} else {
 		fmt.Println("- DBaaS Database: <not created>")
 	}
 	if resources.DBaaSUser != nil && resources.DBaaSUser.ID() != "" {
-		fmt.Printf("- DBaaS User: %s\n", resources.DBaaSUser.Username())
+		fmt.Println(summaryRow("DBaaS User", resources.DBaaSUser.Username(), resources.DBaaSUser.ID(),
+			auditExtras(resources.DBaaSUser.CreatedBy(), resources.DBaaSUser.CreatedAt())...))
 	} else {
 		fmt.Println("- DBaaS User: <not created>")
 	}
 	if resources.Grant != nil && resources.Grant.Username() != "" {
-		fmt.Printf("- DBaaS Grant: %s on %s (%s)\n",
-			resources.Grant.Username(), resources.Grant.DatabaseName(), resources.Grant.RoleName())
+		grantDesc := resources.Grant.Username() + " on " + resources.Grant.DatabaseName() + " (" + resources.Grant.RoleName() + ")"
+		fmt.Println(summaryRow("DBaaS Grant", grantDesc, resources.Grant.ID(),
+			auditExtras(resources.Grant.CreatedBy(), resources.Grant.CreatedAt())...))
 	} else {
 		fmt.Println("- DBaaS Grant: <not created>")
 	}
 
 	// Compute & container platforms
 	if resources.KaaS != nil {
-		fmt.Println(summaryRow("KaaS Cluster", resources.KaaS.Name(), resources.KaaS.KaaSID()))
+		fmt.Println(summaryRow("KaaS Cluster", resources.KaaS.Name(), resources.KaaS.KaaSID(),
+			auditExtras(resources.KaaS.CreatedBy(), resources.KaaS.CreatedAt())...))
 	} else {
 		fmt.Println(summaryRow("KaaS Cluster", "", ""))
 	}
 	if resources.CloudServer != nil {
-		fmt.Println(summaryRow("Cloud Server", resources.CloudServer.Name(), resources.CloudServer.CloudServerID()))
+		fmt.Println(summaryRow("Cloud Server", resources.CloudServer.Name(), resources.CloudServer.CloudServerID(),
+			auditExtras(resources.CloudServer.CreatedBy(), resources.CloudServer.CreatedAt())...))
 	} else {
 		fmt.Println(summaryRow("Cloud Server", "", ""))
 	}
 	if resources.ContainerRegistry != nil {
-		fmt.Println(summaryRow("Container Registry", resources.ContainerRegistry.Name(), resources.ContainerRegistry.ContainerRegistryID()))
+		fmt.Println(summaryRow("Container Registry", resources.ContainerRegistry.Name(), resources.ContainerRegistry.ContainerRegistryID(),
+			auditExtras(resources.ContainerRegistry.CreatedBy(), resources.ContainerRegistry.CreatedAt())...))
 	} else {
 		fmt.Println(summaryRow("Container Registry", "", ""))
 	}
 
 	// Schedule jobs
 	if resources.JobRecurring != nil {
-		fmt.Println(summaryRow("Job (Recurring)", resources.JobRecurring.Name(), resources.JobRecurring.JobID()))
+		fmt.Println(summaryRow("Job (Recurring)", resources.JobRecurring.Name(), resources.JobRecurring.JobID(),
+			auditExtras(resources.JobRecurring.CreatedBy(), resources.JobRecurring.CreatedAt())...))
 	} else {
 		fmt.Println(summaryRow("Job (Recurring)", "", ""))
 	}
 	if resources.JobOneShot != nil {
-		fmt.Println(summaryRow("Job (One-Shot)", resources.JobOneShot.Name(), resources.JobOneShot.JobID()))
+		fmt.Println(summaryRow("Job (One-Shot)", resources.JobOneShot.Name(), resources.JobOneShot.JobID(),
+			auditExtras(resources.JobOneShot.CreatedBy(), resources.JobOneShot.CreatedAt())...))
 	} else {
 		fmt.Println(summaryRow("Job (One-Shot)", "", ""))
 	}
 
 	// VPN stack
 	if resources.VPNTunnel != nil {
-		fmt.Println(summaryRow("VPN Tunnel", resources.VPNTunnel.Name(), resources.VPNTunnel.VPNTunnelID()))
+		fmt.Println(summaryRow("VPN Tunnel", resources.VPNTunnel.Name(), resources.VPNTunnel.VPNTunnelID(),
+			auditExtras(resources.VPNTunnel.CreatedBy(), resources.VPNTunnel.CreatedAt())...))
 	} else {
 		fmt.Println(summaryRow("VPN Tunnel", "", ""))
 	}
 	if resources.VPNRoute != nil {
-		fmt.Println(summaryRow("VPN Route", resources.VPNRoute.Name(), resources.VPNRoute.VPNRouteID(),
-			"cloudSubnet="+resources.VPNRoute.CloudSubnetCIDR()))
+		extras := append([]string{"cloudSubnet=" + resources.VPNRoute.CloudSubnetCIDR()},
+			auditExtras(resources.VPNRoute.CreatedBy(), resources.VPNRoute.CreatedAt())...)
+		fmt.Println(summaryRow("VPN Route", resources.VPNRoute.Name(), resources.VPNRoute.VPNRouteID(), extras...))
 	} else {
 		fmt.Println(summaryRow("VPN Route", "", ""))
 	}
 
 	// KMS stack
 	if resources.KMS != nil {
-		fmt.Println(summaryRow("KMS Instance", resources.KMS.Name(), resources.KMS.KMSID()))
+		fmt.Println(summaryRow("KMS Instance", resources.KMS.Name(), resources.KMS.KMSID(),
+			auditExtras(resources.KMS.CreatedBy(), resources.KMS.CreatedAt())...))
 	} else {
 		fmt.Println(summaryRow("KMS Instance", "", ""))
 	}

--- a/examples/all-resources/orchestrator_delete.go
+++ b/examples/all-resources/orchestrator_delete.go
@@ -277,55 +277,142 @@ func fetchAllResources(ctx context.Context, arubaClient aruba.Client, proj *arub
 	return resources
 }
 
-// printDeletionInventory prints a concise summary of everything fetchAllResources found.
+// printDeletionInventory lists every resource found by fetchAllResources, with
+// CreatedBy and CreatedAt where the resource carries audit metadata.
 func printDeletionInventory(r *ResourceCollection) {
 	fmt.Println("\n=== Inventory ===")
 
-	count := func(b bool) int {
-		if b {
-			return 1
-		}
-		return 0
+	// Project
+	if r.Project != nil {
+		fmt.Println(summaryRow("Project", r.Project.Name(), r.Project.ID(),
+			auditExtras(r.Project.CreatedBy(), r.Project.CreatedAt())...))
+	} else {
+		fmt.Println(summaryRow("Project", "", ""))
 	}
 
-	fmt.Printf("  Project: %d\n", count(r.Project != nil))
+	// VPC & network
+	if r.VPC != nil {
+		fmt.Println(summaryRow("VPC", r.VPC.Name(), r.VPC.ID(),
+			auditExtras(r.VPC.CreatedBy(), r.VPC.CreatedAt())...))
+	}
+	if r.SubnetAdvanced != nil {
+		fmt.Println(summaryRow("Subnet (Advanced)", r.SubnetAdvanced.Name(), r.SubnetAdvanced.ID(),
+			auditExtras(r.SubnetAdvanced.CreatedBy(), r.SubnetAdvanced.CreatedAt())...))
+	}
+	if r.SubnetBasic != nil {
+		fmt.Println(summaryRow("Subnet (Basic)", r.SubnetBasic.Name(), r.SubnetBasic.ID(),
+			auditExtras(r.SubnetBasic.CreatedBy(), r.SubnetBasic.CreatedAt())...))
+	}
+	if r.SecurityGroup != nil {
+		fmt.Println(summaryRow("Security Group", r.SecurityGroup.Name(), r.SecurityGroup.ID(),
+			auditExtras(r.SecurityGroup.CreatedBy(), r.SecurityGroup.CreatedAt())...))
+	}
+	for _, rule := range r.SecurityRulesIngress {
+		if rule != nil {
+			fmt.Println(summaryRow("Security Rule (Ingress/"+rule.Name()+")", rule.Name(), rule.ID(),
+				auditExtras(rule.CreatedBy(), rule.CreatedAt())...))
+		}
+	}
+	if r.SecurityRuleEgress != nil {
+		fmt.Println(summaryRow("Security Rule (Egress)", r.SecurityRuleEgress.Name(), r.SecurityRuleEgress.ID(),
+			auditExtras(r.SecurityRuleEgress.CreatedBy(), r.SecurityRuleEgress.CreatedAt())...))
+	}
+	if r.KeyPair != nil {
+		fmt.Println(summaryRow("SSH Key Pair", r.KeyPair.Name(), r.KeyPair.KeyPairID(),
+			auditExtras(r.KeyPair.CreatedBy(), r.KeyPair.CreatedAt())...))
+	}
+	for _, eip := range r.ElasticIPs {
+		if eip != nil {
+			fmt.Println(summaryRow("Elastic IP", eip.Name(), eip.ID(),
+				auditExtras(eip.CreatedBy(), eip.CreatedAt())...))
+		}
+	}
+	for _, bs := range r.BlockStorages {
+		if bs != nil {
+			fmt.Println(summaryRow("Block Storage", bs.Name(), bs.ID(),
+				auditExtras(bs.CreatedBy(), bs.CreatedAt())...))
+		}
+	}
 
-	fmt.Printf("  KMS: %d  KMS Key: %d  KMIP: %d\n",
-		count(r.KMS != nil), count(r.KMSKey != nil), count(r.Kmip != nil))
+	// VPN stack
+	if r.VPNTunnel != nil {
+		fmt.Println(summaryRow("VPN Tunnel", r.VPNTunnel.Name(), r.VPNTunnel.VPNTunnelID(),
+			auditExtras(r.VPNTunnel.CreatedBy(), r.VPNTunnel.CreatedAt())...))
+	}
+	if r.VPNRoute != nil {
+		extras := append([]string{"cloudSubnet=" + r.VPNRoute.CloudSubnetCIDR()},
+			auditExtras(r.VPNRoute.CreatedBy(), r.VPNRoute.CreatedAt())...)
+		fmt.Println(summaryRow("VPN Route", r.VPNRoute.Name(), r.VPNRoute.VPNRouteID(), extras...))
+	}
 
-	fmt.Printf("  Backup: %d  Restore: %d  Snapshot: %d\n",
-		count(r.Backup != nil), count(r.Restore != nil), count(r.Snapshot != nil))
+	// KMS stack
+	if r.KMS != nil {
+		fmt.Println(summaryRow("KMS Instance", r.KMS.Name(), r.KMS.KMSID(),
+			auditExtras(r.KMS.CreatedBy(), r.KMS.CreatedAt())...))
+	}
+	if r.KMSKey != nil {
+		fmt.Println(summaryRow("KMS Key", r.KMSKey.Name(), r.KMSKey.KeyID()))
+	}
+	if r.Kmip != nil {
+		fmt.Println(summaryRow("KMIP Service", r.Kmip.Name(), r.Kmip.KmipID()))
+	}
 
-	fmt.Printf("  Container Registry: %d\n", count(r.ContainerRegistry != nil))
+	// Backup & restore
+	if r.Backup != nil {
+		fmt.Println(summaryRow("Storage Backup", r.Backup.Name(), r.Backup.BackupID(),
+			auditExtras(r.Backup.CreatedBy(), r.Backup.CreatedAt())...))
+	}
+	if r.Restore != nil {
+		fmt.Println(summaryRow("Storage Restore", r.Restore.Name(), r.Restore.RestoreID(),
+			auditExtras(r.Restore.CreatedBy(), r.Restore.CreatedAt())...))
+	}
+	if r.Snapshot != nil {
+		fmt.Println(summaryRow("Snapshot", r.Snapshot.Name(), r.Snapshot.ID(),
+			auditExtras(r.Snapshot.CreatedBy(), r.Snapshot.CreatedAt())...))
+	}
 
-	jobs := 0
+	// Container Registry
+	if r.ContainerRegistry != nil {
+		fmt.Println(summaryRow("Container Registry", r.ContainerRegistry.Name(), r.ContainerRegistry.ContainerRegistryID(),
+			auditExtras(r.ContainerRegistry.CreatedBy(), r.ContainerRegistry.CreatedAt())...))
+	}
+
+	// Compute & schedule
+	if r.CloudServer != nil {
+		fmt.Println(summaryRow("Cloud Server", r.CloudServer.Name(), r.CloudServer.CloudServerID(),
+			auditExtras(r.CloudServer.CreatedBy(), r.CloudServer.CreatedAt())...))
+	}
+	if r.KaaS != nil {
+		fmt.Println(summaryRow("KaaS Cluster", r.KaaS.Name(), r.KaaS.KaaSID(),
+			auditExtras(r.KaaS.CreatedBy(), r.KaaS.CreatedAt())...))
+	}
 	if r.JobRecurring != nil {
-		jobs++
+		fmt.Println(summaryRow("Job (Recurring)", r.JobRecurring.Name(), r.JobRecurring.JobID(),
+			auditExtras(r.JobRecurring.CreatedBy(), r.JobRecurring.CreatedAt())...))
 	}
 	if r.JobOneShot != nil {
-		jobs++
+		fmt.Println(summaryRow("Job (One-Shot)", r.JobOneShot.Name(), r.JobOneShot.JobID(),
+			auditExtras(r.JobOneShot.CreatedBy(), r.JobOneShot.CreatedAt())...))
 	}
-	fmt.Printf("  Cloud Server: %d  KaaS: %d  Jobs: %d\n",
-		count(r.CloudServer != nil), count(r.KaaS != nil), jobs)
 
-	grants := count(r.Grant != nil)
-	users := count(r.DBaaSUser != nil)
-	dbs := count(r.Database != nil)
-	fmt.Printf("  DBaaS: %d (Database: %d  User: %d  Grant: %d)\n",
-		count(r.DBaaS != nil), dbs, users, grants)
-
-	fmt.Printf("  VPC: %d  Subnets: %d  Security Group: %d  Rules: %d  Key Pair: %d\n",
-		count(r.VPC != nil),
-		count(r.SubnetAdvanced != nil)+count(r.SubnetBasic != nil),
-		count(r.SecurityGroup != nil),
-		len(r.SecurityRulesIngress)+count(r.SecurityRuleEgress != nil),
-		count(r.KeyPair != nil))
-
-	fmt.Printf("  Block Storages: %d  Elastic IPs: %d\n",
-		len(r.BlockStorages), len(r.ElasticIPs))
-
-	fmt.Printf("  VPN Tunnel: %d  VPN Route: %d\n",
-		count(r.VPNTunnel != nil), count(r.VPNRoute != nil))
+	// Database stack
+	if r.DBaaS != nil {
+		fmt.Println(summaryRow("DBaaS", r.DBaaS.Name(), r.DBaaS.DBaaSID(),
+			auditExtras(r.DBaaS.CreatedBy(), r.DBaaS.CreatedAt())...))
+	}
+	if r.Database != nil && r.Database.ID() != "" {
+		fmt.Println(summaryRow("DBaaS Database", r.Database.Name(), r.Database.ID(),
+			auditExtras(r.Database.CreatedBy(), r.Database.CreatedAt())...))
+	}
+	if r.DBaaSUser != nil && r.DBaaSUser.ID() != "" {
+		fmt.Println(summaryRow("DBaaS User", r.DBaaSUser.Username(), r.DBaaSUser.ID(),
+			auditExtras(r.DBaaSUser.CreatedBy(), r.DBaaSUser.CreatedAt())...))
+	}
+	if r.Grant != nil && r.Grant.Username() != "" {
+		grantDesc := r.Grant.Username() + " on " + r.Grant.DatabaseName() + " (" + r.Grant.RoleName() + ")"
+		fmt.Println(summaryRow("DBaaS Grant", grantDesc, r.Grant.ID(),
+			auditExtras(r.Grant.CreatedBy(), r.Grant.CreatedAt())...))
+	}
 }
 
 // deleteAllResources deletes all resources in strict inverse of the creation order

--- a/examples/all-resources/resource_project.go
+++ b/examples/all-resources/resource_project.go
@@ -22,7 +22,8 @@ func createProject(ctx context.Context, arubaClient aruba.Client) *aruba.Project
 	if err != nil {
 		log.Fatalf("✗ Failed to create Project: %s", formatErr(err))
 	}
-	printCreated("Project", created.Name(), created.ID())
+	printCreated("Project", created.Name(), created.ID(),
+		"createdBy="+created.CreatedBy())
 
 	return created
 }

--- a/examples/all-resources/resource_project.go
+++ b/examples/all-resources/resource_project.go
@@ -22,8 +22,7 @@ func createProject(ctx context.Context, arubaClient aruba.Client) *aruba.Project
 	if err != nil {
 		log.Fatalf("✗ Failed to create Project: %s", formatErr(err))
 	}
-	printCreated("Project", created.Name(), created.ID(),
-		"createdBy="+created.CreatedBy())
+	printCreated("Project", created.Name(), created.ID())
 
 	return created
 }

--- a/pkg/aruba/mixin_common.go
+++ b/pkg/aruba/mixin_common.go
@@ -192,6 +192,38 @@ func (m *responseMetadataMixin) Version() string {
 	return *m.meta.Version
 }
 
+// CreatedBy returns the identifier of the actor that created the resource, or "".
+func (m *responseMetadataMixin) CreatedBy() string {
+	if m.meta == nil || m.meta.CreatedBy == nil {
+		return ""
+	}
+	return *m.meta.CreatedBy
+}
+
+// UpdatedBy returns the identifier of the actor that last updated the resource, or "".
+func (m *responseMetadataMixin) UpdatedBy() string {
+	if m.meta == nil || m.meta.UpdatedBy == nil {
+		return ""
+	}
+	return *m.meta.UpdatedBy
+}
+
+// CreatedUser returns the user display name that created the resource, or "".
+func (m *responseMetadataMixin) CreatedUser() string {
+	if m.meta == nil || m.meta.CreatedUser == nil {
+		return ""
+	}
+	return *m.meta.CreatedUser
+}
+
+// UpdatedUser returns the user display name that last updated the resource, or "".
+func (m *responseMetadataMixin) UpdatedUser() string {
+	if m.meta == nil || m.meta.UpdatedUser == nil {
+		return ""
+	}
+	return *m.meta.UpdatedUser
+}
+
 // Raw returns the underlying *types.ResourceMetadataResponse, or nil.
 func (m *responseMetadataMixin) Raw() *types.ResourceMetadataResponse {
 	return m.meta

--- a/pkg/aruba/mixin_common_test.go
+++ b/pkg/aruba/mixin_common_test.go
@@ -148,6 +148,18 @@ func TestResponseMetadataMixin_Nil(t *testing.T) {
 	if m.Version() != "" {
 		t.Errorf("Version() on nil meta = %q", m.Version())
 	}
+	if m.CreatedBy() != "" {
+		t.Errorf("CreatedBy() on nil meta = %q", m.CreatedBy())
+	}
+	if m.UpdatedBy() != "" {
+		t.Errorf("UpdatedBy() on nil meta = %q", m.UpdatedBy())
+	}
+	if m.CreatedUser() != "" {
+		t.Errorf("CreatedUser() on nil meta = %q", m.CreatedUser())
+	}
+	if m.UpdatedUser() != "" {
+		t.Errorf("UpdatedUser() on nil meta = %q", m.UpdatedUser())
+	}
 }
 
 func TestResponseMetadataMixin_Populated(t *testing.T) {
@@ -155,6 +167,10 @@ func TestResponseMetadataMixin_Populated(t *testing.T) {
 	uri := "/projects/p/vpcs/v"
 	ver := "1"
 	proj := "proj-1"
+	createdBy := "aru-297647"
+	updatedBy := "aru-111111"
+	createdUser := "alice"
+	updatedUser := "bob"
 	now := time.Now().UTC().Truncate(time.Second)
 	later := now.Add(time.Hour)
 
@@ -168,6 +184,10 @@ func TestResponseMetadataMixin_Populated(t *testing.T) {
 			},
 			CreationDate: &now,
 			UpdateDate:   &later,
+			CreatedBy:    &createdBy,
+			UpdatedBy:    &updatedBy,
+			CreatedUser:  &createdUser,
+			UpdatedUser:  &updatedUser,
 		},
 	}
 
@@ -188,6 +208,18 @@ func TestResponseMetadataMixin_Populated(t *testing.T) {
 	}
 	if !m.UpdatedAt().Equal(later) {
 		t.Errorf("UpdatedAt() = %v, want %v", m.UpdatedAt(), later)
+	}
+	if m.CreatedBy() != createdBy {
+		t.Errorf("CreatedBy() = %q, want %q", m.CreatedBy(), createdBy)
+	}
+	if m.UpdatedBy() != updatedBy {
+		t.Errorf("UpdatedBy() = %q, want %q", m.UpdatedBy(), updatedBy)
+	}
+	if m.CreatedUser() != createdUser {
+		t.Errorf("CreatedUser() = %q, want %q", m.CreatedUser(), createdUser)
+	}
+	if m.UpdatedUser() != updatedUser {
+		t.Errorf("UpdatedUser() = %q, want %q", m.UpdatedUser(), updatedUser)
 	}
 }
 


### PR DESCRIPTION
## Summary

- Adds `CreatedBy()`, `UpdatedBy()`, `CreatedUser()`, `UpdatedUser()` getters to `responseMetadataMixin` (`pkg/aruba/mixin_common.go`) — all 31 Family-A resource wrappers inherit them via Go method promotion, exactly like the existing `CreatedAt()` / `UpdatedAt()` / `Version()` getters.
- No type changes: `types.ResourceMetadataResponse` already declared all four fields; only the wrapper-layer accessors were missing.
- No signature-breaking changes: purely additive.
- Family-B wrappers (Database, User, Grant) already expose their own `CreatedBy()` from their typed response; Go shadowing keeps those intact.

Closes Arubacloud/acloud-cli#131.

## Test plan

- [ ] `go test ./pkg/aruba/ -run TestResponseMetadataMixin -v` — all three mixin tests pass (nil-safety + populated assertions for all four new getters)
- [ ] `make test` — full suite passes, zero failures
- [ ] `make build` — clean build
- [ ] `make lint` — no new violations
- [ ] Docs: EN `response-handling.md` + `resources.md` and IT equivalents updated (current/Next only)
- [ ] AI artifacts `ai/ARCHITECTURE.md` + `ai/CONVENTIONS.md` updated