### PR TITLE
fix: omit location from Update bodies; handle object-form port in security-rule response (v1.0.7)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,32 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ---
 
+## [1.0.7] — 2026-07-15
+
+### Fixed
+
+- **`RegionalResourceMetadataRequest.Location` omitted from Update requests when region is unset** (`pkg/types`, `pkg/aruba`) —
+  `Location` was typed as `LocationRequest` (value, no `omitempty`), so the SDK always serialised
+  `"location":{"value":"..."}` in every Create and Update request body. The SecurityRule Update
+  endpoint (and potentially others) reject this field with `400 Validation: Location Invalid` when
+  a location is included in an Update. Sending `{"value":""}` also fails — the field must be
+  absent entirely.
+  Fix: `Location` is now `*LocationRequest` with `json:"location,omitempty"`, and `toLocation()`
+  returns `nil` when the region is empty (e.g. after `InRegion("")`) so the field is omitted from
+  the serialised JSON. Create behaviour is unchanged — a region is always set before Create so
+  `toLocation()` still returns a non-nil pointer and the location is included as before.
+
+- **`SecurityRulePropertiesResponse.Port` deserialisation from object form** (`pkg/types`, `pkg/aruba`) —
+  The SecurityRule Get endpoint returns `port` as a plain JSON string (`"80"`), but the Update
+  endpoint returns it as a JSON object (`{"value":"80"}`). The field was typed `string`, causing
+  unmarshalling the Update response to fail with:
+  `json: cannot unmarshal object into Go struct field SecurityRulePropertiesResponse.properties.port of type string`.
+  Fix: `Port` in `SecurityRulePropertiesResponse` is now `FlexPort`, a custom type whose
+  `UnmarshalJSON` accepts both the string and object forms and normalises to a plain string.
+  `MarshalJSON` still emits a plain string so request bodies are unaffected.
+
+---
+
 ## [1.0.6] — 2026-07-14
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,7 +28,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ---
 
-## [1.0.7] — 2026-07-15
+## [1.0.7] — 2026-07-20
 
 ### Fixed
 

--- a/internal/clients/compute/cloudserver_test.go
+++ b/internal/clients/compute/cloudserver_test.go
@@ -230,7 +230,7 @@ func TestCloudServerRequestOmitsOptionalFields(t *testing.T) {
 		req := types.CloudServerRequest{
 			Metadata: types.RegionalResourceMetadataRequest{
 				ResourceMetadataRequest: types.ResourceMetadataRequest{Name: "test-server"},
-				Location: &types.LocationRequest{Value: "ITBG-Bergamo"},
+				Location:                &types.LocationRequest{Value: "ITBG-Bergamo"},
 			},
 			Properties: types.CloudServerPropertiesRequest{
 				Zone: "ITBG-1",
@@ -266,7 +266,7 @@ func TestCreateCloudServer(t *testing.T) {
 	req := types.CloudServerRequest{
 		Metadata: types.RegionalResourceMetadataRequest{
 			ResourceMetadataRequest: types.ResourceMetadataRequest{Name: "new-server"},
-			Location: &types.LocationRequest{Value: "ITBG-Bergamo"},
+			Location:                &types.LocationRequest{Value: "ITBG-Bergamo"},
 		},
 		Properties: types.CloudServerPropertiesRequest{
 			Zone:     "ITBG-1",

--- a/internal/clients/compute/cloudserver_test.go
+++ b/internal/clients/compute/cloudserver_test.go
@@ -230,7 +230,7 @@ func TestCloudServerRequestOmitsOptionalFields(t *testing.T) {
 		req := types.CloudServerRequest{
 			Metadata: types.RegionalResourceMetadataRequest{
 				ResourceMetadataRequest: types.ResourceMetadataRequest{Name: "test-server"},
-				Location:                types.LocationRequest{Value: "ITBG-Bergamo"},
+				Location: &types.LocationRequest{Value: "ITBG-Bergamo"},
 			},
 			Properties: types.CloudServerPropertiesRequest{
 				Zone: "ITBG-1",
@@ -266,7 +266,7 @@ func TestCreateCloudServer(t *testing.T) {
 	req := types.CloudServerRequest{
 		Metadata: types.RegionalResourceMetadataRequest{
 			ResourceMetadataRequest: types.ResourceMetadataRequest{Name: "new-server"},
-			Location:                types.LocationRequest{Value: "ITBG-Bergamo"},
+			Location: &types.LocationRequest{Value: "ITBG-Bergamo"},
 		},
 		Properties: types.CloudServerPropertiesRequest{
 			Zone:     "ITBG-1",

--- a/internal/clients/compute/keypair_test.go
+++ b/internal/clients/compute/keypair_test.go
@@ -223,7 +223,7 @@ func TestCreateKeyPair(t *testing.T) {
 	req := types.KeyPairRequest{
 		Metadata: types.RegionalResourceMetadataRequest{
 			ResourceMetadataRequest: types.ResourceMetadataRequest{Name: "new-keypair"},
-			Location: &types.LocationRequest{Value: "ITBG-Bergamo"},
+			Location:                &types.LocationRequest{Value: "ITBG-Bergamo"},
 		},
 		Properties: types.KeyPairPropertiesRequest{Value: "ssh-rsa AAAAB3Nza..."},
 	}

--- a/internal/clients/compute/keypair_test.go
+++ b/internal/clients/compute/keypair_test.go
@@ -223,7 +223,7 @@ func TestCreateKeyPair(t *testing.T) {
 	req := types.KeyPairRequest{
 		Metadata: types.RegionalResourceMetadataRequest{
 			ResourceMetadataRequest: types.ResourceMetadataRequest{Name: "new-keypair"},
-			Location:                types.LocationRequest{Value: "ITBG-Bergamo"},
+			Location: &types.LocationRequest{Value: "ITBG-Bergamo"},
 		},
 		Properties: types.KeyPairPropertiesRequest{Value: "ssh-rsa AAAAB3Nza..."},
 	}

--- a/internal/clients/network/elastic-ip_test.go
+++ b/internal/clients/network/elastic-ip_test.go
@@ -230,7 +230,7 @@ func TestCreateElasticIP(t *testing.T) {
 		req := types.ElasticIPRequest{
 			Metadata: types.RegionalResourceMetadataRequest{
 				ResourceMetadataRequest: types.ResourceMetadataRequest{Name: "new-eip"},
-				Location:                types.LocationRequest{Value: "ITBG-Bergamo"},
+				Location: &types.LocationRequest{Value: "ITBG-Bergamo"},
 			},
 			Properties: types.ElasticIPPropertiesRequest{
 				BillingPlanCommon: func() *types.BillingPlanCommon {

--- a/internal/clients/network/elastic-ip_test.go
+++ b/internal/clients/network/elastic-ip_test.go
@@ -230,7 +230,7 @@ func TestCreateElasticIP(t *testing.T) {
 		req := types.ElasticIPRequest{
 			Metadata: types.RegionalResourceMetadataRequest{
 				ResourceMetadataRequest: types.ResourceMetadataRequest{Name: "new-eip"},
-				Location: &types.LocationRequest{Value: "ITBG-Bergamo"},
+				Location:                &types.LocationRequest{Value: "ITBG-Bergamo"},
 			},
 			Properties: types.ElasticIPPropertiesRequest{
 				BillingPlanCommon: func() *types.BillingPlanCommon {

--- a/internal/clients/network/vpc_test.go
+++ b/internal/clients/network/vpc_test.go
@@ -233,7 +233,7 @@ func TestCreateVPC(t *testing.T) {
 		req := types.VPCRequest{
 			Metadata: types.RegionalResourceMetadataRequest{
 				ResourceMetadataRequest: types.ResourceMetadataRequest{Name: "new-vpc"},
-				Location:                types.LocationRequest{Value: "ITBG-Bergamo"},
+				Location: &types.LocationRequest{Value: "ITBG-Bergamo"},
 			},
 		}
 		resp, err := svc.Create(context.Background(), "test-project", req, nil)

--- a/internal/clients/network/vpc_test.go
+++ b/internal/clients/network/vpc_test.go
@@ -233,7 +233,7 @@ func TestCreateVPC(t *testing.T) {
 		req := types.VPCRequest{
 			Metadata: types.RegionalResourceMetadataRequest{
 				ResourceMetadataRequest: types.ResourceMetadataRequest{Name: "new-vpc"},
-				Location: &types.LocationRequest{Value: "ITBG-Bergamo"},
+				Location:                &types.LocationRequest{Value: "ITBG-Bergamo"},
 			},
 		}
 		resp, err := svc.Create(context.Background(), "test-project", req, nil)

--- a/internal/clients/schedule/job_test.go
+++ b/internal/clients/schedule/job_test.go
@@ -260,7 +260,7 @@ func TestCreateScheduleJob(t *testing.T) {
 		body := types.JobRequest{
 			Metadata: types.RegionalResourceMetadataRequest{
 				ResourceMetadataRequest: types.ResourceMetadataRequest{Name: "weekly-cleanup"},
-				Location: &types.LocationRequest{Value: "it-eur"},
+				Location:                &types.LocationRequest{Value: "it-eur"},
 			},
 			Properties: types.JobPropertiesRequest{
 				Enabled:      ptr.To(true),
@@ -306,7 +306,7 @@ func TestCreateScheduleJob(t *testing.T) {
 		body := types.JobRequest{
 			Metadata: types.RegionalResourceMetadataRequest{
 				ResourceMetadataRequest: types.ResourceMetadataRequest{Name: "maintenance-window"},
-				Location: &types.LocationRequest{Value: "it-eur"},
+				Location:                &types.LocationRequest{Value: "it-eur"},
 			},
 			Properties: types.JobPropertiesRequest{
 				Enabled:    ptr.To(true),
@@ -486,7 +486,7 @@ func TestUpdateScheduleJob(t *testing.T) {
 		body := types.JobRequest{
 			Metadata: types.RegionalResourceMetadataRequest{
 				ResourceMetadataRequest: types.ResourceMetadataRequest{Name: "updated-backup"},
-				Location: &types.LocationRequest{Value: "it-eur"},
+				Location:                &types.LocationRequest{Value: "it-eur"},
 			},
 			Properties: types.JobPropertiesRequest{
 				Enabled:      ptr.To(false),

--- a/internal/clients/schedule/job_test.go
+++ b/internal/clients/schedule/job_test.go
@@ -260,7 +260,7 @@ func TestCreateScheduleJob(t *testing.T) {
 		body := types.JobRequest{
 			Metadata: types.RegionalResourceMetadataRequest{
 				ResourceMetadataRequest: types.ResourceMetadataRequest{Name: "weekly-cleanup"},
-				Location:                types.LocationRequest{Value: "it-eur"},
+				Location: &types.LocationRequest{Value: "it-eur"},
 			},
 			Properties: types.JobPropertiesRequest{
 				Enabled:      ptr.To(true),
@@ -306,7 +306,7 @@ func TestCreateScheduleJob(t *testing.T) {
 		body := types.JobRequest{
 			Metadata: types.RegionalResourceMetadataRequest{
 				ResourceMetadataRequest: types.ResourceMetadataRequest{Name: "maintenance-window"},
-				Location:                types.LocationRequest{Value: "it-eur"},
+				Location: &types.LocationRequest{Value: "it-eur"},
 			},
 			Properties: types.JobPropertiesRequest{
 				Enabled:    ptr.To(true),
@@ -486,7 +486,7 @@ func TestUpdateScheduleJob(t *testing.T) {
 		body := types.JobRequest{
 			Metadata: types.RegionalResourceMetadataRequest{
 				ResourceMetadataRequest: types.ResourceMetadataRequest{Name: "updated-backup"},
-				Location:                types.LocationRequest{Value: "it-eur"},
+				Location: &types.LocationRequest{Value: "it-eur"},
 			},
 			Properties: types.JobPropertiesRequest{
 				Enabled:      ptr.To(false),

--- a/internal/clients/security/kms_test.go
+++ b/internal/clients/security/kms_test.go
@@ -237,7 +237,7 @@ func TestCreateKMSKey(t *testing.T) {
 		body := types.KmsRequest{
 			Metadata: types.RegionalResourceMetadataRequest{
 				ResourceMetadataRequest: types.ResourceMetadataRequest{Name: "new-encryption-key"},
-				Location:                types.LocationRequest{Value: "it-eur"},
+				Location: &types.LocationRequest{Value: "it-eur"},
 			},
 			Properties: types.KmsPropertiesRequest{BillingPeriod: (*types.BillingPeriod)(ptr.To("Month"))},
 		}
@@ -399,7 +399,7 @@ func TestUpdateKMSKey(t *testing.T) {
 		body := types.KmsRequest{
 			Metadata: types.RegionalResourceMetadataRequest{
 				ResourceMetadataRequest: types.ResourceMetadataRequest{Name: "updated-encryption-key"},
-				Location:                types.LocationRequest{Value: "it-eur"},
+				Location: &types.LocationRequest{Value: "it-eur"},
 			},
 			Properties: types.KmsPropertiesRequest{BillingPeriod: (*types.BillingPeriod)(ptr.To("Year"))},
 		}

--- a/internal/clients/security/kms_test.go
+++ b/internal/clients/security/kms_test.go
@@ -237,7 +237,7 @@ func TestCreateKMSKey(t *testing.T) {
 		body := types.KmsRequest{
 			Metadata: types.RegionalResourceMetadataRequest{
 				ResourceMetadataRequest: types.ResourceMetadataRequest{Name: "new-encryption-key"},
-				Location: &types.LocationRequest{Value: "it-eur"},
+				Location:                &types.LocationRequest{Value: "it-eur"},
 			},
 			Properties: types.KmsPropertiesRequest{BillingPeriod: (*types.BillingPeriod)(ptr.To("Month"))},
 		}
@@ -399,7 +399,7 @@ func TestUpdateKMSKey(t *testing.T) {
 		body := types.KmsRequest{
 			Metadata: types.RegionalResourceMetadataRequest{
 				ResourceMetadataRequest: types.ResourceMetadataRequest{Name: "updated-encryption-key"},
-				Location: &types.LocationRequest{Value: "it-eur"},
+				Location:                &types.LocationRequest{Value: "it-eur"},
 			},
 			Properties: types.KmsPropertiesRequest{BillingPeriod: (*types.BillingPeriod)(ptr.To("Year"))},
 		}

--- a/internal/clients/storage/storage_test.go
+++ b/internal/clients/storage/storage_test.go
@@ -249,7 +249,7 @@ func TestCreateBlockStorageVolume(t *testing.T) {
 		body := types.BlockStorageRequest{
 			Metadata: types.RegionalResourceMetadataRequest{
 				ResourceMetadataRequest: types.ResourceMetadataRequest{Name: "new-volume"},
-				Location:                types.LocationRequest{Value: "it-eur"},
+				Location: &types.LocationRequest{Value: "it-eur"},
 			},
 			Properties: types.BlockStoragePropertiesRequest{
 				SizeGB:        50,

--- a/internal/clients/storage/storage_test.go
+++ b/internal/clients/storage/storage_test.go
@@ -249,7 +249,7 @@ func TestCreateBlockStorageVolume(t *testing.T) {
 		body := types.BlockStorageRequest{
 			Metadata: types.RegionalResourceMetadataRequest{
 				ResourceMetadataRequest: types.ResourceMetadataRequest{Name: "new-volume"},
-				Location: &types.LocationRequest{Value: "it-eur"},
+				Location:                &types.LocationRequest{Value: "it-eur"},
 			},
 			Properties: types.BlockStoragePropertiesRequest{
 				SizeGB:        50,

--- a/pkg/aruba/mixin_common.go
+++ b/pkg/aruba/mixin_common.go
@@ -93,8 +93,11 @@ func (m *regionalMixin) inRegion(region Region) { m.region = region }
 // Region returns the region value.
 func (m *regionalMixin) Region() Region { return m.region }
 
-func (m *regionalMixin) toLocation() types.LocationRequest {
-	return types.LocationRequest{Value: m.region}
+func (m *regionalMixin) toLocation() *types.LocationRequest {
+	if m.region == "" {
+		return nil
+	}
+	return &types.LocationRequest{Value: m.region}
 }
 
 // --------------------------------------------------------------------------

--- a/pkg/aruba/resource_security_rule.go
+++ b/pkg/aruba/resource_security_rule.go
@@ -230,8 +230,7 @@ func (r *SecurityRule) fromResponse(resp *types.SecurityRuleResponse) {
 		p := resp.Properties.Protocol
 		r.protocol = &p
 	}
-	if resp.Properties.Port != "" {
-		p := resp.Properties.Port
+	if p := resp.Properties.Port.String(); p != "" {
 		r.port = &p
 	}
 	if resp.Properties.Target != nil {

--- a/pkg/aruba/resource_security_rule_test.go
+++ b/pkg/aruba/resource_security_rule_test.go
@@ -266,7 +266,7 @@ func securityRuleTestResponse(id, name, uri, projectID string) *types.SecurityRu
 		Properties: types.SecurityRulePropertiesResponse{
 			Direction: dir,
 			Protocol:  proto,
-			Port:      port,
+			Port:      types.FlexPort(port),
 			Target:    &types.RuleTargetCommon{Kind: EndpointTypeIP, Value: "1.2.3.4/32"},
 		},
 		Status: types.ResourceStatusResponse{

--- a/pkg/types/network.security-rule.go
+++ b/pkg/types/network.security-rule.go
@@ -1,6 +1,9 @@
 package types
 
-import "encoding/json"
+import (
+	"encoding/json"
+	"fmt"
+)
 
 // FlexPort unmarshals the security-rule port field from either a plain JSON
 // string ("80") or an object ({"value":"80"}).  The SecurityRule Update
@@ -20,7 +23,7 @@ func (fp *FlexPort) UnmarshalJSON(data []byte) error {
 		*fp = FlexPort(obj.Value)
 		return nil
 	}
-	return nil // best-effort: ignore unrecognised formats
+	return fmt.Errorf("FlexPort: cannot unmarshal %s: expected a JSON string or {\"value\":\"...\"} object", data)
 }
 
 func (fp FlexPort) MarshalJSON() ([]byte, error) { return json.Marshal(string(fp)) }

--- a/pkg/types/network.security-rule.go
+++ b/pkg/types/network.security-rule.go
@@ -1,5 +1,33 @@
 package types
 
+import "encoding/json"
+
+// FlexPort unmarshals the security-rule port field from either a plain JSON
+// string ("80") or an object ({"value":"80"}).  The SecurityRule Update
+// endpoint returns the object form while Get returns a plain string.
+type FlexPort string
+
+func (fp *FlexPort) UnmarshalJSON(data []byte) error {
+	var s string
+	if json.Unmarshal(data, &s) == nil {
+		*fp = FlexPort(s)
+		return nil
+	}
+	var obj struct {
+		Value string `json:"value"`
+	}
+	if json.Unmarshal(data, &obj) == nil {
+		*fp = FlexPort(obj.Value)
+		return nil
+	}
+	return nil // best-effort: ignore unrecognised formats
+}
+
+func (fp FlexPort) MarshalJSON() ([]byte, error) { return json.Marshal(string(fp)) }
+
+// String returns the underlying port string value.
+func (fp FlexPort) String() string { return string(fp) }
+
 // RuleProtocol identifies the L4 protocol for a security rule.
 //
 // Authoritative list: ANY, TCP, UDP, ICMP (fully enumerated in the API docs).
@@ -74,7 +102,8 @@ type SecurityRulePropertiesResponse struct {
 	//   - a single numeric port. For instance "80", "443" etc.
 	//   - a port range. For instance "80-100"
 	//   - the "*" value indicating any ports
-	Port string `json:"port,omitempty"`
+	// FlexPort handles both the plain-string (Get) and object (Update) response formats.
+	Port FlexPort `json:"port,omitempty"`
 
 	// Target The target of the rule (source or destination according to the direction)
 	Target *RuleTargetCommon `json:"target,omitempty"`

--- a/pkg/types/resource.go
+++ b/pkg/types/resource.go
@@ -16,7 +16,7 @@ type ResourceMetadataRequest struct {
 // Regional Resource Metadata Request
 type RegionalResourceMetadataRequest struct {
 	ResourceMetadataRequest
-	Location LocationRequest `json:"location"`
+	Location *LocationRequest `json:"location,omitempty"`
 }
 
 type LocationRequest struct {


### PR DESCRIPTION
## Summary

Two API incompatibilities discovered during acceptance-test runs of the Terraform provider, both affecting Update request/response handling.

### Fix 1 — `Location` always serialised in Update bodies (`pkg/types`, `pkg/aruba`)

**Root cause:** `RegionalResourceMetadataRequest.Location` was typed as `LocationRequest` (a value, no `omitempty`). The SDK therefore always emitted `"location":{"value":"ITBG-Bergamo"}` in every Create *and* Update request body. The SecurityRule Update endpoint rejects any location field with `400 Validation: Location Invalid` — sending `{"value":""}` also fails; the field must be absent entirely.

**Fix:**
- `Location` changed to `*LocationRequest` with `json:"location,omitempty"`.
- `toLocation()` in `mixin_common.go` now returns `nil` when `region` is empty (e.g. after `InRegion("")`), so the location key is omitted from the serialised JSON.
- Create behaviour is **unchanged**: a region is always set before Create, so `toLocation()` still returns a non-nil pointer.

### Fix 2 — `SecurityRulePropertiesResponse.Port` fails to deserialise object form (`pkg/types`, `pkg/aruba`)

**Root cause:** The SecurityRule **Get** endpoint returns `port` as a plain JSON string (`"80"`), but the **Update** endpoint returns it as a JSON object (`{"value":"80"}`). The field was typed `string`, so unmarshalling the Update response panicked with:
```
json: cannot unmarshal object into Go struct field
SecurityRulePropertiesResponse.properties.port of type string
```

**Fix:**
- New `FlexPort` custom type added to `pkg/types`. Its `UnmarshalJSON` accepts both a plain string and an object with a `"value"` key, normalising to a plain string internally.
- `MarshalJSON` still emits a plain string, so request bodies (Create/Update) are unaffected.
- `SecurityRulePropertiesResponse.Port` changed from `string` to `FlexPort`.
- `fromResponse` in `resource_security_rule.go` updated to call `.String()`.

## Test plan

- [x] `go build ./...` passes
- [x] `go test ./...` passes (all packages)
- [x] Verified against live API: SecurityRule Create → Import → Update cycle completes without errors in the Terraform provider acceptance test suite

## Changelog

Entry added under `[1.0.7]` in `CHANGELOG.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
