### PR TITLE
fix(dbaas): send plaintext password in user create/update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ---
 
+## [1.0.9] — 2026-07-28
+
+### Fixed
+
+- **DBaaS user create/update sends base64-encoded password instead of plaintext** (`pkg/aruba`, `pkg/types`) —
+  `toRequest()` was wrapping the caller-supplied password in `base64.StdEncoding.EncodeToString`
+  before placing it in the JSON body. The Aruba Cloud DBaaS API expects a plaintext password; sending
+  an encoded value caused every user creation and password-update request to fail with HTTP 400
+  `"Password does not match the minimum requirements"` because the base64 output contains only
+  alphanumeric characters and no special characters required by the API password policy.
+  Removed the encoding call and dropped the now-unused `encoding/base64` import.
+
+---
+
 ## [1.0.8] — 2026-07-27
 
 ### Added

--- a/pkg/aruba/resource_user.go
+++ b/pkg/aruba/resource_user.go
@@ -2,7 +2,6 @@ package aruba
 
 import (
 	"context"
-	"encoding/base64"
 	"fmt"
 	"time"
 
@@ -55,8 +54,7 @@ func (u *User) InDBaaS(parent Ref) *User { u.intoDBaaS(parent); return u }
 // WithUsername sets the username. Used as the path identifier; required before Create.
 func (u *User) WithUsername(name string) *User { u.username = &name; return u }
 
-// WithPassword sets the clear-text password for Create/Update. The wrapper base64-encodes it
-// at the wire boundary; callers always pass plain text. Write-only: no Password() getter is exposed.
+// WithPassword sets the clear-text password for Create/Update. Write-only: no Password() getter is exposed.
 func (u *User) WithPassword(pw string) *User { u.password = &pw; return u }
 
 // Getters — general → specific
@@ -107,9 +105,7 @@ func (u *User) Raw() *types.UserResponse { return u.response }
 func (u *User) RawJSON() []byte          { return marshalRawJSON(u.response) }
 func (u *User) RawYAML() []byte          { return marshalRawYAML(u.response) }
 
-// RawRequest returns the wire body that would be sent on Create/Update. It
-// includes the base64-encoded password if WithPassword was called — by design,
-// for parity with other wrappers' RawRequest debugging surface. There is no
+// RawRequest returns the wire body that would be sent on Create/Update. There is no
 // Password() accessor on *User; the password is intentionally not exposed
 // through any read-only path other than this wire mirror.
 func (u *User) RawRequest() types.UserRequest { return u.toRequest() }
@@ -117,11 +113,11 @@ func (u *User) RawRequest() types.UserRequest { return u.toRequest() }
 // Wire converters
 
 // toRequest assembles the Create/Update body from current setter state.
-// The API expects the password base64-encoded, so the clear-text value is encoded here at the wire boundary.
+// The API expects the password as plain text.
 func (u *User) toRequest() types.UserRequest {
 	return types.UserRequest{
 		Username: userDerefString(u.username),
-		Password: base64.StdEncoding.EncodeToString([]byte(userDerefString(u.password))),
+		Password: userDerefString(u.password),
 	}
 }
 

--- a/pkg/aruba/resource_user_test.go
+++ b/pkg/aruba/resource_user_test.go
@@ -237,8 +237,7 @@ func TestUser_FromResponse_PreservesPassword(t *testing.T) {
 	u := NewUser().WithPassword(testPassword)
 	u.fromResponse(userTestResponse("alice"))
 	// The locally-set password must survive hydration.
-	wantPw := base64.StdEncoding.EncodeToString([]byte(testPassword))
-	if u.RawRequest().Password != wantPw {
+	if u.RawRequest().Password != testPassword {
 		t.Errorf("fromResponse clobbered the locally-set password; got %q", u.RawRequest().Password)
 	}
 }
@@ -344,9 +343,8 @@ func TestUsersClientAdapter_Create_Success(t *testing.T) {
 	if gotBody.Username != "my-user" {
 		t.Errorf("wire body Username = %q", gotBody.Username)
 	}
-	wantPw := base64.StdEncoding.EncodeToString([]byte(testPassword))
-	if gotBody.Password != wantPw {
-		t.Errorf("wire body Password = %q, want %q", gotBody.Password, wantPw)
+	if gotBody.Password != testPassword {
+		t.Errorf("wire body Password = %q, want plaintext %q", gotBody.Password, testPassword)
 	}
 }
 
@@ -449,9 +447,8 @@ func TestUsersClientAdapter_Update_Success(t *testing.T) {
 	if gotBody.Username != "my-user" {
 		t.Errorf("wire body Username = %q", gotBody.Username)
 	}
-	wantPw := base64.StdEncoding.EncodeToString([]byte(testPassword))
-	if gotBody.Password != wantPw {
-		t.Errorf("wire body Password = %q, want %q", gotBody.Password, wantPw)
+	if gotBody.Password != testPassword {
+		t.Errorf("wire body Password = %q, want plaintext %q", gotBody.Password, testPassword)
 	}
 }
 

--- a/pkg/aruba/resource_user_test.go
+++ b/pkg/aruba/resource_user_test.go
@@ -2,7 +2,6 @@ package aruba
 
 import (
 	"context"
-	"encoding/base64"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -63,9 +62,8 @@ func TestUser_FluentSetters(t *testing.T) {
 		t.Errorf("Err() = %v", u.Err())
 	}
 	// Password should not be readable through Username/ID/etc., only through RawRequest.
-	wantPw := base64.StdEncoding.EncodeToString([]byte(testPassword))
-	if u.RawRequest().Password != wantPw {
-		t.Errorf("RawRequest().Password = %q, want %q", u.RawRequest().Password, wantPw)
+	if u.RawRequest().Password != testPassword {
+		t.Errorf("RawRequest().Password = %q, want %q", u.RawRequest().Password, testPassword)
 	}
 }
 
@@ -162,21 +160,15 @@ func TestUser_ToRequest(t *testing.T) {
 	if req.Username != "alice" {
 		t.Errorf("toRequest().Username = %q", req.Username)
 	}
-	wantPw := base64.StdEncoding.EncodeToString([]byte(testPassword))
-	if req.Password != wantPw {
-		t.Errorf("toRequest().Password = %q, want %q", req.Password, wantPw)
+	if req.Password != testPassword {
+		t.Errorf("toRequest().Password = %q, want plaintext %q", req.Password, testPassword)
 	}
 }
 
-func TestUser_ToRequest_EncodesPassword(t *testing.T) {
+func TestUser_ToRequest_PlaintextPassword(t *testing.T) {
 	u := NewUser().WithPassword(testPassword)
-	encoded := u.toRequest().Password
-	decoded, err := base64.StdEncoding.DecodeString(encoded)
-	if err != nil {
-		t.Fatalf("toRequest().Password is not valid base64: %v", err)
-	}
-	if string(decoded) != testPassword {
-		t.Errorf("decoded password = %q, want %q", string(decoded), testPassword)
+	if u.toRequest().Password != testPassword {
+		t.Errorf("toRequest().Password = %q, want plaintext %q", u.toRequest().Password, testPassword)
 	}
 }
 


### PR DESCRIPTION
Fixes #351

## Summary

- Remove `base64.StdEncoding.EncodeToString` from `toRequest()` in `pkg/aruba/resource_user.go` — the DBaaS API expects plaintext passwords, not base64-encoded ones
- Drop the now-unused `encoding/base64` import
- Update `TestUser_ToRequest`, `TestUser_ToRequest_EncodesPassword`, and `TestUser_FluentSetters` to assert the wire password equals the caller-supplied plaintext

## Root cause

`toRequest()` encoded the password before sending:

```go
// before
Password: base64.StdEncoding.EncodeToString([]byte(userDerefString(u.password))),

// after
Password: userDerefString(u.password),
```

Sending `base64("Cloud#Init27")` = `Q2xvdWQjSW5pdDI3` to the API caused HTTP 400 "Password does not match the minimum requirements" because the encoded string contains only alphanumeric characters and no special characters, which the API password policy requires.

## Test plan

- [ ] `go test ./pkg/aruba/... -run TestUser_` passes
- [ ] `go test ./...` passes
- [ ] Manual: `terraform apply` with `arubacloud_dbaasuser` creates the user without a 400 error

🤖 Generated with [Claude Code](https://claude.com/claude-code)
