### PR TITLE
fix(dbaas-backup): use DatabaseNameRef{Name} instead of ReferenceResourceCommon{URI} for database field

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,28 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ---
 
+## [1.0.5] — 2026-07-13
+
+### Fixed
+
+- **DBaaS Backup wire format** (`pkg/types`, `pkg/aruba`) — `BackupPropertiesRequest.Database` and
+  `BackupPropertiesResponse.Database` were typed as `ReferenceResourceCommon{URI string}`, causing
+  the SDK to send `"database":{"uri":"..."}` on the wire. The backup API requires
+  `"database":{"name":"<db-name>"}` ([OpenAPI spec](https://arubacloud.github.io/api/docs/documents/database/create-database-backup)).
+  Sending the wrong format produced a `400 semantic` error: *Specified Database name is not found.*
+  The new `DatabaseNameRef{Name string}` type is now used for both request and response. The
+  `toRequest()` helper extracts the plain name from a URI path (last segment after `/databases/`)
+  so existing callers using `FromDatabase(aruba.URI("…"))` continue to work without change.
+
+### Added
+
+- **`DatabaseName()` accessor on `DBaaSBackup`** (`pkg/aruba`) — dedicated getter that always
+  returns the bare database name. `DatabaseURI()` is preserved for backward compatibility but its
+  return value is now the raw stored reference (a full URI when set via `FromDatabase`, or the bare
+  name after response hydration). Prefer `DatabaseName()` when you only need the name.
+
+---
+
 ## [1.0.4] — 2026-06-08
 
 ### Added

--- a/docs/website/docs/resources.md
+++ b/docs/website/docs/resources.md
@@ -642,14 +642,20 @@ arubaClient.FromDatabase().DBaaSBackups()
 **Supported operations**: `Create`, `List`, `Get`, `Delete`
 **Async**: yes — call `WaitUntilReady(ctx)` after `Create`.
 
+:::note Auto-generated name
+The backup API ignores the value passed to `Named()` and always generates its own name (e.g. `mysql_wordpress_20260713140736`). Read the actual name back via `backup.Name()` after `Create`.
+:::
+
 ```go
 backup, err := arubaClient.FromDatabase().DBaaSBackups().Create(
     ctx,
     aruba.NewDBaaSBackup().
-        Named("my-db-backup").
         Tagged("backup").
         InProject(proj).
+        InRegion(aruba.RegionITBGBergamo).
+        InZone(aruba.ZoneITBG1).
         FromDBaaS(db).
+        FromDatabase(aruba.URI(db.URI()+"/databases/mydb")).
         BilledBy(aruba.BillingPeriodHour))
 if err != nil {
     log.Fatalf("Create DBaaSBackup: %v", err)
@@ -658,14 +664,15 @@ if err != nil {
 if err := backup.WaitUntilReady(ctx); err != nil {
     log.Fatalf("DBaaS Backup did not become Ready: %v", err)
 }
-fmt.Printf("✓ DBaaS Backup: %s\n", backup.Name())
+fmt.Printf("✓ DBaaS Backup: %s (database: %s)\n", backup.Name(), backup.DatabaseName())
 ```
 
 **Response accessors**:
 - `ID()`, `URI()`, `Name()`, `Tags()`
 - `DBaaSBackupID()` — provider-assigned backup ID
 - `DBaaSURI()` — source DBaaS URI
-- `DatabaseURI()` — source Database URI (if applicable)
+- `DatabaseName()` — name of the source database (preferred over `DatabaseURI()` for name-only access)
+- `DatabaseURI()` — raw stored reference: full URI when set via `FromDatabase`, bare name after response hydration
 - `SizeGB()` — backup size in GB
 - `Zone()` — availability zone
 - `BillingPeriod()` — billing cadence
@@ -674,7 +681,7 @@ fmt.Printf("✓ DBaaS Backup: %s\n", backup.Name())
 - `Raw()` — underlying wire struct
 
 **Setters**:
-- *Name*: `Named(string)`
+- *Name*: `Named(string)` *(ignored by the API — name is auto-generated)*
 - *Labels*: `Tagged(...string)`, `Untagged(...string)`, `RetaggedAs(...string)`
 - *Containment*: `InProject(Ref)`, `FromDBaaS(Ref)`, `FromDatabase(Ref)`
 - *Geography*: `InRegion(Region)`, `InZone(Zone)`

--- a/docs/website/i18n/it/docusaurus-plugin-content-docs/current/resources.md
+++ b/docs/website/i18n/it/docusaurus-plugin-content-docs/current/resources.md
@@ -642,14 +642,20 @@ arubaClient.FromDatabase().DBaaSBackups()
 **Operazioni supportate**: `Create`, `List`, `Get`, `Delete`
 **Asincrono**: sì — chiama `WaitUntilReady(ctx)` dopo `Create`.
 
+:::note Nome generato automaticamente
+L'API di backup ignora il valore passato a `Named()` e genera sempre un proprio nome (es. `mysql_wordpress_20260713140736`). Leggi il nome effettivo tramite `backup.Name()` dopo `Create`.
+:::
+
 ```go
 backup, err := arubaClient.FromDatabase().DBaaSBackups().Create(
     ctx,
     aruba.NewDBaaSBackup().
-        Named("my-db-backup").
         Tagged("backup").
         InProject(proj).
+        InRegion(aruba.RegionITBGBergamo).
+        InZone(aruba.ZoneITBG1).
         FromDBaaS(db).
+        FromDatabase(aruba.URI(db.URI()+"/databases/mydb")).
         BilledBy(aruba.BillingPeriodHour))
 if err != nil {
     log.Fatalf("Create DBaaSBackup: %v", err)
@@ -658,14 +664,15 @@ if err != nil {
 if err := backup.WaitUntilReady(ctx); err != nil {
     log.Fatalf("DBaaS Backup did not become Ready: %v", err)
 }
-fmt.Printf("✓ DBaaS Backup: %s\n", backup.Name())
+fmt.Printf("✓ DBaaS Backup: %s (database: %s)\n", backup.Name(), backup.DatabaseName())
 ```
 
 **Accessor di risposta**:
 - `ID()`, `URI()`, `Name()`, `Tags()`
 - `DBaaSBackupID()` — ID backup assegnato dal provider
 - `DBaaSURI()` — URI del DBaaS sorgente
-- `DatabaseURI()` — URI del Database sorgente (se applicabile)
+- `DatabaseName()` — nome del database sorgente (preferito rispetto a `DatabaseURI()` per accedere solo al nome)
+- `DatabaseURI()` — riferimento grezzo memorizzato: URI completo se impostato tramite `FromDatabase`, nome semplice dopo l'idratazione dalla risposta
 - `SizeGB()` — dimensione del backup in GB
 - `Zone()` — zona di disponibilità
 - `BillingPeriod()` — cadenza di fatturazione
@@ -674,7 +681,7 @@ fmt.Printf("✓ DBaaS Backup: %s\n", backup.Name())
 - `Raw()` — struct wire sottostante
 
 **Setter**:
-- *Name*: `Named(string)`
+- *Name*: `Named(string)` *(ignorato dall'API — il nome viene generato automaticamente)*
 - *Labels*: `Tagged(...string)`, `Untagged(...string)`, `RetaggedAs(...string)`
 - *Containment*: `InProject(Ref)`, `FromDBaaS(Ref)`, `FromDatabase(Ref)`
 - *Geography*: `InRegion(Region)`, `InZone(Zone)`

--- a/internal/clients/database/backup_test.go
+++ b/internal/clients/database/backup_test.go
@@ -29,7 +29,7 @@ func TestListBackups(t *testing.T) {
 							Properties: types.BackupPropertiesResponse{
 								Zone:     "ITBG-1",
 								DBaaS:    types.ReferenceResourceCommon{URI: "/projects/test-project/providers/Aruba.Database/dbaas/dbaas-1"},
-								Database: types.ReferenceResourceCommon{URI: "/projects/test-project/providers/Aruba.Database/dbaas/dbaas-1/databases/db-1"},
+								Database: types.DatabaseNameRef{Name: "db-1"},
 								BillingPlanCommon: func() *types.BillingPlanCommon {
 									v := types.BillingPeriod("Hour")
 									return &types.BillingPlanCommon{BillingPeriod: &v}
@@ -157,7 +157,7 @@ func TestGetBackup(t *testing.T) {
 					Properties: types.BackupPropertiesResponse{
 						Zone:     "ITBG-1",
 						DBaaS:    types.ReferenceResourceCommon{URI: "/projects/test-project/providers/Aruba.Database/dbaas/dbaas-1"},
-						Database: types.ReferenceResourceCommon{URI: "/projects/test-project/providers/Aruba.Database/dbaas/dbaas-1/databases/db-1"},
+						Database: types.DatabaseNameRef{Name: "db-1"},
 						BillingPlanCommon: func() *types.BillingPlanCommon {
 							v := types.BillingPeriod("Hour")
 							return &types.BillingPlanCommon{BillingPeriod: &v}
@@ -294,7 +294,7 @@ func TestCreateBackup(t *testing.T) {
 					Properties: types.BackupPropertiesResponse{
 						Zone:     "ITBG-1",
 						DBaaS:    types.ReferenceResourceCommon{URI: "/projects/test-project/providers/Aruba.Database/dbaas/dbaas-1"},
-						Database: types.ReferenceResourceCommon{URI: "/projects/test-project/providers/Aruba.Database/dbaas/dbaas-1/databases/db-1"},
+						Database: types.DatabaseNameRef{Name: "db-1"},
 						BillingPlanCommon: func() *types.BillingPlanCommon {
 							v := types.BillingPeriod("Hour")
 							return &types.BillingPlanCommon{BillingPeriod: &v}
@@ -317,7 +317,7 @@ func TestCreateBackup(t *testing.T) {
 			Properties: types.BackupPropertiesRequest{
 				Zone:     "ITBG-1",
 				DBaaS:    types.ReferenceResourceCommon{URI: "/projects/test-project/providers/Aruba.Database/dbaas/dbaas-1"},
-				Database: types.ReferenceResourceCommon{URI: "/projects/test-project/providers/Aruba.Database/dbaas/dbaas-1/databases/db-1"},
+				Database: types.DatabaseNameRef{Name: "db-1"},
 				BillingPlanCommon: func() *types.BillingPlanCommon {
 					v := types.BillingPeriod("Hour")
 					return &types.BillingPlanCommon{BillingPeriod: &v}

--- a/pkg/aruba/resource_dbaas_backup.go
+++ b/pkg/aruba/resource_dbaas_backup.go
@@ -3,6 +3,7 @@ package aruba
 import (
 	"context"
 	"fmt"
+	"strings"
 
 	"github.com/Arubacloud/sdk-go/internal/clients/database"
 	"github.com/Arubacloud/sdk-go/internal/restclient"
@@ -171,7 +172,14 @@ func (b *DBaaSBackup) toRequest() types.BackupRequest {
 		props.DBaaS = types.ReferenceResourceCommon{URI: *b.dbaasRef}
 	}
 	if b.databaseRef != nil {
-		props.Database = types.ReferenceResourceCommon{URI: *b.databaseRef}
+		// The backup API identifies databases by name, not by URI.
+		// Extract the name from the last path segment after "/databases/" if the
+		// caller passed a full URI; otherwise use the value as-is (already a name).
+		name := *b.databaseRef
+		if idx := strings.LastIndex(name, "/databases/"); idx >= 0 {
+			name = name[idx+len("/databases/"):]
+		}
+		props.Database = types.DatabaseNameRef{Name: name}
 	}
 	props.BillingPlanCommon = &types.BillingPlanCommon{BillingPeriod: defaultBillingPeriod(b.billingPeriod)}
 	return types.BackupRequest{
@@ -203,8 +211,8 @@ func (b *DBaaSBackup) fromResponse(resp *types.BackupResponse) {
 		v := resp.Properties.DBaaS.URI
 		b.dbaasRef = &v
 	}
-	if resp.Properties.Database.URI != "" {
-		v := resp.Properties.Database.URI
+	if resp.Properties.Database.Name != "" {
+		v := resp.Properties.Database.Name
 		b.databaseRef = &v
 	}
 	if resp.Properties.BillingPlanCommon != nil && resp.Properties.BillingPlanCommon.BillingPeriod != nil {

--- a/pkg/aruba/resource_dbaas_backup.go
+++ b/pkg/aruba/resource_dbaas_backup.go
@@ -138,8 +138,35 @@ func (b *DBaaSBackup) BillingPeriod() BillingPeriod {
 // DBaaSURI returns the source DBaaS URI bound via FromDBaaS, or "" if unset.
 func (b *DBaaSBackup) DBaaSURI() string { return dbaasBackupDerefString(b.dbaasRef) }
 
-// DatabaseURI returns the source database URI bound via FromDatabase, or "" if unset.
+// DatabaseURI returns the raw value stored in the database reference field.
+// When set via FromDatabase it holds the full URI; after fromResponse hydration
+// it holds the bare database name returned by the API. Prefer DatabaseName()
+// when you only need the database name for display or comparison.
 func (b *DBaaSBackup) DatabaseURI() string { return dbaasBackupDerefString(b.databaseRef) }
+
+// DatabaseName returns the database name. If the stored reference is a full URI
+// (set via FromDatabase), the name is extracted as the path segment after
+// "/databases/". If it is already a bare name (set from a response), it is
+// returned as-is.
+func (b *DBaaSBackup) DatabaseName() string { return b.databaseName() }
+
+// databaseName is the shared implementation used by both DatabaseName() and toRequest().
+func (b *DBaaSBackup) databaseName() string {
+	if b.databaseRef == nil {
+		return ""
+	}
+	ref := *b.databaseRef
+	if idx := strings.LastIndex(ref, "/databases/"); idx >= 0 {
+		// Take only the first path segment after "/databases/" so that trailing
+		// slashes or extra segments (e.g. "/databases/mydb/") do not leak through.
+		seg := ref[idx+len("/databases/"):]
+		if end := strings.IndexByte(seg, '/'); end >= 0 {
+			seg = seg[:end]
+		}
+		return seg
+	}
+	return ref
+}
 
 // SizeGB returns the backup storage size in GB from the response, or 0 before hydration.
 func (b *DBaaSBackup) SizeGB() int {
@@ -172,14 +199,7 @@ func (b *DBaaSBackup) toRequest() types.BackupRequest {
 		props.DBaaS = types.ReferenceResourceCommon{URI: *b.dbaasRef}
 	}
 	if b.databaseRef != nil {
-		// The backup API identifies databases by name, not by URI.
-		// Extract the name from the last path segment after "/databases/" if the
-		// caller passed a full URI; otherwise use the value as-is (already a name).
-		name := *b.databaseRef
-		if idx := strings.LastIndex(name, "/databases/"); idx >= 0 {
-			name = name[idx+len("/databases/"):]
-		}
-		props.Database = types.DatabaseNameRef{Name: name}
+		props.Database = types.DatabaseNameRef{Name: b.databaseName()}
 	}
 	props.BillingPlanCommon = &types.BillingPlanCommon{BillingPeriod: defaultBillingPeriod(b.billingPeriod)}
 	return types.BackupRequest{

--- a/pkg/aruba/resource_dbaas_backup_test.go
+++ b/pkg/aruba/resource_dbaas_backup_test.go
@@ -320,8 +320,13 @@ func TestDBaaSBackup_FromResponseHydration(t *testing.T) {
 	if bkp.DBaaSURI() != "/projects/p/providers/Aruba.Database/dbaas/d-1" {
 		t.Errorf("DBaaSURI() = %q", bkp.DBaaSURI())
 	}
+	// After hydration from an API response, databaseRef holds the bare name
+	// returned by the API, so DatabaseURI() and DatabaseName() both return it.
 	if bkp.DatabaseURI() != "mydb" {
-		t.Errorf("DatabaseURI() = %q, want bare name %q", bkp.DatabaseURI(), "mydb")
+		t.Errorf("DatabaseURI() after hydration = %q, want %q", bkp.DatabaseURI(), "mydb")
+	}
+	if bkp.DatabaseName() != "mydb" {
+		t.Errorf("DatabaseName() after hydration = %q, want %q", bkp.DatabaseName(), "mydb")
 	}
 	if bkp.BillingPeriod() != BillingPeriodHour {
 		t.Errorf("BillingPeriod() = %q", bkp.BillingPeriod())

--- a/pkg/aruba/resource_dbaas_backup_test.go
+++ b/pkg/aruba/resource_dbaas_backup_test.go
@@ -221,8 +221,8 @@ func TestDBaaSBackup_ToRequest(t *testing.T) {
 	if req.Properties.DBaaS.URI != dbaasURI {
 		t.Errorf("Properties.DBaaS.URI = %q", req.Properties.DBaaS.URI)
 	}
-	if req.Properties.Database.URI != dbURI {
-		t.Errorf("Properties.Database.URI = %q", req.Properties.Database.URI)
+	if req.Properties.Database.Name != "mydb" {
+		t.Errorf("Properties.Database.Name = %q, want %q", req.Properties.Database.Name, "mydb")
 	}
 	if req.Properties.BillingPlanCommon == nil || req.Properties.BillingPlanCommon.BillingPeriod == nil || *req.Properties.BillingPlanCommon.BillingPeriod != BillingPeriodHour {
 		t.Errorf("Properties.BillingPlanCommon.BillingPeriod = %v", req.Properties.BillingPlanCommon)
@@ -246,8 +246,8 @@ func TestDBaaSBackup_ToRequest_Empty(t *testing.T) {
 	if req.Properties.DBaaS.URI != "" {
 		t.Errorf("DBaaS.URI should be empty, got %q", req.Properties.DBaaS.URI)
 	}
-	if req.Properties.Database.URI != "" {
-		t.Errorf("Database.URI should be empty, got %q", req.Properties.Database.URI)
+	if req.Properties.Database.Name != "" {
+		t.Errorf("Database.Name should be empty for bare wrapper, got %q", req.Properties.Database.Name)
 	}
 }
 
@@ -260,7 +260,6 @@ func dbaasBackupTestResponse(name string) *types.BackupResponse {
 	uri := "/projects/p/providers/Aruba.Database/backups/bkp-1"
 	state := types.State("Active")
 	dbaasURI := "/projects/p/providers/Aruba.Database/dbaas/d-1"
-	dbURI := "/projects/p/providers/Aruba.Database/dbaas/d-1/databases/mydb"
 	return &types.BackupResponse{
 		Metadata: types.ResourceMetadataResponse{
 			ID:               &id,
@@ -275,7 +274,7 @@ func dbaasBackupTestResponse(name string) *types.BackupResponse {
 		Properties: types.BackupPropertiesResponse{
 			Zone:     ZoneITBG1,
 			DBaaS:    types.ReferenceResourceCommon{URI: dbaasURI},
-			Database: types.ReferenceResourceCommon{URI: dbURI},
+			Database: types.DatabaseNameRef{Name: "mydb"},
 			BillingPlanCommon: func() *types.BillingPlanCommon {
 				v := BillingPeriodHour
 				return &types.BillingPlanCommon{BillingPeriod: &v}
@@ -321,8 +320,8 @@ func TestDBaaSBackup_FromResponseHydration(t *testing.T) {
 	if bkp.DBaaSURI() != "/projects/p/providers/Aruba.Database/dbaas/d-1" {
 		t.Errorf("DBaaSURI() = %q", bkp.DBaaSURI())
 	}
-	if bkp.DatabaseURI() != "/projects/p/providers/Aruba.Database/dbaas/d-1/databases/mydb" {
-		t.Errorf("DatabaseURI() = %q", bkp.DatabaseURI())
+	if bkp.DatabaseURI() != "mydb" {
+		t.Errorf("DatabaseURI() = %q, want bare name %q", bkp.DatabaseURI(), "mydb")
 	}
 	if bkp.BillingPeriod() != BillingPeriodHour {
 		t.Errorf("BillingPeriod() = %q", bkp.BillingPeriod())
@@ -449,7 +448,7 @@ func buildDBaaSBackupsTestAdapter(t *testing.T, handler http.HandlerFunc) *dbaas
 
 const dbaasBackupSuccessBody = `{` +
 	`"metadata":{"id":"bkp-1","name":"my-backup","uri":"/projects/p/providers/Aruba.Database/backups/bkp-1","project":{"id":"p"}},` +
-	`"properties":{"datacenter":"ITBG-1","dbaas":{"uri":"/projects/p/providers/Aruba.Database/dbaas/d-1"},"database":{"uri":"/projects/p/providers/Aruba.Database/dbaas/d-1/databases/mydb"},"billingPlan":{"billingPeriod":"Hour"}},` +
+	`"properties":{"datacenter":"ITBG-1","dbaas":{"uri":"/projects/p/providers/Aruba.Database/dbaas/d-1"},"database":{"name":"mydb"},"billingPlan":{"billingPeriod":"Hour"}},` +
 	`"status":{"state":"Active"}}`
 
 // --------------------------------------------------------------------------
@@ -504,8 +503,8 @@ func TestDBaaSBackupsClientAdapter_Create_Success(t *testing.T) {
 	if gotBody.Properties.DBaaS.URI != "/projects/p/providers/Aruba.Database/dbaas/d-1" {
 		t.Errorf("request Properties.DBaaS.URI = %q", gotBody.Properties.DBaaS.URI)
 	}
-	if gotBody.Properties.Database.URI != "/projects/p/providers/Aruba.Database/dbaas/d-1/databases/mydb" {
-		t.Errorf("request Properties.Database.URI = %q", gotBody.Properties.Database.URI)
+	if gotBody.Properties.Database.Name != "mydb" {
+		t.Errorf("request Properties.Database.Name = %q, want %q", gotBody.Properties.Database.Name, "mydb")
 	}
 	if gotBody.Properties.BillingPlanCommon == nil || gotBody.Properties.BillingPlanCommon.BillingPeriod == nil || *gotBody.Properties.BillingPlanCommon.BillingPeriod != BillingPeriodHour {
 		t.Errorf("request Properties.BillingPlanCommon.BillingPeriod = %v", gotBody.Properties.BillingPlanCommon)
@@ -607,8 +606,8 @@ func TestDBaaSBackupsClientAdapter_Create_WithBodyRefs_ViaFake(t *testing.T) {
 	if captured.Properties.DBaaS.URI != dbaasURI {
 		t.Errorf("captured DBaaS.URI = %q", captured.Properties.DBaaS.URI)
 	}
-	if captured.Properties.Database.URI != dbURI {
-		t.Errorf("captured Database.URI = %q", captured.Properties.Database.URI)
+	if captured.Properties.Database.Name != "mydb" {
+		t.Errorf("captured Database.Name = %q, want %q", captured.Properties.Database.Name, "mydb")
 	}
 	if captured.Properties.Zone != Zone(RegionITBGBergamo) {
 		t.Errorf("captured Zone = %q", captured.Properties.Zone)
@@ -836,8 +835,8 @@ func TestDBaaSBackupsClientAdapter_List_TwoItems(t *testing.T) {
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
 		fmt.Fprint(w, `{"total":2,"self":"","prev":"","next":"","first":"","last":"","values":[`+
-			`{"metadata":{"id":"bkp-1","name":"n1","uri":"/projects/p/providers/Aruba.Database/backups/bkp-1","project":{"id":"p"}},"properties":{"datacenter":"ITBG-1","dbaas":{"uri":"/projects/p/providers/Aruba.Database/dbaas/d-1"},"database":{"uri":"/projects/p/providers/Aruba.Database/dbaas/d-1/databases/mydb"},"billingPlan":{"billingPeriod":"Hour"}},"status":{}},`+
-			`{"metadata":{"id":"bkp-2","name":"n2","uri":"/projects/p/providers/Aruba.Database/backups/bkp-2","project":{"id":"p"}},"properties":{"datacenter":"ITBG-1","dbaas":{"uri":"/projects/p/providers/Aruba.Database/dbaas/d-1"},"database":{"uri":"/projects/p/providers/Aruba.Database/dbaas/d-1/databases/mydb"},"billingPlan":{"billingPeriod":"Hour"}},"status":{}}`+
+			`{"metadata":{"id":"bkp-1","name":"n1","uri":"/projects/p/providers/Aruba.Database/backups/bkp-1","project":{"id":"p"}},"properties":{"datacenter":"ITBG-1","dbaas":{"uri":"/projects/p/providers/Aruba.Database/dbaas/d-1"},"database":{"name":"mydb"},"billingPlan":{"billingPeriod":"Hour"}},"status":{}},`+
+			`{"metadata":{"id":"bkp-2","name":"n2","uri":"/projects/p/providers/Aruba.Database/backups/bkp-2","project":{"id":"p"}},"properties":{"datacenter":"ITBG-1","dbaas":{"uri":"/projects/p/providers/Aruba.Database/dbaas/d-1"},"database":{"name":"mydb"},"billingPlan":{"billingPeriod":"Hour"}},"status":{}}`+
 			`]}`)
 	})
 

--- a/pkg/types/database.backup.go
+++ b/pkg/types/database.backup.go
@@ -1,11 +1,18 @@
 package types
 
+// DatabaseNameRef holds the name of a logical database for backup operations.
+// The backup API identifies databases by name (not by URI).
+type DatabaseNameRef struct {
+	Name string `json:"name"`
+}
+
 type BackupPropertiesRequest struct {
 	Zone Zone `json:"datacenter"`
 
 	DBaaS ReferenceResourceCommon `json:"dbaas"`
 
-	Database ReferenceResourceCommon `json:"database"`
+	// Database identifies the logical database to back up by name.
+	Database DatabaseNameRef `json:"database"`
 
 	BillingPlanCommon *BillingPlanCommon `json:"billingPlan,omitempty"`
 }
@@ -21,7 +28,8 @@ type BackupPropertiesResponse struct {
 
 	DBaaS ReferenceResourceCommon `json:"dbaas"`
 
-	Database ReferenceResourceCommon `json:"database"`
+	// Database holds the name of the logical database that was backed up.
+	Database DatabaseNameRef `json:"database"`
 
 	BillingPlanCommon *BillingPlanCommon `json:"billingPlan,omitempty"`
 


### PR DESCRIPTION
## Problem

The backup API ([OpenAPI spec](https://arubacloud.github.io/api/docs/documents/database/create-database-backup)) expects the database to be identified by **name**, not by URI:

```
correct:  "database": {"name": "mydb"}
was:      "database": {"uri": "/projects/.../databases/mydb"}
```

Sending the wrong format results in a `400 semantic` error: *Specified Database name is not found.*

## Changes

- **`pkg/types/database.backup.go`**: introduce `DatabaseNameRef{Name string}` and use it for `BackupPropertiesRequest.Database` and `BackupPropertiesResponse.Database` (previously `ReferenceResourceCommon`)
- **`pkg/aruba/resource_dbaas_backup.go`**:
  - `toRequest()`: extracts the plain name from the URI path (last segment after `/databases/`) and populates `DatabaseNameRef.Name`
  - `fromResponse()`: reads `Database.Name` instead of the old `Database.URI`
- **`pkg/aruba/resource_dbaas_backup_test.go`**: wire JSON and struct assertions updated to match the corrected format

## Test plan
- [x] `go test ./pkg/...` passes
- [x] Acceptance test `TestAccDatabasebackupDataSource` passes against a live environment
- [x] Acceptance test `TestAccDatabasebackupResource` (create + import + stable refresh) passes against a live environment

Discovered while working on [terraform-provider-arubacloud#294](https://github.com/Arubacloud/terraform-provider-arubacloud/issues/294).
