### PR TITLE
docs(kaas): surface EnablePrivateCluster in docs and CHANGELOG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Added
+
+- **`EnablePrivateCluster()` on KaaS** (`pkg/aruba`) — preferred boolean-flag setter for private
+  cluster mode, following the `HighlyAvailable()` naming convention. Thin alias for the existing
+  `WithPrivateCluster()`. Closes the naming gap requested in #323; no import of `pkg/types` needed.
+  `WithAPIServerAccessProfile(*types.KaaSAPIServerAccessProfilePropertiesRequest)` is now marked
+  `Deprecated` — callers should migrate to `EnablePrivateCluster()` and `WithAuthorizedIPRanges()`.
+
+### Fixed
+
+- **`APIServerAuthorizedIPRanges()` returns a defensive copy** — the getter previously returned
+  the underlying slice directly, allowing callers to mutate internal wrapper state.
+
 ---
 
 ## [1.0.3] — 2026-06-08

--- a/docs/website/docs/resources.md
+++ b/docs/website/docs/resources.md
@@ -356,7 +356,7 @@ if err != nil {
 - *Containment*: `InProject(Ref)`
 - *Geography*: `InRegion(Region)`
 - *Descriptive scalars*: `WithKubernetesVersion(KubernetesVersion)`, `WithPodCIDR(string)`, `WithMaxStorageQuotaGB(int)`, `WithIdentity(string, string)`
-- *API server access profile*: `WithPrivateCluster()`, `WithAuthorizedIPRanges(...string)`
+- *API server access profile*: `EnablePrivateCluster()`, `WithAuthorizedIPRanges(...string)` (or the alias `WithPrivateCluster()`)
 - *Attached config*: `WithVPC(Ref)`, `WithSubnet(Ref)`, `WithSecurityGroup(Ref)`, `WithNodeCIDR(string, string)`, `WithNodePools(...*NodePool)`, `WithoutNodePools()`, `ReplaceNodePools(...*NodePool)`
 - *Boolean state*: `HighlyAvailable()`
 - *Billing*: `BilledBy(BillingPeriod)`

--- a/docs/website/i18n/it/docusaurus-plugin-content-docs/current/resources.md
+++ b/docs/website/i18n/it/docusaurus-plugin-content-docs/current/resources.md
@@ -356,7 +356,7 @@ if err != nil {
 - *Containment*: `InProject(Ref)`
 - *Geography*: `InRegion(Region)`
 - *Descriptive scalars*: `WithKubernetesVersion(KubernetesVersion)`, `WithPodCIDR(string)`, `WithMaxStorageQuotaGB(int)`, `WithIdentity(string, string)`
-- *Profilo accesso API server*: `WithPrivateCluster()`, `WithAuthorizedIPRanges(...string)`
+- *Profilo accesso API server*: `EnablePrivateCluster()`, `WithAuthorizedIPRanges(...string)` (alias: `WithPrivateCluster()`)
 - *Attached config*: `WithVPC(Ref)`, `WithSubnet(Ref)`, `WithSecurityGroup(Ref)`, `WithNodeCIDR(string, string)`, `WithNodePools(...*NodePool)`, `WithoutNodePools()`, `ReplaceNodePools(...*NodePool)`
 - *Boolean state*: `HighlyAvailable()`
 - *Billing*: `BilledBy(BillingPeriod)`


### PR DESCRIPTION
## Summary

Closes #323

The code for EnablePrivateCluster() and the Deprecated marker on WithAPIServerAccessProfile landed in main via PR #330 (#324), but issue #323 remained open because:

- The CHANGELOG for v1.0.3 only mentioned WithPrivateCluster(), not the EnablePrivateCluster() specifically requested in #323
- docs/resources.md (EN + IT) still listed WithPrivateCluster() as the primary setter

### Changes

- **CHANGELOG [Unreleased]**: documents EnablePrivateCluster() as the canonical boolean-flag setter, the Deprecated notice on WithAPIServerAccessProfile, and the APIServerAuthorizedIPRanges() copy fix
- **docs/resources.md (EN + IT)**: replaces WithPrivateCluster() with EnablePrivateCluster() as the primary setter, notes the alias

No logic changes - documentation only.

## Test plan

- [ ] go build ./... passes
- [ ] Docs render correctly with EnablePrivateCluster() as the primary setter

?? Generated with [Claude Code](https://claude.com/claude-code)