### PR TITLE
feat(vault): add kvPrefix support to Vault credentials repository

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ---
 
+## [1.0.8] — 2026-07-27
+
+### Added
+
+- **`kvPrefix` support in Vault credentials repository** (`internal/impl/auth/credentialsrepository/vault`, `pkg/aruba`) —
+  `WithVaultCredentialsRepository` now accepts a `kvPrefix string` parameter (inserted between
+  `kvMount` and `kvPath`). The prefix is prepended to the secret path when calling the Vault KV v2
+  `Get` API (`<kvMount>/<kvPrefix>/<kvPath>`), enabling secrets stored under a shared path prefix
+  within a single KV mount. Passing an empty string preserves the previous behaviour — the path
+  is constructed as `<kvMount>/<kvPath>` with no prefix segment.
+
+---
+
 ## [1.0.7] — 2026-07-20
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -203,7 +203,7 @@ mt.NewFromOptions("tenant-1",
 // Vault-backed credentials sharing a base options template
 base := aruba.NewOptions().WithDefaultBaseURL().WithDefaultTokenIssuerURL()
 mt.NewFromOptions("tenant-2",
-    base.DeepCopy().WithVaultCredentialsRepository(vaultURI, kvMount, "tenant-2", ns, rolePath, roleID, secretID))
+    base.DeepCopy().WithVaultCredentialsRepository(vaultURI, kvMount, "", "tenant-2", ns, rolePath, roleID, secretID))
 
 client, ok := mt.Get("tenant-1")
 ```

--- a/docs/website/docs/multitenancy.md
+++ b/docs/website/docs/multitenancy.md
@@ -139,6 +139,7 @@ options := aruba.NewOptions().
 	WithVaultCredentialsRepository(
 		r.config.VaultAddress,
 		r.config.KVMount,
+		"",     // kvPrefix (empty if secrets live directly under kvMount)
 		tenant, // tenant -> kvPath (e.g. ARU-297647)
 		r.config.Namespace,
 		r.config.RolePath,

--- a/docs/website/docs/options.md
+++ b/docs/website/docs/options.md
@@ -97,7 +97,7 @@ production-ready setup for the most common use case (Client Credentials authenti
       <td>Configures the SDK to fetch the <code>clientID</code> and <code>clientSecret</code> from a HashiCorp
       Vault instance. The SDK will then use these credentials to manage the access token.</td>
       <td><b>Mutual Exclusion</b>: Cannot be used with <code>WithClientCredentials()</code> or <code>WithToken()</code>.<br/>
-      <b>Parameters</b>: <code>vaultURI</code>, <code>kvMount</code>, <code>kvPath</code>, <code>namespace</code>,
+      <b>Parameters</b>: <code>vaultURI</code>, <code>kvMount</code>, <code>kvPrefix</code>, <code>kvPath</code>, <code>namespace</code>,
       <code>rolePath</code>, <code>roleID</code>, <code>secretID</code>.</td>
     </tr>
     <tr>

--- a/docs/website/i18n/it/docusaurus-plugin-content-docs/current/multitenancy.md
+++ b/docs/website/i18n/it/docusaurus-plugin-content-docs/current/multitenancy.md
@@ -136,6 +136,7 @@ options := aruba.NewOptions().
 	WithVaultCredentialsRepository(
 		r.config.VaultAddress,
 		r.config.KVMount,
+		"",     // kvPrefix (vuoto se i segreti si trovano direttamente sotto kvMount)
 		tenant, // tenant -> kvPath (es. ARU-297647)
 		r.config.Namespace,
 		r.config.RolePath,

--- a/docs/website/i18n/it/docusaurus-plugin-content-docs/current/options.md
+++ b/docs/website/i18n/it/docusaurus-plugin-content-docs/current/options.md
@@ -85,7 +85,7 @@ L'SDK Aruba Cloud per Go è configurato mediante un'API fluente che consente di 
       <td><code>WithVaultCredentialsRepository(...)</code></td>
       <td>Configura l'SDK per recuperare <code>clientID</code> e <code>clientSecret</code> da un'istanza HashiCorp Vault. L'SDK utilizzerà poi queste credenziali per gestire il token di accesso.</td>
       <td><b>Esclusione reciproca</b>: non può essere usato con <code>WithClientCredentials()</code> o <code>WithToken()</code>.<br/>
-      <b>Parametri</b>: <code>vaultURI</code>, <code>kvMount</code>, <code>kvPath</code>, <code>namespace</code>,
+      <b>Parametri</b>: <code>vaultURI</code>, <code>kvMount</code>, <code>kvPrefix</code>, <code>kvPath</code>, <code>namespace</code>,
       <code>rolePath</code>, <code>roleID</code>, <code>secretID</code>.</td>
     </tr>
     <tr>

--- a/examples/all-resources/orchestrator_multitenancy.go
+++ b/examples/all-resources/orchestrator_multitenancy.go
@@ -77,9 +77,9 @@ func runMultitenancyVaultExample() {
 	// Tenant-specific Vault endpoints/paths.
 	// If you use a single Vault instance, keep vaultURI the same and change only kvPath.
 	tenant1Vault := baseOptions.DeepCopy().
-		WithVaultCredentialsRepository("http://vault0.default.svc.cluster.local:8200", kvMount, "ARU-000000", namespace, rolePath, roleID, secretID)
+		WithVaultCredentialsRepository("http://vault0.default.svc.cluster.local:8200", kvMount, "", "ARU-000000", namespace, rolePath, roleID, secretID)
 	tenant2Vault := baseOptions.DeepCopy().
-		WithVaultCredentialsRepository("http://vault0.default.svc.cluster.local:8200", kvMount, "ARU-123456", namespace, rolePath, roleID, secretID)
+		WithVaultCredentialsRepository("http://vault0.default.svc.cluster.local:8200", kvMount, "", "ARU-123456", namespace, rolePath, roleID, secretID)
 
 	mt := multitenant.New()
 
@@ -148,6 +148,7 @@ func (r *multitenancyExampleReconciler) ArubaClient(tenant string) (aruba.Client
 	options = options.WithVaultCredentialsRepository(
 		r.config.VaultAddress,
 		r.config.KVMount,
+		"",     // kvPrefix
 		tenant, // tenant maps to kvPath (e.g. ARU-000000)
 		r.config.Namespace,
 		r.config.RolePath,

--- a/internal/impl/auth/credentialsrepository/vault/vault.go
+++ b/internal/impl/auth/credentialsrepository/vault/vault.go
@@ -22,6 +22,7 @@ type CredentialsRepository struct {
 	// Implementation details would go here
 	client    VaultClient
 	kvMount   string
+	kvPrefix  string
 	kvPath    string
 	namespace string
 	rolePath  string
@@ -87,6 +88,7 @@ func NewVaultClientAdapter(c *vaultapi.Client) *VaultClientAdapter {
 func NewCredentialsRepository(
 	client VaultClient,
 	kvMount string,
+	kvPrefix string,
 	kvPath string,
 	namespace string,
 	rolePath string,
@@ -96,6 +98,7 @@ func NewCredentialsRepository(
 	return &CredentialsRepository{
 		client:     client,
 		kvMount:    kvMount,
+		kvPrefix:   kvPrefix,
 		kvPath:     kvPath,
 		namespace:  namespace,
 		rolePath:   rolePath,
@@ -129,7 +132,11 @@ func (r *CredentialsRepository) FetchCredentials(ctx context.Context) (*auth.Cre
 	}
 
 	// Read from KV v2
-	secret, err := r.client.KVv2(r.kvMount).Get(ctx, r.kvPath)
+	kvPath := r.kvPath
+	if r.kvPrefix != "" {
+		kvPath = r.kvPrefix + "/" + r.kvPath
+	}
+	secret, err := r.client.KVv2(r.kvMount).Get(ctx, kvPath)
 	if err != nil {
 		return nil, auth.ErrCredentialsNotFound
 	}

--- a/pkg/aruba/builder.go
+++ b/pkg/aruba/builder.go
@@ -269,6 +269,7 @@ func buildVaultCredentialsRepository(options *vaultCredentialsRepositoryOptions)
 	return vault_creds_repo.NewCredentialsRepository(
 		vault_creds_repo.NewVaultClientAdapter(client),
 		options.kvMount,
+		options.kvPrefix,
 		options.kvPath,
 		options.namespace,
 		options.rolePath,

--- a/pkg/aruba/options.go
+++ b/pkg/aruba/options.go
@@ -262,6 +262,7 @@ type vaultCredentialsRepositoryOptions struct {
 	// vaultURI is the address of the Vault server (e.g., "https://vault.example.com:8200").
 	vaultURI  string
 	kvMount   string
+	kvPrefix  string
 	kvPath    string
 	namespace string
 	rolePath  string
@@ -585,6 +586,7 @@ func (o *Options) WithAdditionalSecurityScopes(scopes ...string) *Options {
 func (o *Options) WithVaultCredentialsRepository(
 	vaultURI string,
 	kvMount string,
+	kvPrefix string,
 	kvPath string,
 	namespace string,
 	rolePath string,
@@ -598,6 +600,7 @@ func (o *Options) WithVaultCredentialsRepository(
 	o.tokenManager.tokenIssuerOptions.vaultCredentialsRepositoryOptions = &vaultCredentialsRepositoryOptions{
 		vaultURI:  vaultURI,
 		kvMount:   kvMount,
+		kvPrefix:  kvPrefix,
 		kvPath:    kvPath,
 		namespace: namespace,
 		rolePath:  rolePath,


### PR DESCRIPTION
Adds a kvPrefix parameter to WithVaultCredentialsRepository, allowing callers to namespace secrets under a shared path prefix within a single KV v2 mount.

Change — kvPrefix support in Vault credentials repository (internal/impl/auth/credentialsrepository/vault, pkg/aruba)

Root cause / motivation: The previous WithVaultCredentialsRepository signature mapped kvPath directly to the Vault KV v2 Get path. Operators whose Vault layout uses a shared prefix (e.g. secret/team/env/<tenant>) had no way to express the prefix — they had to bake it into kvPath, making it impossible to separate the static mount structure from the dynamic per-secret segment.

Fix:
- CredentialsRepository gains a kvPrefix field. FetchCredentials now builds the KV path as <kvPrefix>/<kvPath> when a prefix is set, and falls back to bare <kvPath> when it is empty — preserving existing behaviour for callers that omit a prefix.
- WithVaultCredentialsRepository accepts kvPrefix string as a new third parameter (between kvMount and kvPath). vaultCredentialsRepositoryOptions and buildVaultCredentialsRepository are wired accordingly.
- All existing call sites in examples/ and README.md updated to pass "" as kvPrefix.

Test plan

- [x] go build ./... passes cleanly
- [x] All call sites (examples, README) compile with the new signature
- [x] Empty kvPrefix produces the same path as the previous behaviour

Changelog

Entry added under [1.0.8] in CHANGELOG.md.