### PR TITLE
fix(vpn-route): handle SubnetInfoCommon cidr shape in SubnetCIDROrRef

### DIFF
--- a/pkg/aruba/resource_vpn_route.go
+++ b/pkg/aruba/resource_vpn_route.go
@@ -98,8 +98,14 @@ func (r *VPNRoute) RawYAML() []byte              { return marshalRawYAML(r.respo
 // RawRequest returns what toRequest() would emit right now.
 func (r *VPNRoute) RawRequest() types.VPNRouteRequest { return r.toRequest() }
 
-// CloudSubnet returns the configured cloud subnet CIDR ("" if unset).
-func (r *VPNRoute) CloudSubnet() string { return vpnRouteDerefString(r.cloudSubnet) }
+// CloudSubnet returns the cloud-side subnet CIDR ("" if unset).
+// Prefers the server response value; falls back to the locally-cached setter value.
+func (r *VPNRoute) CloudSubnet() string {
+	if r.response != nil && r.response.Properties.CloudSubnet.CIDR != "" {
+		return r.response.Properties.CloudSubnet.CIDR
+	}
+	return vpnRouteDerefString(r.cloudSubnet)
+}
 
 // CloudSubnetCIDR is an alias for CloudSubnet — returns the cloud-side subnet CIDR ("" if unset).
 func (r *VPNRoute) CloudSubnetCIDR() string { return r.CloudSubnet() }

--- a/pkg/types/network.vpn-route.go
+++ b/pkg/types/network.vpn-route.go
@@ -24,9 +24,10 @@ func (s *SubnetCIDROrRef) UnmarshalJSON(data []byte) error {
 		s.CIDR = str
 		return nil
 	}
-	// Full subnet object shape — try both the nested form
-	// (properties.network.address) and the flat form (network.address).
+	// Full subnet object shape — try the SubnetInfoCommon shape (cidr), the nested form
+	// (properties.network.address), and the flat form (network.address).
 	var obj struct {
+		CIDR       string `json:"cidr"`
 		Properties struct {
 			Network struct {
 				Address string `json:"address"`
@@ -39,7 +40,9 @@ func (s *SubnetCIDROrRef) UnmarshalJSON(data []byte) error {
 	if err := json.Unmarshal(data, &obj); err != nil {
 		return err
 	}
-	if obj.Properties.Network.Address != "" {
+	if obj.CIDR != "" {
+		s.CIDR = obj.CIDR
+	} else if obj.Properties.Network.Address != "" {
 		s.CIDR = obj.Properties.Network.Address
 	} else {
 		s.CIDR = obj.Network.Address

--- a/pkg/types/network.vpn-route_test.go
+++ b/pkg/types/network.vpn-route_test.go
@@ -40,6 +40,18 @@ func TestSubnetCIDROrRef_UnmarshalJSON_FlatNetworkObject(t *testing.T) {
 	}
 }
 
+func TestSubnetCIDROrRef_UnmarshalJSON_SubnetInfoShape(t *testing.T) {
+	// SubnetInfoCommon shape: {"cidr":"...","name":"..."} returned by some GET/List responses
+	raw := `{"cidr":"10.3.0.0/24","name":"my-subnet"}`
+	var s types.SubnetCIDROrRef
+	if err := json.Unmarshal([]byte(raw), &s); err != nil {
+		t.Fatalf("UnmarshalJSON error: %v", err)
+	}
+	if s.CIDR != "10.3.0.0/24" {
+		t.Errorf("CIDR = %q, want %q", s.CIDR, "10.3.0.0/24")
+	}
+}
+
 func TestSubnetCIDROrRef_UnmarshalJSON_EmptyString(t *testing.T) {
 	var s types.SubnetCIDROrRef
 	if err := json.Unmarshal([]byte(`""`), &s); err != nil {


### PR DESCRIPTION
## Summary

Closes #327

- SubnetCIDROrRef.UnmarshalJSON now handles three object shapes, in priority order:
  1. Plain CIDR string "10.0.0.0/24" (unchanged)
  2. {"cidr":"...","name":"..."} - the SubnetInfoCommon shape returned by some GET/List responses (new)
  3. {"properties":{"network":{"address":"..."}}} - full subnet object from Create (unchanged)
  4. {"network":{"address":"..."}} - flat variant (unchanged)
- VPNRoute.CloudSubnet() getter now applies the response-preferring pattern: reads from esponse.Properties.CloudSubnet.CIDR first, then falls back to the locally-cached setter value. This ensures pnroute get/list never shows a blank Cloud Subnet even when romResponse leaves the local cache empty.

## Test plan

- [ ] TestSubnetCIDROrRef_UnmarshalJSON_SubnetInfoShape - new case for {"cidr":"..."} shape
- [ ] All existing TestSubnetCIDROrRef_* tests continue to pass
- [ ] All TestVPNRoute_* tests continue to pass

?? Generated with [Claude Code](https://claude.com/claude-code)