### PR TITLE
docs: version the go get install command per docs version

### DIFF
--- a/docs/website/docs/intro.md
+++ b/docs/website/docs/intro.md
@@ -11,7 +11,7 @@ Welcome to the official Go SDK for the Aruba Cloud API. This SDK provides a conv
 Add the SDK to your Go project:
 
 ```bash
-go get github.com/Arubacloud/sdk-go
+go get github.com/Arubacloud/sdk-go@latest
 ```
 
 ## Getting Started

--- a/docs/website/i18n/it/docusaurus-plugin-content-docs/current/intro.md
+++ b/docs/website/i18n/it/docusaurus-plugin-content-docs/current/intro.md
@@ -11,7 +11,7 @@ Benvenuto nell'SDK ufficiale Go per l'API Aruba Cloud. Questo SDK fornisce un mo
 Aggiungi l'SDK al tuo progetto Go:
 
 ```bash
-go get github.com/Arubacloud/sdk-go
+go get github.com/Arubacloud/sdk-go@latest
 ```
 
 ## Iniziare

--- a/docs/website/i18n/it/docusaurus-plugin-content-docs/version-0.1.27/intro.md
+++ b/docs/website/i18n/it/docusaurus-plugin-content-docs/version-0.1.27/intro.md
@@ -13,7 +13,7 @@ Benvenuto nell'SDK ufficiale Go per l'API Aruba Cloud. Questo SDK fornisce un mo
 Aggiungi l'SDK al tuo progetto Go:
 
 ```bash
-go get github.com/Arubacloud/sdk-go
+go get github.com/Arubacloud/sdk-go@v0.1.27
 ```
 
 ## Iniziare

--- a/docs/website/i18n/it/docusaurus-plugin-content-docs/version-0.1.28/intro.md
+++ b/docs/website/i18n/it/docusaurus-plugin-content-docs/version-0.1.28/intro.md
@@ -13,7 +13,7 @@ Benvenuto nell'SDK ufficiale Go per l'API Aruba Cloud. Questo SDK fornisce un mo
 Aggiungi l'SDK al tuo progetto Go:
 
 ```bash
-go get github.com/Arubacloud/sdk-go
+go get github.com/Arubacloud/sdk-go@v0.1.28
 ```
 
 ## Iniziare

--- a/docs/website/i18n/it/docusaurus-plugin-content-docs/version-0.2.0/intro.md
+++ b/docs/website/i18n/it/docusaurus-plugin-content-docs/version-0.2.0/intro.md
@@ -13,7 +13,7 @@ Benvenuto nell'SDK ufficiale Go per l'API Aruba Cloud. Questo SDK fornisce un mo
 Aggiungi l'SDK al tuo progetto Go:
 
 ```bash
-go get github.com/Arubacloud/sdk-go
+go get github.com/Arubacloud/sdk-go@v0.2.0
 ```
 
 ## Iniziare

--- a/docs/website/i18n/it/docusaurus-plugin-content-docs/version-0.2.1/intro.md
+++ b/docs/website/i18n/it/docusaurus-plugin-content-docs/version-0.2.1/intro.md
@@ -11,7 +11,7 @@ Benvenuto nell'SDK ufficiale Go per l'API Aruba Cloud. Questo SDK fornisce un mo
 Aggiungi l'SDK al tuo progetto Go:
 
 ```bash
-go get github.com/Arubacloud/sdk-go
+go get github.com/Arubacloud/sdk-go@v0.2.1
 ```
 
 ## Iniziare

--- a/docs/website/i18n/it/docusaurus-plugin-content-docs/version-0.2.2/intro.md
+++ b/docs/website/i18n/it/docusaurus-plugin-content-docs/version-0.2.2/intro.md
@@ -11,7 +11,7 @@ Benvenuto nell'SDK ufficiale Go per l'API Aruba Cloud. Questo SDK fornisce un mo
 Aggiungi l'SDK al tuo progetto Go:
 
 ```bash
-go get github.com/Arubacloud/sdk-go
+go get github.com/Arubacloud/sdk-go@v0.2.2
 ```
 
 ## Iniziare

--- a/docs/website/i18n/it/docusaurus-plugin-content-docs/version-0.2.3/intro.md
+++ b/docs/website/i18n/it/docusaurus-plugin-content-docs/version-0.2.3/intro.md
@@ -11,7 +11,7 @@ Benvenuto nell'SDK ufficiale Go per l'API Aruba Cloud. Questo SDK fornisce un mo
 Aggiungi l'SDK al tuo progetto Go:
 
 ```bash
-go get github.com/Arubacloud/sdk-go
+go get github.com/Arubacloud/sdk-go@v0.2.3
 ```
 
 ## Iniziare

--- a/docs/website/i18n/it/docusaurus-plugin-content-docs/version-0.3.0/intro.md
+++ b/docs/website/i18n/it/docusaurus-plugin-content-docs/version-0.3.0/intro.md
@@ -11,7 +11,7 @@ Benvenuto nell'SDK ufficiale Go per l'API Aruba Cloud. Questo SDK fornisce un mo
 Aggiungi l'SDK al tuo progetto Go:
 
 ```bash
-go get github.com/Arubacloud/sdk-go
+go get github.com/Arubacloud/sdk-go@v0.3.0
 ```
 
 ## Iniziare

--- a/docs/website/i18n/it/docusaurus-plugin-content-docs/version-1.0.0/intro.md
+++ b/docs/website/i18n/it/docusaurus-plugin-content-docs/version-1.0.0/intro.md
@@ -11,7 +11,7 @@ Benvenuto nell'SDK ufficiale Go per l'API Aruba Cloud. Questo SDK fornisce un mo
 Aggiungi l'SDK al tuo progetto Go:
 
 ```bash
-go get github.com/Arubacloud/sdk-go
+go get github.com/Arubacloud/sdk-go@v1.0.0
 ```
 
 ## Iniziare

--- a/docs/website/i18n/it/docusaurus-plugin-content-docs/version-1.0.1/intro.md
+++ b/docs/website/i18n/it/docusaurus-plugin-content-docs/version-1.0.1/intro.md
@@ -11,7 +11,7 @@ Benvenuto nell'SDK ufficiale Go per l'API Aruba Cloud. Questo SDK fornisce un mo
 Aggiungi l'SDK al tuo progetto Go:
 
 ```bash
-go get github.com/Arubacloud/sdk-go
+go get github.com/Arubacloud/sdk-go@latest
 ```
 
 ## Iniziare

--- a/docs/website/versioned_docs/version-0.2.1/intro.md
+++ b/docs/website/versioned_docs/version-0.2.1/intro.md
@@ -13,7 +13,7 @@ Welcome to the official Go SDK for the Aruba Cloud API. This SDK provides a conv
 Add the SDK to your Go project:
 
 ```bash
-go get github.com/Arubacloud/sdk-go
+go get github.com/Arubacloud/sdk-go@v0.2.1
 ```
 
 ## Getting Started

--- a/docs/website/versioned_docs/version-0.2.2/intro.md
+++ b/docs/website/versioned_docs/version-0.2.2/intro.md
@@ -13,7 +13,7 @@ Welcome to the official Go SDK for the Aruba Cloud API. This SDK provides a conv
 Add the SDK to your Go project:
 
 ```bash
-go get github.com/Arubacloud/sdk-go
+go get github.com/Arubacloud/sdk-go@v0.2.2
 ```
 
 ## Getting Started

--- a/docs/website/versioned_docs/version-0.2.3/intro.md
+++ b/docs/website/versioned_docs/version-0.2.3/intro.md
@@ -13,7 +13,7 @@ Welcome to the official Go SDK for the Aruba Cloud API. This SDK provides a conv
 Add the SDK to your Go project:
 
 ```bash
-go get github.com/Arubacloud/sdk-go
+go get github.com/Arubacloud/sdk-go@v0.2.3
 ```
 
 ## Getting Started

--- a/docs/website/versioned_docs/version-0.3.0/intro.md
+++ b/docs/website/versioned_docs/version-0.3.0/intro.md
@@ -13,7 +13,7 @@ Welcome to the official Go SDK for the Aruba Cloud API. This SDK provides a conv
 Add the SDK to your Go project:
 
 ```bash
-go get github.com/Arubacloud/sdk-go
+go get github.com/Arubacloud/sdk-go@v0.3.0
 ```
 
 ## Getting Started

--- a/docs/website/versioned_docs/version-1.0.0/intro.md
+++ b/docs/website/versioned_docs/version-1.0.0/intro.md
@@ -11,7 +11,7 @@ Welcome to the official Go SDK for the Aruba Cloud API. This SDK provides a conv
 Add the SDK to your Go project:
 
 ```bash
-go get github.com/Arubacloud/sdk-go
+go get github.com/Arubacloud/sdk-go@v1.0.0
 ```
 
 ## Getting Started

--- a/docs/website/versioned_docs/version-1.0.1/intro.md
+++ b/docs/website/versioned_docs/version-1.0.1/intro.md
@@ -11,7 +11,7 @@ Welcome to the official Go SDK for the Aruba Cloud API. This SDK provides a conv
 Add the SDK to your Go project:
 
 ```bash
-go get github.com/Arubacloud/sdk-go
+go get github.com/Arubacloud/sdk-go@latest
 ```
 
 ## Getting Started


### PR DESCRIPTION
## Summary

- `current`/Next docs (EN + IT) and `version-1.0.1` (EN + IT) → `go get github.com/Arubacloud/sdk-go@latest`
- Every older release snapshot (EN + IT, `1.0.0` down to `0.1.27`) → `go get github.com/Arubacloud/sdk-go@v<semver>`

17 `intro.md` files changed — one line each. No bare `go get github.com/Arubacloud/sdk-go` remains anywhere in the site.

## Test plan

- [x] `grep -rn "go get github.com/Arubacloud/sdk-go" docs/ --include="*.md"` — every hit has `@latest` or `@v<semver>`; no bare occurrences
- [ ] `make docs-build` — Docusaurus production build passes