### PR TITLE
docs(vpn-tunnel): correct subnet semantics - reference not provisioning spec

### DIFF
--- a/pkg/aruba/resource_vpn_ipconfig.go
+++ b/pkg/aruba/resource_vpn_ipconfig.go
@@ -42,7 +42,10 @@ func (c *VPNIPConfig) WithElasticIP(v Ref) *VPNIPConfig {
 	return c
 }
 
-// WithSubnet sets the subnet name and CIDR block for this IP configuration.
+// WithSubnet sets the name and CIDR of the subnet the API will provision for this
+// VPN tunnel. The API creates a new subnet with the given name and CIDR during tunnel
+// creation; do NOT pre-create a subnet with the same CIDR — that causes a 400
+// "ipConfigurations.subnet.cidr overlaps with an existing subnet" error.
 func (c *VPNIPConfig) WithSubnet(name, cidr string) *VPNIPConfig {
 	c.subnetName, c.subnetCIDR, c.hasSubnet = name, cidr, true
 	return c

--- a/pkg/aruba/resource_vpn_ipconfig.go
+++ b/pkg/aruba/resource_vpn_ipconfig.go
@@ -42,10 +42,10 @@ func (c *VPNIPConfig) WithElasticIP(v Ref) *VPNIPConfig {
 	return c
 }
 
-// WithSubnet sets the name and CIDR of the subnet the API will provision for this
-// VPN tunnel. The API creates a new subnet with the given name and CIDR during tunnel
-// creation; do NOT pre-create a subnet with the same CIDR — that causes a 400
-// "ipConfigurations.subnet.cidr overlaps with an existing subnet" error.
+// WithSubnet sets the name and CIDR of the existing cloud-side subnet to associate
+// with this VPN tunnel. The CIDR identifies which cloud subnet routes traffic to/from
+// the remote peer; it must not already be used by another VPN tunnel configuration —
+// doing so returns a 400 "ipConfigurations.subnet.cidr overlaps" error.
 func (c *VPNIPConfig) WithSubnet(name, cidr string) *VPNIPConfig {
 	c.subnetName, c.subnetCIDR, c.hasSubnet = name, cidr, true
 	return c

--- a/pkg/types/network.vpn-tunnel.go
+++ b/pkg/types/network.vpn-tunnel.go
@@ -243,7 +243,9 @@ const (
 	VPNClientProtocolIKEv2 VPNClientProtocol = "ikev2"
 )
 
-// SubnetInfoCommon contains subnet CIDR and name for VPN tunnel IP configuration
+// SubnetInfoCommon contains the name and CIDR of the subnet the API will provision
+// for a VPN tunnel. The API creates a new subnet using these values at tunnel-creation
+// time; supplying the CIDR of an existing subnet causes a 400 overlap error.
 type SubnetInfoCommon struct {
 	CIDR string `json:"cidr,omitempty"`
 	Name string `json:"name,omitempty"`

--- a/pkg/types/network.vpn-tunnel.go
+++ b/pkg/types/network.vpn-tunnel.go
@@ -243,9 +243,10 @@ const (
 	VPNClientProtocolIKEv2 VPNClientProtocol = "ikev2"
 )
 
-// SubnetInfoCommon contains the name and CIDR of the subnet the API will provision
-// for a VPN tunnel. The API creates a new subnet using these values at tunnel-creation
-// time; supplying the CIDR of an existing subnet causes a 400 overlap error.
+// SubnetInfoCommon identifies an existing cloud-side subnet by name and CIDR for use
+// in VPN tunnel IP configuration. The CIDR is a routing reference, not a provisioning
+// spec — the subnet must already exist. The 400 "overlaps" error means the same CIDR
+// is already associated with another VPN tunnel configuration.
 type SubnetInfoCommon struct {
 	CIDR string `json:"cidr,omitempty"`
 	Name string `json:"name,omitempty"`


### PR DESCRIPTION
## Summary

Closes #328

Corrects the documentation for VPNIPConfig.WithSubnet() and SubnetInfoCommon.

**Previous (incorrect):** the docstrings said the API *creates* a new subnet from the CIDR, and warned callers not to pre-create it.

**Correct semantics (confirmed by maintainer):** ipConfigurations.subnet.cidr is a **reference** to an existing cloud-side subnet. The CIDR identifies which cloud subnet routes traffic to/from the remote VPN peer - the subnet must already exist. The 400 overlaps error means the same CIDR is already associated with another VPN tunnel configuration, not that a newly provisioned subnet would collide.

### Changes (documentation only)

- pkg/types/network.vpn-tunnel.go - SubnetInfoCommon comment corrected
- pkg/aruba/resource_vpn_ipconfig.go - WithSubnet() docstring corrected

No logic changes.

## Test plan

- [ ] go build ./... passes

?? Generated with [Claude Code](https://claude.com/claude-code)